### PR TITLE
infra: declare computed/CD-owned fields to silence drift-check false positives

### DIFF
--- a/infra/environment.go
+++ b/infra/environment.go
@@ -329,10 +329,10 @@ func runEnvironmentStack(ctx *pulumi.Context, conf *config.Config, env string, t
 		app.EnvironmentVarArgs{Name: pulumi.String("AUTH0_DOMAIN"), Value: pulumi.String(auth0Domain)},
 		app.EnvironmentVarArgs{Name: pulumi.String("AUTH0_AUDIENCE"), Value: pulumi.String(auth0Audience)},
 		app.EnvironmentVarArgs{Name: pulumi.String("CORS_ALLOWED_ORIGINS"), Value: pulumi.String(fmt.Sprintf("https://%s", frontendDomain))},
-		app.EnvironmentVarArgs{Name: pulumi.String("AUTH0_M2M_CLIENT_ID"), SecretRef: pulumi.String("auth0-m2m-client-id")},
-		app.EnvironmentVarArgs{Name: pulumi.String("AUTH0_M2M_CLIENT_SECRET"), SecretRef: pulumi.String("auth0-m2m-client-secret")},
-		app.EnvironmentVarArgs{Name: pulumi.String("ADMIN_API_KEY"), SecretRef: pulumi.String("admin-api-key")},
-		app.EnvironmentVarArgs{Name: pulumi.String("SITE_BUILD_KEY"), SecretRef: pulumi.String("site-build-key")},
+		app.EnvironmentVarArgs{Name: pulumi.String("AUTH0_M2M_CLIENT_ID"), SecretRef: pulumi.String("auth0-m2m-client-id"), Value: pulumi.String("")},
+		app.EnvironmentVarArgs{Name: pulumi.String("AUTH0_M2M_CLIENT_SECRET"), SecretRef: pulumi.String("auth0-m2m-client-secret"), Value: pulumi.String("")},
+		app.EnvironmentVarArgs{Name: pulumi.String("ADMIN_API_KEY"), SecretRef: pulumi.String("admin-api-key"), Value: pulumi.String("")},
+		app.EnvironmentVarArgs{Name: pulumi.String("SITE_BUILD_KEY"), SecretRef: pulumi.String("site-build-key"), Value: pulumi.String("")},
 		// Blob endpoint for the share-cards container (#738 Slice 3): the share-page OG handler
 		// caches baked map cards here. Computed directly from env because the account name is
 		// deterministic (sttowncrier{env}); this avoids a cross-resource dependency on the storage
@@ -429,7 +429,7 @@ func runEnvironmentStack(ctx *pulumi.Context, conf *config.Config, env string, t
 			},
 		},
 		Tags: tags,
-	}, pulumi.IgnoreChanges([]string{"template.containers[0].image", "configuration.ingress.traffic"}))
+	}, pulumi.IgnoreChanges([]string{"template.containers[0].image", "configuration.ingress.traffic", "template.revisionSuffix"}))
 	if err != nil {
 		return err
 	}
@@ -506,7 +506,7 @@ func runEnvironmentStack(ctx *pulumi.Context, conf *config.Config, env string, t
 			OutputLocation: pulumi.String(""),
 		},
 		Tags: tags,
-	})
+	}, pulumi.IgnoreChanges([]string{"branch", "provider", "repositoryUrl"}))
 	if err != nil {
 		return err
 	}
