### PR TITLE
ci(infra): single-source Azure resource names, assert against naming conventions

### DIFF
--- a/.github/config/resource-names.env
+++ b/.github/config/resource-names.env
@@ -1,0 +1,9 @@
+RESOURCE_GROUP_DEV=rg-town-crier-dev
+STORAGE_ACCOUNT_DEV=sttowncrierdev
+SWA_NAME_DEV=swa-town-crier-dev
+CONTAINER_APP_API_DEV=ca-town-crier-api-go-dev
+STORAGE_ACCOUNT_PROD=sttowncrierprod
+SWA_NAME_PROD=swa-town-crier-prod
+CONTAINER_APP_API_PROD=ca-town-crier-api-go-prod
+IMAGE_REPO_API=town-crier-api-go
+IMAGE_REPO_WORKER=town-crier-worker-go

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -33,6 +33,12 @@
 #
 # Requires GitHub Environment:
 #   development            — with OIDC federated credential (environment:development)
+#
+# Requires .github/config/resource-names.env — single source of truth for
+# hardcoded Azure resource names (SWA, storage account, container app,
+# resource group, ACR image repos). Loaded per-job via `cat ... >>
+# "$GITHUB_ENV"` after checkout; asserted against infra/environment.go's
+# naming conventions by an /infra Go test (issue #835 slice 6).
 
 name: CD Dev
 
@@ -200,6 +206,12 @@ jobs:
         with:
           persist-credentials: false
 
+      # Loads the resource-name constants (issue #835 slice 6) into $GITHUB_ENV
+      # so subsequent steps can reference ${{ env.KEY }} instead of inline
+      # literals. Must run after checkout — the file has to be on disk.
+      - name: Load resource names
+        run: cat .github/config/resource-names.env >> "$GITHUB_ENV"
+
       - uses: ./.github/actions/azure-login
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -209,7 +221,7 @@ jobs:
       - uses: ./.github/actions/acr-build-push
         with:
           acr-login-server: ${{ secrets.ACR_LOGIN_SERVER }}
-          image-name: town-crier-api-go
+          image-name: ${{ env.IMAGE_REPO_API }}
           working-directory: api-go
 
   # ── Go Worker: build & push image ───────────────────────
@@ -227,6 +239,12 @@ jobs:
         with:
           persist-credentials: false
 
+      # Loads the resource-name constants (issue #835 slice 6) into $GITHUB_ENV
+      # so subsequent steps can reference ${{ env.KEY }} instead of inline
+      # literals. Must run after checkout — the file has to be on disk.
+      - name: Load resource names
+        run: cat .github/config/resource-names.env >> "$GITHUB_ENV"
+
       - uses: ./.github/actions/azure-login
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -236,7 +254,7 @@ jobs:
       - uses: ./.github/actions/acr-build-push
         with:
           acr-login-server: ${{ secrets.ACR_LOGIN_SERVER }}
-          image-name: town-crier-worker-go
+          image-name: ${{ env.IMAGE_REPO_WORKER }}
           dockerfile: Dockerfile.worker
           working-directory: api-go
 
@@ -257,6 +275,12 @@ jobs:
         with:
           persist-credentials: false
 
+      # Loads the resource-name constants (issue #835 slice 6) into $GITHUB_ENV
+      # so subsequent steps can reference ${{ env.KEY }} instead of inline
+      # literals. Must run after checkout — the file has to be on disk.
+      - name: Load resource names
+        run: cat .github/config/resource-names.env >> "$GITHUB_ENV"
+
       - uses: ./.github/actions/azure-login
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -265,9 +289,9 @@ jobs:
 
       - uses: ./.github/actions/deploy-container-app
         with:
-          app-name: ca-town-crier-api-go-dev
-          resource-group: rg-town-crier-dev
-          image: ${{ secrets.ACR_LOGIN_SERVER }}/town-crier-api-go:${{ github.sha }}
+          app-name: ${{ env.CONTAINER_APP_API_DEV }}
+          resource-group: ${{ env.RESOURCE_GROUP_DEV }}
+          image: ${{ secrets.ACR_LOGIN_SERVER }}/${{ env.IMAGE_REPO_API }}:${{ github.sha }}
 
   # ── Worker: deploy to dev ───────────────────────────────
   worker-deploy:
