### PR TITLE
fix(ios): app-icon badge now clears immediately on in-app mark-read (tc-4x8e0)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+BadgeSync.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+BadgeSync.swift
@@ -10,9 +10,11 @@ import TownCrierDomain
 /// - `syncBadge` runs whenever the scene enters the foreground. A failure
 ///   leaves the existing OS-level badge in place; the next foreground entry
 ///   will retry.
-/// - the push-tap mark-read runs immediately after a push deep-link is routed.
-///   Marking read is idempotent, so any transient failure is acceptable — a
-///   later `fetchState` reconciles.
+/// - the push-tap mark-read runs immediately after a push deep-link is routed,
+///   and on success reconciles the OS badge from the server right away rather
+///   than waiting on the next scenePhase `syncBadge()` (tc-4x8e0). Marking
+///   read is idempotent, so a transient failure is acceptable — a later
+///   `fetchState` reconciles.
 extension AppCoordinator {
   /// Fetches the current `NotificationState` and pushes `totalUnreadCount`
   /// into the application icon badge. Best-effort — errors are swallowed and
@@ -45,7 +47,11 @@ extension AppCoordinator {
   /// (`id.name`); `authorityId` is `id.authority` (which is
   /// `String(authorityId)`) converted back to `Int`. A non-numeric authority
   /// no-ops. Stored as `pendingApplicationMarkRead` so tests can await it;
-  /// production is fire-and-forget.
+  /// production is fire-and-forget. On success, reconciles the OS badge from
+  /// the server via `performBadgeSync()` rather than leaving it to race the
+  /// next scenePhase-triggered `syncBadge()` (tc-4x8e0). A failed mark-read
+  /// leaves the badge untouched — a retry or the next foreground sync
+  /// reconciles.
   private func markPushedApplicationRead(_ id: PlanningApplicationId) {
     guard let notificationStateRepository, let authorityId = Int(id.authority) else {
       return
@@ -57,11 +63,11 @@ extension AppCoordinator {
           applicationUid: applicationUid,
           authorityId: authorityId
         )
+        await self?.performBadgeSync()
       } catch {
         Self.logger.error(
           "Push-tap mark-read failed: \(error.localizedDescription)"
         )
-        _ = self  // retain to keep ARC happy; nothing else to do
       }
     }
   }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel+TapToRead.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel+TapToRead.swift
@@ -22,6 +22,11 @@ extension ApplicationListViewModel {
     }
     let applicationUid = id.name
     applications[index] = applications[index].withLatestUnreadEvent(nil)
+    // Also push the OS app-icon badge, mirroring `markAllRead()`'s clear —
+    // otherwise the badge only catches up on the next foreground sync, i.e.
+    // after a relaunch (tc-4x8e0).
+    globalUnreadCount -= 1
+    badgeSetter?.setBadge(globalUnreadCount)
     pendingMarkRead = Task { [weak self] in
       do {
         try await notificationStateRepository.markApplicationRead(

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel+TapToRead.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel+TapToRead.swift
@@ -25,7 +25,7 @@ extension ApplicationListViewModel {
     // Also push the OS app-icon badge, mirroring `markAllRead()`'s clear —
     // otherwise the badge only catches up on the next foreground sync, i.e.
     // after a relaunch (tc-4x8e0).
-    globalUnreadCount -= 1
+    globalUnreadCount = max(0, globalUnreadCount - 1)
     badgeSetter?.setBadge(globalUnreadCount)
     pendingMarkRead = Task { [weak self] in
       do {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel.swift
@@ -77,8 +77,8 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
   // Internal (not `private`) so the `+GlobalUnread` extension file can drive
   // `refreshGlobalUnread()` (tc-c5m1).
   let notificationStateRepository: NotificationStateRepository?
-  /// Clears the app-icon badge on a successful `markAllRead()` (tc-c5m1).
-  private let badgeSetter: BadgeSetting?
+  // Internal (not `private`): `+TapToRead` also pushes decrements here (tc-c5m1, tc-4x8e0).
+  let badgeSetter: BadgeSetting?
   var zone: WatchZone?
   /// Re-entrancy guard for ``loadApplications()``. A single user action can
   /// trigger the load repeatedly — `.task` firing alongside `.refreshable`, a

--- a/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorBadgeAndPushTapTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorBadgeAndPushTapTests.swift
@@ -33,7 +33,8 @@ struct AppCoordinatorBadgeAndPushTapTests {
 
   private func makeSUT(
     planningRepository: SpyPlanningApplicationRepository,
-    notificationStateRepository: NotificationStateRepository
+    notificationStateRepository: NotificationStateRepository,
+    badgeSetter: BadgeSetting? = nil
   ) -> AppCoordinator {
     AppCoordinator(
       repository: planningRepository,
@@ -45,7 +46,8 @@ struct AppCoordinatorBadgeAndPushTapTests {
       notificationService: SpyNotificationService(),
       appVersionProvider: SpyAppVersionProvider(),
       versionConfigService: SpyVersionConfigService(),
-      notificationStateRepository: notificationStateRepository
+      notificationStateRepository: notificationStateRepository,
+      badgeSetter: badgeSetter
     )
   }
 
@@ -190,6 +192,60 @@ struct AppCoordinatorBadgeAndPushTapTests {
     await sut.waitForPendingApplicationMarkRead()
 
     #expect(stateRepo.markApplicationReadCalls.count == 1)
+  }
+
+  @Test func handlePushTap_successfulMarkRead_reconcilesBadgeFromServer() async {
+    // A successful push-tap mark-read must not just fire the network call —
+    // it should reconcile the OS badge from the server immediately, rather
+    // than leaving it to race the next scenePhase-triggered syncBadge()
+    // (tc-4x8e0).
+    let stateRepo = SpyNotificationStateRepository()
+    stateRepo.fetchStateResult = .success(
+      NotificationState(
+        lastReadAt: Date(timeIntervalSince1970: 0),
+        version: 1,
+        totalUnreadCount: 2
+      )
+    )
+    let planningSpy = SpyPlanningApplicationRepository()
+    planningSpy.fetchApplicationResult = .success(.permitted)
+    let badgeSetter = SpyBadgeSetter()
+    let sut = makeSUT(
+      planningRepository: planningSpy,
+      notificationStateRepository: stateRepo,
+      badgeSetter: badgeSetter
+    )
+    let userInfo: [AnyHashable: Any] = ["applicationRef": "APP-002", "authorityId": 42]
+
+    sut.handlePushTap(userInfo: userInfo)
+
+    await sut.waitForPendingDetailLoad()
+    await sut.waitForPendingApplicationMarkRead()
+
+    #expect(badgeSetter.setBadgeCalls == [2])
+  }
+
+  @Test func handlePushTap_failedMarkRead_doesNotSyncBadge() async {
+    // A failed mark-read must not trigger a badge reconciliation — the next
+    // foreground sync (or a retried mark-read) is the reconciliation path.
+    let stateRepo = SpyNotificationStateRepository()
+    stateRepo.markApplicationReadResult = .failure(DomainError.networkUnavailable)
+    let planningSpy = SpyPlanningApplicationRepository()
+    planningSpy.fetchApplicationResult = .success(.permitted)
+    let badgeSetter = SpyBadgeSetter()
+    let sut = makeSUT(
+      planningRepository: planningSpy,
+      notificationStateRepository: stateRepo,
+      badgeSetter: badgeSetter
+    )
+    let userInfo: [AnyHashable: Any] = ["applicationRef": "APP-002", "authorityId": 42]
+
+    sut.handlePushTap(userInfo: userInfo)
+
+    await sut.waitForPendingDetailLoad()
+    await sut.waitForPendingApplicationMarkRead()
+
+    #expect(badgeSetter.setBadgeCalls.isEmpty)
   }
 
   @Test func handlePushTap_digestPayload_doesNothing() async {

--- a/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelTapToReadTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelTapToReadTests.swift
@@ -111,6 +111,34 @@ struct ApplicationListViewModelTapToReadTests {
     #expect(badgeSetter.setBadgeCalls == [4])
   }
 
+  @Test(
+    "opening an unread application clamps the global unread count at zero rather than going negative"
+  )
+  func selectApplication_unread_clampsGlobalUnreadCountAtZero() async throws {
+    let unread = app(authority: "42", name: "22/1234/FUL", unread: true)
+    let badgeSetter = SpyBadgeSetter()
+    let (sut, _) = try makeSUT(applications: [unread], badgeSetter: badgeSetter)
+    sut.globalUnreadCount = 0
+
+    sut.selectApplication(unread.id)
+
+    #expect(sut.globalUnreadCount == 0)
+    #expect(badgeSetter.setBadgeCalls == [0])
+  }
+
+  @Test("opening an already-read application does not call the badge setter")
+  func selectApplication_read_doesNotCallBadgeSetter() async throws {
+    let read = app(authority: "42", name: "22/1234/FUL", unread: false)
+    let badgeSetter = SpyBadgeSetter()
+    let (sut, _) = try makeSUT(applications: [read], badgeSetter: badgeSetter)
+    sut.globalUnreadCount = 5
+
+    sut.selectApplication(read.id)
+
+    #expect(sut.globalUnreadCount == 5)
+    #expect(badgeSetter.setBadgeCalls.isEmpty)
+  }
+
   @Test("selectApplication still notifies the coordinator for navigation")
   func selectApplication_notifiesCoordinator() async throws {
     let unread = app(authority: "42", name: "22/1234/FUL", unread: true)

--- a/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelTapToReadTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelTapToReadTests.swift
@@ -14,7 +14,8 @@ import TownCrierDomain
 struct ApplicationListViewModelTapToReadTests {
 
   private func makeSUT(
-    applications: [PlanningApplication]
+    applications: [PlanningApplication],
+    badgeSetter: SpyBadgeSetter? = nil
   ) throws -> (ApplicationListViewModel, SpyNotificationStateRepository) {
     let appSpy = SpyPlanningApplicationRepository()
     let stateSpy = SpyNotificationStateRepository()
@@ -23,6 +24,7 @@ struct ApplicationListViewModelTapToReadTests {
       repository: appSpy,
       zone: .cambridge,
       notificationStateRepository: stateSpy,
+      badgeSetter: badgeSetter,
       userDefaults: defaults,
       sortKey: "tap.applicationsListSort"
     )
@@ -90,6 +92,23 @@ struct ApplicationListViewModelTapToReadTests {
     await sut.waitForPendingMarkRead()
 
     #expect(stateSpy.markApplicationReadCalls.isEmpty)
+  }
+
+  @Test(
+    "opening an unread application decrements the global unread count and pushes it to the badge setter"
+  )
+  func selectApplication_unread_decrementsGlobalUnreadCountAndPushesToBadgeSetter() async throws {
+    let unread = app(authority: "42", name: "22/1234/FUL", unread: true)
+    let badgeSetter = SpyBadgeSetter()
+    let (sut, _) = try makeSUT(applications: [unread], badgeSetter: badgeSetter)
+    sut.globalUnreadCount = 5
+
+    sut.selectApplication(unread.id)
+
+    // Synchronous, same as the per-row optimistic clear above — no relaunch
+    // or foreground transition required to move the OS badge (tc-4x8e0).
+    #expect(sut.globalUnreadCount == 4)
+    #expect(badgeSetter.setBadgeCalls == [4])
   }
 
   @Test("selectApplication still notifies the coordinator for navigation")


### PR DESCRIPTION
## Changes

Fixes a bug where the iOS app-icon badge didn't decrement until the app was force-closed and relaunched.

- **Root cause**: the OS badge was only reconciled on scenePhase foreground transitions (`AppCoordinator.syncBadge()`) or a full `markAllRead()`. The in-app single-application "tap to read" flow (`ApplicationListViewModel+TapToRead.swift`) only cleared the row's local unread flag — it never touched `globalUnreadCount`/`badgeSetter`, so the OS badge stayed stale until the next relaunch.
- `ApplicationListViewModel.swift`: widened `badgeSetter` from `private` to internal so the `+TapToRead` extension can reach it (mirrors the existing `notificationStateRepository` visibility).
- `ApplicationListViewModel+TapToRead.swift`: `markReadOnOpen(_:)` now decrements `globalUnreadCount` (clamped at zero) and pushes it to `badgeSetter` synchronously, alongside the existing optimistic per-row clear.
- `AppCoordinator+BadgeSync.swift`: the push-notification-tap mark-read flow (`markPushedApplicationRead(_:)`) now reconciles the badge from the server immediately on success instead of racing the next scenePhase sync.
- 5 new tests (TDD red/green) covering the decrement, zero-clamp, already-read no-op, and both push-tap success/failure paths. Full suite: 1446/1446 passing. SwiftLint clean on all touched files (81 pre-existing violations elsewhere on `main`, unrelated to this change).

Bead: tc-4x8e0

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * App icon badges now update immediately when items are marked read, keeping unread counts in sync sooner.
  * Tapping an unread item now clears the badge count right away, with the count safely clamped at zero.
  * If a read action fails, the badge is left unchanged and will retry on the next refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->