### PR TITLE
feat: per-IP rate limiting on anonymous API routes

### DIFF
--- a/api-go/cmd/api/anonratelimit_wiring_test.go
+++ b/api-go/cmd/api/anonratelimit_wiring_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/auth"
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+)
+
+// anonRateLimitRequest builds a GET request with no Authorization header and a
+// caller-chosen RemoteAddr, driving the full router chain's anonymous path.
+func anonRateLimitRequest(t *testing.T, h http.Handler, path, remoteAddr string) *httptest.ResponseRecorder {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, path, nil)
+	req.RemoteAddr = remoteAddr
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+// newRouterWithAnonLimit builds a minimal store-less router with a
+// caller-chosen anonymous rate-limit budget, so tests can drive the limiter
+// past its threshold without waiting out the production 60-request default.
+func newRouterWithAnonLimit(t *testing.T, logger *slog.Logger, anonRequests, anonWindowSeconds int) http.Handler {
+	t.Helper()
+	return newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", "", nil, nil, "", nil, nil, nil, anonRequests, anonWindowSeconds, logger)
+}
+
+// TestRouter_AnonRateLimitAppliesToAnonymousRoutes proves AnonRateLimit is
+// actually wired into the production dispatch chain (not just unit tested in
+// isolation, GH#868 Phase 1): with a tiny per-router budget, a real anonymous
+// route throttles once that budget is exhausted.
+func TestRouter_AnonRateLimitAppliesToAnonymousRoutes(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.DiscardHandler)
+	h := newRouterWithAnonLimit(t, logger, 2, 60)
+
+	for i := range 2 {
+		rec := anonRateLimitRequest(t, h, "/v1/version-config", "203.0.113.90:1")
+		if rec.Code != http.StatusOK {
+			t.Fatalf("request %d: got %d, want 200", i, rec.Code)
+		}
+	}
+
+	rec := anonRateLimitRequest(t, h, "/v1/version-config", "203.0.113.90:1")
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("3rd request: got %d, want 429", rec.Code)
+	}
+	if got := rec.Header().Get("Retry-After"); got == "" {
+		t.Error("429 missing Retry-After")
+	}
+}
+
+// TestRouter_AnonRateLimitHealthChecksExemptEvenWithTinyBudget confirms the
+// health-check exemption survives the real wiring: with a limit of 1, five
+// consecutive /v1/health hits from the same IP all succeed.
+func TestRouter_AnonRateLimitHealthChecksExemptEvenWithTinyBudget(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.DiscardHandler)
+	h := newRouterWithAnonLimit(t, logger, 1, 60)
+
+	for i := range 5 {
+		rec := anonRateLimitRequest(t, h, "/v1/health", "203.0.113.91:1")
+		if rec.Code != http.StatusOK {
+			t.Fatalf("health request %d: got %d, want 200", i, rec.Code)
+		}
+	}
+}
+
+// TestRouter_AnonRateLimitDoesNotThrottleAuthenticatedTraffic confirms that,
+// wired end to end, an authenticated caller sharing an IP with an exhausted
+// anonymous budget is unaffected — the anonymous limiter must never touch a
+// request carrying a subject.
+func TestRouter_AnonRateLimitDoesNotThrottleAuthenticatedTraffic(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.DiscardHandler)
+	validator := staticValidator{claims: auth.Claims{Subject: "auth0|anonwire"}}
+	h := newRouter(validator, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", "", nil, nil, "", nil, nil, nil, 1, 60, logger)
+
+	const sameIP = "203.0.113.92:1"
+
+	first := anonRateLimitRequest(t, h, "/v1/version-config", sameIP)
+	if first.Code != http.StatusOK {
+		t.Fatalf("first anonymous request: got %d, want 200", first.Code)
+	}
+	second := anonRateLimitRequest(t, h, "/v1/version-config", sameIP)
+	if second.Code != http.StatusTooManyRequests {
+		t.Fatalf("second anonymous request: got %d, want 429 (budget exhausted)", second.Code)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/v1/geocode/SW1A1AA", nil)
+	req.RemoteAddr = sameIP
+	req.Header.Set("Authorization", "Bearer tok")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code == http.StatusTooManyRequests {
+		t.Fatalf("authenticated request throttled by the anonymous limiter: got %d", rec.Code)
+	}
+}

--- a/api-go/cmd/api/main.go
+++ b/api-go/cmd/api/main.go
@@ -188,7 +188,7 @@ func main() {
 		log.Fatalf("designations client: %v", err)
 	}
 
-	srv := platform.NewServer(":"+cfg.Port, newRouter(validator, cfg.CorsAllowedOrigins, store, manager, cascade, exportReaders, deviceStore, stateStore, notifStore, watchZoneStore, appStore, savedStore, geocodeClient, designationClient, offerStore, adminStore, cfg.AdminAPIKey, cfg.SiteBuildKey, jwsVerifier, appleNotifStore, cfg.AppleBundleID, cfg.AppleEnvironments, registry, shareCardCache, logger))
+	srv := platform.NewServer(":"+cfg.Port, newRouter(validator, cfg.CorsAllowedOrigins, store, manager, cascade, exportReaders, deviceStore, stateStore, notifStore, watchZoneStore, appStore, savedStore, geocodeClient, designationClient, offerStore, adminStore, cfg.AdminAPIKey, cfg.SiteBuildKey, jwsVerifier, appleNotifStore, cfg.AppleBundleID, cfg.AppleEnvironments, registry, shareCardCache, cfg.AnonRateLimitRequests, cfg.AnonRateLimitWindowSeconds, logger))
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()

--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -255,9 +255,8 @@ func newRouter(
 	// load that ultimately lands on PlanIt) completely unmetered. It is a no-op
 	// for authenticated requests, so it never interferes with the per-subject
 	// RateLimit it wraps.
-	_ = anonRateLimitWindowSeconds
-	_ = anonRateLimitRequests
-	// TEMP-RED-CHECK: AnonRateLimit deliberately not wired yet.
+	anonWindow := time.Duration(anonRateLimitWindowSeconds) * time.Second
+	dispatch = middleware.AnonRateLimit(middleware.NewAnonRateLimitStore(anonWindow), anonRateLimitRequests, logger)(dispatch)
 	if deviceStore != nil {
 		devicetokens.Routes(mux, deviceStore, time.Now, logger)
 	}

--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -162,7 +162,7 @@ type adminUserStore interface {
 // newRouter wires the feature routes onto a mux and wraps it in the production
 // middleware chain. Ordering, from outermost to innermost:
 //
-//		CORS -> SecurityHeaders -> ErrorBody -> Recover -> RequireAuth -> RateLimit -> RecordActivity -> mux
+//		CORS -> SecurityHeaders -> ErrorBody -> Recover -> RequireAuth -> AnonRateLimit -> RateLimit -> RecordActivity -> mux
 //
 //	  - CORS runs first so its headers are present on every response, including
 //	    the 401s and 500s produced further in.
@@ -173,8 +173,15 @@ type adminUserStore interface {
 //	  - Recover converts a handler panic into a 500 + Detail, which ErrorBody
 //	    then renders — the Go equivalent of ErrorResponseMiddleware's try/catch.
 //	  - RequireAuth applies the Auth0 bearer + fallback-deny policy, then
-//	    dispatches through rate limiting and activity recording (both no-ops for
-//	    anonymous routes, which carry no subject).
+//	    dispatches through AnonRateLimit, rate limiting and activity recording.
+//	  - AnonRateLimit (GH#868 Phase 1) is a no-op for authenticated requests (it
+//	    only meters when auth.Subject is empty) and, unlike RateLimit/
+//	    RecordActivity below, it always wraps dispatch regardless of whether the
+//	    profile store is wired — a store-less boot must not leave anonymous
+//	    routes completely unmetered. GET /health and GET /v1/health are exempt
+//	    (ACA probes; see middleware.AnonRateLimit's doc for the convention).
+//	  - RateLimit/RecordActivity are no-ops for anonymous routes (no subject),
+//	    the mirror image of AnonRateLimit's no-op for authenticated ones.
 //
 // The store parameters are consumer-side interfaces backed by the Postgres
 // stores. Each retains the nil-means-unwired convention so a store-less local
@@ -208,6 +215,8 @@ func newRouter(
 	appleEnvironments []string,
 	registry *metrics.Registry,
 	shareCardCache *blobstore.Store,
+	anonRateLimitRequests int,
+	anonRateLimitWindowSeconds int,
 	logger *slog.Logger,
 ) http.Handler {
 	mux := http.NewServeMux()
@@ -239,6 +248,16 @@ func newRouter(
 			middleware.RecordActivity(profiles.NewActivityRecorder(store), time.Now, logger)(mux),
 		)
 	}
+	// AnonRateLimit (GH#868 Phase 1) always wraps whatever dispatch chain was
+	// built above — unlike RateLimit/RecordActivity, it needs no profile store,
+	// so it must not be skipped on a store-less boot: that would leave every
+	// anonymous route (a scraping target for a future public geo endpoint, and
+	// load that ultimately lands on PlanIt) completely unmetered. It is a no-op
+	// for authenticated requests, so it never interferes with the per-subject
+	// RateLimit it wraps.
+	_ = anonRateLimitWindowSeconds
+	_ = anonRateLimitRequests
+	// TEMP-RED-CHECK: AnonRateLimit deliberately not wired yet.
 	if deviceStore != nil {
 		devicetokens.Routes(mux, deviceStore, time.Now, logger)
 	}
@@ -283,9 +302,10 @@ func newRouter(
 		// same store; it needs no build key (unlike the two SEO routes above) since
 		// it is not a build-time-only surface — it is the public-facing endpoint the
 		// /search web page (tc-geq7h.4) calls directly from a visitor's browser. It is
-		// anonymous to Auth0 (see anonymousPatterns) and subject to the SAME rate
-		// limiting as every other anonymous route: RateLimit no-ops on a request
-		// with no subject (middleware/ratelimit.go), so no new scheme is needed here.
+		// anonymous to Auth0 (see anonymousPatterns) and, like every other anonymous
+		// route, metered by the per-IP AnonRateLimit (GH#868 Phase 1, above): the
+		// per-subject RateLimit no-ops on a request with no subject, but
+		// AnonRateLimit does not — it is the scheme that actually covers this route.
 		applications.SearchRoutes(mux, appStore, authorities.NewLookup(), logger)
 		// The public share page (#738): an anonymous, server-rendered HTML page for a
 		// single application at GET /a/{authoritySlug}/{ref...}. It point-reads the

--- a/api-go/cmd/api/wiring_test.go
+++ b/api-go/cmd/api/wiring_test.go
@@ -275,7 +275,7 @@ func testDesignationClientWith(t *testing.T, baseURL string, httpClient *http.Cl
 
 func newTestHandler(t *testing.T) http.Handler {
 	t.Helper()
-	return newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", "", nil, nil, "", nil, nil, nil, slog.New(slog.DiscardHandler))
+	return newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", "", nil, nil, "", nil, nil, nil, 60, 60, slog.New(slog.DiscardHandler))
 }
 
 // TestRouter_AnonymousRoutesServedWithoutToken confirms the iteration-0/1
@@ -330,7 +330,7 @@ func TestRouter_SharePageAndBySlugAnonymous_ByIdStaysAuthed(t *testing.T) {
 	appStore := foundAppStore{app: app}
 	// denyAllValidator rejects every token, so the by-id route can only pass if it
 	// were (wrongly) anonymous.
-	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, appStore, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", "", nil, nil, "", nil, nil, nil, logger)
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, appStore, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", "", nil, nil, "", nil, nil, nil, 60, 60, logger)
 
 	// (1) Public HTML share page: anonymous, 200 text/html.
 	page := serveReq(t, h, http.MethodGet, "/a/croydon/23/03456/FUL", "", "")
@@ -399,7 +399,7 @@ func TestRouter_ApplicationSearchAnonymous(t *testing.T) {
 		Address:  "10 Downing Street, London",
 	}
 	appStore := foundAppStore{app: app}
-	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, appStore, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", "", nil, nil, "", nil, nil, nil, logger)
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, appStore, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", "", nil, nil, "", nil, nil, nil, 60, 60, logger)
 
 	rec := serveReq(t, h, http.MethodGet, "/v1/applications/search?q=downing", "", "")
 	if rec.Code != http.StatusOK {
@@ -492,7 +492,7 @@ func TestRouter_AuthenticatedPipeline(t *testing.T) {
 	appStore := fakeAppStore{}
 	savedStore := fakeSavedStore{}
 	validator := staticValidator{claims: auth.Claims{Subject: "auth0|wiretest", Email: "wire@example.com", EmailVerified: true}}
-	h := newRouter(validator, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, watchZoneStore, appStore, savedStore, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", "", nil, nil, "", nil, nil, nil, logger)
+	h := newRouter(validator, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, watchZoneStore, appStore, savedStore, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", "", nil, nil, "", nil, nil, nil, 60, 60, logger)
 
 	// Create the profile, then read it back through the same chain.
 	rec := serveReq(t, h, http.MethodPost, "/v1/me", "", "Bearer tok")
@@ -590,7 +590,7 @@ func TestRouter_GeocodeAndDesignationsDispatch(t *testing.T) {
 	validator := staticValidator{claims: auth.Claims{Subject: "auth0|wiretest", Email: "wire@example.com", EmailVerified: true}}
 	geocodeClient := testGeocodeClientWith(t, upstream.URL, upstream.Client())
 	designationClient := testDesignationClientWith(t, upstream.URL, upstream.Client())
-	h := newRouter(validator, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, nil, geocodeClient, designationClient, nil, nil, "", "", nil, nil, "", nil, nil, nil, logger)
+	h := newRouter(validator, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, nil, geocodeClient, designationClient, nil, nil, "", "", nil, nil, "", nil, nil, nil, 60, 60, logger)
 
 	rec := serveReq(t, h, http.MethodGet, "/v1/geocode/SW1A%201AA", "", "Bearer tok")
 	if rec.Code != http.StatusOK {
@@ -629,7 +629,7 @@ func TestRouter_SubscriptionsWired(t *testing.T) {
 		t.Fatalf("NewJWSVerifier: %v", err)
 	}
 
-	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), nil, adminStore, "", "", verifier, notifStore, "uk.towncrierapp.mobile", []string{"Production"}, nil, nil, logger)
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), nil, adminStore, "", "", verifier, notifStore, "uk.towncrierapp.mobile", []string{"Production"}, nil, nil, 60, 60, logger)
 
 	// Webhook is anonymous: a malformed body reaches the handler -> 400 with the
 	// malformed_request envelope, not the WWW-Authenticate 401 fallback.
@@ -659,7 +659,7 @@ func TestRouter_AdminGate(t *testing.T) {
 	logger := slog.New(slog.DiscardHandler)
 	offerStore := fakeOfferStore{}
 	adminStore := fakeAdminStore{}
-	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), offerStore, adminStore, "s3cret", "", nil, nil, "", nil, nil, nil, logger)
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), offerStore, adminStore, "s3cret", "", nil, nil, "", nil, nil, nil, 60, 60, logger)
 
 	// No key: the admin gate rejects with a bodyless 401 and NO WWW-Authenticate
 	// (distinguishing it from the Auth0 fallback-deny).
@@ -690,7 +690,7 @@ func TestRouter_AdminOfferCodesListGate(t *testing.T) {
 	logger := slog.New(slog.DiscardHandler)
 	offerStore := fakeOfferStore{}
 	adminStore := fakeAdminStore{}
-	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), offerStore, adminStore, "s3cret", "", nil, nil, "", nil, nil, nil, logger)
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), offerStore, adminStore, "s3cret", "", nil, nil, "", nil, nil, nil, 60, 60, logger)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	t.Cleanup(cancel)
@@ -719,7 +719,7 @@ func TestRouter_AdminStatsGate(t *testing.T) {
 	adminStore := fakeAdminStore{}
 	// notif (pos 9), saved (pos 12), device (pos 7) all nil: the reach stores are
 	// unwired, exercising the nil-safe reach path through the full router chain.
-	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), offerStore, adminStore, "s3cret", "", nil, nil, "", nil, nil, nil, logger)
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), offerStore, adminStore, "s3cret", "", nil, nil, "", nil, nil, nil, 60, 60, logger)
 
 	statsReq := func(key string) *httptest.ResponseRecorder {
 		t.Helper()
@@ -771,7 +771,7 @@ func TestRouter_RecentApplicationsBuildKeyGate(t *testing.T) {
 
 	logger := slog.New(slog.DiscardHandler)
 	appStore := fakeAppStore{}
-	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, appStore, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", "buildsecret", nil, nil, "", nil, nil, nil, logger)
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, appStore, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", "buildsecret", nil, nil, "", nil, nil, nil, 60, 60, logger)
 
 	// No key: the build gate rejects with a bodyless 401 and NO WWW-Authenticate
 	// (distinguishing it from the Auth0 fallback-deny).
@@ -817,7 +817,7 @@ func TestRouter_NearApplicationsBuildKeyGate(t *testing.T) {
 
 	logger := slog.New(slog.DiscardHandler)
 	appStore := fakeAppStore{}
-	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, appStore, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", "buildsecret", nil, nil, "", nil, nil, nil, logger)
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, appStore, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", "buildsecret", nil, nil, "", nil, nil, nil, 60, 60, logger)
 
 	noKey := nearRequest(t, h, "")
 	if noKey.Code != http.StatusUnauthorized {

--- a/api-go/internal/middleware/anonratelimit.go
+++ b/api-go/internal/middleware/anonratelimit.go
@@ -1,0 +1,157 @@
+package middleware
+
+import (
+	"log/slog"
+	"net/http"
+	"net/netip"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/auth"
+	"github.com/AmyDe/town-crier/api-go/internal/clientip"
+)
+
+// healthCheckPaths are the liveness/readiness probe paths Container Apps hits
+// continuously. They are exempt from anonymous rate limiting: they carry no
+// user data, are not part of the scraping surface this middleware defends
+// (GH#868 Phase 1), and metering them would only spend budget a genuine
+// anonymous caller could otherwise use. This is the chosen convention for the
+// ACA-probe exemption; keep it in lockstep with internal/health's registered
+// paths.
+var healthCheckPaths = map[string]struct{}{
+	"/health":    {},
+	"/v1/health": {},
+}
+
+// AnonRateLimit returns middleware enforcing a fixed-window rate limit keyed
+// by resolved client IP (internal/clientip), applied ONLY to requests with no
+// authenticated subject (auth.Subject(ctx) == ""). Authenticated traffic
+// passes straight through untouched: it is metered by the sibling per-subject
+// RateLimit instead, and this middleware never inspects or affects it
+// (GH#868 Phase 1). A point+radius public endpoint is a whole-table scraping
+// target and drives unmetered load onto PlanIt (our free, single-operator
+// upstream) if left uncapped, hence this second limiter.
+//
+// Requests whose client IP cannot be resolved (clientip.FromRequest returns
+// the invalid zero Addr — which per the clientip package doc happens only
+// when RemoteAddr itself cannot be parsed) collapse onto one shared
+// conservative bucket: the zero Addr is identical for every such request, so
+// no caller that cannot be individually attributed can bypass metering
+// entirely by virtue of being unattributable.
+//
+// On an allowed request it sets X-RateLimit-Limit and X-RateLimit-Remaining;
+// on a throttled one it returns 429 with those headers (Remaining 0) plus
+// Retry-After — the same response contract as the per-subject RateLimit.
+//
+// The client IP itself is never logged, stored, or exported anywhere beyond
+// this in-memory accounting: only the numeric limit/retry values are recorded
+// on a throttle, honouring the clientip package's "in-memory, non-persisted
+// purpose only" constraint.
+func AnonRateLimit(store *anonRateLimitStore, limit int, logger *slog.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if auth.Subject(r.Context()) != "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+			if _, ok := healthCheckPaths[r.URL.Path]; ok {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			addr := clientip.FromRequest(r)
+			result := store.checkAndIncrement(addr, limit)
+			if !result.allowed {
+				w.Header().Set("X-RateLimit-Limit", strconv.Itoa(limit))
+				w.Header().Set("X-RateLimit-Remaining", "0")
+				w.Header().Set("Retry-After", strconv.Itoa(result.retryAfterSeconds()))
+				logger.WarnContext(r.Context(), "anonymous rate limit exceeded",
+					"limit", limit, "retryAfterSeconds", result.retryAfterSeconds())
+				w.WriteHeader(http.StatusTooManyRequests)
+				return
+			}
+
+			w.Header().Set("X-RateLimit-Limit", strconv.Itoa(limit))
+			w.Header().Set("X-RateLimit-Remaining", strconv.Itoa(result.remaining))
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// anonRateLimitStore is an in-memory sliding-window counter keyed by resolved
+// client IP: a per-IP queue of request timestamps, evicting entries older than
+// the window on every check. It mirrors rateLimitStore's mechanism (see
+// ratelimit.go) generalised to a configurable window and a netip.Addr key
+// instead of a user-id string — netip.Addr is a small comparable value, so it
+// works directly as a map key with no string conversion (and therefore no
+// temptation to log it).
+//
+// Eviction is mandatory from day one (regression guard for GH#518, where a
+// per-subject map once grew unbounded because keys were never reclaimed): once
+// an IP's timestamps have all aged out of the window, the map key is deleted
+// rather than left holding an empty slice. This matters even more here than
+// for the per-subject store: the anonymous caller population is unbounded
+// (any IP on the internet), not the bounded set of registered users.
+type anonRateLimitStore struct {
+	now    func() time.Time
+	window time.Duration
+
+	mu       sync.Mutex
+	requests map[netip.Addr][]time.Time
+}
+
+// newAnonRateLimitStore builds a store using the given clock and window
+// (injected for tests).
+func newAnonRateLimitStore(now func() time.Time, window time.Duration) *anonRateLimitStore {
+	return &anonRateLimitStore{now: now, window: window, requests: map[netip.Addr][]time.Time{}}
+}
+
+// NewAnonRateLimitStore builds the production store on the real clock with the
+// given fixed window. It returns the unexported concrete type so callers can
+// only pass it back to AnonRateLimit.
+func NewAnonRateLimitStore(window time.Duration) *anonRateLimitStore {
+	return newAnonRateLimitStore(time.Now, window)
+}
+
+// checkAndIncrement evicts expired timestamps for addr, then either records
+// the request (returning the remaining budget) or denies it (returning the
+// retry-after until the oldest in-window timestamp ages out). See
+// rateLimitStore.checkAndIncrement for the identical compaction/eviction
+// reasoning this mirrors.
+func (s *anonRateLimitStore) checkAndIncrement(addr netip.Addr, limit int) rateLimitResult {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := s.now()
+	windowStart := now.Add(-s.window)
+
+	times := s.requests[addr]
+	kept := times[:0]
+	for _, t := range times {
+		if t.After(windowStart) {
+			kept = append(kept, t)
+		}
+	}
+
+	if len(kept) == 0 {
+		delete(s.requests, addr)
+	} else {
+		s.requests[addr] = kept
+	}
+
+	if len(kept) >= limit {
+		var retryAfter time.Duration
+		if len(kept) > 0 {
+			retryAfter = kept[0].Add(s.window).Sub(now)
+		}
+		if retryAfter < time.Millisecond {
+			retryAfter = time.Millisecond
+		}
+		return rateLimitResult{allowed: false, remaining: 0, retryAfter: retryAfter}
+	}
+
+	kept = append(kept, now)
+	s.requests[addr] = kept
+	return rateLimitResult{allowed: true, remaining: limit - len(kept)}
+}

--- a/api-go/internal/middleware/anonratelimit_test.go
+++ b/api-go/internal/middleware/anonratelimit_test.go
@@ -1,0 +1,371 @@
+package middleware
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/auth"
+)
+
+// anonRequestWithPath builds a GET request carrying no Authorization header
+// (so auth.Subject is empty), driving AnonRateLimit's default anonymous path.
+// remoteAddr sets the TCP peer (r.RemoteAddr); an optional CF-Connecting-IP
+// header can be layered on top via cfHeader.
+func anonRequestWithPath(path, remoteAddr, cfHeader string) *http.Request {
+	r := httptest.NewRequestWithContext(context.Background(), http.MethodGet, path, nil)
+	r.RemoteAddr = remoteAddr
+	if cfHeader != "" {
+		r.Header.Set("CF-Connecting-IP", cfHeader)
+	}
+	return r
+}
+
+// anonRequest is anonRequestWithPath for an ordinary (non-health-check) route.
+func anonRequest(remoteAddr string) *http.Request {
+	return anonRequestWithPath("/v1/applications/search", remoteAddr, "")
+}
+
+func TestAnonRateLimit_AllowedRequestSetsHeaders(t *testing.T) {
+	t.Parallel()
+
+	clock := &fixedClock{t: time.Unix(2000, 0)}
+	store := newAnonRateLimitStore(clock.now, time.Minute)
+	mw := AnonRateLimit(store, 60, slogDiscard())
+
+	rec := httptest.NewRecorder()
+	mw(okHandler()).ServeHTTP(rec, anonRequest("203.0.113.10:51000"))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("X-RateLimit-Limit"); got != "60" {
+		t.Errorf("X-RateLimit-Limit: got %q, want 60", got)
+	}
+	if got := rec.Header().Get("X-RateLimit-Remaining"); got != "59" {
+		t.Errorf("X-RateLimit-Remaining: got %q, want 59", got)
+	}
+}
+
+func TestAnonRateLimit_RequestsBelowLimitAreUnaffected(t *testing.T) {
+	t.Parallel()
+
+	clock := &fixedClock{t: time.Unix(2000, 0)}
+	store := newAnonRateLimitStore(clock.now, time.Minute)
+	mw := AnonRateLimit(store, 5, slogDiscard())
+	h := mw(okHandler())
+
+	for i := range 5 {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, anonRequest("203.0.113.12:51000"))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("request %d: got %d, want 200 (below limit)", i, rec.Code)
+		}
+	}
+}
+
+func TestAnonRateLimit_ExceededReturns429WithHeaders(t *testing.T) {
+	t.Parallel()
+
+	clock := &fixedClock{t: time.Unix(2000, 0)}
+	store := newAnonRateLimitStore(clock.now, time.Minute)
+	mw := AnonRateLimit(store, 60, slogDiscard())
+	h := mw(okHandler())
+
+	for i := range 60 {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, anonRequest("203.0.113.11:51000"))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("request %d: got %d, want 200", i, rec.Code)
+		}
+	}
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, anonRequest("203.0.113.11:51000"))
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("61st request: got %d, want 429", rec.Code)
+	}
+	if got := rec.Header().Get("X-RateLimit-Limit"); got != "60" {
+		t.Errorf("429 X-RateLimit-Limit: got %q, want 60", got)
+	}
+	if got := rec.Header().Get("X-RateLimit-Remaining"); got != "0" {
+		t.Errorf("429 X-RateLimit-Remaining: got %q, want 0", got)
+	}
+	if got := rec.Header().Get("Retry-After"); got == "" || got == "0" {
+		t.Errorf("429 Retry-After: got %q, want a positive seconds value", got)
+	}
+}
+
+// TestAnonRateLimit_AuthenticatedRequestPassesThrough is the acceptance-
+// criterion test: authenticated traffic must never be touched by the
+// anonymous limiter, even when it shares an IP with an anonymous caller who
+// has exhausted the (deliberately tiny, limit=1) anonymous budget.
+func TestAnonRateLimit_AuthenticatedRequestPassesThrough(t *testing.T) {
+	t.Parallel()
+
+	clock := &fixedClock{t: time.Unix(2000, 0)}
+	store := newAnonRateLimitStore(clock.now, time.Minute)
+	mw := AnonRateLimit(store, 1, slogDiscard())
+	h := mw(okHandler())
+
+	for i := range 5 {
+		r := anonRequest("203.0.113.13:51000")
+		r = r.WithContext(auth.WithSubject(r.Context(), "auth0|abc"))
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, r)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("authenticated request %d: got %d, want 200", i, rec.Code)
+		}
+		if got := rec.Header().Get("X-RateLimit-Limit"); got != "" {
+			t.Errorf("authenticated request %d: got anon rate-limit header %q, want none", i, got)
+		}
+	}
+
+	// The same IP, now making its first genuinely anonymous request, still has
+	// its full budget — proving the authenticated loop above never touched the
+	// IP's counter.
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, anonRequest("203.0.113.13:51000"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("first anonymous request on the IP: got %d, want 200", rec.Code)
+	}
+}
+
+func TestAnonRateLimit_DifferentIPsHaveIndependentBudgets(t *testing.T) {
+	t.Parallel()
+
+	clock := &fixedClock{t: time.Unix(2000, 0)}
+	store := newAnonRateLimitStore(clock.now, time.Minute)
+	mw := AnonRateLimit(store, 1, slogDiscard())
+	h := mw(okHandler())
+
+	rec1 := httptest.NewRecorder()
+	h.ServeHTTP(rec1, anonRequest("203.0.113.20:1"))
+	if rec1.Code != http.StatusOK {
+		t.Fatalf("ip1 first request: got %d, want 200", rec1.Code)
+	}
+
+	rec1b := httptest.NewRecorder()
+	h.ServeHTTP(rec1b, anonRequest("203.0.113.20:1"))
+	if rec1b.Code != http.StatusTooManyRequests {
+		t.Fatalf("ip1 second request: got %d, want 429 (budget exhausted)", rec1b.Code)
+	}
+
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, anonRequest("203.0.113.21:1"))
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("ip2 first request: got %d, want 200 (independent budget)", rec2.Code)
+	}
+}
+
+// TestAnonRateLimit_UnresolvableIPsShareOneConservativeBucket pins the spec
+// decision for the "unresolvable client IP" case (issue #868 Phase 1):
+// clientip.FromRequest returns the invalid zero netip.Addr only when
+// RemoteAddr itself cannot be parsed (see the clientip package doc), and the
+// zero value is identical for every such request regardless of the literal
+// garbage that failed to parse — so they collapse onto one shared bucket with
+// no special-casing required in this middleware.
+func TestAnonRateLimit_UnresolvableIPsShareOneConservativeBucket(t *testing.T) {
+	t.Parallel()
+
+	clock := &fixedClock{t: time.Unix(2000, 0)}
+	store := newAnonRateLimitStore(clock.now, time.Minute)
+	mw := AnonRateLimit(store, 1, slogDiscard())
+	h := mw(okHandler())
+
+	rec1 := httptest.NewRecorder()
+	h.ServeHTTP(rec1, anonRequest("garbage-peer-one"))
+	if rec1.Code != http.StatusOK {
+		t.Fatalf("first unresolvable request: got %d, want 200", rec1.Code)
+	}
+
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, anonRequest("garbage-peer-two"))
+	if rec2.Code != http.StatusTooManyRequests {
+		t.Fatalf("second unresolvable request: got %d, want 429 (shared conservative bucket)", rec2.Code)
+	}
+
+	rec3 := httptest.NewRecorder()
+	h.ServeHTTP(rec3, anonRequest("203.0.113.30:1"))
+	if rec3.Code != http.StatusOK {
+		t.Fatalf("resolved-ip request: got %d, want 200 (independent of the shared bucket)", rec3.Code)
+	}
+}
+
+// TestAnonRateLimit_HealthCheckPathsExempt confirms GET /health and
+// GET /v1/health never count against the anonymous budget — ACA's liveness
+// and readiness probes hit these continuously, and metering them would waste
+// budget a genuine anonymous caller could use.
+func TestAnonRateLimit_HealthCheckPathsExempt(t *testing.T) {
+	t.Parallel()
+
+	clock := &fixedClock{t: time.Unix(2000, 0)}
+	store := newAnonRateLimitStore(clock.now, time.Minute)
+	mw := AnonRateLimit(store, 1, slogDiscard())
+	h := mw(okHandler())
+
+	for _, path := range []string{"/health", "/v1/health"} {
+		for i := range 5 {
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, anonRequestWithPath(path, "203.0.113.40:1", ""))
+			if rec.Code != http.StatusOK {
+				t.Fatalf("%s request %d: got %d, want 200 (health checks exempt)", path, i, rec.Code)
+			}
+			if got := rec.Header().Get("X-RateLimit-Limit"); got != "" {
+				t.Errorf("%s request %d: got rate-limit header %q, want none (exempt)", path, i, got)
+			}
+		}
+	}
+}
+
+func TestAnonRateLimit_WindowResets(t *testing.T) {
+	t.Parallel()
+
+	clock := &fixedClock{t: time.Unix(2000, 0)}
+	store := newAnonRateLimitStore(clock.now, time.Minute)
+	mw := AnonRateLimit(store, 2, slogDiscard())
+	h := mw(okHandler())
+
+	for range 2 {
+		h.ServeHTTP(httptest.NewRecorder(), anonRequest("203.0.113.50:1"))
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, anonRequest("203.0.113.50:1"))
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected throttle before window reset, got %d", rec.Code)
+	}
+
+	clock.t = clock.t.Add(61 * time.Second)
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, anonRequest("203.0.113.50:1"))
+	if rec2.Code != http.StatusOK {
+		t.Errorf("after window reset: got %d, want 200", rec2.Code)
+	}
+}
+
+// TestAnonRateLimit_NoClientIPInLogs is the acceptance-criterion test for the
+// clientip package's "never log, store, or export" constraint: it drives an
+// allow then a throttle (the path most likely to want an observability log
+// line) from a distinctive IP, then asserts that IP string never appears in
+// any captured log record's message or attributes.
+func TestAnonRateLimit_NoClientIPInLogs(t *testing.T) {
+	t.Parallel()
+
+	const distinctiveIP = "198.51.100.77"
+
+	spy := &logSpy{}
+	clock := &fixedClock{t: time.Unix(2000, 0)}
+	store := newAnonRateLimitStore(clock.now, time.Minute)
+	mw := AnonRateLimit(store, 1, slog.New(spy))
+	h := mw(okHandler())
+
+	h.ServeHTTP(httptest.NewRecorder(), anonRequest(distinctiveIP+":51000"))
+	h.ServeHTTP(httptest.NewRecorder(), anonRequest(distinctiveIP+":51000"))
+
+	spy.mu.Lock()
+	defer spy.mu.Unlock()
+	if len(spy.records) == 0 {
+		t.Fatal("setup: expected at least one log record from the throttle path")
+	}
+	for _, r := range spy.records {
+		if strings.Contains(r.Message, distinctiveIP) {
+			t.Errorf("log message contains client IP: %q", r.Message)
+		}
+		r.Attrs(func(a slog.Attr) bool {
+			if strings.Contains(a.Value.String(), distinctiveIP) {
+				t.Errorf("log attr %s=%q contains client IP", a.Key, a.Value.String())
+			}
+			return true
+		})
+	}
+}
+
+// hasKey and keyLen are test-only accessors mirroring rateLimitStore's (see
+// ratelimit_test.go), used to assert eviction behaviour without exposing them
+// in production code.
+func (s *anonRateLimitStore) hasKey(addr netip.Addr) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, ok := s.requests[addr]
+	return ok
+}
+
+func (s *anonRateLimitStore) keyLen(addr netip.Addr) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.requests[addr])
+}
+
+// TestAnonRateLimitStore_EvictsIdleIPKey is the GH#518 regression guard for the
+// per-IP store: once an IP's in-window timestamps have all aged out, the next
+// checkAndIncrement call for that IP must reclaim the map key (delete) rather
+// than leave a stale entry sitting in memory forever.
+func TestAnonRateLimitStore_EvictsIdleIPKey(t *testing.T) {
+	t.Parallel()
+
+	addr := netip.MustParseAddr("203.0.113.60")
+	clock := &fixedClock{t: time.Unix(2000, 0)}
+	store := newAnonRateLimitStore(clock.now, time.Minute)
+
+	store.checkAndIncrement(addr, 60)
+	if !store.hasKey(addr) {
+		t.Fatal("setup: expected key present after first request")
+	}
+
+	clock.t = clock.t.Add(61 * time.Second)
+
+	// limit=0 forces the denied path with kept==0 in a single call, making the
+	// deletion observable immediately (mirrors TestRateLimitStore_EvictsIdleUserKey).
+	store.checkAndIncrement(addr, 0)
+
+	if store.hasKey(addr) {
+		t.Error("expected map key deleted after all timestamps aged out, but key still present")
+	}
+}
+
+// TestAnonRateLimitStore_MapStaysBoundedAcrossWindows is the acceptance-
+// criterion test that the store's size shrinks/stays bounded after window
+// expiry, not merely "doesn't grow in the happy path": it seeds several IPs,
+// lets the window expire, then drives a second wave of one request per IP —
+// exactly what continuing real traffic looks like — and asserts the store
+// neither accumulates a second stale timestamp per IP nor grows beyond the
+// active population.
+func TestAnonRateLimitStore_MapStaysBoundedAcrossWindows(t *testing.T) {
+	t.Parallel()
+
+	clock := &fixedClock{t: time.Unix(2000, 0)}
+	store := newAnonRateLimitStore(clock.now, time.Minute)
+
+	addrs := []netip.Addr{
+		netip.MustParseAddr("203.0.113.61"),
+		netip.MustParseAddr("203.0.113.62"),
+		netip.MustParseAddr("203.0.113.63"),
+	}
+	for _, a := range addrs {
+		store.checkAndIncrement(a, 60)
+	}
+	if got := len(store.requests); got != len(addrs) {
+		t.Fatalf("setup: store size = %d, want %d", got, len(addrs))
+	}
+
+	// Advance past the window: every seeded timestamp is now stale.
+	clock.t = clock.t.Add(2 * time.Minute)
+
+	for _, a := range addrs {
+		store.checkAndIncrement(a, 60)
+	}
+
+	if got := len(store.requests); got != len(addrs) {
+		t.Errorf("store size after second window = %d, want %d (bounded, not accumulating)", got, len(addrs))
+	}
+	for _, a := range addrs {
+		if got := store.keyLen(a); got != 1 {
+			t.Errorf("addr %v: stored len = %d, want 1 (stale timestamp evicted before recording the new one)", a, got)
+		}
+	}
+}