@@ -285,6 +309,12 @@ jobs:
         with:
           persist-credentials: false
 
+      # Loads the resource-name constants (issue #835 slice 6) into $GITHUB_ENV
+      # so subsequent steps can reference ${{ env.KEY }} instead of inline
+      # literals. Must run after checkout — the file has to be on disk.
+      - name: Load resource names
+        run: cat .github/config/resource-names.env >> "$GITHUB_ENV"
+
       - uses: ./.github/actions/azure-login
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -296,8 +326,8 @@ jobs:
           # Dev has no poll or poll-bootstrap jobs (ADR 0024).
           jobs: digest digest-hourly dormant-cleanup dev-seed subscription-sweep pg-purge
           env-suffix: dev
-          resource-group: rg-town-crier-dev
-          image: ${{ secrets.ACR_LOGIN_SERVER }}/town-crier-worker-go:${{ github.sha }}
+          resource-group: ${{ env.RESOURCE_GROUP_DEV }}
+          image: ${{ secrets.ACR_LOGIN_SERVER }}/${{ env.IMAGE_REPO_WORKER }}:${{ github.sha }}
 
   # ── Web: deploy to dev ──────────────────────────────
   web-deploy:
@@ -313,6 +343,12 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
+
+      # Loads the resource-name constants (issue #835 slice 6) into $GITHUB_ENV
+      # so subsequent steps can reference ${{ env.KEY }} instead of inline
+      # literals. Must run after checkout — the file has to be on disk.
+      - name: Load resource names
+        run: cat .github/config/resource-names.env >> "$GITHUB_ENV"
 
       # azure-login MUST run before build-web: in render-mode, build-web
       # downloads the weekly seo-snapshot.json from Azure Blob via `az storage
@@ -335,13 +371,13 @@ jobs:
           vite-applicationinsights-connection-string: ${{ vars.VITE_APPLICATIONINSIGHTS_CONNECTION_STRING }}
           seo-town-min-population: ${{ vars.SEO_TOWN_MIN_POPULATION || '5000' }}
           render-mode: 'true'
-          storage-account-name: sttowncrierdev
+          storage-account-name: ${{ env.STORAGE_ACCOUNT_DEV }}
 
       - name: Get SWA deployment token
         id: swa-token
         uses: ./.github/actions/get-swa-token
         with:
-          swa-name: swa-town-crier-dev
+          swa-name: ${{ env.SWA_NAME_DEV }}
 
       - name: Deploy to Azure Static Web Apps
         uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -14,6 +14,14 @@
 #
 # Requires GitHub Environment:
 #   production             — with OIDC federated credential (environment:production)
+#
+# Requires .github/config/resource-names.env — single source of truth for
+# hardcoded Azure resource names (storage account, container app, ACR image
+# repos). Loaded per-job via `cat ... >> "$GITHUB_ENV"` after checkout.
+# resource-group and swa-name are NOT in this file — they come from Pulumi
+# stack outputs (see the `infra` job below) rather than a hardcoded literal.
+# The file is asserted against infra/environment.go's naming conventions by
+# an /infra Go test (issue #835 slice 6).
 
 name: CD Production
 
@@ -126,11 +134,18 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
+      # Loads the resource-name constants (issue #835 slice 6) into $GITHUB_ENV
+      # so subsequent steps can reference ${{ env.KEY }} (or, in `run:` steps,
+      # the plain shell var) instead of inline literals. Must run after
+      # checkout — the file has to be on disk.
+      - name: Load resource names
+        run: cat .github/config/resource-names.env >> "$GITHUB_ENV"
+
       - name: Resolve release image
         id: resolve-image
         uses: ./.github/actions/resolve-release-image
         with:
-          repo-name: town-crier-api-go
+          repo-name: ${{ env.IMAGE_REPO_API }}
           display-name: "Go API"
           acr-login-server: ${{ secrets.ACR_LOGIN_SERVER }}
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -139,7 +154,7 @@ jobs:
 
       - uses: ./.github/actions/deploy-container-app
         with:
