### PR TITLE
feat: public GET /v1/applications/near-point endpoint

### DIFF
--- a/api-go/cmd/api/anonymous_patterns_test.go
+++ b/api-go/cmd/api/anonymous_patterns_test.go
@@ -35,6 +35,29 @@ func TestAnonymousPatterns_IncludesApplicationSearch(t *testing.T) {
 	}
 }
 
+// TestAnonymousPatterns_IncludesNearPoint pins the anonymity of the public
+// applications-near-a-point endpoint (GH#868 Phase 2): a resident browsing the
+// map before creating an account needs no token. The middleware keys on the
+// exact registered pattern string, so this must match the route wired in
+// applications byte-for-byte. This is a DIFFERENT route from the build-key
+// SEO endpoint below (GET /v1/applications/near) — do not confuse the two.
+func TestAnonymousPatterns_IncludesNearPoint(t *testing.T) {
+	t.Parallel()
+
+	const nearPoint = "GET /v1/applications/near-point"
+	if _, ok := anonymousPatterns[nearPoint]; !ok {
+		t.Errorf("anonymousPatterns must include %q", nearPoint)
+	}
+
+	const buildKeySEONear = "GET /v1/applications/near"
+	if _, ok := anonymousPatterns[buildKeySEONear]; !ok {
+		t.Errorf("anonymousPatterns must still include the distinct build-key SEO route %q", buildKeySEONear)
+	}
+	if nearPoint == buildKeySEONear {
+		t.Fatal("near-point and the build-key SEO near route must be distinct patterns")
+	}
+}
+
 // TestAnonymousPatterns_IncludesSharePage pins the anonymity of the public
 // server-rendered share page (#738). The auth middleware keys on the exact
 // registered pattern string, so this must match the route wired in sharepage

--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -65,6 +65,16 @@ var anonymousPatterns = map[string]struct{}{
 	// authority pages; the second feeds town pages (bounded geo query).
 	"GET /v1/authorities/{id}/applications": {},
 	"GET /v1/applications/near":             {},
+	// The public applications-near-a-point endpoint (GH#868 Phase 2) is anonymous
+	// to Auth0: it backs the iOS anonymous browse map, letting a fresh install
+	// see real applications near a point before creating an account. It is a
+	// DIFFERENT route from the build-key SEO endpoint immediately above — that
+	// one is build-time-only and gated by X-Build-Key inside the handler; this
+	// one is a genuine public runtime endpoint, metered solely by the per-IP
+	// AnonRateLimit (GH#868 Phase 1) plus its own radius/limit clamps (a
+	// point+radius read is a far more attractive whole-table scraping target
+	// than the text search below).
+	"GET /v1/applications/near-point": {},
 	// The by-slug application read is anonymous (public planning data only, no
 	// user/subscriber data, no refresh-on-tap): it resolves an authority slug to
 	// its area id and point-reads the application, feeding the public share page
@@ -306,6 +316,14 @@ func newRouter(
 		// per-subject RateLimit no-ops on a request with no subject, but
 		// AnonRateLimit does not — it is the scheme that actually covers this route.
 		applications.SearchRoutes(mux, appStore, authorities.NewLookup(), logger)
+		// The public applications-near-a-point endpoint (GH#868 Phase 2) reads from
+		// the same store; unlike SearchRoutes it needs no authority-slug resolver
+		// (NearbyResult, unlike SearchResult, carries no authoritySlug field — see
+		// result.go). It is anonymous to Auth0 (see anonymousPatterns, a route
+		// distinct from the build-key SEO NearRoutes above) and, like every other
+		// anonymous route, metered by the per-IP AnonRateLimit (GH#868 Phase 1)
+		// plus its own radius/limit clamps.
+		applications.NearPointRoutes(mux, appStore, logger)
 		// The public share page (#738): an anonymous, server-rendered HTML page for a
 		// single application at GET /a/{authoritySlug}/{ref...}. It point-reads the
 		// same applications store and resolves the authority slug via the static

--- a/api-go/cmd/api/wiring_test.go
+++ b/api-go/cmd/api/wiring_test.go
@@ -158,6 +158,14 @@ func (f foundAppStore) Search(context.Context, string, string, int) ([]applicati
 	return []applications.PlanningApplication{f.app}, false, nil
 }
 
+// FindNearbyPage unconditionally returns the fixture application, ignoring the
+// lat/lng/radius/limit/cursor args — this fake exists only to give the
+// anonymous near-point route's end-to-end wiring test (GH#868 Phase 2) a real
+// record to render and serialise.
+func (f foundAppStore) FindNearbyPage(context.Context, float64, float64, float64, int, string) ([]applications.PlanningApplication, string, error) {
+	return []applications.PlanningApplication{f.app}, "", nil
+}
+
 // fakeSavedStore is a savedapplications.Store returning the empty path.
 type fakeSavedStore struct{}
 
@@ -413,6 +421,48 @@ func TestRouter_ApplicationSearchAnonymous(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), `"reference":"23/03456/FUL"`) {
 		t.Errorf("body missing reference 23/03456/FUL (planit_name, not uid); body = %s", rec.Body.String())
+	}
+}
+
+// TestRouter_NearPointAnonymous is the end-to-end wiring guard for the public
+// applications-near-a-point endpoint (GH#868 Phase 2): it boots the FULL
+// router with a store that returns a real application, then proves
+// GET /v1/applications/near-point serves anonymously (no token, 200
+// application/json) with a bare-array body — the same raw-domain wire shape
+// (NearbyResult) the authed nearby page emits. The pattern string match is a
+// drift guard: a rename here without updating anonymousPatterns would silently
+// 401 the route.
+func TestRouter_NearPointAnonymous(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.DiscardHandler)
+	app := applications.PlanningApplication{
+		Name:     "23/03456/FUL",
+		UID:      "croydon-23-03456-FUL",
+		AreaName: "Croydon",
+		AreaID:   301,
+		Address:  "10 Downing Street, London",
+	}
+	appStore := foundAppStore{app: app}
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, appStore, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", "", nil, nil, "", nil, nil, nil, 60, 60, logger)
+
+	rec := serveReq(t, h, http.MethodGet, "/v1/applications/near-point?lat=51.5&lng=-0.1", "", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /v1/applications/near-point status = %d, want 200 (anonymous); body = %s", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	if !strings.Contains(rec.Body.String(), `"name":"23/03456/FUL"`) {
+		t.Errorf("body missing planit_name 23/03456/FUL; body = %s", rec.Body.String())
+	}
+	if !strings.HasPrefix(strings.TrimSpace(rec.Body.String()), "[") {
+		t.Errorf("body must be a bare JSON array, got: %s", rec.Body.String())
+	}
+
+	badReq := serveReq(t, h, http.MethodGet, "/v1/applications/near-point", "", "")
+	if badReq.Code != http.StatusBadRequest {
+		t.Fatalf("GET /v1/applications/near-point (no lat/lng) status = %d, want 400", badReq.Code)
 	}
 }
 

