### PR TITLE
infra: ignore networkRuleSet ipRules/virtualNetworkRules instead of declaring

### DIFF
--- a/infra/environment.go
+++ b/infra/environment.go
@@ -864,13 +864,15 @@ func createSeoSnapshotStorage(ctx *pulumi.Context, env string, resourceGroupName
 		EnableHttpsTrafficOnly: pulumi.Bool(true),
 		MinimumTlsVersion:      pulumi.String(string(storage.MinimumTlsVersion_TLS1_2)),
 		NetworkRuleSet: &storage.NetworkRuleSetArgs{
-			Bypass:              pulumi.String("None"),
-			DefaultAction:       storage.DefaultActionAllow,
-			IpRules:             storage.IPRuleArray{},
-			VirtualNetworkRules: storage.VirtualNetworkRuleArray{},
+			Bypass:        pulumi.String("None"),
+			DefaultAction: storage.DefaultActionAllow,
 		},
 		Tags: tags,
-	})
+		// Azure's API is inconsistent about echoing networkRuleSet.ipRules/virtualNetworkRules
+		// as [] vs omitting them entirely — dev and prod disagreed in opposite directions when
+		// this was declared as an explicit empty array, so ignore both sub-paths rather than
+		// chase a literal value that only matches one stack (tc-61eoz.8).
+	}, pulumi.IgnoreChanges([]string{"networkRuleSet.ipRules", "networkRuleSet.virtualNetworkRules"}))
 	if err != nil {
 		return pulumi.StringOutput{}, pulumi.StringOutput{}, err
 	}


### PR DESCRIPTION
## Summary
- Follow-up to #862, which declared `IpRules`/`VirtualNetworkRules` as explicit empty arrays to fix the residual dev/prod drift. That fixed prod, but the re-triggered drift-check (run 28787795991) showed dev flipped to the *opposite* direction: `+ ipRules: []` / `+ virtualNetworkRules: []` instead of `-`. Azure's API isn't consistent about echoing these two sub-fields as `[]` vs omitting them entirely between the two stacks — no single literal value satisfies both.
- Switches to `IgnoreChanges` on `networkRuleSet.ipRules` / `networkRuleSet.virtualNetworkRules` instead of declaring a value, so Pulumi stops asserting either direction. `Bypass`/`DefaultAction` stay explicitly declared since those matched cleanly on both stacks already.

## Test plan
- [x] `gofmt`/`go build`/`go vet`/`go test` clean
- [ ] Merge, re-trigger `infra-drift-check.yml`, confirm all three stacks (dev/prod/shared) go fully clean

tc-61eoz.8 / issue #835 slice 7.

https://claude.ai/code/session_01PZqahDfeeojbkU82kG813v

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of storage account network settings across environments, reducing unnecessary differences shown during previews and deployments.
  * Prevented repeated drift caused by platform-returned network rule details, making infrastructure updates more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->