-          app-name: ca-town-crier-api-go-prod
+          app-name: ${{ env.CONTAINER_APP_API_PROD }}
           resource-group: ${{ needs.infra.outputs.resource-group }}
           image: ${{ steps.resolve-image.outputs.image }}
 
@@ -154,7 +169,7 @@ jobs:
         run: |
           ACR_SERVER="${{ secrets.ACR_LOGIN_SERVER }}"
           ACR_NAME="${ACR_SERVER%.azurecr.io}"
-          REPO="town-crier-api-go"
+          REPO="${IMAGE_REPO_API}"
           az acr import \
             --name "$ACR_NAME" \
             --source "${{ steps.resolve-image.outputs.image }}" \
@@ -174,6 +189,13 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
+      # Loads the resource-name constants (issue #835 slice 6) into $GITHUB_ENV
+      # so subsequent steps can reference ${{ env.KEY }} (or, in `run:` steps,
+      # the plain shell var) instead of inline literals. Must run after
+      # checkout — the file has to be on disk.
+      - name: Load resource names
+        run: cat .github/config/resource-names.env >> "$GITHUB_ENV"
+
       # Same rationale as the Go API job above. Pinning the worker jobs to a
       # digest makes each release run an exact, reproducible image instead of
       # whatever :latest happens to resolve to at run time.
@@ -181,7 +203,7 @@ jobs:
         id: resolve-image
         uses: ./.github/actions/resolve-release-image
         with:
-          repo-name: town-crier-worker-go
+          repo-name: ${{ env.IMAGE_REPO_WORKER }}
           display-name: "worker"
           acr-login-server: ${{ secrets.ACR_LOGIN_SERVER }}
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -206,7 +228,7 @@ jobs:
         run: |
           ACR_SERVER="${{ secrets.ACR_LOGIN_SERVER }}"
           ACR_NAME="${ACR_SERVER%.azurecr.io}"
-          REPO="town-crier-worker-go"
+          REPO="${IMAGE_REPO_WORKER}"
           az acr import \
             --name "$ACR_NAME" \
             --source "${{ steps.resolve-image.outputs.image }}" \
@@ -224,6 +246,15 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
+
+      # Loads the resource-name constants (issue #835 slice 6) into $GITHUB_ENV
+      # so subsequent steps can reference ${{ env.KEY }} instead of inline
+      # literals. Must run after checkout — the file has to be on disk.
+      # (swa-name for prod is NOT in this file — it comes from the Pulumi
+      # stack output above, needs.infra.outputs.swa-name, not a hardcoded
+      # literal.)
+      - name: Load resource names
+        run: cat .github/config/resource-names.env >> "$GITHUB_ENV"
 
       # azure-login MUST run before build-web: in render-mode, build-web
       # downloads the weekly seo-snapshot.json from Azure Blob via `az storage
@@ -246,7 +277,7 @@ jobs:
           vite-applicationinsights-connection-string: ${{ vars.VITE_APPLICATIONINSIGHTS_CONNECTION_STRING }}
           seo-town-min-population: ${{ vars.SEO_TOWN_MIN_POPULATION || '5000' }}
           render-mode: 'true'
-          storage-account-name: sttowncrierprod
+          storage-account-name: ${{ env.STORAGE_ACCOUNT_PROD }}
 
       - name: Get SWA deployment token
         id: swa-token

--- a/.github/workflows/dev-container-app-cleanup.yml
+++ b/.github/workflows/dev-container-app-cleanup.yml
@@ -30,6 +30,13 @@
 #
 # Requires GitHub Environment:
 #   development            — with OIDC federated credential (environment:development)
+#
+# Requires .github/config/resource-names.env — single source of truth for
+# the dev resource group name. Loaded into $GITHUB_ENV by the `cleanup` job
+# (after checkout, as RESOURCE_GROUP_DEV) rather than a workflow-level `env:`
+# literal, so it can't drift from cd-dev.yml/seo-refresh.yml. Asserted
+# against infra/environment.go's naming conventions by an /infra Go test
+# (issue #835 slice 6).
 
 name: Dev Container App Cleanup
 
