### PR TITLE
feat: App Store campaign attribution and CTA batch on SEO pages

### DIFF
--- a/api-go/internal/sharepage/handler_test.go
+++ b/api-go/internal/sharepage/handler_test.go
@@ -178,6 +178,9 @@ func TestServe_KnownApplication_RendersMetaAndVisibleContent(t *testing.T) {
 		"Get the app",
 		"Instant notifications about planning updates like this one.",
 		"town-crier-planning-alerts",
+		// Apple only attributes ct campaigns when the pt provider token is
+		// also present (tc-fgoyj).
+		"pt=128810278",
 		"ct=share-page",
 		"mt=8",
 	}

--- a/api-go/internal/sharepage/view.go
+++ b/api-go/internal/sharepage/view.go
@@ -19,10 +19,15 @@ const (
 	appleAppID = "6764095657"
 
 	// App Store deep link, mirroring the web appStoreUrl('share-page') shape: the
-	// campaign-free base, the share-page campaign token, and mt=8.
-	appStoreBaseURL    = "https://apps.apple.com/gb/app/town-crier-planning-alerts/id6764095657"
-	shareCampaignToken = "share-page"
-	appStoreMediaType  = "8"
+	// campaign-free base, the provider token, the share-page campaign token, and
+	// mt=8. The provider token (pt) is the App Store Connect account id Apple
+	// requires alongside ct — a bare ct is silently dropped from App Analytics.
+	// It is a build-time constant identifying us, never the visitor; mirrors
+	// APP_STORE_PROVIDER_TOKEN in web/src/config/links.ts.
+	appStoreBaseURL       = "https://apps.apple.com/gb/app/town-crier-planning-alerts/id6764095657"
+	appStoreProviderToken = "128810278"
+	shareCampaignToken    = "share-page"
+	appStoreMediaType     = "8"
 
 	// homeURL is the Town Crier marketing homepage. The share page has no
 	// per-application web destination, so the always-present homepage link
@@ -36,10 +41,11 @@ const (
 	ogDescriptionMaxRunes = 200
 )
 
-// ctaURL is the sticky-CTA App Store link carrying the share-page campaign token,
-// e.g. .../id6764095657?ct=share-page&mt=8.
+// ctaURL is the sticky-CTA App Store link carrying the provider and share-page
+// campaign tokens, e.g. .../id6764095657?pt=128810278&ct=share-page&mt=8.
 func ctaURL() string {
-	return appStoreBaseURL + "?ct=" + shareCampaignToken + "&mt=" + appStoreMediaType
+	return appStoreBaseURL + "?pt=" + appStoreProviderToken +
+		"&ct=" + shareCampaignToken + "&mt=" + appStoreMediaType
 }
 
 // pageView is the pre-formatted, template-ready projection of a

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -31,6 +31,7 @@
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
         "jsdom": "^29.0.0",
+        "qrcode": "^1.5.4",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.57.0",
         "vite": "^8.0.16",
@@ -1859,7 +1860,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2002,6 +2002,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001799",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
@@ -2048,6 +2058,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
       }
     },
     "node_modules/color-convert": {
@@ -2172,6 +2194,16 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
@@ -2206,6 +2238,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
@@ -2229,6 +2268,13 @@
       "integrity": "sha512-ZWP5eB4BVPW/ZYo9252hQZHZ5XavtsTgpbhcmMmRwymavC5AsLWQWBPaKMeNd2LW0KGby5HPXvj7+sr4ta5j/Q==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/entities": {
       "version": "6.0.1",
@@ -2598,6 +2644,16 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2719,6 +2775,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -3392,6 +3458,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3463,6 +3539,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/postcss": {
@@ -3542,6 +3628,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/react": {
@@ -3639,6 +3743,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -3648,6 +3762,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -3729,6 +3850,13 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
@@ -3788,6 +3916,34 @@
       "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
@@ -4279,6 +4435,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -4306,6 +4469,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -4323,12 +4501,112 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -33,6 +33,7 @@
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
     "jsdom": "^29.0.0",
+    "qrcode": "^1.5.4",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",
     "vite": "^8.0.16",

--- a/web/scripts/lib/__tests__/qr.test.mjs
+++ b/web/scripts/lib/__tests__/qr.test.mjs
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { qrSvg } from '../qr.mjs';
+
+const URL = 'https://apps.apple.com/gb/app/town-crier-planning-alerts/id6764095657?pt=128810278&ct=seo-lpa-qr&mt=8';
+
+describe('qrSvg', () => {
+  it('renders a self-contained inline SVG with an accessible name', () => {
+    const svg = qrSvg(URL, 'Town Crier on the App Store');
+    expect(svg.startsWith('<svg ')).toBe(true);
+    expect(svg.endsWith('</svg>')).toBe(true);
+    expect(svg).toContain('role="img"');
+    expect(svg).toContain('aria-label="Town Crier on the App Store"');
+    // Self-contained: no external references of any kind (the xmlns namespace
+    // identifier is the only URL-shaped string allowed).
+    expect(svg).not.toContain('href');
+    expect(svg).not.toContain('url(');
+    expect(svg.match(/https?:/g)).toEqual(['http:']);
+  });
+
+  it('draws a white tile with black modules regardless of theme, so cameras can always read it', () => {
+    const svg = qrSvg(URL, 'label');
+    expect(svg).toContain('fill="#FFFFFF"');
+    expect(svg).toContain('fill="#000000"');
+    expect(svg).not.toContain('var(--');
+  });
+
+  it('includes the QR quiet zone in the viewBox', () => {
+    const svg = qrSvg(URL, 'label');
+    const viewBox = svg.match(/viewBox="0 0 (\d+) \1"/);
+    expect(viewBox).not.toBeNull();
+    // Smallest QR version is 21 modules; plus a 4-module quiet zone per side.
+    expect(Number(viewBox[1])).toBeGreaterThanOrEqual(21 + 8);
+  });
+
+  it('is deterministic for the same payload and differs across payloads', () => {
+    expect(qrSvg(URL, 'label')).toBe(qrSvg(URL, 'label'));
+    expect(qrSvg(URL, 'label')).not.toBe(qrSvg(`${URL}x`, 'label'));
+  });
+
+  it('escapes HTML in the aria label', () => {
+    const svg = qrSvg(URL, 'a "quoted" <label> & more');
+    expect(svg).toContain('aria-label="a &quot;quoted&quot; &lt;label&gt; &amp; more"');
+    expect(svg).not.toContain('<label>');
+  });
+});

--- a/web/scripts/lib/__tests__/render-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-page.test.mjs
@@ -265,16 +265,77 @@ describe('renderPlanningPage', () => {
     );
   });
 
-  it('tags every download CTA with the ct=seo-lpa campaign token', () => {
+  it('tags each download CTA with its own per-surface campaign token (tc-fgoyj)', () => {
     const html = renderPlanningPage(pageData());
-    const tagged = appStoreUrl('seo-lpa');
-    // Header "Get the app" + inline CTA above the list + bottom banner CTA
-    // (tc-r4n9.3 adds the inline one, on top of the pre-existing two).
-    const occurrences = html.split(`href="${tagged}"`).length - 1;
-    expect(occurrences).toBe(3);
-    expect(html).toContain('ct=seo-lpa');
+    // One ct token per placement so App Analytics attributes store arrivals
+    // to the surface that sent them. The QR block has no href (its link lives
+    // in the QR modules) and the mid-list card needs a longer list, so the
+    // 2-app fixture carries exactly these three.
+    for (const surface of ['seo-lpa-hdr', 'seo-lpa-inline', 'seo-lpa-btm']) {
+      const occurrences = html.split(`href="${appStoreUrl(surface)}"`).length - 1;
+      expect(occurrences, surface).toBe(1);
+    }
+    // Every store link carries the provider token — Apple ignores ct without pt.
+    expect(html).toContain('pt=');
     // Never the bare, campaign-free URL in a CTA href.
     expect(html).not.toContain(`href="${APP_DOWNLOAD_URL}"`);
+  });
+
+  describe('mid-list CTA card (tc-fgoyj)', () => {
+    /** @returns {import('../render-shared.mjs').PlanningApplicationItem[]} */
+    function manyApplications(count) {
+      return Array.from({ length: count }, (_, i) => ({
+        uid: `BDB/2026/${1000 + i}`,
+        name: `26/${1000 + i}/FUL`,
+        address: `${i + 1} Mill Road, Basingstoke, RG21 1AA`,
+        description: 'Erection of two-storey rear extension',
+        appState: 'Permitted',
+        startDate: '2026-01-15',
+        lastDifferent: '2026-06-12T09:30:00+00:00',
+        link: null,
+        url: null,
+      }));
+    }
+
+    // The bare class name also appears in the inline stylesheet, so assertions
+    // target the rendered card markup.
+    const MID_CARD = 'class="appCard appCard--cta"';
+
+    it('slots a CTA card into a long list, after the eighth application', () => {
+      const html = renderPlanningPage(pageData({ applications: manyApplications(12) }));
+      expect(html).toContain(MID_CARD);
+      expect(html).toContain(`href="${appStoreUrl('seo-lpa-mid')}"`);
+      expect(html).toContain('Get told when the next one lands');
+      // After the 8th card, before the 9th. Scoped to the rendered list —
+      // the JSON-LD in <head> repeats the addresses much earlier in the page.
+      const list = html.slice(html.indexOf('<ul class="appList">'));
+      expect(list.indexOf('8 Mill Road')).toBeLessThan(list.indexOf(MID_CARD));
+      expect(list.indexOf(MID_CARD)).toBeLessThan(list.indexOf('9 Mill Road'));
+    });
+
+    it('omits the card on a short list so two CTAs never sit almost back to back', () => {
+      const html = renderPlanningPage(pageData());
+      expect(html).not.toContain(MID_CARD);
+      expect(html).not.toContain('ct=seo-lpa-mid');
+    });
+  });
+
+  describe('desktop QR block (tc-fgoyj)', () => {
+    it('renders an inline QR code inside the bottom CTA banner', () => {
+      const html = renderPlanningPage(pageData());
+      const cta = html.match(/<section class="cta">[\s\S]*?<\/section>/);
+      expect(cta).not.toBeNull();
+      const [ctaHtml] = cta;
+      expect(ctaHtml).toContain('class="cta__qr"');
+      expect(ctaHtml).toContain('<svg class="qr" role="img"');
+      expect(ctaHtml).toContain('scan with your phone camera');
+    });
+
+    it('hides the QR block on touch devices via the pointer media query', () => {
+      const html = renderPlanningPage(pageData());
+      expect(html).toContain('.cta__qr { display: none; }');
+      expect(html).toContain('@media (hover: hover) and (pointer: fine)');
+    });
   });
 
   it('includes a CTA to the App Store for the area', () => {
@@ -306,7 +367,7 @@ describe('renderPlanningPage', () => {
     expect(header).not.toBeNull();
     const [headerHtml] = header;
     expect(headerHtml).toContain('siteHeader__cta');
-    expect(headerHtml).toContain(`href="${appStoreUrl('seo-lpa')}"`);
+    expect(headerHtml).toContain(`href="${appStoreUrl('seo-lpa-hdr')}"`);
     expect(headerHtml).toContain('Get the app');
     // Match the bottom CTA's link safety exactly.
     expect(headerHtml).toContain('rel="noopener"');
@@ -319,7 +380,9 @@ describe('renderPlanningPage', () => {
     const html = renderPlanningPage(pageData());
     expect(html).toContain('<section class="cta">');
     expect(html).toContain('class="cta__button"');
-    expect(html).toContain('Download on the App Store');
+    // "free" is honest (the download is free; the free tier is the weekly
+    // digest) and one of the oldest CTR levers there is.
+    expect(html).toContain('Download free on the App Store');
   });
 
   it('carries the mandatory PlanIt + OGL + OS + OSM attribution', () => {

--- a/web/scripts/lib/__tests__/render-shared.test.mjs
+++ b/web/scripts/lib/__tests__/render-shared.test.mjs
@@ -5,6 +5,8 @@ import {
   renderStatusSummary,
   renderDataUpdated,
   renderInlineCta,
+  renderMidListCta,
+  renderQrBlock,
   pageStyles,
 } from '../render-shared.mjs';
 import { ATTRIBUTION_LINES } from '../constants.mjs';
@@ -549,5 +551,82 @@ describe('pageStyles light-first token flip (tc-r4n9.1)', () => {
     // visible to anyone reading the generated page source.
     expect(root).toMatch(/\/\*[^]*share page[^]*\*\//i);
     expect(root.toLowerCase()).toContain('faf8f5');
+  });
+});
+
+describe('renderMidListCta and mid-list injection (tc-fgoyj)', () => {
+  const STORE_HREF = 'https://apps.apple.com/x?pt=1&ct=seo-lpa-mid&mt=8';
+  const MID_CARD = 'class="appCard appCard--cta"';
+
+  /** @param {number} count */
+  function manyApplications(count) {
+    return Array.from({ length: count }, (_, i) =>
+      application({
+        uid: `BDB/2026/${1000 + i}`,
+        name: `26/${1000 + i}/FUL`,
+        address: `${i + 1} Mill Road, Basingstoke, RG21 1AA`,
+      }),
+    );
+  }
+
+  it('renders a card-shaped CTA naming the area, never disguised as an application', () => {
+    const html = renderMidListCta('Basingstoke and Deane', STORE_HREF);
+    expect(html).toContain(MID_CARD);
+    expect(html).toContain('Get told when the next one lands');
+    expect(html).toContain('Town Crier watches Basingstoke and Deane');
+    // The store href is a build-time literal, interpolated as-is (escaping
+    // would mangle the & in its query string).
+    expect(html).toContain(`href="${STORE_HREF}"`);
+    expect(html).toContain('rel="noopener"');
+    expect(html).toContain('target="_blank"');
+    // A pitch card must not carry application-card furniture.
+    expect(html).not.toContain('appCard__address');
+    expect(html).not.toContain('View details');
+  });
+
+  it('HTML-escapes the area name', () => {
+    const html = renderMidListCta('<script>alert(1)</script>', STORE_HREF);
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+
+  it('injects the card after the 8th application when the list has 12 or more', () => {
+    const html = renderApplicationsList(manyApplications(12), SLUG, {
+      area: 'Basingstoke and Deane',
+      storeHref: STORE_HREF,
+    });
+    expect(html).toContain(MID_CARD);
+    expect(html.indexOf('8 Mill Road')).toBeLessThan(html.indexOf(MID_CARD));
+    expect(html.indexOf(MID_CARD)).toBeLessThan(html.indexOf('9 Mill Road'));
+  });
+
+  it('skips the card below 12 applications, and always without a midCta argument', () => {
+    const withCta = renderApplicationsList(manyApplications(11), SLUG, {
+      area: 'Basingstoke and Deane',
+      storeHref: STORE_HREF,
+    });
+    expect(withCta).not.toContain(MID_CARD);
+    const withoutArg = renderApplicationsList(manyApplications(12), SLUG);
+    expect(withoutArg).not.toContain(MID_CARD);
+  });
+});
+
+describe('renderQrBlock (tc-fgoyj)', () => {
+  const STORE_HREF = 'https://apps.apple.com/x?pt=1&ct=seo-lpa-qr&mt=8';
+
+  it('wraps an inline QR SVG and a plain-language caption', () => {
+    const html = renderQrBlock(STORE_HREF);
+    expect(html).toContain('class="cta__qr"');
+    expect(html).toContain('<svg class="qr" role="img"');
+    expect(html).toContain('aria-label="QR code linking to Town Crier on the App Store"');
+    expect(html).toContain('Or scan with your phone camera to get the app.');
+  });
+
+  it('hides the block on touch devices and shows it for mouse/trackpad pointers', () => {
+    const css = pageStyles();
+    expect(css).toContain('.cta__qr { display: none; }');
+    const mediaBlock = css.slice(css.indexOf('@media (hover: hover) and (pointer: fine)'));
+    expect(mediaBlock).toContain('.cta__qr {');
+    expect(mediaBlock).toContain('display: flex;');
   });
 });

--- a/web/scripts/lib/__tests__/render-town-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-town-page.test.mjs
@@ -208,16 +208,77 @@ describe('renderTownPage', () => {
     );
   });
 
-  it('tags every download CTA with the ct=seo-town campaign token', () => {
+  it('tags each download CTA with its own per-surface campaign token (tc-fgoyj)', () => {
     const html = renderTownPage(townData());
-    const tagged = appStoreUrl('seo-town');
-    // Header "Get the app" + inline CTA above the list + bottom banner CTA
-    // (tc-r4n9.3 adds the inline one, on top of the pre-existing two).
-    const occurrences = html.split(`href="${tagged}"`).length - 1;
-    expect(occurrences).toBe(3);
-    expect(html).toContain('ct=seo-town');
+    // One ct token per placement so App Analytics attributes store arrivals
+    // to the surface that sent them. The QR block has no href (its link lives
+    // in the QR modules) and the mid-list card needs a longer list, so the
+    // 2-app fixture carries exactly these three.
+    for (const surface of ['seo-town-hdr', 'seo-town-inline', 'seo-town-btm']) {
+      const occurrences = html.split(`href="${appStoreUrl(surface)}"`).length - 1;
+      expect(occurrences, surface).toBe(1);
+    }
+    // Every store link carries the provider token — Apple ignores ct without pt.
+    expect(html).toContain('pt=');
     // Never the bare, campaign-free URL in a CTA href.
     expect(html).not.toContain(`href="${APP_DOWNLOAD_URL}"`);
+  });
+
+  describe('mid-list CTA card (tc-fgoyj)', () => {
+    /** @returns {import('../render-shared.mjs').PlanningApplicationItem[]} */
+    function manyApplications(count) {
+      return Array.from({ length: count }, (_, i) => ({
+        uid: `CW/2026/${1000 + i}`,
+        name: `26/${1000 + i}`,
+        address: `${i + 1} Lemon Quay, Truro, TR1 2LW`,
+        description: 'Change of use of ground floor from retail to café',
+        appState: 'Permitted',
+        startDate: '2026-01-12',
+        lastDifferent: '2026-06-12T09:30:00+00:00',
+        link: null,
+        url: null,
+      }));
+    }
+
+    // The bare class name also appears in the inline stylesheet, so assertions
+    // target the rendered card markup.
+    const MID_CARD = 'class="appCard appCard--cta"';
+
+    it('slots a CTA card naming the town into a long list, after the eighth application', () => {
+      const html = renderTownPage(townData({ applications: manyApplications(12) }));
+      expect(html).toContain(MID_CARD);
+      expect(html).toContain(`href="${appStoreUrl('seo-town-mid')}"`);
+      expect(html).toContain('Town Crier watches Truro');
+      // After the 8th card, before the 9th. Scoped to the rendered list —
+      // the JSON-LD in <head> repeats the addresses much earlier in the page.
+      const list = html.slice(html.indexOf('<ul class="appList">'));
+      expect(list.indexOf('8 Lemon Quay')).toBeLessThan(list.indexOf(MID_CARD));
+      expect(list.indexOf(MID_CARD)).toBeLessThan(list.indexOf('9 Lemon Quay'));
+    });
+
+    it('omits the card on a short list so two CTAs never sit almost back to back', () => {
+      const html = renderTownPage(townData());
+      expect(html).not.toContain(MID_CARD);
+      expect(html).not.toContain('ct=seo-town-mid');
+    });
+  });
+
+  describe('desktop QR block (tc-fgoyj)', () => {
+    it('renders an inline QR code inside the bottom CTA banner', () => {
+      const html = renderTownPage(townData());
+      const cta = html.match(/<section class="cta">[\s\S]*?<\/section>/);
+      expect(cta).not.toBeNull();
+      const [ctaHtml] = cta;
+      expect(ctaHtml).toContain('class="cta__qr"');
+      expect(ctaHtml).toContain('<svg class="qr" role="img"');
+      expect(ctaHtml).toContain('scan with your phone camera');
+    });
+
+    it('hides the QR block on touch devices via the pointer media query', () => {
+      const html = renderTownPage(townData());
+      expect(html).toContain('.cta__qr { display: none; }');
+      expect(html).toContain('@media (hover: hover) and (pointer: fine)');
+    });
   });
 
   describe('inline alerts CTA above the list (tc-r4n9.3)', () => {
@@ -247,7 +308,7 @@ describe('renderTownPage', () => {
     expect(header).not.toBeNull();
     const [headerHtml] = header;
     expect(headerHtml).toContain('siteHeader__cta');
-    expect(headerHtml).toContain(`href="${appStoreUrl('seo-town')}"`);
+    expect(headerHtml).toContain(`href="${appStoreUrl('seo-town-hdr')}"`);
     expect(headerHtml).toContain('Get the app');
     // Match the bottom CTA's link safety exactly.
     expect(headerHtml).toContain('rel="noopener"');
@@ -260,7 +321,9 @@ describe('renderTownPage', () => {
     const html = renderTownPage(townData());
     expect(html).toContain('<section class="cta">');
     expect(html).toContain('class="cta__button"');
-    expect(html).toContain('Download on the App Store');
+    // "free" is honest (the download is free; the free tier is the weekly
+    // digest) and one of the oldest CTR levers there is.
+    expect(html).toContain('Download free on the App Store');
   });
 
   it('carries the mandatory PlanIt + OGL + OS + OSM attribution', () => {

--- a/web/scripts/lib/constants.mjs
+++ b/web/scripts/lib/constants.mjs
@@ -59,11 +59,25 @@ export const APP_DOWNLOAD_URL =
 export const APPLE_APP_ID = '6764095657';
 
 /**
+ * App Store Connect provider token (`pt`). Apple only attributes a `ct`
+ * campaign when the link ALSO carries the account's provider token — a bare
+ * `ct` is silently dropped from App Analytics, which is why the original
+ * `ct`-only links never showed up under Campaigns. One static value for the
+ * whole developer account; it identifies us, never the visitor. Mirrors
+ * `src/config/links.ts`, kept in lockstep by the drift-guard test.
+ * @type {string}
+ */
+export const APP_STORE_PROVIDER_TOKEN = '128810278';
+
+/**
  * Build a campaign-tagged App Store link from the campaign-free
- * {@link APP_DOWNLOAD_URL}. The `ct` token surfaces under App Store Connect →
- * App Analytics → Acquisition so installs can be attributed to the surface that
- * sent them (e.g. `seo-lpa`, `seo-town`, `web-home`); `mt=8` is Apple's
- * software-app media type. Cookieless and aggregate — sets nothing on-device.
+ * {@link APP_DOWNLOAD_URL}. The `pt` provider token plus the `ct` campaign
+ * token surface under App Store Connect → App Analytics → Acquisition so
+ * installs can be attributed to the surface that sent them (e.g.
+ * `seo-lpa-inline`, `seo-town-btm`, `web-home`); `mt=8` is Apple's
+ * software-app media type. Cookieless and aggregate — the tokens are
+ * build-time constants, identical for every visitor, so nothing is stored
+ * on-device and no visitor is identifiable.
  *
  * `APP_DOWNLOAD_URL` is deliberately left campaign-free so the byte-equal
  * lockstep guard between this file and `src/config/links.ts` still holds.
@@ -72,7 +86,7 @@ export const APPLE_APP_ID = '6764095657';
  * @returns {string}
  */
 export function appStoreUrl(campaign) {
-  return `${APP_DOWNLOAD_URL}?ct=${encodeURIComponent(campaign)}&mt=8`;
+  return `${APP_DOWNLOAD_URL}?pt=${APP_STORE_PROVIDER_TOKEN}&ct=${encodeURIComponent(campaign)}&mt=8`;
 }
 
 /**

--- a/web/scripts/lib/qr.mjs
+++ b/web/scripts/lib/qr.mjs
@@ -1,0 +1,55 @@
+/**
+ * Build-time QR code rendering for the static planning pages.
+ *
+ * Desktop visitors who click an App Store link land on Apple's web listing and
+ * have to remember to find the app on their phone later — intent usually dies
+ * there. A QR code lets them scan straight to the store instead. The code is
+ * generated at prerender time and inlined as SVG, keeping the pages
+ * self-contained (no runtime JS, no image request, no third-party call).
+ *
+ * Uses the `qrcode` package's synchronous low-level `create()` API (the
+ * high-level `toString()` is Promise-based, and every page renderer here is
+ * sync) and draws the module matrix as a single `<path>`.
+ */
+
+import QRCode from 'qrcode';
+import { escapeHtml } from './format.mjs';
+
+/** Quiet-zone border around the module matrix, in modules. The QR spec's
+ * minimum for reliable scanning is 4. */
+const QUIET_ZONE = 4;
+
+/**
+ * Render `text` as a self-contained SVG QR code.
+ *
+ * Colours are deliberately hard-coded rather than theme tokens: the tile must
+ * stay dark-on-light in dark mode too, or older phone cameras refuse to read
+ * it. The page's stylesheet handles sizing and rounding; the SVG itself only
+ * carries the viewBox, a white tile and the black module path.
+ *
+ * @param {string} text        the URL (or any payload) to encode
+ * @param {string} ariaLabel   accessible name for the graphic
+ * @returns {string} an inline `<svg>` element
+ */
+export function qrSvg(text, ariaLabel) {
+  const qr = QRCode.create(text, { errorCorrectionLevel: 'M' });
+  const size = qr.modules.size;
+  const boxSize = size + QUIET_ZONE * 2;
+
+  const segments = [];
+  for (let row = 0; row < size; row += 1) {
+    for (let col = 0; col < size; col += 1) {
+      if (qr.modules.get(row, col)) {
+        segments.push(`M${col + QUIET_ZONE} ${row + QUIET_ZONE}h1v1h-1z`);
+      }
+    }
+  }
+
+  return (
+    `<svg class="qr" role="img" aria-label="${escapeHtml(ariaLabel)}" ` +
+    `viewBox="0 0 ${boxSize} ${boxSize}" shape-rendering="crispEdges" xmlns="http://www.w3.org/2000/svg">` +
+    `<rect width="${boxSize}" height="${boxSize}" fill="#FFFFFF"/>` +
+    `<path d="${segments.join('')}" fill="#000000"/>` +
+    `</svg>`
+  );
+}

--- a/web/scripts/lib/render-page.mjs
+++ b/web/scripts/lib/render-page.mjs
@@ -7,6 +7,7 @@ import {
   renderStatusSummary,
   renderDataUpdated,
   renderInlineCta,
+  renderQrBlock,
   renderAttributionList,
 } from './render-shared.mjs';
 
@@ -130,7 +131,12 @@ export function renderPlanningPage(data) {
   const jsonLd = buildJsonLd(data, canonical);
   const year = new Date().getFullYear();
 
-  const applicationsList = renderApplicationsList(data.applications, data.slug);
+  // One ct token per CTA surface (all under the same pt provider token), so
+  // App Analytics shows which placement actually sends people to the store.
+  const applicationsList = renderApplicationsList(data.applications, data.slug, {
+    area: data.areaName,
+    storeHref: appStoreUrl('seo-lpa-mid'),
+  });
   const townLinks = renderTownLinks(data);
   const attribution = renderAttributionList();
   const dataUpdated = renderDataUpdated(data.applications);
@@ -162,7 +168,7 @@ ${pageStyles()}
         <a href="/">Town Crier</a>
         <nav class="siteHeader__nav">
           <a href="/">Home</a>
-          <a class="siteHeader__cta" href="${appStoreUrl('seo-lpa')}" rel="noopener" target="_blank">Get the app</a>
+          <a class="siteHeader__cta" href="${appStoreUrl('seo-lpa-hdr')}" rel="noopener" target="_blank">Get the app</a>
         </nav>
       </header>
       <nav class="breadcrumb" aria-label="Breadcrumb">
@@ -175,7 +181,7 @@ ${pageStyles()}
         <h1>Planning applications in ${area}</h1>
         ${dataUpdated}
         <p class="lead">${lead}</p>
-${renderInlineCta(data.areaName, appStoreUrl('seo-lpa'))}
+${renderInlineCta(data.areaName, appStoreUrl('seo-lpa-inline'))}
 
 ${renderStatusSummary(data.statusBreakdown)}
 
@@ -205,9 +211,11 @@ ${townLinks}
           <h2>Get push alerts for ${area}</h2>
           <p>
             Draw a circle on the map and Town Crier will notify you the moment a new
-            planning application is submitted or decided inside it.
+            planning application is submitted or decided inside it. Most councils
+            allow around three weeks for comments, so hearing early matters.
           </p>
-          <a class="cta__button" href="${appStoreUrl('seo-lpa')}" rel="noopener" target="_blank">Download on the App Store</a>
+          <a class="cta__button" href="${appStoreUrl('seo-lpa-btm')}" rel="noopener" target="_blank">Download free on the App Store</a>
+${renderQrBlock(appStoreUrl('seo-lpa-qr'))}
         </section>
       </main>
 

--- a/web/scripts/lib/render-shared.mjs
+++ b/web/scripts/lib/render-shared.mjs
@@ -18,6 +18,7 @@ import {
   dataUpdatedLine,
   formatDate,
 } from './format.mjs';
+import { qrSvg } from './qr.mjs';
 
 /**
  * @typedef {Object} PlanningApplicationItem
@@ -149,6 +150,37 @@ ${body}
 }
 
 /**
+ * How far down the list the mid-list CTA card sits, and the smallest list that
+ * gets one. Eight cards in is past the point a reader is clearly engaged but
+ * well before the bottom banner; short lists skip it so the page never shows
+ * two CTAs almost back to back.
+ */
+const MID_LIST_CTA_AFTER = 8;
+const MID_LIST_CTA_MIN_APPLICATIONS = 12;
+
+/**
+ * Render the mid-list CTA card (tc-fgoyj): a card-shaped `<li>` slotted into
+ * the applications list itself, because on a full 30-card page the inline pill
+ * above the list and the banner below it are separated by a very long scroll
+ * with no ask in between. Styled as a card so it reads as part of the list,
+ * but visibly a Town Crier pitch — never disguised as an application.
+ *
+ * @param {string} area   the resident-facing area name (authority or town)
+ * @param {string} storeHref   the campaign-tagged App Store link for this
+ *   surface; build-time constructed from a hardcoded campaign literal, so —
+ *   matching every other CTA here — interpolated as-is rather than through
+ *   `escapeHtml` (which would mangle the `&` in its query string)
+ * @returns {string}
+ */
+export function renderMidListCta(area, storeHref) {
+  return `      <li class="appCard appCard--cta">
+        <h3 class="appCard__ctaHeading">Get told when the next one lands</h3>
+        <p class="appCard__ctaBody">Town Crier watches ${escapeHtml(area)} and alerts you when a new application is submitted or decided. Free to download.</p>
+        <a class="ctaInline__button" href="${storeHref}" rel="noopener" target="_blank">Get the app</a>
+      </li>`;
+}
+
+/**
  * Render the recent-applications list body (the `<li>` cards joined by newlines).
  *
  * @param {PlanningApplicationItem[]} applications
@@ -156,10 +188,17 @@ ${body}
  *   each card can link to its share page. Omitted (or no ref on the app) -> the
  *   card renders without a link at all (decision 6 retired the external
  *   PlanIt/council per-card links, so there is no other href to fall back to).
+ * @param {{ area: string, storeHref: string }} [midCta] when present and the
+ *   list is long enough, a mid-list CTA card is slotted in after the
+ *   {@link MID_LIST_CTA_AFTER}th application.
  * @returns {string}
  */
-export function renderApplicationsList(applications, authoritySlug) {
-  return applications.map((app) => renderApplication(app, authoritySlug)).join('\n');
+export function renderApplicationsList(applications, authoritySlug, midCta) {
+  const cards = applications.map((app) => renderApplication(app, authoritySlug));
+  if (midCta && applications.length >= MID_LIST_CTA_MIN_APPLICATIONS) {
+    cards.splice(MID_LIST_CTA_AFTER, 0, renderMidListCta(midCta.area, midCta.storeHref));
+  }
+  return cards.join('\n');
 }
 
 /**
@@ -249,6 +288,26 @@ export function renderInlineCta(area, storeHref) {
   return `        <p class="ctaInline">
           <a class="ctaInline__button" href="${storeHref}" rel="noopener" target="_blank">Get push alerts for ${escapeHtml(area)} →</a>
         </p>`;
+}
+
+/**
+ * Render the QR block for the bottom CTA banner (tc-fgoyj). Hidden on touch
+ * devices by the stylesheet (see `.cta__qr`) and shown only where the primary
+ * pointer is a mouse/trackpad: a desktop visitor who clicks the App Store link
+ * lands on Apple's web listing and has to remember the app later, whereas a
+ * scan puts the store on the phone in their hand. Generated at build time and
+ * inlined, so the page stays self-contained.
+ *
+ * @param {string} storeHref   the campaign-tagged App Store link to encode
+ *   (give the QR its own `ct` token so scans are attributable separately from
+ *   clicks)
+ * @returns {string}
+ */
+export function renderQrBlock(storeHref) {
+  return `          <div class="cta__qr">
+            ${qrSvg(storeHref, 'QR code linking to Town Crier on the App Store')}
+            <p class="cta__qrCaption">Or scan with your phone camera to get the app.</p>
+          </div>`;
 }
 
 /**
@@ -486,6 +545,12 @@ export function pageStyles() {
       font-weight: 700;
     }
     .ctaInline__button:hover { background: var(--tc-amber-hover); }
+    /* Mid-list CTA card (tc-fgoyj): shares the card chrome so it sits
+       naturally in the list, with centred copy and the pill button so it is
+       unmistakably a Town Crier pitch rather than an application. */
+    .appCard--cta { text-align: center; padding: var(--tc-space-lg); }
+    .appCard__ctaHeading { margin: 0 0 var(--tc-space-sm); }
+    .appCard__ctaBody { margin: 0 0 var(--tc-space-md); color: var(--tc-text-secondary); }
     .cta {
       margin: var(--tc-space-xl) 0;
       padding: var(--tc-space-lg);
@@ -493,6 +558,27 @@ export function pageStyles() {
       border: 1px solid var(--tc-border);
       border-radius: var(--tc-radius-md);
       text-align: center;
+    }
+    /* Desktop-only QR (tc-fgoyj): pointer/hover media queries approximate
+       "no App Store on this device" without any UA sniffing or JS. The SVG's
+       own colours stay dark-on-light in dark mode (see qr.mjs) — only the
+       frame is themed. */
+    .cta__qr { display: none; }
+    @media (hover: hover) and (pointer: fine) {
+      .cta__qr {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: var(--tc-space-sm);
+        margin-top: var(--tc-space-lg);
+      }
+      .cta__qr svg.qr {
+        width: 132px;
+        height: 132px;
+        border: 1px solid var(--tc-border);
+        border-radius: var(--tc-radius-md);
+      }
+      .cta__qrCaption { margin: 0; font-size: 0.875rem; color: var(--tc-text-secondary); }
     }
     .cta__button {
       display: inline-block;

--- a/web/scripts/lib/render-town-page.mjs
+++ b/web/scripts/lib/render-town-page.mjs
@@ -27,6 +27,7 @@ import {
   renderStatusSummary,
   renderDataUpdated,
   renderInlineCta,
+  renderQrBlock,
   renderAttributionList,
 } from './render-shared.mjs';
 
@@ -120,7 +121,12 @@ export function renderTownPage(data) {
   const jsonLd = buildTownJsonLd(data, canonical, authorityCanonical);
   const year = new Date().getFullYear();
 
-  const applicationsList = renderApplicationsList(data.applications, data.authoritySlug);
+  // One ct token per CTA surface (all under the same pt provider token), so
+  // App Analytics shows which placement actually sends people to the store.
+  const applicationsList = renderApplicationsList(data.applications, data.authoritySlug, {
+    area: data.townName,
+    storeHref: appStoreUrl('seo-town-mid'),
+  });
   // Town pages credit the ONS Built-Up-Area + NRS gazetteers (their centroid
   // sources) on top of the base PlanIt/OGL/OS/OSM lines; authority pages keep the
   // base list since they don't use the gazetteer.
@@ -154,7 +160,7 @@ ${pageStyles()}
         <a href="/">Town Crier</a>
         <nav class="siteHeader__nav">
           <a href="/">Home</a>
-          <a class="siteHeader__cta" href="${appStoreUrl('seo-town')}" rel="noopener" target="_blank">Get the app</a>
+          <a class="siteHeader__cta" href="${appStoreUrl('seo-town-hdr')}" rel="noopener" target="_blank">Get the app</a>
         </nav>
       </header>
       <nav class="breadcrumb" aria-label="Breadcrumb">
@@ -168,7 +174,7 @@ ${pageStyles()}
         <h1>Planning applications in ${town}</h1>
         ${dataUpdated}
         <p class="lead">${lead}</p>
-${renderInlineCta(data.townName, appStoreUrl('seo-town'))}
+${renderInlineCta(data.townName, appStoreUrl('seo-town-inline'))}
 
 ${renderStatusSummary(data.statusBreakdown)}
 
@@ -199,9 +205,11 @@ ${applicationsList}
           <h2>Get push alerts for ${town}</h2>
           <p>
             Draw a circle on the map and Town Crier will notify you the moment a new
-            planning application is submitted or decided inside it.
+            planning application is submitted or decided inside it. Most councils
+            allow around three weeks for comments, so hearing early matters.
           </p>
-          <a class="cta__button" href="${appStoreUrl('seo-town')}" rel="noopener" target="_blank">Download on the App Store</a>
+          <a class="cta__button" href="${appStoreUrl('seo-town-btm')}" rel="noopener" target="_blank">Download free on the App Store</a>
+${renderQrBlock(appStoreUrl('seo-town-qr'))}
         </section>
       </main>
 

--- a/web/src/__tests__/planning-cta-link.test.ts
+++ b/web/src/__tests__/planning-cta-link.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { APP_DOWNLOAD_URL, APPLE_APP_ID, appStoreUrl } from '../config/links';
+import {
+  APP_DOWNLOAD_URL,
+  APPLE_APP_ID,
+  APP_STORE_PROVIDER_TOKEN,
+  appStoreUrl,
+} from '../config/links';
 // The prerender build script is plain ESM (`.mjs`) and cannot import the app's
 // TypeScript modules at runtime, so it keeps its own copy of the App Store URL,
 // the numeric App Store id, and the campaign-tagging helper. These guards fail
@@ -7,6 +12,7 @@ import { APP_DOWNLOAD_URL, APPLE_APP_ID, appStoreUrl } from '../config/links';
 import {
   APP_DOWNLOAD_URL as PRERENDER_APP_DOWNLOAD_URL,
   APPLE_APP_ID as PRERENDER_APPLE_APP_ID,
+  APP_STORE_PROVIDER_TOKEN as PRERENDER_PROVIDER_TOKEN,
   appStoreUrl as prerenderAppStoreUrl,
 } from '../../scripts/lib/constants.mjs';
 
@@ -21,19 +27,30 @@ describe('planning page CTA link', () => {
     expect(APP_DOWNLOAD_URL).toContain(APPLE_APP_ID);
   });
 
+  it('keeps the provider token in lockstep with config/links.ts', () => {
+    expect(PRERENDER_PROVIDER_TOKEN).toBe(APP_STORE_PROVIDER_TOKEN);
+  });
+
   it('keeps appStoreUrl() byte-identical between the two copies for the same campaign', () => {
-    for (const campaign of ['seo-lpa', 'seo-town', 'web-home']) {
+    for (const campaign of ['seo-lpa-inline', 'seo-town-btm', 'web-home']) {
       expect(prerenderAppStoreUrl(campaign)).toBe(appStoreUrl(campaign));
     }
   });
 
-  it('appStoreUrl() appends the campaign token and mt=8 to the campaign-free base', () => {
-    expect(appStoreUrl('web-home')).toBe(`${APP_DOWNLOAD_URL}?ct=web-home&mt=8`);
+  it('appStoreUrl() appends the provider token, campaign token and mt=8 to the campaign-free base', () => {
+    // Apple's App Analytics only records a ct campaign when pt is also present,
+    // so the helper must always emit both.
+    expect(appStoreUrl('web-home')).toBe(
+      `${APP_DOWNLOAD_URL}?pt=${APP_STORE_PROVIDER_TOKEN}&ct=web-home&mt=8`,
+    );
     // The base constant itself stays campaign-free so the lockstep guard holds.
     expect(APP_DOWNLOAD_URL).not.toContain('ct=');
+    expect(APP_DOWNLOAD_URL).not.toContain('pt=');
   });
 
   it('appStoreUrl() URL-encodes the campaign value', () => {
-    expect(appStoreUrl('a b&c')).toBe(`${APP_DOWNLOAD_URL}?ct=a%20b%26c&mt=8`);
+    expect(appStoreUrl('a b&c')).toBe(
+      `${APP_DOWNLOAD_URL}?pt=${APP_STORE_PROVIDER_TOKEN}&ct=a%20b%26c&mt=8`,
+    );
   });
 });

--- a/web/src/config/links.ts
+++ b/web/src/config/links.ts
@@ -17,14 +17,27 @@ export const APP_DOWNLOAD_URL =
 export const APPLE_APP_ID = '6764095657';
 
 /**
+ * App Store Connect provider token (`pt`). Apple only attributes a `ct`
+ * campaign when the link ALSO carries the account's provider token — a bare
+ * `ct` is silently dropped from App Analytics, which is why the original
+ * `ct`-only links never showed up under Campaigns. One static value for the
+ * whole developer account; it identifies us, never the visitor. Mirrors
+ * `scripts/lib/constants.mjs`, kept in lockstep by the drift-guard test.
+ */
+export const APP_STORE_PROVIDER_TOKEN = '128810278';
+
+/**
  * Build a campaign-tagged App Store link from the campaign-free
- * {@link APP_DOWNLOAD_URL}. The `ct` token lets App Store Connect attribute
- * installs to the surface that sent them (e.g. `web-home` for the SPA CTAs);
- * `mt=8` is Apple's software-app media type. Cookieless and aggregate.
+ * {@link APP_DOWNLOAD_URL}. The `pt` provider token plus the `ct` campaign
+ * token let App Store Connect attribute installs to the surface that sent
+ * them (e.g. `web-home` for the SPA CTAs); `mt=8` is Apple's software-app
+ * media type. Cookieless and aggregate: the tokens are build-time constants,
+ * identical for every visitor, so nothing is stored on-device and no visitor
+ * is identifiable.
  *
  * `APP_DOWNLOAD_URL` stays campaign-free so the byte-equal lockstep guard with
  * `scripts/lib/constants.mjs` still holds.
  */
 export function appStoreUrl(campaign: string): string {
-  return `${APP_DOWNLOAD_URL}?ct=${encodeURIComponent(campaign)}&mt=8`;
+  return `${APP_DOWNLOAD_URL}?pt=${APP_STORE_PROVIDER_TOKEN}&ct=${encodeURIComponent(campaign)}&mt=8`;
 }


### PR DESCRIPTION
## Changes

- **`pt=` provider token on every campaign-tagged App Store link** (web SEO pages, SPA `links.ts`, Go share page). Apple silently drops `ct` campaign tokens unless `pt` is present, so none of the existing tokens ever appeared in App Analytics — this makes the web→store funnel measurable for the first time.
- **Per-surface `ct` tokens on /planning/ pages** (`seo-lpa-hdr/-inline/-mid/-btm/-qr`, same for `seo-town-*`) so App Analytics shows which placement sends people to the store.
- **Mid-list CTA card** after the 8th application on lists of 12+ — a full 30-card page previously had no ask between the inline pill and the bottom banner.
- **Desktop-only QR code** in the bottom banner (`(hover: hover) and (pointer: fine)` media query, no UA sniffing/JS; build-time inline SVG via new `qrcode` devDependency). Desktop clicks on apps.apple.com are a dead end; a scan puts the store on the phone in hand.
- **Banner copy**: adds the three-week comment-window line; button now reads "Download free on the App Store".

All links remain static build-time constants — no cookies, no storage, nothing per-visitor; consistent with the no-tracking stance.

Bead: tc-fgoyj

---
*Auto-shipped via ship skill*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AguvZ3PJK1o7iuztnbpFV9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a QR code option to app download sections on planning pages for easier mobile access.
  * Introduced a new mid-list app download card that appears in longer application lists.

* **Bug Fixes**
  * Updated app store links to use improved tracking across header, inline, bottom, and mid-list download placements.
  * Changed download button text to “Download free on the App Store” for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->