### PR TITLE
chore(ios): bump MARKETING_VERSION 1.2.6 -> 1.2.7

### DIFF
--- a/mobile/ios/project.yml
+++ b/mobile/ios/project.yml
@@ -26,7 +26,7 @@ targets:
         DEVELOPMENT_TEAM: 4574VQ7N2X
         TARGETED_DEVICE_FAMILY: "1"
         INFOPLIST_GENERATION_MODE: GeneratedFile
-        MARKETING_VERSION: "1.2.6"
+        MARKETING_VERSION: "1.2.7"
         CURRENT_PROJECT_VERSION: "1"
         GENERATE_INFOPLIST_FILE: "YES"
         INFOPLIST_KEY_UIApplicationSceneManifest_Generation: "YES"


### PR DESCRIPTION
## Changes
- Bump `MARKETING_VERSION` in `mobile/ios/project.yml` from `1.2.6` to `1.2.7`

1.2.6 shipped to the live App Store, closing the TestFlight pre-release train. `cd-ios-testflight` has 409'd twice in a row (v0.16.1, v0.16.2) with `Invalid Pre-Release Train: train version '1.2.6' is closed for new build submissions`. Bumping the marketing version opens a new train so the pending v0.16.3 TestFlight upload (and any future one) can succeed.

(tc-1t58p)

---
*Auto-shipped via ship skill*