### PR TITLE
fix(ios): anonymous map same-address clusters open a disambiguation list (#877)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousClusterStackDetector.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousClusterStackDetector.swift
@@ -1,0 +1,56 @@
+import MapKit
+
+/// Pure, value-level detection of a "stacked" (same-address) map cluster tap
+/// on the anonymous map (GH#877) — members whose coordinates are so close
+/// together that no amount of MapKit zoom can ever visually separate them.
+/// Deliberately free of `UIKit`/`UIViewRepresentable` (unlike
+/// ``AnonymousClusteredMapView``, which is gated behind `canImport(UIKit)`)
+/// so it is directly unit-testable everywhere `swift test` runs, including
+/// macOS, with no simulator required.
+///
+/// Mirrors the authenticated map's server-computed `MapCluster.isStacked`
+/// (GH#722) with an on-device rule: the anonymous map's client-side
+/// `MKMapView` clustering (`clusteringIdentifier`) has no server
+/// "unsplittable" signal to consult, so the decision is made here, on tap.
+enum AnonymousClusterStackDetector {
+  /// Same-address applications carry identical (or near-identical) coordinates
+  /// from PlanIt, so this is generous — roughly 1 metre — well below any real
+  /// spread between distinct sites.
+  static let coincidenceEpsilonDegrees: Double = 1e-5
+
+  /// MapKit's own zoom floor, mirroring the halving the coordinator's zoom-in
+  /// branch already applies (`max(span / 2, 0.0005)`): below this span the map
+  /// cannot zoom in any further, so a multi-member cluster here can never
+  /// split visually — even when its members' coordinates exceed the
+  /// coincidence epsilon.
+  static let zoomFloorDegrees: Double = 0.001
+
+  /// Whether a cluster tap should open the disambiguation list instead of
+  /// zooming in further. A cluster of fewer than two members is never
+  /// "stacked" — there is nothing to disambiguate.
+  static func isStacked(
+    memberCoordinates: [CLLocationCoordinate2D],
+    regionSpanDegrees: Double
+  ) -> Bool {
+    guard memberCoordinates.count > 1 else { return false }
+    if regionSpanDegrees <= zoomFloorDegrees {
+      return true
+    }
+    return maxPairwiseDelta(memberCoordinates) <= coincidenceEpsilonDegrees
+  }
+
+  /// The largest latitude or longitude difference across every pair of
+  /// members — the "can zoom ever split these apart" measure.
+  private static func maxPairwiseDelta(_ coordinates: [CLLocationCoordinate2D]) -> Double {
+    var maxDelta = 0.0
+    for i in coordinates.indices {
+      for j in coordinates.index(after: i)..<coordinates.endIndex {
+        maxDelta = max(
+          maxDelta,
+          abs(coordinates[i].latitude - coordinates[j].latitude),
+          abs(coordinates[i].longitude - coordinates[j].longitude))
+      }
+    }
+    return maxDelta
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousClusteredMapView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousClusteredMapView.swift
@@ -204,8 +204,8 @@
         mapView.deselectAnnotation(annotation, animated: false)
 
         if let cluster = annotation as? MKClusterAnnotation {
-          let members = cluster.memberAnnotations.compactMap { annotation in
-            annotation as? AnonymousApplicationAnnotation
+          let members = cluster.memberAnnotations.compactMap { memberAnnotation in
+            memberAnnotation as? AnonymousApplicationAnnotation
           }
           let regionSpan = max(mapView.region.span.latitudeDelta, mapView.region.span.longitudeDelta)
           let isStacked = AnonymousClusterStackDetector.isStacked(

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousClusteredMapView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousClusteredMapView.swift
@@ -78,10 +78,14 @@
   extension AnonymousClusteredMapView {
     /// `MKMapViewDelegate` for ``AnonymousClusteredMapView``. Styles individual
     /// and MapKit-synthesised cluster markers, routes a single-pin tap to
-    /// ``AnonymousMapViewModel/selectApplication(_:)`` and a cluster tap to a
-    /// zoom-in (MapKit's own clustering re-splits the group at the finer zoom
-    /// level — there is no server-side "stacked/unsplittable" concept here),
-    /// renders the radius preview circle, and forwards viewport changes to
+    /// ``AnonymousMapViewModel/selectApplication(_:)``, and a cluster tap
+    /// either to a zoom-in (MapKit's own clustering re-splits the group at the
+    /// finer zoom level) or, when ``AnonymousClusterStackDetector`` finds the
+    /// members coincident (or the region is already at its zoom floor), to
+    /// ``AnonymousMapViewModel/selectStack(_:)`` — there is no server-side
+    /// "stacked/unsplittable" signal here, so the decision is made on-device
+    /// (GH#877). Also renders the radius preview circle and forwards viewport
+    /// changes to
     /// ``AnonymousMapViewModel/regionDidChange(centreLat:centreLon:radiusMetres:)``,
     /// which debounces internally.
     @MainActor
@@ -200,15 +204,29 @@
         mapView.deselectAnnotation(annotation, animated: false)
 
         if let cluster = annotation as? MKClusterAnnotation {
-          // MapKit's own clustering re-splits the group once the map zooms in
-          // far enough — there is no server-side "unsplittable/stacked" case
-          // to special-case here (unlike `ClusteredMapView`).
-          var region = mapView.region
-          region.center = cluster.coordinate
-          region.span = MKCoordinateSpan(
-            latitudeDelta: max(region.span.latitudeDelta / 2, 0.0005),
-            longitudeDelta: max(region.span.longitudeDelta / 2, 0.0005))
-          mapView.setRegion(region, animated: true)
+          let members = cluster.memberAnnotations.compactMap { annotation in
+            annotation as? AnonymousApplicationAnnotation
+          }
+          let regionSpan = max(mapView.region.span.latitudeDelta, mapView.region.span.longitudeDelta)
+          let isStacked = AnonymousClusterStackDetector.isStacked(
+            memberCoordinates: members.map(\.coordinate), regionSpanDegrees: regionSpan)
+
+          if isStacked {
+            // Coincident (or effectively coincident) members: no zoom level
+            // can ever split them, so open the disambiguation list instead
+            // (GH#877). No network call — every member's full
+            // `PlanningApplication` is already loaded from `near-point`.
+            viewModel.selectStack(members.map(\.application))
+          } else {
+            // Splittable cluster: MapKit's own clustering re-splits the group
+            // once the map zooms in far enough.
+            var region = mapView.region
+            region.center = cluster.coordinate
+            region.span = MKCoordinateSpan(
+              latitudeDelta: max(region.span.latitudeDelta / 2, 0.0005),
+              longitudeDelta: max(region.span.longitudeDelta / 2, 0.0005))
+            mapView.setRegion(region, animated: true)
+          }
         } else if let point = annotation as? AnonymousApplicationAnnotation {
           viewModel.selectApplication(point.application)
         }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMapView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMapView.swift
@@ -8,7 +8,9 @@ import TownCrierDomain
 /// on-device (GH#868 Phase 3 refinement), and pins a persistent
 /// ``AccountCTABanner`` — with a live monitoring-radius picker above it — over
 /// the bottom safe area. A pin tap shows a reduced-feature summary preview; a
-/// cluster tap zooms in; anything deeper than the summary preview routes to
+/// cluster tap zooms in, unless its members are coincident (same address),
+/// in which case it opens a ``StackedApplicationsSheet`` disambiguation list
+/// instead (GH#877); anything deeper than the summary preview routes to
 /// sign-up.
 ///
 /// On iOS, pins render via ``AnonymousClusteredMapView`` (`MKMapView` +
@@ -68,6 +70,20 @@ public struct AnonymousMapView: View {
         viewModel.requestSignUp()
       }
     }
+    // Disambiguation list for a coincident ("stacked") cluster tap (GH#877).
+    // Its `onDismiss` presents the chosen row's summary, so the list always
+    // finishes dismissing before the summary appears — the two `.sheet`s are
+    // never both up (mirrors `MapView.swift`).
+    .sheet(
+      item: Binding(
+        get: { viewModel.stackedApplications },
+        set: { _ in viewModel.clearStack() }
+      ),
+      onDismiss: { viewModel.presentPendingSummaryIfNeeded() },
+      content: { stacked in
+        StackedApplicationsSheet(stacked: stacked, onSelect: viewModel.selectFromStack)
+      }
+    )
   }
 
   // MARK: - Radius picker

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMapViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMapViewModel.swift
@@ -2,16 +2,30 @@ import Foundation
 import TownCrierDomain
 
 /// Drives the anonymous (pre-signup) map: pins near a stored coordinate, no
-/// account, no watch zone, no clustering (GH#868 Phase 3). A deliberately
-/// reduced feature set versus the authenticated ``MapViewModel`` — no save, no
-/// status filters, no stacked-cell disambiguation — so it is a small,
-/// self-contained view model rather than a shared abstraction over the two.
+/// account, no watch zone, no server-side clustering (GH#868 Phase 3). A
+/// deliberately reduced feature set versus the authenticated ``MapViewModel``
+/// — no save, no status filters — so it is a small, self-contained view model
+/// rather than a shared abstraction over the two. It does, however, support
+/// the same same-address disambiguation list (GH#877) via ``selectStack(_:)``
+/// / ``selectFromStack(_:)``, reusing ``StackedApplications`` and
+/// ``StackedApplicationsSheet`` from the Map feature.
 @MainActor
 public final class AnonymousMapViewModel: ObservableObject, ErrorHandlingViewModel {
   @Published public private(set) var applications: [PlanningApplication] = []
   @Published public private(set) var isLoading = false
   @Published public internal(set) var error: DomainError?
   @Published public private(set) var selectedApplication: PlanningApplication?
+  /// The applications stacked at the tapped coincident cluster (GH#877),
+  /// presented as a disambiguation list via the shared
+  /// ``StackedApplicationsSheet``. Nil when no stacked cluster is open.
+  @Published public private(set) var stackedApplications: StackedApplications?
+  /// The application whose *summary* sheet should open once the
+  /// disambiguation list has finished dismissing. Set by
+  /// ``selectFromStack(_:)`` and consumed by
+  /// ``presentPendingSummaryIfNeeded()`` from the list sheet's `onDismiss`, so
+  /// the list and the summary are never on screen at once (SwiftUI's
+  /// two-sheets race) — mirrors ``MapViewModel``'s handoff.
+  @Published public private(set) var pendingSummaryApplication: PlanningApplication?
   @Published public private(set) var centreLat: Double
   @Published public private(set) var centreLon: Double
   @Published public private(set) var radiusMetres: Double
@@ -132,6 +146,44 @@ public final class AnonymousMapViewModel: ObservableObject, ErrorHandlingViewMod
 
   public func clearSelection() {
     selectedApplication = nil
+  }
+
+  /// Opens the disambiguation list for a "stacked" (same-address) cluster tap
+  /// (GH#877). Unlike the authenticated map's `MapViewModel.selectStack(_:)`,
+  /// this makes no repository call: `near-point` already returned every
+  /// member as a full `PlanningApplication`, so the coordinator hands them
+  /// straight through. `id` is derived from the member ids so re-tapping the
+  /// same coincident cluster re-presents the same list rather than a spurious
+  /// second sheet.
+  public func selectStack(_ applications: [PlanningApplication]) {
+    let id = applications.map(\.id.value).joined(separator: ",")
+    stackedApplications = StackedApplications(id: id, applications: applications)
+  }
+
+  /// Handles a tap on a disambiguation-list row. Stashes the chosen
+  /// application as ``pendingSummaryApplication`` and clears
+  /// ``stackedApplications`` to dismiss the list. The list sheet's
+  /// `onDismiss` then calls ``presentPendingSummaryIfNeeded()`` so the summary
+  /// opens only after the list has gone.
+  public func selectFromStack(_ application: PlanningApplication) {
+    pendingSummaryApplication = application
+    stackedApplications = nil
+  }
+
+  /// Presents any pending stacked-row summary via ``selectApplication(_:)``,
+  /// clearing the pending slot first so it fires exactly once. Invoked from
+  /// the disambiguation list sheet's `onDismiss`. No-op when nothing is
+  /// pending (e.g. the user swiped the list away instead of tapping a row).
+  public func presentPendingSummaryIfNeeded() {
+    guard let pending = pendingSummaryApplication else { return }
+    pendingSummaryApplication = nil
+    selectApplication(pending)
+  }
+
+  /// Dismisses the disambiguation list without selecting a row — wired to the
+  /// list sheet's dismiss binding (swipe-to-dismiss).
+  public func clearStack() {
+    stackedApplications = nil
   }
 
   /// Any deeper touch than the summary preview (full detail, save) or the CTA

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapView.swift
@@ -70,7 +70,7 @@ public struct MapView: View {
       ),
       onDismiss: { viewModel.presentPendingSummaryIfNeeded() },
       content: { stacked in
-        StackedApplicationsSheet(stacked: stacked, viewModel: viewModel)
+        StackedApplicationsSheet(stacked: stacked, onSelect: viewModel.selectFromStack)
       }
     )
   }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapViewModel.swift
@@ -2,15 +2,6 @@ import Combine
 import Foundation
 import TownCrierDomain
 
-/// The applications stacked at one unsplittable map cell, wrapped as an
-/// `Identifiable` value so it can drive a `.sheet(item:)` for the disambiguation
-/// list (GH#722). `id` is the source cluster's id, so re-tapping the same stacked
-/// cell re-presents the same list rather than a spurious second sheet.
-struct StackedApplications: Identifiable, Equatable, Sendable {
-  let id: String
-  let applications: [PlanningApplication]
-}
-
 /// ViewModel driving the map view with server-computed cluster aggregates
 /// (GH#698). Instead of eager-draining every application in the zone, the map
 /// fetches only the clusters inside the current viewport and refetches

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/StackedApplications.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/StackedApplications.swift
@@ -9,8 +9,15 @@ import TownCrierDomain
 /// Shared between the authenticated map (``MapViewModel``) and the anonymous
 /// map (``AnonymousMapViewModel``, GH#877) — both present the same
 /// ``StackedApplicationsSheet``, so this wrapper lives in its own file rather
-/// than inside either view model.
-struct StackedApplications: Identifiable, Equatable, Sendable {
-  let id: String
-  let applications: [PlanningApplication]
+/// than inside either view model. `public` because ``AnonymousMapViewModel``
+/// exposes its `stackedApplications` property publicly, unlike the
+/// module-internal ``MapViewModel``.
+public struct StackedApplications: Identifiable, Equatable, Sendable {
+  public let id: String
+  public let applications: [PlanningApplication]
+
+  public init(id: String, applications: [PlanningApplication]) {
+    self.id = id
+    self.applications = applications
+  }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/StackedApplications.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/StackedApplications.swift
@@ -1,0 +1,16 @@
+import TownCrierDomain
+
+/// The applications stacked at one unsplittable map cell, wrapped as an
+/// `Identifiable` value so it can drive a `.sheet(item:)` for the
+/// disambiguation list (GH#722). `id` is the source cluster's id, so
+/// re-tapping the same stacked cell re-presents the same list rather than a
+/// spurious second sheet.
+///
+/// Shared between the authenticated map (``MapViewModel``) and the anonymous
+/// map (``AnonymousMapViewModel``, GH#877) — both present the same
+/// ``StackedApplicationsSheet``, so this wrapper lives in its own file rather
+/// than inside either view model.
+struct StackedApplications: Identifiable, Equatable, Sendable {
+  let id: String
+  let applications: [PlanningApplication]
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/StackedApplicationsSheet.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/StackedApplicationsSheet.swift
@@ -3,17 +3,21 @@ import TownCrierDomain
 
 /// A bottom sheet listing the planning applications stacked at one location —
 /// the disambiguation list shown when a coincident ("unsplittable") map cluster
-/// is tapped (GH#722). Zoom can never separate such members, so instead of
-/// zooming the user picks from this list; each row opens that application's
-/// existing summary sheet via the view model's row-select, exactly as a
-/// single-pin tap does.
+/// is tapped (GH#722, and GH#877 on the anonymous map). Zoom can never separate
+/// such members, so instead of zooming the user picks from this list; each row
+/// opens that application's existing summary sheet via the injected
+/// ``onSelect`` closure, exactly as a single-pin tap does.
 ///
-/// Tapping a row hands off through ``MapViewModel/selectFromStack(_:)`` so the
-/// list dismisses before the summary presents — the two sheets are never on
-/// screen at once (SwiftUI's two-sheets race).
+/// Presentation-only — no concrete view model dependency — so both the
+/// authenticated map (``MapViewModel/selectFromStack(_:)``) and the anonymous
+/// map (``AnonymousMapViewModel/selectFromStack(_:)``) can present the same
+/// sheet. The caller's `onSelect` is expected to hand off through its own
+/// view model's dismiss-then-present pattern so the list dismisses before the
+/// summary presents — the two sheets are never on screen at once (SwiftUI's
+/// two-sheets race).
 struct StackedApplicationsSheet: View {
   let stacked: StackedApplications
-  @ObservedObject var viewModel: MapViewModel
+  let onSelect: (PlanningApplication) -> Void
 
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
@@ -23,7 +27,7 @@ struct StackedApplicationsSheet: View {
         LazyVStack(spacing: 0) {
           ForEach(stacked.applications) { application in
             Button {
-              viewModel.selectFromStack(application)
+              onSelect(application)
             } label: {
               StackedApplicationRow(application: application)
                 .contentShape(Rectangle())

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousClusterStackDetectorTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousClusterStackDetectorTests.swift
@@ -1,0 +1,110 @@
+import MapKit
+import Testing
+
+@testable import TownCrierPresentation
+
+/// Covers the pure, value-level "stacked" (same-address) cluster-tap
+/// detection rule (GH#877) — the epsilon/zoom-floor decision that
+/// ``AnonymousClusteredMapView/Coordinator`` uses in place of the
+/// authenticated map's server-computed `MapCluster.isStacked`. Deliberately
+/// free of `MKMapView`/`UIViewRepresentable` so it runs without a simulator.
+@Suite("AnonymousClusterStackDetector")
+struct AnonymousClusterStackDetectorTests {
+  private func coordinate(_ latitude: Double, _ longitude: Double) -> CLLocationCoordinate2D {
+    CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+  }
+
+  @Test func isStacked_allMembersShareOneCoordinate_returnsTrue() {
+    let members = [
+      coordinate(51.5, -0.12),
+      coordinate(51.5, -0.12),
+      coordinate(51.5, -0.12),
+    ]
+
+    let result = AnonymousClusterStackDetector.isStacked(
+      memberCoordinates: members, regionSpanDegrees: 0.05)
+
+    #expect(result)
+  }
+
+  @Test func isStacked_membersWithinEpsilon_returnsTrue() {
+    // Same-address applications from PlanIt carry near-identical but not
+    // bit-for-bit-equal coordinates — must still count as coincident.
+    let members = [
+      coordinate(51.500_000, -0.120_000),
+      coordinate(51.500_001, -0.120_001),
+    ]
+
+    let result = AnonymousClusterStackDetector.isStacked(
+      memberCoordinates: members, regionSpanDegrees: 0.05)
+
+    #expect(result)
+  }
+
+  @Test func isStacked_spreadMembers_returnsFalse() {
+    let members = [
+      coordinate(51.5, -0.12),
+      coordinate(51.6, -0.20),
+    ]
+
+    let result = AnonymousClusterStackDetector.isStacked(
+      memberCoordinates: members, regionSpanDegrees: 0.05)
+
+    #expect(!result)
+  }
+
+  @Test func isStacked_regionSpanAtZoomFloor_treatsSpreadMembersAsStacked() {
+    // Below the zoom floor MapKit cannot zoom in any further, so a
+    // multi-member cluster here can never split visually — even when its
+    // members exceed the coincidence epsilon.
+    let members = [
+      coordinate(51.5, -0.12),
+      coordinate(51.50005, -0.12005),
+    ]
+
+    let result = AnonymousClusterStackDetector.isStacked(
+      memberCoordinates: members, regionSpanDegrees: 0.001)
+
+    #expect(result)
+  }
+
+  @Test func isStacked_regionSpanBelowZoomFloor_treatsSpreadMembersAsStacked() {
+    let members = [
+      coordinate(51.5, -0.12),
+      coordinate(51.6, -0.20),
+    ]
+
+    let result = AnonymousClusterStackDetector.isStacked(
+      memberCoordinates: members, regionSpanDegrees: 0.0005)
+
+    #expect(result)
+  }
+
+  @Test func isStacked_regionSpanAboveZoomFloor_spreadMembersReturnFalse() {
+    let members = [
+      coordinate(51.5, -0.12),
+      coordinate(51.6, -0.20),
+    ]
+
+    let result = AnonymousClusterStackDetector.isStacked(
+      memberCoordinates: members, regionSpanDegrees: 0.002)
+
+    #expect(!result)
+  }
+
+  @Test func isStacked_singleMember_returnsFalse() {
+    let members = [coordinate(51.5, -0.12)]
+
+    let result = AnonymousClusterStackDetector.isStacked(
+      memberCoordinates: members, regionSpanDegrees: 0.05)
+
+    #expect(!result)
+  }
+
+  @Test func isStacked_noMembers_returnsFalse() {
+    let result = AnonymousClusterStackDetector.isStacked(
+      memberCoordinates: [], regionSpanDegrees: 0.05)
+
+    #expect(!result)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousMapViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousMapViewModelTests.swift
@@ -221,4 +221,65 @@ struct AnonymousMapViewModelTests {
     // is drawn around did not — the two are deliberately decoupled.
     #expect(sut.centreLat == 10)
   }
+
+  // MARK: - Stacked (same-address) cluster disambiguation (GH#877)
+
+  @Test func selectStack_publishesStackedApplicationsWithAllMembersInOrder() {
+    let (sut, _) = makeSUT()
+    let members = [PlanningApplication.pendingReview, .permitted, .rejected]
+
+    sut.selectStack(members)
+
+    #expect(sut.stackedApplications?.applications == members)
+  }
+
+  @Test func selectStack_makesNoRepositoryCall() {
+    // Unlike the authenticated map's `MapViewModel.selectStack(_:)`, the
+    // anonymous map already holds full `PlanningApplication` objects from the
+    // `near-point` fetch — no point read is needed.
+    let (sut, repository) = makeSUT()
+
+    sut.selectStack([.pendingReview, .permitted])
+
+    #expect(repository.fetchNearbyCalls.isEmpty)
+  }
+
+  @Test func selectFromStack_clearsStackedApplicationsWithoutImmediatelySelecting() {
+    let (sut, _) = makeSUT()
+    sut.selectStack([.pendingReview, .permitted])
+
+    sut.selectFromStack(.permitted)
+
+    // The list dismisses first — the summary must NOT be up yet (no two
+    // sheets at once).
+    #expect(sut.stackedApplications == nil)
+    #expect(sut.selectedApplication == nil)
+  }
+
+  @Test func presentPendingSummaryIfNeeded_presentsTheChosenApplicationAfterListDismisses() {
+    let (sut, _) = makeSUT()
+    sut.selectStack([.pendingReview, .permitted])
+    sut.selectFromStack(.permitted)
+
+    sut.presentPendingSummaryIfNeeded()
+
+    #expect(sut.selectedApplication == .permitted)
+  }
+
+  @Test func presentPendingSummaryIfNeeded_noOpWhenNothingPending() {
+    let (sut, _) = makeSUT()
+
+    sut.presentPendingSummaryIfNeeded()
+
+    #expect(sut.selectedApplication == nil)
+  }
+
+  @Test func clearStack_clearsStackedApplications() {
+    let (sut, _) = makeSUT()
+    sut.selectStack([.pendingReview, .permitted])
+
+    sut.clearStack()
+
+    #expect(sut.stackedApplications == nil)
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousMapViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousMapViewTests.swift
@@ -12,4 +12,18 @@ struct AnonymousMapViewTests {
     let sut = AnonymousMapView(viewModel: viewModel)
     _ = sut.body
   }
+
+  /// Compiles and renders with the stacked-cluster disambiguation sheet
+  /// (GH#877) populated, exercising the `.sheet(item:onDismiss:)` wiring
+  /// added alongside the existing summary sheet.
+  @Test func body_renders_withStackedApplicationsPresented() {
+    let viewModel = AnonymousMapViewModel(
+      repository: SpyAnonymousApplicationsRepository(), coordinate: .cambridge)
+    viewModel.selectStack([.pendingReview, .permitted])
+    let sut = AnonymousMapView(viewModel: viewModel)
+
+    _ = sut.body
+
+    #expect(viewModel.stackedApplications?.applications == [.pendingReview, .permitted])
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/StackedApplicationsSheetTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/StackedApplicationsSheetTests.swift
@@ -1,0 +1,29 @@
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+/// Smoke-tests ``StackedApplicationsSheet``'s presentation-only, closure-injected
+/// API (GH#877) — it must build and render with no concrete `MapViewModel`
+/// dependency, so both the authenticated and anonymous maps can present the
+/// same sheet.
+@MainActor
+@Suite("StackedApplicationsSheet")
+struct StackedApplicationsSheetTests {
+  @Test func body_renders_withClosureInjectedOnSelect() {
+    let stacked = StackedApplications(id: "stack-1", applications: [.pendingReview, .permitted])
+    let sut = StackedApplicationsSheet(stacked: stacked) { _ in }
+
+    _ = sut.body
+  }
+
+  @Test func onSelect_invokedWithTappedApplication() {
+    let stacked = StackedApplications(id: "stack-1", applications: [.pendingReview, .permitted])
+    var received: PlanningApplication?
+    let sut = StackedApplicationsSheet(stacked: stacked) { received = $0 }
+
+    sut.onSelect(.permitted)
+
+    #expect(received == .permitted)
+  }
+}


### PR DESCRIPTION
## Changes
- Anonymous map cluster taps now branch on a new pure `AnonymousClusterStackDetector` (coincidence epsilon 1e-5°, zoom-floor 0.001° fallback): stacked same-address clusters open the disambiguation list; spread clusters still zoom in (GH #877, bead tc-ket8u).
- `AnonymousMapViewModel` gains `stackedApplications` state with `selectStack`/`selectFromStack` — no network call, the applications are already loaded from `near-point`.
- `StackedApplicationsSheet` generalised from a concrete `MapViewModel` dependency to an `onSelect` closure and reused by both maps (single component for the #857 restyle); authed map call site updated mechanically, behaviour unchanged.
- Sim-verified live against dev (Birmingham B4 6NH): stacked sheet content, list→summary dismiss handoff, and spread-cluster zoom all confirmed.

Release-Note: Tapping a map cluster of applications at the same address now lists them so you can open each one.

---
*Auto-shipped via ship skill*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ApYCEogBeZYu7UP4LEouyW