--- a/api-go/internal/platform/config.go
+++ b/api-go/internal/platform/config.go
@@ -36,6 +36,17 @@ type Config struct {
 	// Defaults to localhost dev origin.
 	CorsAllowedOrigins []string
 
+	// AnonRateLimitRequests and AnonRateLimitWindowSeconds configure the
+	// per-IP anonymous rate limiter (middleware.AnonRateLimit, GH#868 Phase 1):
+	// the request budget and fixed window applied to every unauthenticated
+	// request, keyed on the client IP resolved via internal/clientip. Loaded
+	// from ANON_RATE_LIMIT_REQUESTS / ANON_RATE_LIMIT_WINDOW_SECONDS,
+	// defaulting to 60 requests per 60-second window so an unset env never
+	// leaves anonymous routes (a scraping target for a public geo endpoint,
+	// and load that ultimately lands on PlanIt) unmetered.
+	AnonRateLimitRequests      int
+	AnonRateLimitWindowSeconds int
+
 	// AzureClientID pins the user-assigned managed identity used for AAD auth
 	// (azidentity) by the Postgres pool (passwordless Entra token) and the Service
 	// Bus client (tc-6ig5). Empty falls back to the ambient managed identity.
@@ -254,6 +265,9 @@ func LoadConfig() (Config, error) {
 		Auth0Domain:        os.Getenv("AUTH0_DOMAIN"),
 		Auth0Audience:      os.Getenv("AUTH0_AUDIENCE"),
 		CorsAllowedOrigins: parseOrigins(os.Getenv("CORS_ALLOWED_ORIGINS")),
+
+		AnonRateLimitRequests:      getenvInt("ANON_RATE_LIMIT_REQUESTS", 60),
+		AnonRateLimitWindowSeconds: getenvInt("ANON_RATE_LIMIT_WINDOW_SECONDS", 60),
 
 		AzureClientID: os.Getenv("AZURE_CLIENT_ID"),
 

--- a/api-go/internal/platform/config_test.go
+++ b/api-go/internal/platform/config_test.go
@@ -371,6 +371,38 @@ func TestLoadConfig_CorsAllowedOrigins(t *testing.T) {
 	}
 }
 
+func TestLoadConfig_AnonRateLimitDefaults(t *testing.T) {
+	t.Setenv("ANON_RATE_LIMIT_REQUESTS", "")
+	t.Setenv("ANON_RATE_LIMIT_WINDOW_SECONDS", "")
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.AnonRateLimitRequests != 60 {
+		t.Errorf("AnonRateLimitRequests default: got %d, want 60", cfg.AnonRateLimitRequests)
+	}
+	if cfg.AnonRateLimitWindowSeconds != 60 {
+		t.Errorf("AnonRateLimitWindowSeconds default: got %d, want 60", cfg.AnonRateLimitWindowSeconds)
+	}
+}
+
+func TestLoadConfig_AnonRateLimitOverrides(t *testing.T) {
+	t.Setenv("ANON_RATE_LIMIT_REQUESTS", "30")
+	t.Setenv("ANON_RATE_LIMIT_WINDOW_SECONDS", "10")
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.AnonRateLimitRequests != 30 {
+		t.Errorf("AnonRateLimitRequests override: got %d, want 30", cfg.AnonRateLimitRequests)
+	}
+	if cfg.AnonRateLimitWindowSeconds != 10 {
+		t.Errorf("AnonRateLimitWindowSeconds override: got %d, want 10", cfg.AnonRateLimitWindowSeconds)
+	}
+}
+
 func TestLoadConfig_PollingDefaults(t *testing.T) {
 	// Clear any inherited overrides so the defaults are exercised.
 	for _, k := range []string{


### PR DESCRIPTION
## Changes
- Add `middleware.AnonRateLimit`: a fixed-window rate limiter keyed on client IP (`internal/clientip`), applied only to unauthenticated requests (no-op when a subject is present, so it never touches the existing per-subject `RateLimit`)
- In-memory store mirrors the existing per-subject limiter's mechanism, with mandatory stale-entry eviction from day one (regression guard for #518, where the per-subject map once grew unbounded)
- Unresolvable client IPs (clientip's zero `netip.Addr`) collapse onto a single shared conservative bucket
- `/health` and `/v1/health` exempted (ACA probes)
- New config: `ANON_RATE_LIMIT_REQUESTS` / `ANON_RATE_LIMIT_WINDOW_SECONDS`, defaulting to 60 req / 60s
- Wired into `cmd/api/wiring.go` so it wraps every anonymous route unconditionally (even on a store-less boot, unlike the profile-store-gated `RateLimit`/`RecordActivity`)
- 429 responses carry `Retry-After` + `X-RateLimit-*` headers; only numeric limit/retry values are ever logged, never the client IP
- Fixed a stale comment on `SearchRoutes` that incorrectly claimed the old per-subject limiter already covered anonymous traffic

This is Phase 1 of #868 (anonymous browse mode), unblocked by the ADR + LIA + privacy disclosure in #871. It unblocks Phase 2 (the public `near-point` endpoint) — no API endpoint changes here, only the rate limiter and its wiring.

(tc-2xi4x)

---
*Auto-shipped via ship skill*