### PR TITLE
infra: declare empty ipRules/virtualNetworkRules on SEO storage NetworkRuleSet

### DIFF
--- a/infra/environment.go
+++ b/infra/environment.go
@@ -864,8 +864,10 @@ func createSeoSnapshotStorage(ctx *pulumi.Context, env string, resourceGroupName
 		EnableHttpsTrafficOnly: pulumi.Bool(true),
 		MinimumTlsVersion:      pulumi.String(string(storage.MinimumTlsVersion_TLS1_2)),
 		NetworkRuleSet: &storage.NetworkRuleSetArgs{
-			Bypass:        pulumi.String("None"),
-			DefaultAction: storage.DefaultActionAllow,
+			Bypass:              pulumi.String("None"),
+			DefaultAction:       storage.DefaultActionAllow,
+			IpRules:             storage.IPRuleArray{},
+			VirtualNetworkRules: storage.VirtualNetworkRuleArray{},
 		},
 		Tags: tags,
 	})


### PR DESCRIPTION
## Summary
- Follow-up to #861. Its `NetworkRuleSet` fix silenced most of dev/prod's drift-check but left one residual diff on the SEO snapshot storage account (`sttowncrierdev`/`sttowncrierprod`): Azure returns `ipRules: []` and `virtualNetworkRules: []` even when the rest of `networkRuleSet` matches, and a Go nil slice doesn't satisfy that — Pulumi still proposed removing them.
- Confirmed by re-triggering `infra-drift-check.yml` after #861 merged (run 28787403515): shared went fully clean, but dev/prod each had exactly this one remaining `~ networkRuleSet: { - ipRules: [], - virtualNetworkRules: [] }` diff. Declaring both as explicit empty arrays matches Azure's actual response.

## Test plan
- [x] `gofmt`/`go build`/`go vet`/`go test` clean
- [x] `actionlint`/`zizmor` clean (no workflow changes, ran as a matter of course)
- [ ] Merge, re-trigger `infra-drift-check.yml`, confirm dev/prod both go fully clean this time

tc-61eoz.8 / issue #835 slice 7.

https://claude.ai/code/session_01PZqahDfeeojbkU82kG813v