### PR TITLE
feat(ios): cluster anonymous map pins + live radius picker before signup

### DIFF
--- a/mobile/ios/packages/town-crier-data/Sources/AnonymousBrowse/UserDefaultsAnonymousBrowseStateRepository.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/AnonymousBrowse/UserDefaultsAnonymousBrowseStateRepository.swift
@@ -24,6 +24,7 @@ public final class UserDefaultsAnonymousBrowseStateRepository: AnonymousBrowseSt
     return AnonymousBrowseState(
       postcode: postcode,
       coordinate: coordinate,
+      radiusMetres: stored.radiusMetres,
       createdAt: Date(timeIntervalSince1970: stored.createdAt)
     )
   }
@@ -33,6 +34,7 @@ public final class UserDefaultsAnonymousBrowseStateRepository: AnonymousBrowseSt
       postcode: state.postcode.value,
       latitude: state.coordinate.latitude,
       longitude: state.coordinate.longitude,
+      radiusMetres: state.radiusMetres,
       createdAt: state.createdAt.timeIntervalSince1970
     )
     guard let data = try? encoder.encode(stored) else { return }
@@ -50,6 +52,33 @@ public final class UserDefaultsAnonymousBrowseStateRepository: AnonymousBrowseSt
     let postcode: String
     let latitude: Double
     let longitude: Double
+    let radiusMetres: Double
     let createdAt: TimeInterval
+
+    private enum CodingKeys: String, CodingKey {
+      case postcode, latitude, longitude, radiusMetres, createdAt
+    }
+
+    init(postcode: String, latitude: Double, longitude: Double, radiusMetres: Double, createdAt: TimeInterval) {
+      self.postcode = postcode
+      self.latitude = latitude
+      self.longitude = longitude
+      self.radiusMetres = radiusMetres
+      self.createdAt = createdAt
+    }
+
+    /// Custom decode so a blob saved before `radiusMetres` existed (GH#868
+    /// Phase 3, pre-refinement) still loads — a live TestFlight tester's
+    /// already-persisted anonymous session shouldn't be silently dropped by
+    /// this change. Falls back to the same 2000m default
+    /// `AnonymousBrowseState` itself seeds.
+    init(from decoder: Decoder) throws {
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+      postcode = try container.decode(String.self, forKey: .postcode)
+      latitude = try container.decode(Double.self, forKey: .latitude)
+      longitude = try container.decode(Double.self, forKey: .longitude)
+      createdAt = try container.decode(TimeInterval.self, forKey: .createdAt)
+      radiusMetres = try container.decodeIfPresent(Double.self, forKey: .radiusMetres) ?? 2000
+    }
   }
 }

