### PR TITLE
ci: add --diff to drift-check for property-level failure detail

### DIFF
--- a/.github/workflows/infra-drift-check.yml
+++ b/.github/workflows/infra-drift-check.yml
@@ -120,7 +120,10 @@ jobs:
 
       # --expect-no-changes makes this exit non-zero the moment the refreshed
       # state shows any diff from the program — the drift-detection mechanism
-      # itself, no extra scripting needed.
+      # itself, no extra scripting needed. --diff prints property-level detail
+      # (not just "~ resource changed") so a failure is diagnosable straight
+      # from the run log, without a follow-up local `pulumi preview --diff`
+      # (which needs secrets that only exist in this job's ephemeral config).
       - name: Pulumi drift check (${{ matrix.stack }})
         working-directory: infra
         env:
@@ -129,7 +132,7 @@ jobs:
           ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-        run: pulumi preview --non-interactive --refresh --expect-no-changes
+        run: pulumi preview --non-interactive --refresh --diff --expect-no-changes
 
   # ── Weekly Cloudflare IPv4 staleness check ───────────
   cf-ip-check:


### PR DESCRIPTION
## Summary
- Adds `--diff` to the `infra-drift-check.yml` drift-check step so a future failure shows the actual property-level cause (e.g. which field inside `~template` changed) directly in the run log, instead of just a resource-level `~ resource changed` summary.

## Context
The first real run of this workflow (tc-61eoz.8, discovered from issue #835 slice 7) found `~template` diffs on every worker job and the API container app across dev/prod. Investigating locally with `pulumi preview --refresh --diff` strongly suggests these are refresh-reconciliation noise from CD's out-of-band `az`-managed image deploys (already covered by existing `IgnoreChanges`) rather than real drift, but a full local repro is blocked — the local `Pulumi.{dev,prod}.yaml` doesn't have four of the six secrets this program requires (they're injected into CI's ephemeral checkout only). This flag lets CI itself produce the missing detail safely, without touching local secrets.

## Test plan
- [x] `actionlint` clean
- [x] `zizmor` clean, no findings
- [ ] Merge, then re-trigger `infra-drift-check.yml` via `workflow_dispatch` and inspect the full property-level diff in the run log

https://claude.ai/code/session_01PZqahDfeeojbkU82kG813v

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved drift-check output so failures include more detailed, property-level information directly in the workflow logs.
  * Reduced the need to run an extra local preview when investigating infrastructure drift.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->