### PR TITLE
feat(ios): appearance picker on the anonymous welcome screen (#878)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
@@ -58,6 +58,11 @@ public final class AppCoordinator: ObservableObject {
   // nothing. Internal (not private) so the AppCoordinator+Onboarding
   // extension can read it.
   let anonymousBrowseStateRepository: AnonymousBrowseStateRepository?
+  // Single live source of truth for the appearance preference (GH#878),
+  // shared with the anonymous welcome screen. Optional so existing call
+  // sites/tests that don't exercise appearance inject nothing — forwarded
+  // as-is to `SettingsViewModel`, which falls back to its own store.
+  private let appearanceStore: AppearanceStore?
   let notificationService: NotificationService
   // Internal (not private) so the AppCoordinator+WatchZones extension can read it.
   let offlineRepository: OfflineAwareRepository?
@@ -118,7 +123,8 @@ public final class AppCoordinator: ObservableObject {
     notificationStateRepository: NotificationStateRepository? = nil,
     badgeSetter: BadgeSetting? = nil,
     reviewPromptTracker: ReviewPromptTracker? = nil,
-    anonymousBrowseStateRepository: AnonymousBrowseStateRepository? = nil
+    anonymousBrowseStateRepository: AnonymousBrowseStateRepository? = nil,
+    appearanceStore: AppearanceStore? = nil
   ) {
     self.repository = repository
     self.authService = authService
@@ -147,6 +153,7 @@ public final class AppCoordinator: ObservableObject {
     self.badgeSetter = badgeSetter
     self.reviewPromptTracker = reviewPromptTracker
     self.anonymousBrowseStateRepository = anonymousBrowseStateRepository
+    self.appearanceStore = appearanceStore
 
     // Restore the last successfully resolved tier so that paying users
     // retain feature access immediately, even before the live resolution
@@ -256,7 +263,8 @@ public final class AppCoordinator: ObservableObject {
       subscriptionService: subscriptionService,
       userProfileRepository: userProfileRepository,
       appVersionProvider: appVersionProvider,
-      notificationService: notificationService
+      notificationService: notificationService,
+      appearanceStore: appearanceStore
     )
   }
 

--- a/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Colors/AppearanceStore.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Colors/AppearanceStore.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Single live source of truth for the user's appearance preference
+/// (System/Light/Dark/OLED Dark), persisted to UserDefaults under the same
+/// `"appearanceMode"` key `SettingsViewModel` has always used (GH#878).
+///
+/// Owned once at the composition root (`TownCrierApp.swift`) and injected
+/// into both `SettingsViewModel` (Settings picker) and the anonymous
+/// welcome screen's appearance control (`WelcomeViewModel`), so a change
+/// from either surface live-updates the root `.preferredColorScheme`
+/// immediately. A second object merely writing the same UserDefaults key
+/// would persist correctly but would NOT live-update the already-published
+/// scheme until relaunch — this type exists so there is exactly one
+/// `@Published` instance for every consumer to share.
+@MainActor
+public final class AppearanceStore: ObservableObject {
+  public static let appearanceModeKey = "appearanceMode"
+
+  @Published public var appearanceMode: AppearanceMode {
+    didSet {
+      defaults.set(appearanceMode.rawValue, forKey: Self.appearanceModeKey)
+    }
+  }
+
+  private let defaults: UserDefaults
+
+  public init(defaults: UserDefaults = .standard) {
+    self.defaults = defaults
+    let storedRaw = defaults.string(forKey: Self.appearanceModeKey) ?? ""
+    self.appearanceMode = AppearanceMode(rawValue: storedRaw) ?? .system
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousBrowseCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousBrowseCoordinator.swift
@@ -31,6 +31,11 @@ public final class AnonymousBrowseCoordinator: ObservableObject {
   /// radius picker so a slider drag re-persists the postcode/coordinate
   /// alongside the newly chosen radius (GH#868 Phase 3 refinement).
   private var currentState: AnonymousBrowseState?
+  /// Single live source of truth for the appearance preference (GH#878),
+  /// shared with `SettingsViewModel` — injected by the composition root so
+  /// the welcome screen's appearance control and the root
+  /// `.preferredColorScheme` observe the exact same instance.
+  private let appearanceStore: AppearanceStore
 
   /// Fired by "I already have an account", the postcode-entry back button's
   /// sibling CTA paths, and the map's CTA banner / deeper-action taps — all
@@ -41,11 +46,13 @@ public final class AnonymousBrowseCoordinator: ObservableObject {
   public init(
     geocoder: PostcodeGeocoder,
     stateRepository: AnonymousBrowseStateRepository,
-    applicationsRepository: AnonymousApplicationsRepository
+    applicationsRepository: AnonymousApplicationsRepository,
+    appearanceStore: AppearanceStore? = nil
   ) {
     self.geocoder = geocoder
     self.stateRepository = stateRepository
     self.applicationsRepository = applicationsRepository
+    self.appearanceStore = appearanceStore ?? AppearanceStore()
     self.screen = .welcome
     self.mapViewModel = nil
 
@@ -60,6 +67,7 @@ public final class AnonymousBrowseCoordinator: ObservableObject {
 
   public func makeWelcomeViewModel() -> WelcomeViewModel {
     WelcomeViewModel(
+      appearanceStore: appearanceStore,
       onGetStarted: { [weak self] in self?.screen = .postcodeEntry },
       onSignIn: { [weak self] in self?.onRequestSignIn?() }
     )

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/WelcomeView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/WelcomeView.swift
@@ -4,6 +4,10 @@ import SwiftUI
 /// session and no persisted anonymous browse state (GH#868 Phase 3). "Get
 /// started" routes to postcode entry with no account and no Auth0 call;
 /// "I already have an account" routes into the existing Auth0 login flow.
+///
+/// Also carries a compact top-trailing appearance control (GH#878): an
+/// anonymous user has no way into Settings, so this is the only place they
+/// can switch off the system theme before creating an account.
 public struct WelcomeView: View {
   @StateObject private var viewModel: WelcomeViewModel
 
@@ -42,5 +46,42 @@ public struct WelcomeView: View {
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(Color.tcBackground)
+    .overlay(alignment: .topTrailing) {
+      appearanceMenu
+        .padding(.top, TCSpacing.small)
+        .padding(.trailing, TCSpacing.medium)
+    }
+  }
+
+  /// Top-trailing icon button opening a `Menu` of all four `AppearanceMode`
+  /// cases — same set and display names as the Settings picker. A `Picker`
+  /// nested inside the `Menu` gets SwiftUI's built-in checkmark-on-selected
+  /// rendering for free, so the current mode is indicated without hand-rolled
+  /// per-row styling.
+  private var appearanceMenu: some View {
+    Menu {
+      Picker(selection: appearanceModeBinding) {
+        ForEach(AppearanceMode.allCases, id: \.self) { mode in
+          Text(mode.displayName).tag(mode)
+        }
+      } label: {
+        EmptyView()
+      }
+    } label: {
+      Image(systemName: "circle.lefthalf.filled")
+        .font(.system(.body))
+        .foregroundStyle(Color.tcTextSecondary)
+        // Apple HIG minimum tap target, matching the Buttons component spec.
+        .frame(width: 44, height: 44)
+        .contentShape(Rectangle())
+    }
+    .accessibilityLabel("Appearance")
+  }
+
+  private var appearanceModeBinding: Binding<AppearanceMode> {
+    Binding(
+      get: { viewModel.appearanceMode },
+      set: { viewModel.selectAppearanceMode($0) }
+    )
   }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/WelcomeViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/WelcomeViewModel.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 
 /// Backs the anonymous browse flow's welcome screen (GH#868 Phase 3): a thin
@@ -16,15 +17,25 @@ public final class WelcomeViewModel: ObservableObject {
   private let onGetStarted: (() -> Void)?
   private let onSignIn: (() -> Void)?
   private let appearanceStore: AppearanceStore
+  // Forwards the shared store's own `objectWillChange` into this ViewModel's
+  // — without this, `WelcomeView` (which observes `self`, not the store
+  // directly) never re-renders when the mode changes from elsewhere (e.g.
+  // Settings), so the welcome Menu's Picker shows a stale checkmark on
+  // reopen even though `appearanceMode` itself always reads the live value.
+  private var appearanceStoreSubscription: AnyCancellable?
 
   public init(
     appearanceStore: AppearanceStore? = nil,
     onGetStarted: (() -> Void)? = nil,
     onSignIn: (() -> Void)? = nil
   ) {
-    self.appearanceStore = appearanceStore ?? AppearanceStore()
+    let store = appearanceStore ?? AppearanceStore()
+    self.appearanceStore = store
     self.onGetStarted = onGetStarted
     self.onSignIn = onSignIn
+    appearanceStoreSubscription = store.objectWillChange.sink { [weak self] in
+      self?.objectWillChange.send()
+    }
   }
 
   /// "Get started" — routes to postcode entry. Deliberately never calls Auth0;

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/WelcomeViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/WelcomeViewModel.swift
@@ -4,12 +4,25 @@ import Foundation
 /// ViewModel whose only job is to expose the two entry intents. Navigation is
 /// decided by ``AnonymousBrowseCoordinator``, which wires the callbacks —
 /// mirrors ``MapViewModel/onApplicationSelected``.
+///
+/// Also exposes the appearance control (GH#878): `appearanceMode` and
+/// `selectAppearanceMode(_:)` forward directly to the injected
+/// ``AppearanceStore`` — the same single live instance `SettingsViewModel`
+/// reads and writes — so a mode picked here is immediately what the root
+/// `.preferredColorScheme` and the Settings picker both see, with no second
+/// copy of the state to diverge.
 @MainActor
 public final class WelcomeViewModel: ObservableObject {
   private let onGetStarted: (() -> Void)?
   private let onSignIn: (() -> Void)?
+  private let appearanceStore: AppearanceStore
 
-  public init(onGetStarted: (() -> Void)? = nil, onSignIn: (() -> Void)? = nil) {
+  public init(
+    appearanceStore: AppearanceStore? = nil,
+    onGetStarted: (() -> Void)? = nil,
+    onSignIn: (() -> Void)? = nil
+  ) {
+    self.appearanceStore = appearanceStore ?? AppearanceStore()
     self.onGetStarted = onGetStarted
     self.onSignIn = onSignIn
   }
@@ -23,5 +36,19 @@ public final class WelcomeViewModel: ObservableObject {
   /// "I already have an account" — routes to the existing Auth0 login flow.
   public func signIn() {
     onSignIn?()
+  }
+
+  /// The currently active appearance mode — a live read-through to the
+  /// shared ``AppearanceStore``, never a separate copy.
+  public var appearanceMode: AppearanceMode {
+    appearanceStore.appearanceMode
+  }
+
+  /// Picks a new appearance mode from the welcome screen's Menu. Writes
+  /// straight through to the shared store, which persists it and — because
+  /// the store is the same instance the app root observes — live-updates the
+  /// colour scheme immediately.
+  public func selectAppearanceMode(_ mode: AppearanceMode) {
+    appearanceStore.appearanceMode = mode
   }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Settings/SettingsViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Settings/SettingsViewModel.swift
@@ -41,6 +41,11 @@ public final class SettingsViewModel: ObservableObject, ErrorHandlingViewModel {
   private let appVersionProvider: AppVersionProvider
   private let notificationService: NotificationService
   private let appearanceStore: AppearanceStore
+  // Forwards the shared store's own `objectWillChange` into this ViewModel's
+  // (GH#878 follow-up) — a change originating elsewhere (e.g. the welcome
+  // screen) must still invalidate any open `SettingsView`, not just changes
+  // made through this ViewModel's own Picker binding.
+  private var appearanceStoreSubscription: AnyCancellable?
   private let exportFileWriter: (Data) throws -> URL
 
   public init(
@@ -67,8 +72,12 @@ public final class SettingsViewModel: ObservableObject, ErrorHandlingViewModel {
       )
     self.appVersionProvider = appVersionProvider
     self.notificationService = notificationService
-    self.appearanceStore = appearanceStore ?? AppearanceStore(defaults: defaults)
+    let store = appearanceStore ?? AppearanceStore(defaults: defaults)
+    self.appearanceStore = store
     self.exportFileWriter = exportFileWriter
+    appearanceStoreSubscription = store.objectWillChange.sink { [weak self] in
+      self?.objectWillChange.send()
+    }
   }
 
   /// The currently active appearance mode — a live read-through to the

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Settings/SettingsViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Settings/SettingsViewModel.swift
@@ -26,15 +26,13 @@ public final class SettingsViewModel: ObservableObject, ErrorHandlingViewModel {
   /// User-facing message shown when an export fails. `nil` when there is no
   /// export error to display; the View presents an alert while it is non-nil.
   @Published public private(set) var exportErrorMessage: String?
-  @Published public var appearanceMode: AppearanceMode {
-    didSet {
-      defaults.set(appearanceMode.rawValue, forKey: Self.appearanceModeKey)
-    }
-  }
 
   public var onLogout: (() -> Void)?
 
-  static let appearanceModeKey = "appearanceMode"
+  /// Alias kept for source compatibility — the key itself now lives on
+  /// ``AppearanceStore``, the single live source of truth shared with the
+  /// anonymous welcome screen's appearance control (GH#878).
+  static let appearanceModeKey = AppearanceStore.appearanceModeKey
 
   private let authService: AuthenticationService
   private let subscriptionService: SubscriptionService
@@ -42,7 +40,7 @@ public final class SettingsViewModel: ObservableObject, ErrorHandlingViewModel {
   private let tierResolver: SubscriptionTierResolving
   private let appVersionProvider: AppVersionProvider
   private let notificationService: NotificationService
-  private let defaults: UserDefaults
+  private let appearanceStore: AppearanceStore
   private let exportFileWriter: (Data) throws -> URL
 
   public init(
@@ -53,6 +51,7 @@ public final class SettingsViewModel: ObservableObject, ErrorHandlingViewModel {
     appVersionProvider: AppVersionProvider,
     notificationService: NotificationService,
     defaults: UserDefaults = .standard,
+    appearanceStore: AppearanceStore? = nil,
     exportFileWriter: @escaping (Data) throws -> URL = SettingsViewModel.writeExportToTempFile
   ) {
     self.authService = authService
@@ -68,11 +67,16 @@ public final class SettingsViewModel: ObservableObject, ErrorHandlingViewModel {
       )
     self.appVersionProvider = appVersionProvider
     self.notificationService = notificationService
-    self.defaults = defaults
+    self.appearanceStore = appearanceStore ?? AppearanceStore(defaults: defaults)
     self.exportFileWriter = exportFileWriter
+  }
 
-    let storedRaw = defaults.string(forKey: Self.appearanceModeKey) ?? ""
-    self.appearanceMode = AppearanceMode(rawValue: storedRaw) ?? .system
+  /// The currently active appearance mode — a live read-through to the
+  /// shared ``AppearanceStore`` (GH#878), never a separate copy. Bound by the
+  /// Settings picker via `$viewModel.appearanceMode`.
+  public var appearanceMode: AppearanceMode {
+    get { appearanceStore.appearanceMode }
+    set { appearanceStore.appearanceMode = newValue }
   }
 
   public var appVersion: String {

--- a/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
+++ b/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
@@ -15,6 +15,13 @@ struct TownCrierApp: App {
   @StateObject private var forceUpdateViewModel: ForceUpdateViewModel
   @StateObject private var settingsViewModel: SettingsViewModel
   @StateObject private var anonymousBrowseCoordinator: AnonymousBrowseCoordinator
+  // Single live source of truth for the appearance preference (GH#878): the
+  // ONE `AppearanceStore` instance shared by `SettingsViewModel`, the
+  // anonymous welcome screen's appearance control, and the root
+  // `.preferredColorScheme` below — a second object merely writing the same
+  // UserDefaults key would persist but not live-update this scheme until
+  // relaunch.
+  @StateObject private var appearanceStore: AppearanceStore
   private let crashReporter: CrashReporter
   private let notificationDelegate: NotificationDelegate
   private let pushRegistrar: PushNotificationRegistrar
@@ -25,6 +32,12 @@ struct TownCrierApp: App {
       domain: "towncrierapp.uk.auth0.com",
       audience: APIEnvironment.current.baseURL.absoluteString
     )
+
+    // Owned once here (GH#878) — every consumer below (`AppCoordinator`,
+    // `AnonymousBrowseCoordinator`, and this struct's own `appearanceStore`
+    // StateObject) shares this exact instance.
+    let sharedAppearanceStore = AppearanceStore()
+    _appearanceStore = StateObject(wrappedValue: sharedAppearanceStore)
 
     let authService = Auth0AuthenticationService(config: auth0Config)
     let appVersionProvider = BundleAppVersionProvider()
@@ -98,7 +111,8 @@ struct TownCrierApp: App {
       notificationStateRepository: notificationStateRepository,
       badgeSetter: UIApplicationBadgeSetter(),
       reviewPromptTracker: reviewPromptTracker,
-      anonymousBrowseStateRepository: anonymousBrowseStateRepository
+      anonymousBrowseStateRepository: anonymousBrowseStateRepository,
+      appearanceStore: sharedAppearanceStore
     )
     reviewRequester.coordinator = appCoordinator  // weak; coordinator owns the tracker
     _coordinator = StateObject(wrappedValue: appCoordinator)
@@ -122,7 +136,8 @@ struct TownCrierApp: App {
     let anonymousCoordinator = AnonymousBrowseCoordinator(
       geocoder: anonymousGeocoder,
       stateRepository: anonymousBrowseStateRepository,
-      applicationsRepository: anonymousApplicationsRepository
+      applicationsRepository: anonymousApplicationsRepository,
+      appearanceStore: sharedAppearanceStore
     )
     anonymousCoordinator.onRequestSignIn = {
       Task { @MainActor in await loginVM.login() }
@@ -226,7 +241,7 @@ struct TownCrierApp: App {
         Task { await coordinator.syncBadge() }
       }
       .requestingReview(when: coordinator)
-      .preferredColorScheme(settingsViewModel.appearanceMode.preferredColorScheme)
+      .preferredColorScheme(appearanceStore.appearanceMode.preferredColorScheme)
       .alert(
         coordinator.deepLinkError?.userTitle ?? "Error",
         isPresented: Binding(

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousBrowseCoordinatorTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousBrowseCoordinatorTests.swift
@@ -8,7 +8,8 @@ import TownCrierDomain
 @MainActor
 struct AnonymousBrowseCoordinatorTests {
   private func makeSUT(
-    persistedState: AnonymousBrowseState? = nil
+    persistedState: AnonymousBrowseState? = nil,
+    appearanceStore: AppearanceStore? = nil
   ) -> (
     AnonymousBrowseCoordinator, SpyPostcodeGeocoder, SpyAnonymousBrowseStateRepository,
     SpyAnonymousApplicationsRepository
@@ -20,7 +21,8 @@ struct AnonymousBrowseCoordinatorTests {
     let sut = AnonymousBrowseCoordinator(
       geocoder: geocoder,
       stateRepository: stateRepository,
-      applicationsRepository: applicationsRepository
+      applicationsRepository: applicationsRepository,
+      appearanceStore: appearanceStore
     )
     return (sut, geocoder, stateRepository, applicationsRepository)
   }
@@ -141,6 +143,32 @@ struct AnonymousBrowseCoordinatorTests {
     let (sut, _, _, _) = makeSUT(persistedState: stateWithRadius)
 
     #expect(sut.mapViewModel?.selectedRadiusMetres == 1500)
+  }
+
+  // MARK: - Appearance (GH#878)
+
+  @Test func makeWelcomeViewModel_usesTheInjectedAppearanceStore() {
+    let defaults = UserDefaults(suiteName: UUID().uuidString)
+    // swiftlint:disable:next force_unwrapping
+    let appearanceStore = AppearanceStore(defaults: defaults!)
+    appearanceStore.appearanceMode = .oledDark
+    let (sut, _, _, _) = makeSUT(appearanceStore: appearanceStore)
+
+    let welcomeVM = sut.makeWelcomeViewModel()
+
+    #expect(welcomeVM.appearanceMode == .oledDark)
+  }
+
+  @Test func welcomeViewModel_selectAppearanceMode_updatesTheSameInjectedStore() {
+    let defaults = UserDefaults(suiteName: UUID().uuidString)
+    // swiftlint:disable:next force_unwrapping
+    let appearanceStore = AppearanceStore(defaults: defaults!)
+    let (sut, _, _, _) = makeSUT(appearanceStore: appearanceStore)
+    let welcomeVM = sut.makeWelcomeViewModel()
+
+    welcomeVM.selectAppearanceMode(.dark)
+
+    #expect(appearanceStore.appearanceMode == .dark)
   }
 
   // MARK: - Reset (sign-out)

--- a/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorAppearanceModeTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorAppearanceModeTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+/// GH#878: the composition root injects one shared `AppearanceStore` into
+/// `AppCoordinator`, which `makeSettingsViewModel()` must forward rather than
+/// let `SettingsViewModel` fall back to a private store — otherwise the
+/// Settings picker would silently diverge from the welcome screen's control.
+@Suite("AppCoordinator -- Appearance Mode")
+@MainActor
+struct AppCoordinatorAppearanceModeTests {
+  private func makeSUT(appearanceStore: AppearanceStore? = nil) -> AppCoordinator {
+    AppCoordinator(
+      repository: SpyPlanningApplicationRepository(),
+      authService: SpyAuthenticationService(),
+      subscriptionService: SpySubscriptionService(),
+      userProfileRepository: SpyUserProfileRepository(),
+      watchZoneRepository: SpyWatchZoneRepository(),
+      geocoder: SpyPostcodeGeocoder(),
+      onboardingRepository: SpyOnboardingRepository(),
+      notificationService: SpyNotificationService(),
+      appVersionProvider: SpyAppVersionProvider(),
+      versionConfigService: SpyVersionConfigService(),
+      appearanceStore: appearanceStore
+    )
+  }
+
+  @Test func makeSettingsViewModel_usesTheInjectedAppearanceStore() {
+    let defaults = UserDefaults(suiteName: UUID().uuidString)
+    // swiftlint:disable:next force_unwrapping
+    let appearanceStore = AppearanceStore(defaults: defaults!)
+    appearanceStore.appearanceMode = .oledDark
+    let sut = makeSUT(appearanceStore: appearanceStore)
+
+    let vm = sut.makeSettingsViewModel()
+
+    #expect(vm.appearanceMode == .oledDark)
+  }
+
+  @Test func makeSettingsViewModel_settingAppearanceMode_updatesTheSameInjectedStore() {
+    let defaults = UserDefaults(suiteName: UUID().uuidString)
+    // swiftlint:disable:next force_unwrapping
+    let appearanceStore = AppearanceStore(defaults: defaults!)
+    let sut = makeSUT(appearanceStore: appearanceStore)
+    let vm = sut.makeSettingsViewModel()
+
+    vm.appearanceMode = .light
+
+    #expect(appearanceStore.appearanceMode == .light)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/AppearanceStoreTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AppearanceStoreTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Testing
+
+@testable import TownCrierPresentation
+
+/// GH#878: single live source of truth for the app's appearance preference,
+/// shared between the Settings picker and the anonymous welcome screen's
+/// appearance control. Persists to the same `"appearanceMode"` UserDefaults
+/// key `SettingsViewModel` has always used (mirrors
+/// `SettingsAppearanceModeTests`' persistence-test conventions).
+@Suite("AppearanceStore")
+@MainActor
+struct AppearanceStoreTests {
+  private func makeDefaults() -> UserDefaults {
+    // swiftlint:disable:next force_unwrapping
+    UserDefaults(suiteName: UUID().uuidString)!
+  }
+
+  @Test func appearanceMode_defaultsToSystem_whenNothingStored() {
+    let sut = AppearanceStore(defaults: makeDefaults())
+
+    #expect(sut.appearanceMode == .system)
+  }
+
+  @Test func appearanceMode_defaultsToSystem_forUnknownStoredRawValue() {
+    let defaults = makeDefaults()
+    defaults.set("not-a-real-mode", forKey: AppearanceStore.appearanceModeKey)
+
+    let sut = AppearanceStore(defaults: defaults)
+
+    #expect(sut.appearanceMode == .system)
+  }
+
+  @Test func settingAppearanceMode_persistsRawValueToUserDefaults() {
+    let defaults = makeDefaults()
+    let sut = AppearanceStore(defaults: defaults)
+
+    sut.appearanceMode = .oledDark
+
+    #expect(defaults.string(forKey: AppearanceStore.appearanceModeKey) == "oledDark")
+  }
+
+  @Test func freshInstance_roundTripsPersistedValue() {
+    let defaults = makeDefaults()
+    let first = AppearanceStore(defaults: defaults)
+    first.appearanceMode = .dark
+
+    let second = AppearanceStore(defaults: defaults)
+
+    #expect(second.appearanceMode == .dark)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/SettingsAppearanceModeTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/SettingsAppearanceModeTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import Testing
 import TownCrierDomain
@@ -85,5 +86,32 @@ struct SettingsAppearanceModeTests {
     let sut = makeSUT(appearanceMode: .dark)
 
     #expect(sut.appearanceMode == .dark)
+  }
+
+  // MARK: - Live re-render when the store changes from elsewhere (GH#878 follow-up)
+
+  /// The Settings Picker happened to look fine when the change originated
+  /// from the Picker's own binding — SwiftUI's `ObservedObject.Wrapper`
+  /// setter sends `objectWillChange` on our behalf in that one case. This
+  /// test targets a change that originates elsewhere (e.g. the welcome
+  /// screen's control), which that self-triggered path can't cover.
+  @Test func externalStoreMutation_notifiesSettingsViewModelObjectWillChange() {
+    let store = AppearanceStore(defaults: UserDefaults(suiteName: UUID().uuidString) ?? .standard)
+    let sut = SettingsViewModel(
+      authService: SpyAuthenticationService(),
+      subscriptionService: SpySubscriptionService(),
+      userProfileRepository: SpyUserProfileRepository(),
+      appVersionProvider: SpyAppVersionProvider(),
+      notificationService: SpyNotificationService(),
+      appearanceStore: store
+    )
+    var notified = false
+    let subscription = sut.objectWillChange.sink { _ in notified = true }
+
+    withExtendedLifetime(subscription) {
+      store.appearanceMode = .oledDark
+    }
+
+    #expect(notified)
   }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/WelcomeAppearanceModeTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WelcomeAppearanceModeTests.swift
@@ -1,0 +1,102 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+/// GH#878: appearance control on the anonymous welcome screen. Mirrors
+/// `SettingsAppearanceModeTests`' persistence-test conventions (injected
+/// `UserDefaults(suiteName:)`), but the crux of this suite is the
+/// single-source-of-truth guarantee — a mode picked from the welcome screen
+/// must be exactly what `SettingsViewModel` exposes afterwards, with no
+/// separate copy of the state to diverge.
+@Suite("WelcomeViewModel -- Appearance Mode")
+@MainActor
+struct WelcomeAppearanceModeTests {
+  private func makeDefaults() -> UserDefaults {
+    // swiftlint:disable:next force_unwrapping
+    UserDefaults(suiteName: UUID().uuidString)!
+  }
+
+  private func makeSettingsViewModel(
+    defaults: UserDefaults,
+    appearanceStore: AppearanceStore
+  ) -> SettingsViewModel {
+    SettingsViewModel(
+      authService: SpyAuthenticationService(),
+      subscriptionService: SpySubscriptionService(),
+      userProfileRepository: SpyUserProfileRepository(),
+      appVersionProvider: SpyAppVersionProvider(),
+      notificationService: SpyNotificationService(),
+      defaults: defaults,
+      appearanceStore: appearanceStore
+    )
+  }
+
+  @Test func appearanceMode_defaultsToStoreValue() {
+    let store = AppearanceStore(defaults: makeDefaults())
+    let sut = WelcomeViewModel(appearanceStore: store)
+
+    #expect(sut.appearanceMode == .system)
+  }
+
+  @Test func selectAppearanceMode_updatesExposedAppearanceMode() {
+    let store = AppearanceStore(defaults: makeDefaults())
+    let sut = WelcomeViewModel(appearanceStore: store)
+
+    sut.selectAppearanceMode(.dark)
+
+    #expect(sut.appearanceMode == .dark)
+  }
+
+  @Test func selectAppearanceMode_persistsRawValueToUserDefaults() {
+    let defaults = makeDefaults()
+    let store = AppearanceStore(defaults: defaults)
+    let sut = WelcomeViewModel(appearanceStore: store)
+
+    sut.selectAppearanceMode(.oledDark)
+
+    #expect(defaults.string(forKey: AppearanceStore.appearanceModeKey) == "oledDark")
+  }
+
+  @Test func selectAppearanceMode_updatesTheSharedStoreDirectly() {
+    let store = AppearanceStore(defaults: makeDefaults())
+    let sut = WelcomeViewModel(appearanceStore: store)
+
+    sut.selectAppearanceMode(.light)
+
+    #expect(store.appearanceMode == .light)
+  }
+
+  // MARK: - One source of truth with Settings (no divergence)
+
+  @Test func selectAppearanceMode_isReflectedBySettingsViewModel_sharingSameStore() {
+    let defaults = makeDefaults()
+    let store = AppearanceStore(defaults: defaults)
+    let welcomeVM = WelcomeViewModel(appearanceStore: store)
+    let settingsVM = makeSettingsViewModel(defaults: defaults, appearanceStore: store)
+
+    welcomeVM.selectAppearanceMode(.oledDark)
+
+    #expect(settingsVM.appearanceMode == .oledDark)
+  }
+
+  @Test func settingsViewModelChange_isReflectedByWelcomeViewModel_sharingSameStore() {
+    let defaults = makeDefaults()
+    let store = AppearanceStore(defaults: defaults)
+    let welcomeVM = WelcomeViewModel(appearanceStore: store)
+    let settingsVM = makeSettingsViewModel(defaults: defaults, appearanceStore: store)
+
+    settingsVM.appearanceMode = .dark
+
+    #expect(welcomeVM.appearanceMode == .dark)
+  }
+
+  // MARK: - Existing WelcomeViewModel callback behaviour is untouched
+
+  @Test func missingAppearanceStore_defaultsToSystem() {
+    let sut = WelcomeViewModel()
+
+    #expect(sut.appearanceMode == .system)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/WelcomeAppearanceModeTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WelcomeAppearanceModeTests.swift
@@ -94,9 +94,15 @@ struct WelcomeAppearanceModeTests {
 
   // MARK: - Existing WelcomeViewModel callback behaviour is untouched
 
-  @Test func missingAppearanceStore_defaultsToSystem() {
+  @Test func missingAppearanceStore_stillConstructsAValidViewModel() {
+    // No injected store — falls back to `AppearanceStore()` (real
+    // `UserDefaults.standard`), mirroring `SettingsViewModel`'s own
+    // `.standard` fallback. Deliberately does not assert a specific mode:
+    // `.standard` is shared, real device/host state, not a value this test
+    // owns (see `AppearanceStoreTests` for the isolated-defaults coverage of
+    // the actual `.system` fallback behaviour).
     let sut = WelcomeViewModel()
 
-    #expect(sut.appearanceMode == .system)
+    _ = sut.appearanceMode
   }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/WelcomeAppearanceModeTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WelcomeAppearanceModeTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import Testing
 import TownCrierDomain
@@ -90,6 +91,29 @@ struct WelcomeAppearanceModeTests {
     settingsVM.appearanceMode = .dark
 
     #expect(welcomeVM.appearanceMode == .dark)
+  }
+
+  // MARK: - Live re-render when the store changes from elsewhere (defect repro)
+
+  /// GH#878 follow-up: live-simulator verification found reopening the
+  /// welcome Menu after picking Dark/Light still showed "System" checked —
+  /// the underlying store value was correct, but `WelcomeViewModel` never
+  /// forwarded the store's change into its own `objectWillChange`, so
+  /// SwiftUI never rebuilt the Menu's Picker. `appearanceMode` being a live
+  /// read-through (already covered above) is necessary but not sufficient —
+  /// this test targets the missing notification specifically, by mutating
+  /// the store WITHOUT going through `sut.selectAppearanceMode(_:)`.
+  @Test func externalStoreMutation_notifiesWelcomeViewModelObjectWillChange() {
+    let store = AppearanceStore(defaults: makeDefaults())
+    let sut = WelcomeViewModel(appearanceStore: store)
+    var notified = false
+    let subscription = sut.objectWillChange.sink { _ in notified = true }
+
+    withExtendedLifetime(subscription) {
+      store.appearanceMode = .dark
+    }
+
+    #expect(notified)
   }
 
   // MARK: - Existing WelcomeViewModel callback behaviour is untouched

--- a/mobile/ios/town-crier-tests/Sources/Features/WelcomeViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WelcomeViewTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 
 @testable import TownCrierPresentation
@@ -12,6 +13,16 @@ struct WelcomeViewTests {
 
   @Test func body_renders_withCallbacksWired() {
     let viewModel = WelcomeViewModel(onGetStarted: {}, onSignIn: {})
+    let sut = WelcomeView(viewModel: viewModel)
+    _ = sut.body
+  }
+
+  // MARK: - Appearance menu (GH#878)
+
+  @Test func body_renders_withAppearanceStoreWired() {
+    // swiftlint:disable:next force_unwrapping
+    let store = AppearanceStore(defaults: UserDefaults(suiteName: UUID().uuidString)!)
+    let viewModel = WelcomeViewModel(appearanceStore: store, onGetStarted: {}, onSignIn: {})
     let sut = WelcomeView(viewModel: viewModel)
     _ = sut.body
   }


### PR DESCRIPTION
## Changes
- New `AppearanceStore` (ObservableObject, existing `"appearanceMode"` UserDefaults key, `.system` fallback) extracted as the single live source of truth; owned by `TownCrierApp` as `@StateObject`, and the root `.preferredColorScheme` now reads it directly (GH #878, bead tc-2rene).
- `WelcomeView` gains a top-trailing 44×44pt appearance Menu (System / Light / Dark / OLED Dark) via `WelcomeViewModel` pass-throughs; `SettingsViewModel.appearanceMode` becomes a pass-through to the same store, so the Settings picker and welcome control can never diverge.
- Both consuming ViewModels forward the store's `objectWillChange` (Combine sink) — fixes a sim-verified defect where the reopened menu showed a stale checked item.
- Sim-verified live: immediate restyle in all four modes, relaunch persistence, and correct selection indicator through every mode change.

Release-Note: Switch between light and dark looks right from the welcome screen.

---
*Auto-shipped via ship skill*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ApYCEogBeZYu7UP4LEouyW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a theme/appearance selector on the anonymous welcome screen.
  * Appearance choices now stay in sync between welcome and settings screens.
  * App-wide appearance updates now apply live across the UI.

* **Bug Fixes**
  * Improved consistency so changing appearance in one place updates all related screens immediately.
  * Restored saved appearance correctly when reopening the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->