--- a/api-go/internal/applications/nearpoint.go
+++ b/api-go/internal/applications/nearpoint.go
@@ -1,0 +1,214 @@
+package applications
+
+import (
+	"context"
+	"encoding/base64"
+	"log/slog"
+	"math"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// nearPointDefaultRadiusMetres, nearPointMinRadiusMetres, and
+// nearPointMaxRadiusMetres bound the optional ?radius= query parameter: a
+// present-but-out-of-range numeric value is CLAMPED into [min, max] rather than
+// rejected (an omitted or genuinely unparseable value falls back to the
+// default) — see parseNearPointRadius. This is a public, unauthenticated
+// endpoint and, unlike the text search, a point+radius read is a whole-table
+// scraping target (tile the UK with radius queries and dump the whole table):
+// the radius/limit clamps here are a second, complementary layer of defense on
+// top of the per-IP anonymous rate limiter (GH#868 Phase 1), not a substitute
+// for it (GH#868 Phase 2).
+const (
+	nearPointDefaultRadiusMetres = 2000
+	nearPointMinRadiusMetres     = 100
+	nearPointMaxRadiusMetres     = 5000
+)
+
+// nearPointDefaultLimit and nearPointMaxLimit bound how many rows a single page
+// returns; a present-but-out-of-range numeric ?limit= is clamped into
+// [1, nearPointMaxLimit] (an omitted or unparseable value falls back to the
+// default), mirroring the radius clamp above.
+const (
+	nearPointDefaultLimit = 100
+	nearPointMaxLimit     = 200
+)
+
+// nearPointTimeout bounds a single near-point call end-to-end, matching
+// search.go's searchTimeout: this is a public, unauthenticated endpoint
+// sharing a Postgres pool with prod's core watch-zone/notification reads
+// (psql-town-crier-shared) — a pathological query must fail fast with a 500
+// rather than hold a pool connection open for tens of seconds (tc-z5i5j
+// incident precedent). It is defense-in-depth alongside the radius/limit
+// clamps above, not a substitute for them.
+const nearPointTimeout = 8 * time.Second
+
+// nearPointStore is the consumer-side store the near-point handler needs: the
+// same generic KNN + ST_DWithin keyset page already used by the authed
+// watch-zone nearby endpoints and the anonymous demo account. *PostgresStore
+// satisfies it structurally.
+type nearPointStore interface {
+	FindNearbyPage(ctx context.Context, latitude, longitude, radiusMetres float64, limit int, cursor string) ([]PlanningApplication, string, error)
+}
+
+// nearPointHandler serves the public applications-near-a-point endpoint.
+type nearPointHandler struct {
+	store  nearPointStore
+	logger *slog.Logger
+}
+
+// NearPointRoutes registers the public GET /v1/applications/near-point
+// endpoint (GH#868 Phase 2). It is kept in cmd/api/wiring.go's
+// anonymousPatterns — a DIFFERENT route from the build-key-gated
+// GET /v1/applications/near SEO route (applications.NearRoutes) — and reads
+// only public planning data from Postgres.
+func NearPointRoutes(mux *http.ServeMux, store nearPointStore, logger *slog.Logger) {
+	h := &nearPointHandler{store: store, logger: logger}
+	mux.HandleFunc("GET /v1/applications/near-point", h.nearPoint)
+}
+
+// nearPoint validates lat/lng (required), radius/limit (optional, clamped),
+// and cursor (optional, opaque), then returns one nearest-first page of
+// applications within radius of (lat, lng). A missing/invalid lat/lng or a
+// malformed cursor is a bodyless 400; a store failure is a bodyless 500 (both
+// envelopes backfilled by middleware.ErrorBody). The response body is a bare
+// JSON array of NearbyResult, with the continuation token (when present) in
+// the X-Next-Cursor header — exact parity with the authed nearby list.
+func (h *nearPointHandler) nearPoint(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+
+	lat, lng, ok := parseNearPointCoordinates(q.Get("lat"), q.Get("lng"))
+	if !ok {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	radius := parseNearPointRadius(q.Get("radius"))
+	limit := parseNearPointLimit(q.Get("limit"))
+
+	// decodeNearPointCursor strips the transport-layer base64 wrapping; a
+	// malformed wrapper is a clean 400, never a silent reset to page one.
+	cursor, ok := decodeNearPointCursor(q.Get("cursor"))
+	if !ok {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), nearPointTimeout)
+	defer cancel()
+
+	apps, nextCursor, err := h.store.FindNearbyPage(ctx, lat, lng, radius, limit, cursor)
+	if err != nil {
+		serverError(w, r, h.logger, "find applications near point", err)
+		return
+	}
+
+	results := make([]NearbyResult, 0, len(apps))
+	for _, a := range apps {
+		results = append(results, NearbyResultOf(a))
+	}
+
+	// Set the continuation header before writeJSON, which calls WriteHeader;
+	// omitted entirely when the page is the last.
+	if nextCursor != "" {
+		w.Header().Set("X-Next-Cursor", encodeNearPointCursor(nextCursor))
+	}
+	writeJSON(w, r, h.logger, results)
+}
+
+// parseNearPointCoordinates parses and validates the required lat/lng query
+// params: both must parse as finite floats in valid geographic range
+// ([-90,90] / [-180,180]), mirroring watchzones.createRequest.valid(). Note
+// strconv.ParseFloat accepts the literal strings "NaN"/"Inf"/"+Inf"/"-Inf", so
+// the finiteness check is required even though ParseFloat itself succeeded.
+func parseNearPointCoordinates(rawLat, rawLng string) (lat, lng float64, ok bool) {
+	lat, err := strconv.ParseFloat(strings.TrimSpace(rawLat), 64)
+	if err != nil {
+		return 0, 0, false
+	}
+	lng, err = strconv.ParseFloat(strings.TrimSpace(rawLng), 64)
+	if err != nil {
+		return 0, 0, false
+	}
+	if math.IsNaN(lat) || math.IsInf(lat, 0) || math.IsNaN(lng) || math.IsInf(lng, 0) {
+		return 0, 0, false
+	}
+	if lat < -90 || lat > 90 {
+		return 0, 0, false
+	}
+	if lng < -180 || lng > 180 {
+		return 0, 0, false
+	}
+	return lat, lng, true
+}
+
+// parseNearPointRadius clamps the optional ?radius= into
+// [nearPointMinRadiusMetres, nearPointMaxRadiusMetres]. Unset, empty,
+// non-numeric, or non-finite falls back to nearPointDefaultRadiusMetres; any
+// other parseable value (including zero or negative) is clamped into the
+// bound rather than rejected.
+func parseNearPointRadius(raw string) float64 {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nearPointDefaultRadiusMetres
+	}
+	n, err := strconv.ParseFloat(raw, 64)
+	if err != nil || math.IsNaN(n) || math.IsInf(n, 0) {
+		return nearPointDefaultRadiusMetres
+	}
+	if n < nearPointMinRadiusMetres {
+		return nearPointMinRadiusMetres
+	}
+	if n > nearPointMaxRadiusMetres {
+		return nearPointMaxRadiusMetres
+	}
+	return n
+}
+
+// parseNearPointLimit clamps the optional ?limit= into [1, nearPointMaxLimit].
+// Unset, empty, or non-numeric falls back to nearPointDefaultLimit; any other
+// parseable value (including zero or negative) is clamped into the bound
+// rather than rejected.
+func parseNearPointLimit(raw string) int {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nearPointDefaultLimit
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		return nearPointDefaultLimit
+	}
+	if n < 1 {
+		return 1
+	}
+	if n > nearPointMaxLimit {
+		return nearPointMaxLimit
+	}
+	return n
+}
+
+// decodeNearPointCursor base64url-decodes an opaque ?cursor= value into the
+// store's raw keyset continuation token, mirroring
+// watchzones.decodeCursor/encodeCursor's exact semantics (that package is
+// unexported, so this is a deliberate parallel implementation, not a shared
+// one). An empty value means the first page (ok). A malformed value is
+// rejected (ok == false) so a garbage cursor is a clean 400, not a silent
+// reset to the first page.
+func decodeNearPointCursor(raw string) (string, bool) {
+	if raw == "" {
+		return "", true
+	}
+	b, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return "", false
+	}
+	return string(b), true
+}
+
+// encodeNearPointCursor base64url-encodes the store's raw keyset continuation
+// token for the X-Next-Cursor response header — header- and URL-safe, unpadded.
+func encodeNearPointCursor(token string) string {
+	return base64.RawURLEncoding.EncodeToString([]byte(token))
+}