@@ -47,9 +54,6 @@ permissions:
   contents: read
   id-token: write
 
-env:
-  RESOURCE_GROUP: rg-town-crier-dev
-
 jobs:
   cleanup:
     name: Deactivate stale dev revisions
@@ -60,6 +64,13 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
+
+      # Loads the resource-name constants (issue #835 slice 6) into $GITHUB_ENV
+      # as RESOURCE_GROUP_DEV (used throughout this job in place of the old
+      # workflow-level RESOURCE_GROUP literal). Must run after checkout — the
+      # file has to be on disk.
+      - name: Load resource names
+        run: cat .github/config/resource-names.env >> "$GITHUB_ENV"
 
       - uses: ./.github/actions/azure-login
         with:
@@ -72,12 +83,12 @@ jobs:
         run: |
           set -euo pipefail
           APPS=$(az containerapp list \
-            --resource-group "${RESOURCE_GROUP}" \
+            --resource-group "${RESOURCE_GROUP_DEV}" \
             --query "[?properties.configuration.activeRevisionsMode=='Multiple'].name" \
             -o tsv)
 
           if [ -z "${APPS}" ]; then
-            echo "No Multiple-mode Container Apps found in ${RESOURCE_GROUP}."
+            echo "No Multiple-mode Container Apps found in ${RESOURCE_GROUP_DEV}."
           else
             echo "Found Multiple-mode apps:"
             echo "${APPS}"