@@ -707,7 +707,7 @@ func addGoWorkerEnv(envVars app.EnvironmentVarArray, ec envContext, workerMode s
 	if workerMode == "poll-sb" || workerMode == "digest" || workerMode == "hourly-digest" {
 		envVars = append(envVars,
 			app.EnvironmentVarArgs{Name: pulumi.String("APNS_ENABLED"), Value: pulumi.String("true")},
-			app.EnvironmentVarArgs{Name: pulumi.String("APNS_AUTH_KEY"), SecretRef: pulumi.String("apns-auth-key")},
+			app.EnvironmentVarArgs{Name: pulumi.String("APNS_AUTH_KEY"), SecretRef: pulumi.String("apns-auth-key"), Value: pulumi.String("")},
 			app.EnvironmentVarArgs{Name: pulumi.String("APNS_KEY_ID"), Value: pulumi.String("L2J5PQASN5")},
 			app.EnvironmentVarArgs{Name: pulumi.String("APNS_TEAM_ID"), Value: pulumi.String("4574VQ7N2X")},
 			app.EnvironmentVarArgs{Name: pulumi.String("APNS_BUNDLE_ID"), Value: pulumi.String(apnsBundleID)},
@@ -723,14 +723,14 @@ func addGoWorkerEnv(envVars app.EnvironmentVarArray, ec envContext, workerMode s
 		envVars = append(envVars,
 			app.EnvironmentVarArgs{Name: pulumi.String("FCM_ENABLED"), Value: pulumi.String("true")},
 			app.EnvironmentVarArgs{Name: pulumi.String("FCM_PROJECT_ID"), Value: pulumi.String(ec.fcmProjectID)},
-			app.EnvironmentVarArgs{Name: pulumi.String("FCM_SERVICE_ACCOUNT_JSON"), SecretRef: pulumi.String("fcm-service-account")},
+			app.EnvironmentVarArgs{Name: pulumi.String("FCM_SERVICE_ACCOUNT_JSON"), SecretRef: pulumi.String("fcm-service-account"), Value: pulumi.String("")},
 		)
 	}
 
 	// digest / hourly-digest: ACS email transport (the poll worker sends no email).
 	if workerMode == "digest" || workerMode == "hourly-digest" {
 		envVars = append(envVars,
-			app.EnvironmentVarArgs{Name: pulumi.String("ACS_CONNECTION_STRING"), SecretRef: pulumi.String("acs-connection-string")},
+			app.EnvironmentVarArgs{Name: pulumi.String("ACS_CONNECTION_STRING"), SecretRef: pulumi.String("acs-connection-string"), Value: pulumi.String("")},
 		)
 	}
 
@@ -753,8 +753,8 @@ func addGoWorkerEnv(envVars app.EnvironmentVarArray, ec envContext, workerMode s
 	if workerMode == "dormant-cleanup" || workerMode == "subscription-sweep" {
 		envVars = append(envVars,
 			app.EnvironmentVarArgs{Name: pulumi.String("AUTH0_DOMAIN"), Value: pulumi.String(ec.auth0Domain)},
-			app.EnvironmentVarArgs{Name: pulumi.String("AUTH0_M2M_CLIENT_ID"), SecretRef: pulumi.String("auth0-m2m-client-id")},
-			app.EnvironmentVarArgs{Name: pulumi.String("AUTH0_M2M_CLIENT_SECRET"), SecretRef: pulumi.String("auth0-m2m-client-secret")},
+			app.EnvironmentVarArgs{Name: pulumi.String("AUTH0_M2M_CLIENT_ID"), SecretRef: pulumi.String("auth0-m2m-client-id"), Value: pulumi.String("")},
+			app.EnvironmentVarArgs{Name: pulumi.String("AUTH0_M2M_CLIENT_SECRET"), SecretRef: pulumi.String("auth0-m2m-client-secret"), Value: pulumi.String("")},
 		)
 	}
 
@@ -863,7 +863,11 @@ func createSeoSnapshotStorage(ctx *pulumi.Context, env string, resourceGroupName
 		AllowSharedKeyAccess:   pulumi.Bool(false),
 		EnableHttpsTrafficOnly: pulumi.Bool(true),
 		MinimumTlsVersion:      pulumi.String(string(storage.MinimumTlsVersion_TLS1_2)),
-		Tags:                   tags,
+		NetworkRuleSet: &storage.NetworkRuleSetArgs{
+			Bypass:        pulumi.String("None"),
+			DefaultAction: storage.DefaultActionAllow,
+		},
+		Tags: tags,
 	})
 	if err != nil {
 		return pulumi.StringOutput{}, pulumi.StringOutput{}, err

--- a/infra/shared.go
+++ b/infra/shared.go
@@ -305,6 +305,7 @@ func runSharedStack(ctx *pulumi.Context, conf *config.Config, tags pulumi.String
 		},
 		Storage: &dbforpostgresql.StorageArgs{
 			StorageSizeGB: pulumi.Int(32),
+			Type:          dbforpostgresql.StorageType_Premium_LRS,
 		},
 		HighAvailability: &dbforpostgresql.HighAvailabilityArgs{
 			Mode: dbforpostgresql.PostgreSqlFlexibleServerHighAvailabilityModeDisabled,


### PR DESCRIPTION
## Summary

infra-drift-check.yml's first-ever run (issue #835 slice 7, tc-61eoz.7) correctly failed on all three Pulumi stacks (dev/prod/shared) — every proposed diff traced back to the Pulumi program declaring less state than Azure actually reports, computes, or that CD manages. This PR closes tc-61eoz.8 by declaring each field explicitly so the program matches Azure's actual (unchanged) behavior. **Zero functional change to any live resource** — every edit either mirrors a value Azure already computes/defaults, or tells Pulumi to ignore a field that CD/GitHub deployment tooling legitimately owns outside this program.

Six edits, all in `infra/environment.go` + `infra/shared.go`:

1. **Add `Value: ""` alongside `SecretRef`** on 9 `EnvironmentVarArgs` entries (4 on the API ContainerApp, 5 across `addGoWorkerEnv`'s worker-job env vars) — Azure's Container Apps API always returns `secretRef` and `value: ""` together; the missing `Value` in the program was exactly what refresh flagged as drift.
2. **Add `template.revisionSuffix`** to the API ContainerApp's existing `IgnoreChanges` list — CD sets this per-deploy (`r<run-id>-1`), same category as the already-ignored `template.containers[0].image`.
3. **Add `IgnoreChanges([branch, provider, repositoryUrl])`** to the Static Web App — this is GitHub-deployment-source metadata the program never declares (our actual deploys go through `Azure/static-web-apps-deploy` with a token, not git integration), so it will always drift otherwise.
4. **Declare `NetworkRuleSet{Bypass: None, DefaultAction: Allow}`** on the SEO snapshot storage account (`createSeoSnapshotStorage`) — matches the account's live, fully-open posture (confirmed via `az storage account show`).
5. **Declare `Storage.Type: Premium_LRS`** on the shared Postgres Flexible Server — this is Azure's own documented default when the field is unspecified.

All SDK field types verified with `go doc` against the pinned `pulumi-azure-native-sdk` v3.16.0 in this repo's `go.mod` before editing (e.g. `EnvironmentVarArgs.Value` is `pulumi.StringPtrInput` and coexists with `SecretRef`; `NetworkRuleSetArgs.DefaultAction`/`StorageArgs.Type` accept the same typed-constant pattern already used elsewhere in this file, `storage.AccessTierHot` / `dbforpostgresql.CreateModeDefault`).

Linked epic: https://github.com/AmyDe/town-crier/issues/835 (slice 7 follow-up, tc-61eoz.8, discovered-from tc-61eoz.7).

## Test plan

- [x] `cd infra && gofmt -l .` — clean
- [x] `go build ./...` — passes
- [x] `go vet ./...` — passes
- [x] `go test ./...` — 10/10 passing (includes the resource-naming-convention test; unaffected since no resource names changed, only field values)
- [x] `pulumi preview --refresh --diff --stack shared --non-interactive --expect-no-changes` — clean exit 0, "36 unchanged" (needed `ARM_SUBSCRIPTION_ID` exported locally; shared needs no Pulumi secrets per the workflow's own comment). This directly confirms edit 6 eliminates the Postgres `storage.type` diff.
- [ ] dev/prod stack previews could not be run locally — `environment.go:134`'s `config.RequireSecret("adminApiKey")` (and 3 others) panics outside CI's ephemeral checkout, a pre-existing orthogonal gap unrelated to this change. Recommend watching the next scheduled `infra-drift-check.yml` run post-merge to confirm dev/prod go clean too.
- [x] Scope check: `git diff --name-only` against merge-base shows only `infra/` files touched.

Do not merge — the requester will watch the PR gate and merge.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01PZqahDfeeojbkU82kG813v