--- a/api-go/internal/applications/nearpoint_integration_test.go
+++ b/api-go/internal/applications/nearpoint_integration_test.go
@@ -46,7 +46,7 @@ func TestNearPointHandler_Integration_RealPostGIS(t *testing.T) {
 	firstURL := "/v1/applications/near-point?lat=" + strconv.FormatFloat(pgCentreLat, 'f', -1, 64) +
 		"&lng=" + strconv.FormatFloat(pgCentreLon, 'f', -1, 64) + "&radius=6000&limit=2"
 	rec := httptest.NewRecorder()
-	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, firstURL, nil))
+	mux.ServeHTTP(rec, httptest.NewRequestWithContext(ctx, http.MethodGet, firstURL, nil))
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("page 1 status = %d, want 200; body = %s", rec.Code, rec.Body.String())
@@ -65,7 +65,7 @@ func TestNearPointHandler_Integration_RealPostGIS(t *testing.T) {
 
 	secondURL := firstURL + "&cursor=" + nextCursor
 	rec2 := httptest.NewRecorder()
-	mux.ServeHTTP(rec2, httptest.NewRequest(http.MethodGet, secondURL, nil))
+	mux.ServeHTTP(rec2, httptest.NewRequestWithContext(ctx, http.MethodGet, secondURL, nil))
 
 	if rec2.Code != http.StatusOK {
 		t.Fatalf("page 2 status = %d, want 200; body = %s", rec2.Code, rec2.Body.String())

--- a/api-go/internal/applications/nearpoint_integration_test.go
+++ b/api-go/internal/applications/nearpoint_integration_test.go
@@ -1,0 +1,84 @@
+//go:build integration
+
+package applications
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+)
+
+// TestNearPointHandler_Integration_RealPostGIS drives the full HTTP handler —
+// param parsing, the store's KNN + ST_DWithin query, and JSON encoding —
+// against real PostGIS (ADR 0032). Fakes cannot honestly model true KNN
+// distance ordering or ST_DWithin's radius filter, so this pins the whole
+// pipeline the way the anonymous iOS browse map actually exercises it:
+// nearest-first ordering, the radius filter excluding a far application, and
+// keyset pagination across pages with no overlap or gap.
+func TestNearPointHandler_Integration_RealPostGIS(t *testing.T) {
+	// Not run with t.Parallel(): newAppPGStore's pgtest.New holds a
+	// process-wide advisory lock for the test's duration (see pgtest.New).
+	store := newAppPGStore(t)
+	ctx := context.Background()
+
+	for _, a := range []PlanningApplication{
+		at(pgApp("APP-100", 100), 100),
+		at(pgApp("APP-500", 100), 500),
+		at(pgApp("APP-FAR", 100), 50000), // outside every radius used below
+	} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	mux := http.NewServeMux()
+	NearPointRoutes(mux, store, slog.New(slog.DiscardHandler))
+
+	// limit=2: page 1 comes back FULL (2 rows), which always mints a
+	// continuation cursor regardless of whether more rows truly exist
+	// (FindNearbyPage's documented contract — see collectPage, zonepage.go);
+	// page 2 then comes back short of the limit (1 row), which is what
+	// actually reports exhaustion with an empty cursor.
+	firstURL := "/v1/applications/near-point?lat=" + strconv.FormatFloat(pgCentreLat, 'f', -1, 64) +
+		"&lng=" + strconv.FormatFloat(pgCentreLon, 'f', -1, 64) + "&radius=6000&limit=2"
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, firstURL, nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("page 1 status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	var page1 []NearbyResult
+	if err := json.Unmarshal(rec.Body.Bytes(), &page1); err != nil {
+		t.Fatalf("page 1 body not a bare JSON array: %v; body = %s", err, rec.Body.String())
+	}
+	if len(page1) != 2 || page1[0].Name != "APP-100" || page1[1].Name != "APP-500" {
+		t.Fatalf("page 1 = %+v, want [APP-100, APP-500] nearest-first", page1)
+	}
+	nextCursor := rec.Header().Get("X-Next-Cursor")
+	if nextCursor == "" {
+		t.Fatal("expected X-Next-Cursor after a full page")
+	}
+
+	secondURL := firstURL + "&cursor=" + nextCursor
+	rec2 := httptest.NewRecorder()
+	mux.ServeHTTP(rec2, httptest.NewRequest(http.MethodGet, secondURL, nil))
+
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("page 2 status = %d, want 200; body = %s", rec2.Code, rec2.Body.String())
+	}
+	var page2 []NearbyResult
+	if err := json.Unmarshal(rec2.Body.Bytes(), &page2); err != nil {
+		t.Fatalf("page 2 body not a bare JSON array: %v; body = %s", err, rec2.Body.String())
+	}
+	// APP-FAR (50km) is excluded by the 6km radius, so page 2 is empty.
+	if len(page2) != 0 {
+		t.Fatalf("page 2 = %+v, want empty (APP-FAR excluded by radius)", page2)
+	}
+	if got := rec2.Header().Get("X-Next-Cursor"); got != "" {
+		t.Fatalf("expected empty X-Next-Cursor at exhaustion, got %q", got)
+	}
+}

--- a/api-go/internal/applications/nearpoint_test.go
+++ b/api-go/internal/applications/nearpoint_test.go
@@ -1,0 +1,165 @@
+package applications
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// fakeNearPointStore is a hand-written nearPointStore fake that records the
+// last call's arguments and returns caller-configured results.
+type fakeNearPointStore struct {
+	apps       []PlanningApplication
+	nextCursor string
+	err        error
+
+	calledLat    float64
+	calledLng    float64
+	calledRadius float64
+	calledLimit  int
+	calledCursor string
+}
+
+func (f *fakeNearPointStore) FindNearbyPage(_ context.Context, latitude, longitude, radiusMetres float64, limit int, cursor string) ([]PlanningApplication, string, error) {
+	f.calledLat = latitude
+	f.calledLng = longitude
+	f.calledRadius = radiusMetres
+	f.calledLimit = limit
+	f.calledCursor = cursor
+	if f.err != nil {
+		return nil, "", f.err
+	}
+	return f.apps, f.nextCursor, nil
+}
+
+// newNearPointTestHandler builds a near-point mux wired to the given fake
+// store, discarding log output.
+func newNearPointTestHandler(store *fakeNearPointStore) http.Handler {
+	mux := http.NewServeMux()
+	NearPointRoutes(mux, store, slog.New(slog.DiscardHandler))
+	return mux
+}
+
+// TestNearPointHandler_RequiresLatLng proves a missing or unparseable lat/lng
+// is a bodyless 400 and never reaches the store.
+func TestNearPointHandler_RequiresLatLng(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{"missing both", "/v1/applications/near-point"},
+		{"missing lng", "/v1/applications/near-point?lat=51.5"},
+		{"missing lat", "/v1/applications/near-point?lng=-0.1"},
+		{"non-numeric lat", "/v1/applications/near-point?lat=abc&lng=-0.1"},
+		{"non-numeric lng", "/v1/applications/near-point?lat=51.5&lng=xyz"},
+		{"lat out of range high", "/v1/applications/near-point?lat=91&lng=-0.1"},
+		{"lat out of range low", "/v1/applications/near-point?lat=-91&lng=-0.1"},
+		{"lng out of range high", "/v1/applications/near-point?lat=51.5&lng=181"},
+		{"lng out of range low", "/v1/applications/near-point?lat=51.5&lng=-181"},
+		{"lat is NaN literal", "/v1/applications/near-point?lat=NaN&lng=-0.1"},
+		{"lat is Inf literal", "/v1/applications/near-point?lat=Inf&lng=-0.1"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := &fakeNearPointStore{}
+			h := newNearPointTestHandler(store)
+
+			req := httptest.NewRequest(http.MethodGet, tc.url, nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400", rec.Code)
+			}
+			if rec.Body.Len() != 0 {
+				t.Errorf("body = %q, want empty (bodyless 400)", rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestNearPointHandler_ValidLatLngUsesDefaults proves a bare valid lat/lng
+// call reaches the store with the documented defaults: radius 2000m, limit
+// 100, no cursor.
+func TestNearPointHandler_ValidLatLngUsesDefaults(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeNearPointStore{}
+	h := newNearPointTestHandler(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/applications/near-point?lat=51.5&lng=-0.1", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	if store.calledLat != 51.5 || store.calledLng != -0.1 {
+		t.Errorf("store called with (%v, %v), want (51.5, -0.1)", store.calledLat, store.calledLng)
+	}
+	if store.calledRadius != nearPointDefaultRadiusMetres {
+		t.Errorf("radius = %v, want default %v", store.calledRadius, nearPointDefaultRadiusMetres)
+	}
+	if store.calledLimit != nearPointDefaultLimit {
+		t.Errorf("limit = %v, want default %v", store.calledLimit, nearPointDefaultLimit)
+	}
+	if store.calledCursor != "" {
+		t.Errorf("cursor = %q, want empty first page", store.calledCursor)
+	}
+}
+
+// TestNearPointHandler_ResponseShape proves the body is a bare JSON array of
+// NearbyResult (not wrapped in an envelope), matching the authed nearby page.
+func TestNearPointHandler_ResponseShape(t *testing.T) {
+	t.Parallel()
+
+	app := PlanningApplication{Name: "24/0001/FUL", UID: "uid-1", AreaName: "Testshire", AreaID: 100, Address: "1 Test Street"}
+	store := &fakeNearPointStore{apps: []PlanningApplication{app}}
+	h := newNearPointTestHandler(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/applications/near-point?lat=51.5&lng=-0.1", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json; charset=utf-8" {
+		t.Errorf("Content-Type = %q", ct)
+	}
+
+	var results []NearbyResult
+	if err := json.Unmarshal(rec.Body.Bytes(), &results); err != nil {
+		t.Fatalf("body is not a bare JSON array: %v; body = %s", err, rec.Body.String())
+	}
+	if len(results) != 1 || results[0].Name != app.Name || results[0].UID != app.UID {
+		t.Errorf("results = %+v, want one NearbyResult matching %+v", results, app)
+	}
+}
+
+// TestNearPointHandler_StoreError proves a store failure is a bodyless 500.
+func TestNearPointHandler_StoreError(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeNearPointStore{err: errors.New("boom")}
+	h := newNearPointTestHandler(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/applications/near-point?lat=51.5&lng=-0.1", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("body = %q, want empty (bodyless 500)", rec.Body.String())
+	}
+}

--- a/api-go/internal/applications/nearpoint_test.go
+++ b/api-go/internal/applications/nearpoint_test.go
@@ -145,6 +145,173 @@ func TestNearPointHandler_ResponseShape(t *testing.T) {
 	}
 }
 
+// TestNearPointHandler_RadiusClamping proves ?radius= is clamped into
+// [100, 5000], defaulting to 2000 when unset or unparseable, and passing a
+// genuinely in-range value straight through.
+func TestNearPointHandler_RadiusClamping(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		radius     string
+		wantRadius float64
+	}{
+		{"unset falls back to default", "", nearPointDefaultRadiusMetres},
+		{"non-numeric falls back to default", "banana", nearPointDefaultRadiusMetres},
+		{"below minimum clamps to minimum", "50", nearPointMinRadiusMetres},
+		{"zero clamps to minimum", "0", nearPointMinRadiusMetres},
+		{"negative clamps to minimum", "-500", nearPointMinRadiusMetres},
+		{"above maximum clamps to maximum", "9000", nearPointMaxRadiusMetres},
+		{"in range passes through", "1500", 1500},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := &fakeNearPointStore{}
+			h := newNearPointTestHandler(store)
+
+			url := "/v1/applications/near-point?lat=51.5&lng=-0.1"
+			if tc.name != "unset falls back to default" {
+				url += "&radius=" + tc.radius
+			}
+
+			req := httptest.NewRequest(http.MethodGet, url, nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+			}
+			if store.calledRadius != tc.wantRadius {
+				t.Errorf("radius = %v, want %v", store.calledRadius, tc.wantRadius)
+			}
+		})
+	}
+}
+
+// TestNearPointHandler_LimitClamping proves ?limit= is clamped into
+// [1, 200], defaulting to 100 when unset or unparseable, and passing a
+// genuinely in-range value straight through.
+func TestNearPointHandler_LimitClamping(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		limit     string
+		wantLimit int
+	}{
+		{"unset falls back to default", "", nearPointDefaultLimit},
+		{"non-numeric falls back to default", "banana", nearPointDefaultLimit},
+		{"zero clamps to one", "0", 1},
+		{"negative clamps to one", "-5", 1},
+		{"above maximum clamps to maximum", "500", nearPointMaxLimit},
+		{"in range passes through", "42", 42},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := &fakeNearPointStore{}
+			h := newNearPointTestHandler(store)
+
+			url := "/v1/applications/near-point?lat=51.5&lng=-0.1"
+			if tc.name != "unset falls back to default" {
+				url += "&limit=" + tc.limit
+			}
+
+			req := httptest.NewRequest(http.MethodGet, url, nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+			}
+			if store.calledLimit != tc.wantLimit {
+				t.Errorf("limit = %v, want %v", store.calledLimit, tc.wantLimit)
+			}
+		})
+	}
+}
+
+// TestNearPointHandler_CursorRoundTrip proves the store's next-page token
+// round-trips through the X-Next-Cursor response header and back through
+// ?cursor= to the exact same store call.
+func TestNearPointHandler_CursorRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeNearPointStore{nextCursor: "raw-keyset-token"}
+	h := newNearPointTestHandler(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/applications/near-point?lat=51.5&lng=-0.1", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	nextHeader := rec.Header().Get("X-Next-Cursor")
+	if nextHeader == "" {
+		t.Fatal("expected X-Next-Cursor header on a full page")
+	}
+	if nextHeader == store.nextCursor {
+		t.Error("X-Next-Cursor should be base64url-wrapped, not the raw store token")
+	}
+
+	store2 := &fakeNearPointStore{}
+	h2 := newNearPointTestHandler(store2)
+	req2 := httptest.NewRequest(http.MethodGet, "/v1/applications/near-point?lat=51.5&lng=-0.1&cursor="+nextHeader, nil)
+	rec2 := httptest.NewRecorder()
+	h2.ServeHTTP(rec2, req2)
+
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec2.Code, rec2.Body.String())
+	}
+	if store2.calledCursor != store.nextCursor {
+		t.Errorf("decoded cursor = %q, want %q", store2.calledCursor, store.nextCursor)
+	}
+}
+
+// TestNearPointHandler_CursorOmittedOnLastPage proves the header is absent
+// when the store reports no further page.
+func TestNearPointHandler_CursorOmittedOnLastPage(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeNearPointStore{}
+	h := newNearPointTestHandler(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/applications/near-point?lat=51.5&lng=-0.1", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("X-Next-Cursor"); got != "" {
+		t.Errorf("X-Next-Cursor = %q, want absent on last page", got)
+	}
+}
+
+// TestNearPointHandler_MalformedCursorIsBadRequest proves a malformed cursor
+// is rejected as a clean 400, never silently reset to page one.
+func TestNearPointHandler_MalformedCursorIsBadRequest(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeNearPointStore{}
+	h := newNearPointTestHandler(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/applications/near-point?lat=51.5&lng=-0.1&cursor=not-valid-base64url!!!", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("body = %q, want empty (bodyless 400)", rec.Body.String())
+	}
+}
+
 // TestNearPointHandler_StoreError proves a store failure is a bodyless 500.
 func TestNearPointHandler_StoreError(t *testing.T) {
 	t.Parallel()

--- a/api-go/internal/applications/nearpoint_test.go
+++ b/api-go/internal/applications/nearpoint_test.go
@@ -72,7 +72,7 @@ func TestNearPointHandler_RequiresLatLng(t *testing.T) {
 			store := &fakeNearPointStore{}
 			h := newNearPointTestHandler(store)
 
-			req := httptest.NewRequest(http.MethodGet, tc.url, nil)
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, tc.url, nil)
 			rec := httptest.NewRecorder()
 			h.ServeHTTP(rec, req)
 
@@ -95,7 +95,7 @@ func TestNearPointHandler_ValidLatLngUsesDefaults(t *testing.T) {
 	store := &fakeNearPointStore{}
 	h := newNearPointTestHandler(store)
 
-	req := httptest.NewRequest(http.MethodGet, "/v1/applications/near-point?lat=51.5&lng=-0.1", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/applications/near-point?lat=51.5&lng=-0.1", nil)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 
@@ -125,7 +125,7 @@ func TestNearPointHandler_ResponseShape(t *testing.T) {
 	store := &fakeNearPointStore{apps: []PlanningApplication{app}}
 	h := newNearPointTestHandler(store)
 
-	req := httptest.NewRequest(http.MethodGet, "/v1/applications/near-point?lat=51.5&lng=-0.1", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/applications/near-point?lat=51.5&lng=-0.1", nil)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 
@@ -176,7 +176,7 @@ func TestNearPointHandler_RadiusClamping(t *testing.T) {
 				url += "&radius=" + tc.radius
 			}
 
-			req := httptest.NewRequest(http.MethodGet, url, nil)
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
 			rec := httptest.NewRecorder()
 			h.ServeHTTP(rec, req)
 
@@ -220,7 +220,7 @@ func TestNearPointHandler_LimitClamping(t *testing.T) {
 				url += "&limit=" + tc.limit
 			}
 
-			req := httptest.NewRequest(http.MethodGet, url, nil)
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
 			rec := httptest.NewRecorder()
 			h.ServeHTTP(rec, req)
 
@@ -243,7 +243,7 @@ func TestNearPointHandler_CursorRoundTrip(t *testing.T) {
 	store := &fakeNearPointStore{nextCursor: "raw-keyset-token"}
 	h := newNearPointTestHandler(store)
 
-	req := httptest.NewRequest(http.MethodGet, "/v1/applications/near-point?lat=51.5&lng=-0.1", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/applications/near-point?lat=51.5&lng=-0.1", nil)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 
@@ -260,7 +260,7 @@ func TestNearPointHandler_CursorRoundTrip(t *testing.T) {
 
 	store2 := &fakeNearPointStore{}
 	h2 := newNearPointTestHandler(store2)
-	req2 := httptest.NewRequest(http.MethodGet, "/v1/applications/near-point?lat=51.5&lng=-0.1&cursor="+nextHeader, nil)
+	req2 := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/applications/near-point?lat=51.5&lng=-0.1&cursor="+nextHeader, nil)
 	rec2 := httptest.NewRecorder()
 	h2.ServeHTTP(rec2, req2)
 
@@ -280,7 +280,7 @@ func TestNearPointHandler_CursorOmittedOnLastPage(t *testing.T) {
 	store := &fakeNearPointStore{}
 	h := newNearPointTestHandler(store)
 
-	req := httptest.NewRequest(http.MethodGet, "/v1/applications/near-point?lat=51.5&lng=-0.1", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/applications/near-point?lat=51.5&lng=-0.1", nil)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 
@@ -300,7 +300,7 @@ func TestNearPointHandler_MalformedCursorIsBadRequest(t *testing.T) {
 	store := &fakeNearPointStore{}
 	h := newNearPointTestHandler(store)
 
-	req := httptest.NewRequest(http.MethodGet, "/v1/applications/near-point?lat=51.5&lng=-0.1&cursor=not-valid-base64url!!!", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/applications/near-point?lat=51.5&lng=-0.1&cursor=not-valid-base64url!!!", nil)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 
@@ -319,7 +319,7 @@ func TestNearPointHandler_StoreError(t *testing.T) {
 	store := &fakeNearPointStore{err: errors.New("boom")}
 	h := newNearPointTestHandler(store)
 
-	req := httptest.NewRequest(http.MethodGet, "/v1/applications/near-point?lat=51.5&lng=-0.1", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/applications/near-point?lat=51.5&lng=-0.1", nil)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 


### PR DESCRIPTION
## Changes
- New `internal/applications/nearpoint.go`: public, unauthenticated `GET /v1/applications/near-point` — nearest-first applications within a radius of a point, reusing `PostgresStore.FindNearbyPage` directly (the same KNN + `ST_DWithin` query already proven anonymous by the demo account)
- Required `lat`/`lng` (validated to [-90,90]/[-180,180], rejecting NaN/Inf — `strconv.ParseFloat` parses the literal "NaN"/"Inf" strings, so this needed an explicit finiteness check); missing/invalid → 400
- Optional `radius` (default 2000m, clamped to [100, 5000]) and `limit` (default 100, clamped to [1, 200]) — present-but-out-of-range values clamp rather than reject, matching the issue spec exactly
- Optional `cursor`, same base64url opaque-token semantics as the authed watch-zone nearby list (`watchzones.decodeCursor`/`encodeCursor`); malformed cursor is a 400, never a silent reset to page one
- Response: bare JSON array of `applications.NearbyResult` (existing DTO, no new serialization — exact parity with the authed nearby page for iOS decoding reuse), continuation token in `X-Next-Cursor` header, omitted on the last page
- 8s `context.WithTimeout`, matching `search.go`'s hardening template
- Added to `anonymousPatterns` in `cmd/api/wiring.go` — automatically covered by the Phase 1 per-IP rate limiter, no extra wiring needed there
- Deliberately a different route from `GET /v1/applications/near` (the existing X-Build-Key-gated SEO endpoint) — untouched by this PR

This is Phase 2 of #868 (anonymous browse mode), unblocked by Phase 1's per-IP rate limiting (#872). It unblocks Phase 3 (iOS anonymous browse UI, not in this PR).

Tests: unit tests with a fake store (validation matrix, clamping, cursor round-trip, response shape) plus a `//go:build integration` test against real PostGIS via the `pgtest` harness, and a wiring test asserting the route sits in `anonymousPatterns` and is reachable with no `Authorization` header.

(tc-izi96)

---
*Auto-shipped via ship skill*