@@ -100,7 +111,7 @@ jobs:
           {
             echo "## Dev Container App revision cleanup"
             echo
-            echo "Resource group: \`${RESOURCE_GROUP}\`"
+            echo "Resource group: \`${RESOURCE_GROUP_DEV}\`"
             echo
             echo "| App | Mode | Deactivated | Active after |"
             echo "| --- | --- | ---: | ---: |"
@@ -131,7 +142,7 @@ jobs:
             # Field note: revision list returns objects where 'name' is a
             # TOP-LEVEL field and timestamps/flags live under 'properties'.
             KEEP=$(az containerapp revision list \
-              --resource-group "${RESOURCE_GROUP}" \
+              --resource-group "${RESOURCE_GROUP_DEV}" \
               --name "${APP}" \
               --query "sort_by([?properties.active], &properties.createdTime)[-1].name" \
               -o tsv)
@@ -140,7 +151,7 @@ jobs:
 
             # All other active revisions are stale.
             STALE=$(az containerapp revision list \
-              --resource-group "${RESOURCE_GROUP}" \
+              --resource-group "${RESOURCE_GROUP_DEV}" \
               --name "${APP}" \
               --query "[?properties.active && name!='${KEEP}'].name" \
               -o tsv)
@@ -151,7 +162,7 @@ jobs:
                 [ -z "${REV}" ] && continue
                 echo "Deactivating ${REV}"
                 az containerapp revision deactivate \
-                  --resource-group "${RESOURCE_GROUP}" \
+                  --resource-group "${RESOURCE_GROUP_DEV}" \
                   --name "${APP}" \
                   --revision "${REV}"
                 count=$((count + 1))
@@ -161,7 +172,7 @@ jobs:
             fi
 
             ACTIVE_AFTER=$(az containerapp revision list \
-              --resource-group "${RESOURCE_GROUP}" \
+              --resource-group "${RESOURCE_GROUP_DEV}" \
               --name "${APP}" \
               --query "length([?properties.active])" \
               -o tsv)

--- a/.github/workflows/seo-refresh.yml
+++ b/.github/workflows/seo-refresh.yml
@@ -53,6 +53,12 @@
 #   development, production  — each with an OIDC federated credential. The
 #   `environment:` block on each job selects that environment's vars.* values
 #   (dev → api-dev, prod → api).
+#
+# Requires .github/config/resource-names.env — single source of truth for
+# hardcoded Azure resource names (SWA, storage account). Loaded per-job via
+# `cat ... >> "$GITHUB_ENV"` after checkout; asserted against
+# infra/environment.go's naming conventions by an /infra Go test (issue #835
+# slice 6).
 
 name: SEO Refresh
 
@@ -101,6 +107,13 @@ jobs:
         with:
           persist-credentials: false
 
+      # Loads the resource-name constants (issue #835 slice 6) into $GITHUB_ENV
+      # so subsequent steps can reference ${{ env.KEY }} (or, in `run:` steps,
+      # the plain shell var) instead of inline literals. Must run after
+      # checkout — the file has to be on disk.
+      - name: Load resource names
+        run: cat .github/config/resource-names.env >> "$GITHUB_ENV"
+
       # SPA only — empty site-build-key skips the build-time prerender.
       - uses: ./.github/actions/build-web
         with:
@@ -132,7 +145,7 @@ jobs:
         run: |
           az storage blob upload \
             --auth-mode login \
-            --account-name sttowncrierdev \
+            --account-name "${STORAGE_ACCOUNT_DEV}" \
             --container-name seo-snapshot \
             --name seo-snapshot.json \
             --file web/seo-snapshot.json \
@@ -147,7 +160,7 @@ jobs:
         id: swa-token
         uses: ./.github/actions/get-swa-token
         with:
-          swa-name: swa-town-crier-dev
+          swa-name: ${{ env.SWA_NAME_DEV }}
 
       - name: Deploy to Azure Static Web Apps
         uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1
@@ -160,9 +173,11 @@ jobs:
           skip_api_build: true
 
   # ── Web: daily full refresh prod ────────────────────────
-  # No infra job here, so swa-name and the storage account name are hardcoded
-  # (cd-prod reads these from Pulumi outputs; this data-only refresh has no
-  # Pulumi step). Names match infra/environment.go.
+  # No infra job here, so swa-name and the storage account name come from
+  # .github/config/resource-names.env (cd-prod reads these from Pulumi
+  # outputs instead; this data-only refresh has no Pulumi step). The env file
+  # is asserted against infra/environment.go's naming conventions by an
+  # /infra Go test (issue #835 slice 6).
   web-prod:
     name: "Web: Daily refresh prod"
     # Schedule always runs; manual runs honour the `environment` selector.
@@ -176,6 +191,13 @@ jobs:
         with:
           persist-credentials: false
 
+      # Loads the resource-name constants (issue #835 slice 6) into $GITHUB_ENV
+      # so subsequent steps can reference ${{ env.KEY }} (or, in `run:` steps,
+      # the plain shell var) instead of inline literals. Must run after
+      # checkout — the file has to be on disk.
+      - name: Load resource names
+        run: cat .github/config/resource-names.env >> "$GITHUB_ENV"
+
       # SPA only — empty site-build-key skips the build-time prerender.
       - uses: ./.github/actions/build-web
         with:
@@ -207,7 +229,7 @@ jobs:
         run: |
           az storage blob upload \
             --auth-mode login \
-            --account-name sttowncrierprod \
+            --account-name "${STORAGE_ACCOUNT_PROD}" \
             --container-name seo-snapshot \
             --name seo-snapshot.json \
             --file web/seo-snapshot.json \
@@ -222,7 +244,7 @@ jobs:
         id: swa-token
         uses: ./.github/actions/get-swa-token
         with:
-          swa-name: swa-town-crier-prod
+          swa-name: ${{ env.SWA_NAME_PROD }}
 
       - name: Deploy to Azure Static Web Apps
         uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1

--- a/infra/environment.go
+++ b/infra/environment.go
@@ -178,8 +178,8 @@ func runEnvironmentStack(ctx *pulumi.Context, conf *config.Config, env string, t
 	}).(pulumi.StringOutput)
 
 	// Resource Group