--- a/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/AnonymousBrowseState.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/AnonymousBrowseState.swift
@@ -11,11 +11,20 @@ import Foundation
 public struct AnonymousBrowseState: Equatable, Sendable {
   public let postcode: Postcode
   public let coordinate: Coordinate
+  /// The live monitoring radius the user chose on the anonymous map before
+  /// signing up (GH#868 Phase 3 refinement), carried into onboarding so the
+  /// wizard's radius step lands pre-set rather than reset to a default.
+  /// Defaults to 2000m (the free tier's cap) for the brief window between
+  /// postcode resolution and the user's first radius-slider interaction.
+  public let radiusMetres: Double
   public let createdAt: Date
 
-  public init(postcode: Postcode, coordinate: Coordinate, createdAt: Date) {
+  public init(
+    postcode: Postcode, coordinate: Coordinate, radiusMetres: Double = 2000, createdAt: Date
+  ) {
     self.postcode = postcode
     self.coordinate = coordinate
+    self.radiusMetres = radiusMetres
     self.createdAt = createdAt
   }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+Onboarding.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+Onboarding.swift
@@ -60,7 +60,8 @@ extension AppCoordinator {
     // Anonymous state is cleared immediately after so a future sign-out
     // starts from the welcome screen, not a stale anonymous map.
     if let anonymousBrowseStateRepository, let state = anonymousBrowseStateRepository.load() {
-      viewModel.prefill(postcode: state.postcode, coordinate: state.coordinate)
+      viewModel.prefill(
+        postcode: state.postcode, coordinate: state.coordinate, radiusMetres: state.radiusMetres)
       anonymousBrowseStateRepository.clear()
     }
 

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousBrowseCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousBrowseCoordinator.swift
@@ -27,6 +27,10 @@ public final class AnonymousBrowseCoordinator: ObservableObject {
   private let geocoder: PostcodeGeocoder
   private let stateRepository: AnonymousBrowseStateRepository
   private let applicationsRepository: AnonymousApplicationsRepository
+  /// The state backing the current map session, kept in sync with the live
+  /// radius picker so a slider drag re-persists the postcode/coordinate
+  /// alongside the newly chosen radius (GH#868 Phase 3 refinement).
+  private var currentState: AnonymousBrowseState?
 
   /// Fired by "I already have an account", the postcode-entry back button's
   /// sibling CTA paths, and the map's CTA banner / deeper-action taps — all
@@ -48,8 +52,9 @@ public final class AnonymousBrowseCoordinator: ObservableObject {
     // Relaunch persistence (GH#868 Phase 3.5): a saved anonymous session
     // routes straight to the map, never back through welcome.
     if let state = stateRepository.load() {
+      currentState = state
       screen = .map
-      mapViewModel = makeMapViewModel(coordinate: state.coordinate)
+      mapViewModel = makeMapViewModel(state: state)
     }
   }
 
@@ -66,7 +71,8 @@ public final class AnonymousBrowseCoordinator: ObservableObject {
     viewModel.onBack = { [weak self] in self?.screen = .welcome }
     viewModel.onResolved = { [weak self] state in
       guard let self else { return }
-      mapViewModel = makeMapViewModel(coordinate: state.coordinate)
+      currentState = state
+      mapViewModel = makeMapViewModel(state: state)
       screen = .map
     }
     return viewModel
@@ -79,14 +85,34 @@ public final class AnonymousBrowseCoordinator: ObservableObject {
   /// never anonymous before signing in).
   public func reset() {
     stateRepository.clear()
+    currentState = nil
     mapViewModel = nil
     screen = .welcome
   }
 
-  private func makeMapViewModel(coordinate: Coordinate) -> AnonymousMapViewModel {
+  private func makeMapViewModel(state: AnonymousBrowseState) -> AnonymousMapViewModel {
     let viewModel = AnonymousMapViewModel(
-      repository: applicationsRepository, coordinate: coordinate)
+      repository: applicationsRepository,
+      coordinate: state.coordinate,
+      radiusMetres: state.radiusMetres)
     viewModel.onRequestSignUp = { [weak self] in self?.onRequestSignIn?() }
+    viewModel.onRadiusChanged = { [weak self] radius in self?.persistRadius(radius) }
     return viewModel
+  }
+
+  /// Re-saves the current session's postcode/coordinate with a newly chosen
+  /// radius (GH#868 Phase 3 refinement) so the post-signup handoff into
+  /// onboarding carries whatever the user last picked. No-op if called
+  /// before any state exists (shouldn't happen: the radius picker only shows
+  /// once the map — and therefore `currentState` — exists).
+  private func persistRadius(_ radiusMetres: Double) {
+    guard let state = currentState else { return }
+    let updated = AnonymousBrowseState(
+      postcode: state.postcode,
+      coordinate: state.coordinate,
+      radiusMetres: radiusMetres,
+      createdAt: state.createdAt)
+    currentState = updated
+    stateRepository.save(updated)
   }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousClusteredMapView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousClusteredMapView.swift
@@ -1,0 +1,262 @@
+#if canImport(UIKit)
+  import MapKit
+  import SwiftUI
+  import TownCrierDomain
+
+  /// A UIKit `MKMapView` wrapped for SwiftUI that renders the anonymous map's
+  /// pins with MapKit's built-in CLIENT-SIDE clustering (`clusteringIdentifier`)
+  /// — unlike the authenticated map's `ClusteredMapView`, which renders
+  /// server-computed cluster aggregates. near-point returns at most 200
+  /// individual points (GH#868 Phase 2), a small enough set that on-device
+  /// grid clustering is correct and needs no new backend endpoint (GH#868
+  /// Phase 3 refinement).
+  ///
+  /// Reuses `ClusteredMapView`'s visual language (amber count bubble,
+  /// status-coloured single pin, `MKCircle` radius overlay) without touching
+  /// that file — the anonymous surface is a deliberately reduced,
+  /// self-contained screen (see `AnonymousMapView`'s header).
+  @MainActor
+  struct AnonymousClusteredMapView: UIViewRepresentable {
+    /// Observed so `updateUIView` re-runs whenever the ViewModel publishes —
+    /// a refetch, a selection, a radius-slider drag. A plain stored reference
+    /// is NOT enough: SwiftUI treats the representable as unchanged when its
+    /// only stored property is the same `AnonymousMapViewModel` instance, so
+    /// it skips `updateUIView` and new pins/radius changes never reach the
+    /// map (mirrors `ClusteredMapView`).
+    @ObservedObject var viewModel: AnonymousMapViewModel
+
+    static let markerReuseIdentifier = "anonymous-planning-application"
+    static let clusteringIdentifier = "anonymous-planning-application-cluster"
+
+    func makeCoordinator() -> Coordinator {
+      Coordinator(viewModel: viewModel)
+    }
+
+    func makeUIView(context: Context) -> MKMapView {
+      let mapView = MKMapView()
+      mapView.delegate = context.coordinator
+      mapView.pointOfInterestFilter = .excludingAll
+      mapView.register(
+        MKMarkerAnnotationView.self,
+        forAnnotationViewWithReuseIdentifier: Self.markerReuseIdentifier)
+
+      let coordinator = context.coordinator
+      coordinator.frameCamera(
+        on: mapView,
+        centre: Self.coordinate(for: viewModel.anchorCoordinate),
+        radius: viewModel.selectedRadiusMetres,
+        animated: false)
+      coordinator.syncAnnotations(on: mapView, desired: viewModel.applications)
+      coordinator.applyRadiusOverlay(
+        to: mapView,
+        anchor: viewModel.anchorCoordinate,
+        radius: viewModel.selectedRadiusMetres)
+      return mapView
+    }
+
+    func updateUIView(_ mapView: MKMapView, context: Context) {
+      let coordinator = context.coordinator
+      coordinator.syncAnnotations(on: mapView, desired: viewModel.applications)
+      coordinator.applyRadiusOverlay(
+        to: mapView,
+        anchor: viewModel.anchorCoordinate,
+        radius: viewModel.selectedRadiusMetres)
+      // Reframe only when the selected radius actually changed, so a pin
+      // refetch (pan/zoom exploring) never yanks the user's current viewport
+      // back — mirrors `ClusteredMapView.frameCameraIfZoneChanged`.
+      coordinator.reframeIfRadiusChanged(
+        on: mapView,
+        centre: Self.coordinate(for: viewModel.anchorCoordinate),
+        radius: viewModel.selectedRadiusMetres)
+    }
+
+    static func coordinate(for coordinate: Coordinate) -> CLLocationCoordinate2D {
+      CLLocationCoordinate2D(latitude: coordinate.latitude, longitude: coordinate.longitude)
+    }
+  }
+
+  extension AnonymousClusteredMapView {
+    /// `MKMapViewDelegate` for ``AnonymousClusteredMapView``. Styles individual
+    /// and MapKit-synthesised cluster markers, routes a single-pin tap to
+    /// ``AnonymousMapViewModel/selectApplication(_:)`` and a cluster tap to a
+    /// zoom-in (MapKit's own clustering re-splits the group at the finer zoom
+    /// level — there is no server-side "stacked/unsplittable" concept here),
+    /// renders the radius preview circle, and forwards viewport changes to
+    /// ``AnonymousMapViewModel/regionDidChange(centreLat:centreLon:radiusMetres:)``,
+    /// which debounces internally.
+    @MainActor
+    final class Coordinator: NSObject, MKMapViewDelegate {
+      private let viewModel: AnonymousMapViewModel
+
+      /// The radius the camera is currently framed on, so a pin refetch never
+      /// reframes — only an actual radius-slider change does.
+      private var framedRadius: Double?
+      /// The currently-rendered radius circle and the radius it was drawn
+      /// for, so it's redrawn only when the radius actually changes.
+      private var radiusOverlay: MKCircle?
+      private var renderedRadius: Double?
+
+      init(viewModel: AnonymousMapViewModel) {
+        self.viewModel = viewModel
+      }
+
+      // MARK: - Annotation diffing
+
+      /// Applies only the delta between the displayed pins and `desired` — at
+      /// most 200 points, so a full diff stays cheap.
+      func syncAnnotations(on mapView: MKMapView, desired: [PlanningApplication]) {
+        let current = mapView.annotations.compactMap { $0 as? AnonymousApplicationAnnotation }
+        let currentIds = Set(current.map(\.applicationId))
+        let desiredById = Dictionary(
+          uniqueKeysWithValues: desired.compactMap { application in
+            application.location != nil ? (application.id, application) : nil
+          })
+
+        let toRemove = current.filter { !desiredById.keys.contains($0.applicationId) }
+        if !toRemove.isEmpty {
+          mapView.removeAnnotations(toRemove)
+        }
+
+        let toAdd =
+          desiredById.values
+          .filter { !currentIds.contains($0.id) }
+          .compactMap(AnonymousApplicationAnnotation.init(application:))
+        if !toAdd.isEmpty {
+          mapView.addAnnotations(toAdd)
+        }
+      }
+
+      // MARK: - Radius overlay
+
+      func applyRadiusOverlay(to mapView: MKMapView, anchor: Coordinate, radius: Double) {
+        if renderedRadius == radius {
+          return
+        }
+        if let radiusOverlay {
+          mapView.removeOverlay(radiusOverlay)
+        }
+        let circle = MKCircle(
+          center: AnonymousClusteredMapView.coordinate(for: anchor), radius: radius)
+        mapView.addOverlay(circle, level: .aboveRoads)
+        radiusOverlay = circle
+        renderedRadius = radius
+      }
+
+      // MARK: - Camera framing
+
+      func frameCamera(
+        on mapView: MKMapView, centre: CLLocationCoordinate2D, radius: Double, animated: Bool
+      ) {
+        // Span 2.5x the radius so the whole circle plus a margin is visible.
+        let region = MKCoordinateRegion(
+          center: centre, latitudinalMeters: radius * 2.5, longitudinalMeters: radius * 2.5)
+        mapView.setRegion(region, animated: animated)
+        framedRadius = radius
+      }
+
+      func reframeIfRadiusChanged(
+        on mapView: MKMapView, centre: CLLocationCoordinate2D, radius: Double
+      ) {
+        guard radius != framedRadius else { return }
+        frameCamera(on: mapView, centre: centre, radius: radius, animated: true)
+      }
+
+      // MARK: - MKMapViewDelegate
+
+      func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
+        if annotation is MKUserLocation { return nil }
+        let view = mapView.dequeueReusableAnnotationView(
+          withIdentifier: AnonymousClusteredMapView.markerReuseIdentifier, for: annotation)
+        guard let marker = view as? MKMarkerAnnotationView else { return view }
+        marker.canShowCallout = false
+
+        if let cluster = annotation as? MKClusterAnnotation {
+          // Brand amber: a cluster is a navigational aggregate, not a status,
+          // so it takes the design system's brand accent rather than any
+          // `tcStatus*` colour (which would falsely imply a single status for
+          // the group) — mirrors `ClusteredMapView`.
+          marker.markerTintColor = UIColor(Color.tcAmber)
+          marker.glyphImage = nil
+          marker.glyphText = Self.bubbleGlyph(for: cluster.memberAnnotations.count)
+          marker.displayPriority = .required
+        } else if let point = annotation as? AnonymousApplicationAnnotation {
+          marker.clusteringIdentifier = AnonymousClusteredMapView.clusteringIdentifier
+          marker.markerTintColor = UIColor(point.status.displayColor)
+          marker.glyphText = nil
+          marker.glyphImage = UIImage(systemName: "mappin.circle.fill")
+          marker.displayPriority = .defaultHigh
+        }
+        return marker
+      }
+
+      /// The count shown inside an amber bubble, capped so a fully-zoomed-out
+      /// dense cluster stays legible.
+      private static func bubbleGlyph(for count: Int) -> String {
+        count > 999 ? "999+" : "\(count)"
+      }
+
+      func mapView(_ mapView: MKMapView, didSelect view: MKAnnotationView) {
+        guard let annotation = view.annotation else { return }
+        mapView.deselectAnnotation(annotation, animated: false)
+
+        if let cluster = annotation as? MKClusterAnnotation {
+          // MapKit's own clustering re-splits the group once the map zooms in
+          // far enough — there is no server-side "unsplittable/stacked" case
+          // to special-case here (unlike `ClusteredMapView`).
+          var region = mapView.region
+          region.center = cluster.coordinate
+          region.span = MKCoordinateSpan(
+            latitudeDelta: max(region.span.latitudeDelta / 2, 0.0005),
+            longitudeDelta: max(region.span.longitudeDelta / 2, 0.0005))
+          mapView.setRegion(region, animated: true)
+        } else if let point = annotation as? AnonymousApplicationAnnotation {
+          viewModel.selectApplication(point.application)
+        }
+      }
+
+      func mapView(_ mapView: MKMapView, regionDidChangeAnimated animated: Bool) {
+        // `AnonymousMapViewModel.regionDidChange` debounces internally
+        // (cancels/reschedules its own pending fetch), so forwarding every
+        // intermediate `regionDidChangeAnimated` call here still collapses to
+        // one fetch once a pan/zoom gesture settles.
+        let region = mapView.region
+        let span = max(region.span.latitudeDelta, region.span.longitudeDelta)
+        viewModel.regionDidChange(
+          centreLat: region.center.latitude,
+          centreLon: region.center.longitude,
+          radiusMetres: span * 111_320 / 2)
+      }
+
+      func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
+        guard let circle = overlay as? MKCircle else {
+          return MKOverlayRenderer(overlay: overlay)
+        }
+        let renderer = MKCircleRenderer(circle: circle)
+        renderer.strokeColor = UIColor(Color.tcAmber.opacity(0.3))
+        renderer.fillColor = UIColor(Color.tcAmber.opacity(0.08))
+        renderer.lineWidth = 1.5
+        return renderer
+      }
+    }
+  }
+
+  /// A reference-type `MKAnnotation` wrapping a value-type `PlanningApplication`
+  /// so MapKit can hold it and cluster it client-side. Carries the application
+  /// the coordinator needs to style the marker and route a tap. Fails to
+  /// initialise for an application with no `location` — such applications are
+  /// filtered out before reaching the map.
+  final class AnonymousApplicationAnnotation: NSObject, MKAnnotation {
+    let application: PlanningApplication
+    let applicationId: PlanningApplicationId
+    let coordinate: CLLocationCoordinate2D
+    var status: ApplicationStatus { application.status }
+
+    init?(application: PlanningApplication) {
+      guard let location = application.location else { return nil }
+      self.application = application
+      self.applicationId = application.id
+      self.coordinate = CLLocationCoordinate2D(
+        latitude: location.latitude, longitude: location.longitude)
+    }
+  }
+#endif

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMapView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMapView.swift
@@ -3,43 +3,61 @@ import SwiftUI
 import TownCrierDomain
 
 /// The anonymous (pre-signup) map (GH#868 Phase 3) — the only screen in
-/// anonymous mode: no tab bar, no list, no settings, no clustering. Centred on
-/// the stored coordinate, fetches pins via ``AnonymousMapViewModel``, and pins
-/// a persistent ``AccountCTABanner`` above the bottom safe area. A pin tap
-/// shows a reduced-feature summary preview; anything deeper routes to
+/// anonymous mode: no tab bar, no list, no settings. Centred on the stored
+/// coordinate, fetches pins via ``AnonymousMapViewModel``, clusters them
+/// on-device (GH#868 Phase 3 refinement), and pins a persistent
+/// ``AccountCTABanner`` — with a live monitoring-radius picker above it — over
+/// the bottom safe area. A pin tap shows a reduced-feature summary preview; a
+/// cluster tap zooms in; anything deeper than the summary preview routes to
 /// sign-up.
 ///
-/// A self-contained SwiftUI `Map` rather than the authenticated `MapView`'s
-/// `ClusteredMapView` (`MKMapView` + clustering delegate): the anonymous
-/// surface is deliberately a reduced feature set, so a smaller parallel view
-/// is lower risk than widening the authenticated map's machinery behind a new
-/// shared protocol. See the Phase 3 handoff notes for the full rationale.
+/// On iOS, pins render via ``AnonymousClusteredMapView`` (`MKMapView` +
+/// MapKit's built-in client-side clustering — near-point returns at most 200
+/// points, so on-device clustering is correct with no new backend endpoint).
+/// On macOS (the SPM compile target for `swift build`/`swift test`, which has
+/// no UIKit), a SwiftUI `Map` fallback plots pins directly with no clustering
+/// — mirrors the authenticated `MapView`'s dual-path pattern.
 public struct AnonymousMapView: View {
   @StateObject private var viewModel: AnonymousMapViewModel
-  @State private var cameraPosition: MapCameraPosition
+  #if !canImport(UIKit)
+    @State private var cameraPosition: MapCameraPosition
+  #endif
 
   public init(viewModel: AnonymousMapViewModel) {
     _viewModel = StateObject(wrappedValue: viewModel)
-    _cameraPosition = State(
-      initialValue: .region(
-        MKCoordinateRegion(
-          center: CLLocationCoordinate2D(
-            latitude: viewModel.centreLat, longitude: viewModel.centreLon),
-          latitudinalMeters: viewModel.radiusMetres * 2.5,
-          longitudinalMeters: viewModel.radiusMetres * 2.5
-        )))
+    #if !canImport(UIKit)
+      _cameraPosition = State(
+        initialValue: .region(
+          MKCoordinateRegion(
+            center: CLLocationCoordinate2D(
+              latitude: viewModel.anchorCoordinate.latitude,
+              longitude: viewModel.anchorCoordinate.longitude),
+            latitudinalMeters: viewModel.selectedRadiusMetres * 2.5,
+            longitudinalMeters: viewModel.selectedRadiusMetres * 2.5
+          )))
+    #endif
   }
 
   public var body: some View {
     ZStack(alignment: .bottom) {
       mapBody
-      AccountCTABanner(
-        onCreateAccount: { viewModel.requestSignUp() },
-        onSignIn: { viewModel.requestSignUp() }
-      )
+      VStack(spacing: TCSpacing.small) {
+        radiusPickerCard
+        AccountCTABanner(
+          onCreateAccount: { viewModel.requestSignUp() },
+          onSignIn: { viewModel.requestSignUp() }
+        )
+      }
     }
     .background(Color.tcBackground)
     .task { await viewModel.loadInitial() }
+    #if !canImport(UIKit)
+      .onChange(of: viewModel.selectedRadiusMetres) { _, _ in
+        withAnimation {
+          updateCameraPosition()
+        }
+      }
+    #endif
     .sheet(
       item: Binding(
         get: { viewModel.selectedApplication },
@@ -52,39 +70,49 @@ public struct AnonymousMapView: View {
     }
   }
 
-  private var mapBody: some View {
-    Map(position: $cameraPosition) {
-      ForEach(viewModel.applications) { application in
-        if let location = application.location {
-          Annotation(
-            application.reference.value,
-            coordinate: CLLocationCoordinate2D(
-              latitude: location.latitude, longitude: location.longitude),
-            anchor: .bottom
-          ) {
-            pin(for: application)
-              .onTapGesture { viewModel.selectApplication(application) }
-          }
-        }
-      }
-    }
-    .mapStyle(.standard(elevation: .flat))
-    .onMapCameraChange(frequency: .onEnd) { context in
-      let span = max(context.region.span.latitudeDelta, context.region.span.longitudeDelta)
-      viewModel.regionDidChange(
-        centreLat: context.region.center.latitude,
-        centreLon: context.region.center.longitude,
-        // Half the span's on-the-ground metres, matching MapViewModel's own
-        // degrees-to-metres approximation for a rough "visible radius".
-        radiusMetres: span * 111_320 / 2
+  // MARK: - Radius picker
+
+  /// Live monitoring-radius `Slider`, mirroring `RadiusPickerStepView`'s
+  /// paradigm (same `formatRadius` label, `tcAmber` tint) so the anonymous
+  /// preview and the post-signup wizard feel like one continuous control.
+  private var radiusPickerCard: some View {
+    VStack(spacing: TCSpacing.small) {
+      Text(formatRadius(viewModel.selectedRadiusMetres))
+        .font(TCTypography.bodyEmphasis)
+        .foregroundStyle(Color.tcTextPrimary)
+
+      Slider(
+        value: Binding(
+          get: { viewModel.selectedRadiusMetres },
+          set: { viewModel.updateSelectedRadius($0) }
+        ),
+        in: AnonymousMapViewModel.minSelectedRadiusMetres...AnonymousMapViewModel
+          .maxSelectedRadiusMetres,
+        step: 100
       )
+      .tint(Color.tcAmber)
+      .accessibilityLabel("Monitoring radius")
+      .accessibilityValue(formatRadius(viewModel.selectedRadiusMetres))
     }
-    .overlay {
+    .padding(TCSpacing.medium)
+    .background(Color.tcSurfaceElevated)
+    .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.large))
+    .padding(.horizontal, TCSpacing.medium)
+  }
+
+  // MARK: - Map body
+
+  private var mapBody: some View {
+    ZStack {
+      #if canImport(UIKit)
+        AnonymousClusteredMapView(viewModel: viewModel)
+          .ignoresSafeArea(edges: .bottom)
+      #else
+        macOSMapContent
+      #endif
       if viewModel.isLoading && viewModel.applications.isEmpty {
         ProgressView()
       }
-    }
-    .overlay {
       if let error = viewModel.error, viewModel.applications.isEmpty {
         ErrorStateView(error: error) {
           await viewModel.loadInitial()
@@ -94,15 +122,72 @@ public struct AnonymousMapView: View {
     }
   }
 
-  private func pin(for application: PlanningApplication) -> some View {
-    Image(systemName: "mappin.circle.fill")
-      .font(.system(.title2))
-      .foregroundStyle(application.status.displayColor)
-      .background(
-        Circle()
-          .fill(Color.tcSurface)
-          .frame(width: 20, height: 20)
+  // MARK: - macOS SwiftUI Map fallback (not compiled on iOS)
+
+  #if !canImport(UIKit)
+    @ViewBuilder
+    private var macOSMapContent: some View {
+      Map(position: $cameraPosition) {
+        ForEach(viewModel.applications) { application in
+          if let location = application.location {
+            Annotation(
+              application.reference.value,
+              coordinate: CLLocationCoordinate2D(
+                latitude: location.latitude, longitude: location.longitude),
+              anchor: .bottom
+            ) {
+              pin(for: application)
+                .onTapGesture { viewModel.selectApplication(application) }
+            }
+          }
+        }
+
+        MapCircle(
+          center: CLLocationCoordinate2D(
+            latitude: viewModel.anchorCoordinate.latitude,
+            longitude: viewModel.anchorCoordinate.longitude
+          ),
+          radius: viewModel.selectedRadiusMetres
+        )
+        .foregroundStyle(Color.tcAmber.opacity(0.08))
+        .stroke(Color.tcAmber.opacity(0.3), lineWidth: 1.5)
+      }
+      .mapStyle(.standard(elevation: .flat))
+      .onMapCameraChange(frequency: .onEnd) { context in
+        let span = max(context.region.span.latitudeDelta, context.region.span.longitudeDelta)
+        viewModel.regionDidChange(
+          centreLat: context.region.center.latitude,
+          centreLon: context.region.center.longitude,
+          // Half the span's on-the-ground metres, matching MapViewModel's own
+          // degrees-to-metres approximation for a rough "visible radius".
+          radiusMetres: span * 111_320 / 2
+        )
+      }
+    }
+
+    private func pin(for application: PlanningApplication) -> some View {
+      Image(systemName: "mappin.circle.fill")
+        .font(.system(.title2))
+        .foregroundStyle(application.status.displayColor)
+        .background(
+          Circle()
+            .fill(Color.tcSurface)
+            .frame(width: 20, height: 20)
+        )
+        .accessibilityLabel(application.status.displayLabel)
+    }
+
+    private func updateCameraPosition() {
+      cameraPosition = .region(
+        MKCoordinateRegion(
+          center: CLLocationCoordinate2D(
+            latitude: viewModel.anchorCoordinate.latitude,
+            longitude: viewModel.anchorCoordinate.longitude
+          ),
+          latitudinalMeters: viewModel.selectedRadiusMetres * 2.5,
+          longitudinalMeters: viewModel.selectedRadiusMetres * 2.5
+        )
       )
-      .accessibilityLabel(application.status.displayLabel)
-  }
+    }
+  #endif
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMapViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMapViewModel.swift
@@ -15,6 +15,13 @@ public final class AnonymousMapViewModel: ObservableObject, ErrorHandlingViewMod
   @Published public private(set) var centreLat: Double
   @Published public private(set) var centreLon: Double
   @Published public private(set) var radiusMetres: Double
+  /// The user-chosen live monitoring radius (GH#868 Phase 3 refinement),
+  /// decoupled from `radiusMetres`: this one drives the drawn preview circle
+  /// and is carried into onboarding, while `radiusMetres` drives the
+  /// viewport-following near-point fetch as the user pans/zooms — mirrors
+  /// the authenticated map, where the zone circle is fixed while pins follow
+  /// the viewport.
+  @Published public private(set) var selectedRadiusMetres: Double
 
   /// Mirrors the near-point endpoint's own [100, 5000]m clamp client-side
   /// (GH#868 Phase 2), so a pan/zoom gesture never requests a radius the
@@ -22,6 +29,20 @@ public final class AnonymousMapViewModel: ObservableObject, ErrorHandlingViewMod
   public static let minRadiusMetres: Double = 100
   public static let maxRadiusMetres: Double = 5000
   public static let defaultLimit = 200
+
+  /// The live radius picker's bounds. The upper bound mirrors the free
+  /// tier's cap (`WatchZoneLimits(tier: .free).maxRadiusMetres`), so the
+  /// radius an anonymous user picks here is exactly what a free account gets
+  /// after signup — never a false preview of a bigger zone than they can
+  /// actually have.
+  public static let minSelectedRadiusMetres: Double = 100
+  public static let maxSelectedRadiusMetres: Double = WatchZoneLimits(tier: .free).maxRadiusMetres
+
+  /// The postcode-resolved point the radius preview circle is drawn around
+  /// and the camera reframes to. Fixed for the view model's lifetime, unlike
+  /// `centreLat`/`centreLon`, which follow the viewport as the user pans/
+  /// zooms.
+  public let anchorCoordinate: Coordinate
 
   private let repository: AnonymousApplicationsRepository
   private let debounceNanoseconds: UInt64
@@ -32,6 +53,11 @@ public final class AnonymousMapViewModel: ObservableObject, ErrorHandlingViewMod
   /// such features itself, so every one of them routes to sign-up instead.
   public var onRequestSignUp: (() -> Void)?
 
+  /// Fired whenever the live radius picker changes, so the coordinator can
+  /// persist the chosen radius into `AnonymousBrowseState` ahead of the
+  /// post-signup handoff into onboarding (GH#868 Phase 3 refinement).
+  public var onRadiusChanged: ((Double) -> Void)?
+
   public init(
     repository: AnonymousApplicationsRepository,
     coordinate: Coordinate,
@@ -41,7 +67,9 @@ public final class AnonymousMapViewModel: ObservableObject, ErrorHandlingViewMod
     self.repository = repository
     self.centreLat = coordinate.latitude
     self.centreLon = coordinate.longitude
+    self.anchorCoordinate = coordinate
     self.radiusMetres = radiusMetres
+    self.selectedRadiusMetres = Self.clampSelectedRadius(radiusMetres)
     self.debounceNanoseconds = debounceNanoseconds
   }
 
@@ -62,9 +90,9 @@ public final class AnonymousMapViewModel: ObservableObject, ErrorHandlingViewMod
     self.radiusMetres = clampedRadius
 
     pendingRegionChangeTask?.cancel()
-    let debounceNanoseconds = self.debounceNanoseconds
+    let debounceDuration = debounceNanoseconds
     pendingRegionChangeTask = Task { [weak self] in
-      try? await Task.sleep(nanoseconds: debounceNanoseconds)
+      try? await Task.sleep(nanoseconds: debounceDuration)
       guard !Task.isCancelled else { return }
       await self?.fetch(latitude: centreLat, longitude: centreLon, radiusMetres: clampedRadius)
     }
@@ -111,5 +139,18 @@ public final class AnonymousMapViewModel: ObservableObject, ErrorHandlingViewMod
   /// features.
   public func requestSignUp() {
     onRequestSignUp?()
+  }
+
+  /// Updates the live radius picker, clamping to
+  /// `[minSelectedRadiusMetres, maxSelectedRadiusMetres]` and notifying
+  /// `onRadiusChanged` so the coordinator can persist it. Called from the
+  /// map's radius `Slider` (GH#868 Phase 3 refinement).
+  public func updateSelectedRadius(_ metres: Double) {
+    selectedRadiusMetres = Self.clampSelectedRadius(metres)
+    onRadiusChanged?(selectedRadiusMetres)
+  }
+
+  private static func clampSelectedRadius(_ metres: Double) -> Double {
+    min(max(metres, minSelectedRadiusMetres), maxSelectedRadiusMetres)
   }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/OnboardingViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/OnboardingViewModel.swift
@@ -92,17 +92,22 @@ public final class OnboardingViewModel: ObservableObject, ErrorHandlingViewModel
     }
   }
 
-  /// Seeds the wizard's postcode/coordinate from an already-resolved location
-  /// and jumps straight to the radius step, skipping postcode entry a second
-  /// time. Used for the anonymous browse post-signup handoff (GH#868 Phase
-  /// 3.5): a user who located themselves before creating an account
-  /// shouldn't be asked for their postcode again. Additive — the normal
-  /// (non-prefilled) flow through `.postcodeEntry` -> ``submitPostcode()`` is
-  /// unchanged for every other caller.
-  public func prefill(postcode: Postcode, coordinate: Coordinate) {
+  /// Seeds the wizard's postcode/coordinate/radius from an already-resolved
+  /// anonymous browse session and jumps straight to the radius step,
+  /// skipping postcode entry a second time. Used for the anonymous browse
+  /// post-signup handoff (GH#868 Phase 3.5, radius carried through in the
+  /// Phase 3 refinement): a user who located themselves — and picked a live
+  /// monitoring radius — before creating an account shouldn't be asked for
+  /// either again. `radiusMetres` is clamped to `[100, maxRadiusMetres]` so a
+  /// stale or legacy persisted value can never land outside the radius
+  /// step's own slider bounds. Additive — the normal (non-prefilled) flow
+  /// through `.postcodeEntry` -> ``submitPostcode()`` is unchanged for every
+  /// other caller.
+  public func prefill(postcode: Postcode, coordinate: Coordinate, radiusMetres: Double) {
     postcodeInput = postcode.value
     validatedPostcode = postcode
     geocodedCoordinate = coordinate
+    selectedRadiusMetres = min(max(radiusMetres, 100), maxRadiusMetres)
     currentStep = .radiusPicker
   }
 

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousBrowseCoordinatorTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousBrowseCoordinatorTests.swift
@@ -107,6 +107,42 @@ struct AnonymousBrowseCoordinatorTests {
     #expect(requested)
   }
 
+  // MARK: - Live radius picker persistence (GH#868 Phase 3 refinement)
+
+  @Test func mapViewModel_radiusChange_persistsUpdatedStateWithSamePostcodeAndCoordinate() {
+    let (sut, _, stateRepository, _) = makeSUT(persistedState: testState)
+
+    sut.mapViewModel?.updateSelectedRadius(1500)
+
+    #expect(stateRepository.saveCalls.last?.radiusMetres == 1500)
+    #expect(stateRepository.saveCalls.last?.postcode == testState.postcode)
+    #expect(stateRepository.saveCalls.last?.coordinate == testState.coordinate)
+  }
+
+  @Test func postcodeEntryViewModel_onResolved_thenRadiusChange_persistsAgainstResolvedState() {
+    let (sut, _, stateRepository, _) = makeSUT()
+    let postcodeVM = sut.makePostcodeEntryViewModel()
+    postcodeVM.onResolved?(testState)
+
+    sut.mapViewModel?.updateSelectedRadius(500)
+
+    #expect(stateRepository.saveCalls.last?.radiusMetres == 500)
+    #expect(stateRepository.saveCalls.last?.postcode == testState.postcode)
+  }
+
+  @Test func init_withPersistedState_seedsMapViewModelSelectedRadiusFromPersistedRadius() {
+    let stateWithRadius = AnonymousBrowseState(
+      postcode: testState.postcode,
+      coordinate: testState.coordinate,
+      radiusMetres: 1500,
+      createdAt: testState.createdAt
+    )
+
+    let (sut, _, _, _) = makeSUT(persistedState: stateWithRadius)
+
+    #expect(sut.mapViewModel?.selectedRadiusMetres == 1500)
+  }
+
   // MARK: - Reset (sign-out)
 
   @Test func reset_clearsStateAndReturnsToWelcome() {

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousBrowseStateTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousBrowseStateTests.swift
@@ -30,4 +30,29 @@ struct AnonymousBrowseStateTests {
 
     #expect(first == second)
   }
+
+  // MARK: - radiusMetres (GH#868 Phase 3 refinement)
+
+  @Test("radiusMetres defaults to 2000 when not provided")
+  func init_defaultsRadiusMetresTo2000() throws {
+    let postcode = try Postcode("CB1 2AD")
+    let coordinate = try Coordinate(latitude: 52.2053, longitude: 0.1218)
+
+    let sut = AnonymousBrowseState(
+      postcode: postcode, coordinate: coordinate, createdAt: Date(timeIntervalSince1970: 0))
+
+    #expect(sut.radiusMetres == 2000)
+  }
+
+  @Test("stores an explicit radiusMetres")
+  func init_storesExplicitRadiusMetres() throws {
+    let postcode = try Postcode("CB1 2AD")
+    let coordinate = try Coordinate(latitude: 52.2053, longitude: 0.1218)
+
+    let sut = AnonymousBrowseState(
+      postcode: postcode, coordinate: coordinate, radiusMetres: 1500,
+      createdAt: Date(timeIntervalSince1970: 0))
+
+    #expect(sut.radiusMetres == 1500)
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousBrowseStateTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousBrowseStateTests.swift
@@ -50,8 +50,11 @@ struct AnonymousBrowseStateTests {
     let coordinate = try Coordinate(latitude: 52.2053, longitude: 0.1218)
 
     let sut = AnonymousBrowseState(
-      postcode: postcode, coordinate: coordinate, radiusMetres: 1500,
-      createdAt: Date(timeIntervalSince1970: 0))
+      postcode: postcode,
+      coordinate: coordinate,
+      radiusMetres: 1500,
+      createdAt: Date(timeIntervalSince1970: 0)
+    )
 
     #expect(sut.radiusMetres == 1500)
   }

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousMapViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousMapViewModelTests.swift
@@ -153,4 +153,72 @@ struct AnonymousMapViewModelTests {
 
     #expect(invoked)
   }
+
+  // MARK: - Live radius picker (GH#868 Phase 3 refinement)
+
+  @Test func selectedRadiusMetres_seedsFromInitialRadius() {
+    let (sut, _) = makeSUT(radiusMetres: 1500)
+
+    #expect(sut.selectedRadiusMetres == 1500)
+  }
+
+  @Test func selectedRadiusMetres_clampsToFreeTierMaxWhenInitialRadiusIsLarger() {
+    // The fetch radius (server clamp: [100, 5000]) can exceed the free-tier
+    // cap the live picker is bounded to — the seeded picker value must never
+    // preview a zone bigger than a free account can actually have.
+    let (sut, _) = makeSUT(radiusMetres: 5000)
+
+    #expect(sut.selectedRadiusMetres == 2000)
+  }
+
+  @Test func maxSelectedRadiusMetres_matchesFreeTierCap() {
+    #expect(AnonymousMapViewModel.maxSelectedRadiusMetres == 2000)
+  }
+
+  @Test func updateSelectedRadius_updatesValue() {
+    let (sut, _) = makeSUT()
+
+    sut.updateSelectedRadius(750)
+
+    #expect(sut.selectedRadiusMetres == 750)
+  }
+
+  @Test func updateSelectedRadius_clampsAboveFreeTierMax() {
+    let (sut, _) = makeSUT()
+
+    sut.updateSelectedRadius(3000)
+
+    #expect(sut.selectedRadiusMetres == 2000)
+  }
+
+  @Test func updateSelectedRadius_clampsBelowMinimum() {
+    let (sut, _) = makeSUT()
+
+    sut.updateSelectedRadius(10)
+
+    #expect(sut.selectedRadiusMetres == 100)
+  }
+
+  @Test func updateSelectedRadius_invokesOnRadiusChangedWithClampedValue() {
+    let (sut, _) = makeSUT()
+    var received: Double?
+    sut.onRadiusChanged = { received = $0 }
+
+    sut.updateSelectedRadius(9000)
+
+    #expect(received == 2000)
+  }
+
+  @Test func anchorCoordinate_staysFixedAcrossRegionChanges() async {
+    let (sut, repository) = makeSUT(coordinate: .cambridge)
+    repository.fetchNearbyResult = .success([])
+
+    sut.regionDidChange(centreLat: 10, centreLon: 10, radiusMetres: 2000)
+    await sut.waitForPendingRegionChangeRefetch()
+
+    #expect(sut.anchorCoordinate == .cambridge)
+    // The viewport-following centre moved, but the anchor the radius circle
+    // is drawn around did not — the two are deliberately decoupled.
+    #expect(sut.centreLat == 10)
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorOnboardingTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorOnboardingTests.swift
@@ -163,7 +163,7 @@ struct AppCoordinatorOnboardingTests {
     let postcode = try Postcode("CB1 2AD")
     let coordinate = try Coordinate(latitude: 52.2053, longitude: 0.1218)
     anonymousRepo.loadResult = AnonymousBrowseState(
-      postcode: postcode, coordinate: coordinate, createdAt: Date())
+      postcode: postcode, coordinate: coordinate, radiusMetres: 1500, createdAt: Date())
     let sut = makeSUT(anonymousBrowseStateRepository: anonymousRepo)
 
     let vm = sut.makeOnboardingViewModel()
@@ -171,6 +171,7 @@ struct AppCoordinatorOnboardingTests {
     #expect(vm.postcodeInput == "CB1 2AD")
     #expect(vm.geocodedCoordinate == coordinate)
     #expect(vm.currentStep == .radiusPicker)
+    #expect(vm.selectedRadiusMetres == 1500)
     #expect(anonymousRepo.clearCallCount == 1)
   }
 

--- a/mobile/ios/town-crier-tests/Sources/Features/OnboardingViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/OnboardingViewModelTests.swift
@@ -294,19 +294,19 @@ struct OnboardingViewModelTests {
     let postcode = try Postcode("CB1 2AD")
     let coordinate = try Coordinate(latitude: 52.2053, longitude: 0.1218)
 
-    sut.prefill(postcode: postcode, coordinate: coordinate)
+    sut.prefill(postcode: postcode, coordinate: coordinate, radiusMetres: 1500)
 
     #expect(sut.postcodeInput == "CB1 2AD")
     #expect(sut.geocodedCoordinate == coordinate)
     #expect(sut.currentStep == .radiusPicker)
+    #expect(sut.selectedRadiusMetres == 1500)
   }
 
   @Test func prefill_thenConfirmRadius_createsZoneAtPrefilledLocation() async throws {
     let (sut, _, _, _, _) = makeSUT()
     let postcode = try Postcode("CB1 2AD")
     let coordinate = try Coordinate(latitude: 52.2053, longitude: 0.1218)
-    sut.prefill(postcode: postcode, coordinate: coordinate)
-    sut.selectedRadiusMetres = 1500
+    sut.prefill(postcode: postcode, coordinate: coordinate, radiusMetres: 1500)
 
     var completedZone: WatchZone?
     sut.onComplete = { zone in completedZone = zone }
@@ -316,6 +316,28 @@ struct OnboardingViewModelTests {
     #expect(completedZone != nil)
     #expect(completedZone?.centre == coordinate)
     #expect(completedZone?.radiusMetres == 1500)
+  }
+
+  @Test func prefill_withRadiusAboveTierMax_clampsToMaxRadiusMetres() throws {
+    let (sut, _, _, _, _) = makeSUT()
+    let postcode = try Postcode("CB1 2AD")
+    let coordinate = try Coordinate(latitude: 52.2053, longitude: 0.1218)
+
+    // Free tier's cap is 2000; the anonymous picker itself is bounded there
+    // too, so this only guards against a stale/legacy persisted radius.
+    sut.prefill(postcode: postcode, coordinate: coordinate, radiusMetres: 5000)
+
+    #expect(sut.selectedRadiusMetres == 2000)
+  }
+
+  @Test func prefill_withRadiusBelowMinimum_clampsTo100() throws {
+    let (sut, _, _, _, _) = makeSUT()
+    let postcode = try Postcode("CB1 2AD")
+    let coordinate = try Coordinate(latitude: 52.2053, longitude: 0.1218)
+
+    sut.prefill(postcode: postcode, coordinate: coordinate, radiusMetres: 10)
+
+    #expect(sut.selectedRadiusMetres == 100)
   }
 
   @Test func prefill_doesNotAffectNormalNonPrefilledFlow() async {

--- a/mobile/ios/town-crier-tests/Sources/Features/UserDefaultsAnonymousBrowseStateRepositoryTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/UserDefaultsAnonymousBrowseStateRepositoryTests.swift
@@ -77,4 +77,37 @@ struct UserDefaultsAnonymousBrowseStateRepositoryTests {
 
     #expect(sut.load() == nil)
   }
+
+  // MARK: - radiusMetres (GH#868 Phase 3 refinement)
+
+  @Test("save then load round-trips the radius")
+  func saveThenLoad_roundTripsRadius() throws {
+    let sut = makeSUT()
+    let state = AnonymousBrowseState(
+      postcode: try Postcode("CB1 2AD"),
+      coordinate: try Coordinate(latitude: 52.2053, longitude: 0.1218),
+      radiusMetres: 1500,
+      createdAt: Date(timeIntervalSince1970: 1_700_000_000)
+    )
+
+    sut.save(state)
+
+    #expect(sut.load()?.radiusMetres == 1500)
+  }
+
+  @Test("load tolerates a legacy blob saved before radiusMetres existed, defaulting to 2000")
+  func load_toleratesLegacyBlobWithoutRadiusMetres() throws {
+    // swiftlint:disable:next force_unwrapping
+    let defaults = UserDefaults(suiteName: UUID().uuidString)!
+    let sut = UserDefaultsAnonymousBrowseStateRepository(defaults: defaults)
+    let legacyJSON = """
+      {"postcode":"CB1 2AD","latitude":52.2053,"longitude":0.1218,"createdAt":1700000000}
+      """
+    defaults.set(Data(legacyJSON.utf8), forKey: "anonymousBrowseState")
+
+    let loaded = sut.load()
+
+    #expect(loaded?.radiusMetres == 2000)
+    #expect(loaded?.postcode.value == "CB1 2AD")
+  }
 }


### PR DESCRIPTION
## Changes

Refines the anonymous (pre-signup) map from TestFlight feedback on #874, so it reads as an honest preview of the logged-in free-tier watch-zone map. GH #868 Phase 3 refinement.

**1. Map pins now cluster.** `AnonymousMapView` was a plain SwiftUI `Map` with one annotation per pin. New `AnonymousClusteredMapView` (UIKit `MKMapView`) uses MapKit's built-in **client-side clustering** (`clusteringIdentifier`) — `near-point` returns ≤200 points, so on-device grid clustering is correct with no new backend endpoint. Amber count bubbles for groups, status-coloured pins for singles, tap a bubble to zoom in and split it, tap a pin for the existing summary sheet. Reuses `ClusteredMapView`'s visual language without touching that file. The macOS SPM test target keeps a SwiftUI `Map` fallback (no UIKit), mirroring `MapView`'s dual-path pattern.

**2. Live radius picker before sign-up.** A `Slider` (100m–2km, capped at the free tier's `WatchZoneLimits(.free).maxRadiusMetres`) sits above the CTA banner. Dragging it redraws an amber radius circle around the postcode and re-frames the camera live — so what an anonymous user picks is exactly the zone a free account gets. Two decoupled radii: `selectedRadiusMetres` drives the drawn circle + the onboarding handoff; the viewport span still drives the `near-point` fetch as the user pans/zooms (mirrors the authenticated map, where the zone circle is fixed while pins follow the viewport).

**3. Chosen radius carries into onboarding.** `AnonymousBrowseState` gains `radiusMetres` (persisted, with a legacy-blob-tolerant decode defaulting to 2km so anonymous sessions saved by the current #874 TestFlight build still load). `OnboardingViewModel.prefill` gains a `radiusMetres:` param, so the post-signup wizard's radius step lands pre-set to what the user already chose.

Untouched: `URLSessionAPIClient`, `MapView`, `ClusteredMapView`, `ApplicationSummarySheet`, `MapViewModel`, and the `AccountCTABanner` copy.

## Tests / verification

Swift Testing throughout; `swift build` + `swift test` (1538) green; `swiftlint --strict` clean against both the CI-pinned 0.63.2 and local 0.65.0; full `xcodebuild` sim build succeeded (the only compile path for the UIKit-guarded clustered view). Live simulator verification (Sonnet + mobile-mcp, SW1A 1AA / Westminster): 6/6 pass — clustering with recursive declustering, slider redraw + reframe down to a 100m ring, pin summary sheet, banner copy clean.

Release-Note: You can now set your monitoring radius on the map before creating an account, and nearby applications group together as you zoom out.

(tc-4go2u)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a live radius picker for anonymous map browsing.
  * Radius selection now persists across sessions and carries through to onboarding.
  * Map browsing now supports clustered pins and a radius overlay for clearer viewing.

* **Bug Fixes**
  * Restored previously saved radius values when reopening anonymous browsing.
  * Legacy saved sessions without a radius now open with a sensible default.
  * Radius changes are kept in sync when moving between browse and onboarding flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->