### PR TITLE
feat(api): near-point results carry authoritySlug (#879 Phase 1)

### DIFF
--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -316,14 +316,14 @@ func newRouter(
 		// per-subject RateLimit no-ops on a request with no subject, but
 		// AnonRateLimit does not — it is the scheme that actually covers this route.
 		applications.SearchRoutes(mux, appStore, authorities.NewLookup(), logger)
-		// The public applications-near-a-point endpoint (GH#868 Phase 2) reads from
-		// the same store; unlike SearchRoutes it needs no authority-slug resolver
-		// (NearbyResult, unlike SearchResult, carries no authoritySlug field — see
-		// result.go). It is anonymous to Auth0 (see anonymousPatterns, a route
-		// distinct from the build-key SEO NearRoutes above) and, like every other
-		// anonymous route, metered by the per-IP AnonRateLimit (GH#868 Phase 1)
-		// plus its own radius/limit clamps.
-		applications.NearPointRoutes(mux, appStore, logger)
+		// The public applications-near-a-point endpoint (GH#868 Phase 2; GH#879
+		// Phase 1 added the authority-slug resolver so each result carries
+		// authoritySlug, mirroring SearchRoutes) reads from the same store. It is
+		// anonymous to Auth0 (see anonymousPatterns, a route distinct from the
+		// build-key SEO NearRoutes above) and, like every other anonymous route,
+		// metered by the per-IP AnonRateLimit (GH#868 Phase 1) plus its own
+		// radius/limit clamps.
+		applications.NearPointRoutes(mux, appStore, authorities.NewLookup(), logger)
 		// The public share page (#738): an anonymous, server-rendered HTML page for a
 		// single application at GET /a/{authoritySlug}/{ref...}. It point-reads the
 		// same applications store and resolves the authority slug via the static

--- a/api-go/cmd/api/wiring_test.go
+++ b/api-go/cmd/api/wiring_test.go
@@ -429,9 +429,11 @@ func TestRouter_ApplicationSearchAnonymous(t *testing.T) {
 // router with a store that returns a real application, then proves
 // GET /v1/applications/near-point serves anonymously (no token, 200
 // application/json) with a bare-array body — the same raw-domain wire shape
-// (NearbyResult) the authed nearby page emits. The pattern string match is a
-// drift guard: a rename here without updating anonymousPatterns would silently
-// 401 the route.
+// (NearbyResult) the authed nearby page emits, plus a resolved authoritySlug
+// (GH#879 Phase 1) so an anonymously-loaded application can build a share URL
+// or a by-slug detail fetch. The pattern string match is a drift guard: a
+// rename here without updating anonymousPatterns would silently 401 the
+// route.
 func TestRouter_NearPointAnonymous(t *testing.T) {
 	t.Parallel()
 
@@ -440,7 +442,7 @@ func TestRouter_NearPointAnonymous(t *testing.T) {
 		Name:     "23/03456/FUL",
 		UID:      "croydon-23-03456-FUL",
 		AreaName: "Croydon",
-		AreaID:   301,
+		AreaID:   301, // the real Croydon id, so SlugForAreaID(301) == "croydon"
 		Address:  "10 Downing Street, London",
 	}
 	appStore := foundAppStore{app: app}
@@ -455,6 +457,9 @@ func TestRouter_NearPointAnonymous(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), `"name":"23/03456/FUL"`) {
 		t.Errorf("body missing planit_name 23/03456/FUL; body = %s", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"authoritySlug":"croydon"`) {
+		t.Errorf("body missing authoritySlug croydon; body = %s", rec.Body.String())
 	}
 	if !strings.HasPrefix(strings.TrimSpace(rec.Body.String()), "[") {
 		t.Errorf("body must be a bare JSON array, got: %s", rec.Body.String())

--- a/api-go/internal/applications/nearpoint.go
+++ b/api-go/internal/applications/nearpoint.go
@@ -55,17 +55,21 @@ type nearPointStore interface {
 
 // nearPointHandler serves the public applications-near-a-point endpoint.
 type nearPointHandler struct {
-	store  nearPointStore
-	logger *slog.Logger
+	store    nearPointStore
+	resolver authoritySlugResolver
+	logger   *slog.Logger
 }
 
 // NearPointRoutes registers the public GET /v1/applications/near-point
 // endpoint (GH#868 Phase 2). It is kept in cmd/api/wiring.go's
 // anonymousPatterns — a DIFFERENT route from the build-key-gated
 // GET /v1/applications/near SEO route (applications.NearRoutes) — and reads
-// only public planning data from Postgres.
-func NearPointRoutes(mux *http.ServeMux, store nearPointStore, logger *slog.Logger) {
-	h := &nearPointHandler{store: store, logger: logger}
+// only public planning data from Postgres. The resolver populates each
+// result's AuthoritySlug (GH#879 Phase 1), mirroring SearchRoutes, so an
+// anonymously-loaded application can build a share URL or a by-slug detail
+// fetch.
+func NearPointRoutes(mux *http.ServeMux, store nearPointStore, resolver authoritySlugResolver, logger *slog.Logger) {
+	h := &nearPointHandler{store: store, resolver: resolver, logger: logger}
 	mux.HandleFunc("GET /v1/applications/near-point", h.nearPoint)
 }
 

--- a/api-go/internal/applications/nearpoint.go
+++ b/api-go/internal/applications/nearpoint.go
@@ -111,7 +111,9 @@ func (h *nearPointHandler) nearPoint(w http.ResponseWriter, r *http.Request) {
 
 	results := make([]NearbyResult, 0, len(apps))
 	for _, a := range apps {
-		results = append(results, NearbyResultOf(a))
+		result := NearbyResultOf(a)
+		result.AuthoritySlug = h.authoritySlug(r.Context(), a)
+		results = append(results, result)
 	}
 
 	// Set the continuation header before writeJSON, which calls WriteHeader;
@@ -120,6 +122,12 @@ func (h *nearPointHandler) nearPoint(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Next-Cursor", encodeNearPointCursor(nextCursor))
 	}
 	writeJSON(w, r, h.logger, results)
+}
+
+// authoritySlug returns the URL slug for the application's authority. See
+// resolveAuthoritySlugFor (respond.go) for the round-trip/fallback behaviour.
+func (h *nearPointHandler) authoritySlug(ctx context.Context, app PlanningApplication) string {
+	return resolveAuthoritySlugFor(ctx, h.resolver, h.logger, "near-point authority slug", app)
 }
 
 // parseNearPointCoordinates parses and validates the required lat/lng query

--- a/api-go/internal/applications/nearpoint_integration_test.go
+++ b/api-go/internal/applications/nearpoint_integration_test.go
@@ -36,7 +36,7 @@ func TestNearPointHandler_Integration_RealPostGIS(t *testing.T) {
 	}
 
 	mux := http.NewServeMux()
-	NearPointRoutes(mux, store, slog.New(slog.DiscardHandler))
+	NearPointRoutes(mux, store, testResolver(), slog.New(slog.DiscardHandler))
 
 	// limit=2: page 1 comes back FULL (2 rows), which always mints a
 	// continuation cursor regardless of whether more rows truly exist

--- a/api-go/internal/applications/nearpoint_test.go
+++ b/api-go/internal/applications/nearpoint_test.go
@@ -37,10 +37,11 @@ func (f *fakeNearPointStore) FindNearbyPage(_ context.Context, latitude, longitu
 }
 
 // newNearPointTestHandler builds a near-point mux wired to the given fake
-// store, discarding log output.
+// store and testResolver() (the shared fakeResolver from handler_test.go,
+// which maps AreaID 471 <-> "city-of-london"), discarding log output.
 func newNearPointTestHandler(store *fakeNearPointStore) http.Handler {
 	mux := http.NewServeMux()
-	NearPointRoutes(mux, store, slog.New(slog.DiscardHandler))
+	NearPointRoutes(mux, store, testResolver(), slog.New(slog.DiscardHandler))
 	return mux
 }
 
@@ -142,6 +143,67 @@ func TestNearPointHandler_ResponseShape(t *testing.T) {
 	}
 	if len(results) != 1 || results[0].Name != app.Name || results[0].UID != app.UID {
 		t.Errorf("results = %+v, want one NearbyResult matching %+v", results, app)
+	}
+}
+
+// TestNearPointHandler_AuthoritySlugResolved proves each result carries its
+// authority's resolved URL slug (GH#879 Phase 1) — the field ResultOf leaves
+// unset on the authed embeddings (watchzones/savedapplications), but which the
+// anonymous near-point endpoint needs so a client can build a share URL or a
+// by-slug detail fetch without ever holding a session.
+func TestNearPointHandler_AuthoritySlugResolved(t *testing.T) {
+	t.Parallel()
+
+	app := PlanningApplication{Name: "1/1", UID: "uid-471", AreaName: "City of London", AreaID: 471}
+	store := &fakeNearPointStore{apps: []PlanningApplication{app}}
+	h := newNearPointTestHandler(store)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/applications/near-point?lat=51.5&lng=-0.1", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	var results []NearbyResult
+	if err := json.Unmarshal(rec.Body.Bytes(), &results); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results: got %d, want 1", len(results))
+	}
+	if want := "city-of-london"; results[0].AuthoritySlug != want {
+		t.Errorf("authoritySlug = %q, want %q", results[0].AuthoritySlug, want)
+	}
+}
+
+// TestNearPointHandler_AuthoritySlugFallback proves an application whose area
+// id the resolver doesn't know falls back to slugifying its raw area name,
+// exactly like the search and by-id/by-slug handlers (see
+// TestSearchHandler_AuthoritySlugFallback).
+func TestNearPointHandler_AuthoritySlugFallback(t *testing.T) {
+	t.Parallel()
+
+	app := PlanningApplication{Name: "1/1", UID: "uid-999999", AreaName: "Some Unknown Council", AreaID: 999999}
+	store := &fakeNearPointStore{apps: []PlanningApplication{app}}
+	h := newNearPointTestHandler(store)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/applications/near-point?lat=51.5&lng=-0.1", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	var results []NearbyResult
+	if err := json.Unmarshal(rec.Body.Bytes(), &results); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results: got %d, want 1", len(results))
+	}
+	if want := "some-unknown-council"; results[0].AuthoritySlug != want {
+		t.Errorf("authoritySlug fallback: got %q, want %q", results[0].AuthoritySlug, want)
 	}
 }
 

--- a/api-go/internal/applications/result.go
+++ b/api-go/internal/applications/result.go
@@ -66,9 +66,9 @@ func ResultOf(a PlanningApplication) Result {
 }
 
 // NearbyResult is the wire shape of a raw domain PlanningApplication, as emitted
-// by the watch-zone create response. It is exactly Result without
-// latestUnreadEvent — that field is a Result projection concern, absent from
-// the domain shape.
+// by the watch-zone create response and the public near-point endpoint. It is
+// exactly Result without latestUnreadEvent — that field is a Result projection
+// concern, absent from the domain shape.
 type NearbyResult struct {
 	Name          string              `json:"name"`
 	UID           string              `json:"uid"`
@@ -88,6 +88,15 @@ type NearbyResult struct {
 	URL           *string             `json:"url"`
 	Link          *string             `json:"link"`
 	LastDifferent platform.DotNetTime `json:"lastDifferent"`
+	// AuthoritySlug is the URL slug of the application's authority, emitted ONLY
+	// by the public near-point endpoint (internal/applications/nearpoint.go,
+	// GH#879 Phase 1) so an anonymously-loaded application can build a share URL
+	// or a by-slug detail fetch. It is DELIBERATELY omitempty and NOT set by
+	// NearbyResultOf: the watch-zone create response
+	// (watchzones.handler.create -> createResult.NearbyApplications), which also
+	// embeds NearbyResult via NearbyResultOf, leaves it "" and so stays
+	// byte-identical on the wire — mirroring Result.AuthoritySlug/ResultOf above.
+	AuthoritySlug string `json:"authoritySlug,omitempty"`
 }
 
 // RecentByAuthorityResult is the wire shape of the build-time SEO endpoint


### PR DESCRIPTION
## Changes
- `GET /v1/applications/near-point` results now carry `authoritySlug`, resolved per row via the same `resolveAuthoritySlugFor` helper the search and detail handlers use — so an anonymously-loaded application can build a share URL or a by-slug detail fetch (GH #879 Phase 1, bead tc-hq9h7.1).
- `NearbyResult` gains an `omitempty` `AuthoritySlug` field; `NearbyResultOf` is deliberately untouched, so the watch-zone create response that also embeds `NearbyResult` stays byte-identical on the wire.
- Tests: handler unit tests for resolved + fallback slugs (mirroring the search handler's), and the anonymous end-to-end wiring test now asserts the slug.

Closes #879? No — first of five phases; see the epic for the rest.

---
*Auto-shipped via ship skill*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ApYCEogBeZYu7UP4LEouyW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Public nearby application results now include an `authoritySlug` field, making it easier to build slug-based links from search and nearby views.
  * Nearby results can now resolve slugs from authority data, with a sensible fallback when no match is found.

* **Bug Fixes**
  * Improved consistency in the public nearby endpoint response so returned items now carry the expected authority slug value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->