-	resourceGroup, err := resources.NewResourceGroup(ctx, fmt.Sprintf("rg-town-crier-%s", env), &resources.ResourceGroupArgs{
-		ResourceGroupName: pulumi.String(fmt.Sprintf("rg-town-crier-%s", env)),
+	resourceGroup, err := resources.NewResourceGroup(ctx, ResourceGroupName(env), &resources.ResourceGroupArgs{
+		ResourceGroupName: pulumi.String(ResourceGroupName(env)),
 		Tags:              tags,
 	})
 	if err != nil {
@@ -322,7 +322,7 @@ func runEnvironmentStack(ctx *pulumi.Context, conf *config.Config, env string, t
 	// API authenticates to town_crier_dev via Entra managed identity (GH #653). AZURE_CLIENT_ID
 	// is already present and reused for the token fetch — no duplication.
 	apiEnvVars := app.EnvironmentVarArray{
-		app.EnvironmentVarArgs{Name: pulumi.String("OTEL_SERVICE_NAME"), Value: pulumi.String("town-crier-api-go")},
+		app.EnvironmentVarArgs{Name: pulumi.String("OTEL_SERVICE_NAME"), Value: pulumi.String(ImageRepoAPI)},
 		// Read by the in-process Azure Monitor metrics exporter (tc-0rt1).
 		app.EnvironmentVarArgs{Name: pulumi.String("APPLICATIONINSIGHTS_CONNECTION_STRING"), Value: appInsightsConnectionString},
 		app.EnvironmentVarArgs{Name: pulumi.String("AZURE_CLIENT_ID"), Value: cosmosDataIdentityClientID},
@@ -398,8 +398,8 @@ func runEnvironmentStack(ctx *pulumi.Context, conf *config.Config, env string, t
 		configuration.MaxInactiveRevisions = pulumi.Int(5)
 	}
 
-	_, err = app.NewContainerApp(ctx, fmt.Sprintf("ca-town-crier-api-go-%s", env), &app.ContainerAppArgs{
-		ContainerAppName:     pulumi.String(fmt.Sprintf("ca-town-crier-api-go-%s", env)),
+	_, err = app.NewContainerApp(ctx, ContainerAppAPIName(env), &app.ContainerAppArgs{
+		ContainerAppName:     pulumi.String(ContainerAppAPIName(env)),
 		ResourceGroupName:    resourceGroup.Name,
 		ManagedEnvironmentId: containerAppsEnvironmentID,
 		Configuration:        configuration,
@@ -493,8 +493,8 @@ func runEnvironmentStack(ctx *pulumi.Context, conf *config.Config, env string, t
 	}
 
 	// Static Web App (Landing Page)
-	staticWebApp, err := web.NewStaticSite(ctx, fmt.Sprintf("swa-town-crier-%s", env), &web.StaticSiteArgs{
-		Name:              pulumi.String(fmt.Sprintf("swa-town-crier-%s", env)),
+	staticWebApp, err := web.NewStaticSite(ctx, StaticWebAppName(env), &web.StaticSiteArgs{
+		Name:              pulumi.String(StaticWebAppName(env)),
 		ResourceGroupName: resourceGroup.Name,
 		Location:          pulumi.String("westeurope"),
 		Sku: &web.SkuDescriptionArgs{
@@ -550,7 +550,7 @@ func runEnvironmentStack(ctx *pulumi.Context, conf *config.Config, env string, t
 func createWorkerJob(ctx *pulumi.Context, ec envContext, nameSuffix, cronExpression string, replicaTimeout int, workerMode string, pollingBus *serviceBusPollingInfra) error {
 	// Base env shared by every worker job.
 	envVars := app.EnvironmentVarArray{
-		app.EnvironmentVarArgs{Name: pulumi.String("OTEL_SERVICE_NAME"), Value: pulumi.String("town-crier-worker-go")},
+		app.EnvironmentVarArgs{Name: pulumi.String("OTEL_SERVICE_NAME"), Value: pulumi.String(ImageRepoWorker)},
 		app.EnvironmentVarArgs{Name: pulumi.String("WORKER_MODE"), Value: pulumi.String(workerMode)},
 		app.EnvironmentVarArgs{Name: pulumi.String("AZURE_CLIENT_ID"), Value: ec.cosmosDataIdentityClientID},
 		app.EnvironmentVarArgs{Name: pulumi.String("APPLICATIONINSIGHTS_CONNECTION_STRING"), Value: ec.appInsightsConnectionString},
@@ -851,8 +851,8 @@ func createSeoSnapshotStorage(ctx *pulumi.Context, env string, resourceGroupName
 	// Storage account names are 3-24 chars, lowercase alphanumeric, globally unique. "st" prefix
 	// follows the resource-type naming convention; the hyphens from the usual "-town-crier-"
 	// pattern are dropped because they are invalid in a storage account name.
-	account, err := storage.NewStorageAccount(ctx, fmt.Sprintf("sttowncrier%s", env), &storage.StorageAccountArgs{
-		AccountName:       pulumi.String(fmt.Sprintf("sttowncrier%s", env)),
+	account, err := storage.NewStorageAccount(ctx, StorageAccountName(env), &storage.StorageAccountArgs{
+		AccountName:       pulumi.String(StorageAccountName(env)),
 		ResourceGroupName: resourceGroupName,
 		Kind:              pulumi.String(string(storage.KindStorageV2)),
 		Sku: &storage.SkuArgs{

--- a/infra/names.go
+++ b/infra/names.go
@@ -1,0 +1,42 @@
+package main
+
+import "fmt"
+
+// Azure resource-naming conventions, extracted into pure functions so they have exactly
+// one definition each. These are called both by the real resource-creation sites below
+// and by names_test.go, which asserts .github/config/resource-names.env — the single
+// source of truth consumed by the GitHub Actions workflows — matches what this program
+// actually names each resource (issue #835 slice 6). Do not change the literal formats
+// without also updating resource-names.env: Pulumi resource identity is keyed off these
+// strings (see main.go), so a format change is a rename, not a refactor.
+
+const (
+	// ImageRepoAPI is the ACR repository name for the API container image. It has no
+	// per-env suffix (one image repo, tagged per release, shared by dev and prod) and
+	// doubles as the API's OTEL_SERVICE_NAME.
+	ImageRepoAPI = "town-crier-api-go"
+	// ImageRepoWorker is the ACR repository name for the worker container image. It
+	// has no per-env suffix and doubles as the worker's OTEL_SERVICE_NAME.
+	ImageRepoWorker = "town-crier-worker-go"
+)
+
+// ResourceGroupName returns the Azure resource group name for env ("dev" or "prod").
+func ResourceGroupName(env string) string {
+	return fmt.Sprintf("rg-town-crier-%s", env)
+}
+
+// ContainerAppAPIName returns the Azure Container App name for the Go API, for env.
+func ContainerAppAPIName(env string) string {
+	return fmt.Sprintf("ca-town-crier-api-go-%s", env)
+}
+
+// StaticWebAppName returns the Azure Static Web App (landing page) name for env.
+func StaticWebAppName(env string) string {
+	return fmt.Sprintf("swa-town-crier-%s", env)
+}
+
+// StorageAccountName returns the Azure Storage Account name for env. Storage account
+// names are 3-24 chars, lowercase alphanumeric only, globally unique — no hyphens.
+func StorageAccountName(env string) string {
+	return fmt.Sprintf("sttowncrier%s", env)
+}

--- a/infra/names_test.go
+++ b/infra/names_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bufio"
+	"os"
+	"strings"
+	"testing"
+)
+
+// resourceNamesEnvPath is the single source of truth for Azure resource names consumed
+// by the GitHub Actions workflows (cd-dev.yml, cd-prod.yml, seo-refresh.yml,
+// dev-container-app-cleanup.yml), relative to this package.
+const resourceNamesEnvPath = "../.github/config/resource-names.env"
+
+// parseResourceNamesEnv reads a flat KEY=value file into a map. resource-names.env is
+// deliberately free of comments and blank lines — it gets cat-appended straight into
+// GitHub Actions' $GITHUB_ENV, whose parser requires strict KEY=value lines — so a line
+// without "=" is treated as a malformed file, not a comment to skip.
+func parseResourceNamesEnv(t *testing.T, path string) map[string]string {
+	t.Helper()
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer f.Close()
+
+	values := make(map[string]string)
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			t.Fatalf("%s: line %q has no '=' separator", path, line)
+		}
+		values[key] = value
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan %s: %v", path, err)
+	}
+	return values
+}
+
+// TestResourceNamesEnv_MatchesNamingConventions asserts that every value committed to
+// .github/config/resource-names.env matches what environment.go's own naming functions
+// produce for the real Pulumi resources — the same functions the resource-creation call
+// sites in environment.go use — so a name changed in one place without the other fails
+// CI (issue #835 slice 6 acceptance criterion).
+func TestResourceNamesEnv_MatchesNamingConventions(t *testing.T) {
+	t.Parallel()
+
+	got := parseResourceNamesEnv(t, resourceNamesEnvPath)
+
+	cases := []struct {
+		key  string
+		want string
+	}{
+		{"RESOURCE_GROUP_DEV", ResourceGroupName("dev")},
+		{"STORAGE_ACCOUNT_DEV", StorageAccountName("dev")},
+		{"SWA_NAME_DEV", StaticWebAppName("dev")},
+		{"CONTAINER_APP_API_DEV", ContainerAppAPIName("dev")},
+		{"STORAGE_ACCOUNT_PROD", StorageAccountName("prod")},
+		{"SWA_NAME_PROD", StaticWebAppName("prod")},
+		{"CONTAINER_APP_API_PROD", ContainerAppAPIName("prod")},
+		// The image repo names have no per-env suffix — they are the OTEL_SERVICE_NAME
+		// literals shared by dev and prod, doubling as the ACR repository names.
+		{"IMAGE_REPO_API", ImageRepoAPI},
+		{"IMAGE_REPO_WORKER", ImageRepoWorker},
+	}
+
+	seen := make(map[string]bool, len(cases))
+	for _, tc := range cases {
+		seen[tc.key] = true
+		t.Run(tc.key, func(t *testing.T) {
+			t.Parallel()
+
+			gotValue, ok := got[tc.key]
+			if !ok {
+				t.Fatalf("%s is missing from %s; the naming convention produces %q", tc.key, resourceNamesEnvPath, tc.want)
+			}
+			if gotValue != tc.want {
+				t.Fatalf("%s=%q in %s does not match the naming convention, which produces %q — update resource-names.env (or environment.go, if the convention itself changed)", tc.key, gotValue, resourceNamesEnvPath, tc.want)
+			}
+		})
+	}
+
+	// Coverage check: a key added to resource-names.env without a matching case above
+	// would otherwise pass silently and drift unnoticed.
+	for key := range got {
+		if !seen[key] {
+			t.Errorf("%s defines %s, which this test does not assert — add a case to TestResourceNamesEnv_MatchesNamingConventions", resourceNamesEnvPath, key)
+		}
+	}
+}


### PR DESCRIPTION
## Changes
- New `.github/config/resource-names.env` — single source of truth for Azure resource names previously hardcoded/duplicated across `cd-dev.yml`, `cd-prod.yml`, `seo-refresh.yml`, `dev-container-app-cleanup.yml` (SWA names, storage accounts, container app name, resource group, ACR image repos). Each consuming job loads it via `cat ... >> "$GITHUB_ENV"` immediately after checkout (and before any local composite-action call — respects slice 5's checkout-ordering fix).
- `infra/environment.go`: extracted the four inline `fmt.Sprintf` naming patterns (resource group, container app, static web app, storage account) into pure functions in new `infra/names.go`, plus two consts for the un-suffixed image-repo/OTEL_SERVICE_NAME literals. Byte-for-byte identical output — confirmed the Pulumi URN identity strings are unchanged (a URN change would trigger destroy+recreate on the next `pulumi up`).
- New `infra/names_test.go`: parses `resource-names.env` and asserts every value matches what `environment.go`'s own naming functions produce — so the workflow-level file, the real Pulumi resource names, and the test all derive from one source. Includes a coverage check that fails if the env file ever gains a key with no matching test case.

**Verification (independently re-run, not just trusted from the workers' reports):** `go build`/`go vet`/`gofmt -l`/`go test -v` all clean, all 9 subtests pass; `actionlint`/`zizmor` clean across the whole repo; manually mutated `RESOURCE_GROUP_DEV` to a wrong value, confirmed the test fails with a specific, actionable message naming the drifted key and both values, then reverted (tree confirmed clean before commit).

Slice 6 of 7 from #835 (memo 0014 CI hardening).

---
*Auto-shipped via ship skill*