### PR TITLE
feat(ios): anonymous full application detail + signed-out share-link fix (#879 Phase 2)

### DIFF
--- a/mobile/ios/packages/town-crier-data/Sources/Repositories/APIAnonymousApplicationDetailRepository.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Repositories/APIAnonymousApplicationDetailRepository.swift
@@ -1,0 +1,40 @@
+import Foundation
+import TownCrierDomain
+
+/// Fetches a single planning application by its public share identity with no
+/// account or session (GH#879 Phase 2), backed by the public
+/// `GET /v1/applications/by-slug/{authoritySlug}/{ref...}` endpoint via
+/// ``AnonymousURLSessionAPIClient``. Reuses ``PlanningApplicationDTO`` and its
+/// `toDomain()` mapping — the wire shape is identical to the authed by-slug
+/// read, `APIPlanningApplicationRepository.fetchApplication(bySlug:ref:)`,
+/// which this deliberately mirrors so the two decode paths never drift.
+public final class APIAnonymousApplicationDetailRepository: AnonymousApplicationDetailRepository,
+  Sendable {
+  private let apiClient: AnonymousURLSessionAPIClient
+
+  public init(apiClient: AnonymousURLSessionAPIClient) {
+    self.apiClient = apiClient
+  }
+
+  public func fetchApplication(bySlug authoritySlug: String, ref: String) async throws
+    -> PlanningApplication {
+    let dto: PlanningApplicationDTO
+    do {
+      // The greedy `{**ref}` segment preserves slashes in the full
+      // area-prefixed PlanIt name, so `ref` interpolates raw exactly like
+      // `APIPlanningApplicationRepository.fetchApplication(bySlug:ref:)`.
+      dto = try await apiClient.request(
+        .get("/v1/applications/by-slug/\(authoritySlug)/\(ref)")
+      )
+    } catch APIError.notFound {
+      throw DomainError.applicationNotFound(
+        PlanningApplicationId(authority: authoritySlug, name: ref)
+      )
+    } catch let domainError as DomainError {
+      throw domainError
+    } catch {
+      throw error.toDomainError()
+    }
+    return dto.toDomain()
+  }
+}

--- a/mobile/ios/packages/town-crier-domain/Sources/Protocols/AnonymousApplicationDetailRepository.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/Protocols/AnonymousApplicationDetailRepository.swift
@@ -1,0 +1,16 @@
+/// Port for anonymous (no-account, no-session) planning application detail
+/// reads (GH#879 Phase 2): the public by-slug share endpoint, with no
+/// `AuthenticationService` requirement. A distinct protocol from
+/// ``PlanningApplicationRepository`` — rather than making that repository's
+/// `fetchApplication(bySlug:ref:)` do double duty — so the anonymous detail
+/// path can never accidentally depend on (or be satisfied by a fake for) the
+/// full authenticated repository surface.
+public protocol AnonymousApplicationDetailRepository: Sendable {
+  /// Fetches a single application by its public share identity — the
+  /// API-emitted authority slug plus the full area-prefixed PlanIt ref
+  /// (slashes preserved). Backs both an inbound share Universal Link
+  /// resolved with no session, and the anonymous detail screen's
+  /// stale-while-revalidate ``refresh()``.
+  func fetchApplication(bySlug authoritySlug: String, ref: String) async throws
+    -> PlanningApplication
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+Detail.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+Detail.swift
@@ -11,6 +11,19 @@ extension AppCoordinator {
   /// server (bd tc-sslz, tc-udby). Also used by the map summary sheet's
   /// "View full details" button (tc-1q07), which already holds the full object.
   func showApplicationDetail(_ application: PlanningApplication) {
+    isDetailApplicationAnonymous = false
+    detailApplication = application
+  }
+
+  /// Presents the detail sheet in anonymous mode from an already-loaded
+  /// application (GH#879 Phase 2) — the anonymous map/summary sheet's "View
+  /// full details" button. No network call, mirrors
+  /// ``showApplicationDetail(_:)-(PlanningApplication)`` but flags the
+  /// resulting detail view model as anonymous so
+  /// ``makeApplicationDetailViewModel(application:)`` hides Save, skips
+  /// saved-state, and refreshes via the by-slug read.
+  public func showAnonymousApplicationDetail(_ application: PlanningApplication) {
+    isDetailApplicationAnonymous = true
     detailApplication = application
   }
 
@@ -30,6 +43,7 @@ extension AppCoordinator {
         // After the await resumes we must check `Task.isCancelled` so a
         // superseded fetch does not stomp the latest tap's mutation.
         guard !Task.isCancelled else { return }
+        isDetailApplicationAnonymous = false
         detailApplication = application
       } catch let domainError as DomainError {
         guard !Task.isCancelled else { return }
@@ -42,18 +56,31 @@ extension AppCoordinator {
   }
 
   /// Resolves an inbound public share Universal Link `/a/{authoritySlug}/{ref...}`
-  /// (GH #738 Slice 4) into the native detail screen. The anonymous by-slug read
-  /// returns the full application, so this presents it directly — no round-trip
-  /// through the by-id fetch. Same cancellation-guard pattern as
-  /// ``showApplicationDetail(_:)-(PlanningApplicationId)`` so overlapping opens
-  /// collapse to a single presentation.
+  /// (GH #738 Slice 4) into the native detail screen. Routes to the anonymous
+  /// by-slug repository when there is no session (GH#879 Phase 2) — the authed
+  /// `URLSessionAPIClient` throws `sessionExpired` before any HTTP call with no
+  /// session, which previously surfaced a misleading "Session Expired" alert to
+  /// a signed-out user tapping a share link. A signed-in session always keeps
+  /// today's authed path: read-state marking and the by-id refresh-on-tap route
+  /// are authed-only server behaviours. Falls back to the authed repository if
+  /// no anonymous repository was injected, preserving prior behaviour. Same
+  /// cancellation-guard pattern as ``showApplicationDetail(_:)-(PlanningApplicationId)``
+  /// so overlapping opens collapse to a single presentation.
   func showApplicationDetail(bySlug authoritySlug: String, ref: String) {
     pendingDetailLoad?.cancel()
     pendingDetailLoad = Task { [weak self] in
       guard let self else { return }
+      let isAnonymous = await authService.currentSession() == nil
       do {
-        let application = try await repository.fetchApplication(bySlug: authoritySlug, ref: ref)
+        let application: PlanningApplication
+        if isAnonymous, let anonymousApplicationDetailRepository {
+          application = try await anonymousApplicationDetailRepository.fetchApplication(
+            bySlug: authoritySlug, ref: ref)
+        } else {
+          application = try await repository.fetchApplication(bySlug: authoritySlug, ref: ref)
+        }
         guard !Task.isCancelled else { return }
+        isDetailApplicationAnonymous = isAnonymous && anonymousApplicationDetailRepository != nil
         detailApplication = application
       } catch let domainError as DomainError {
         guard !Task.isCancelled else { return }
@@ -69,5 +96,45 @@ extension AppCoordinator {
   /// `showApplicationDetail` fetch. Replaces flaky `Task.sleep` waits.
   public func waitForPendingDetailLoad() async {
     await pendingDetailLoad?.value
+  }
+
+  /// Factory for the detail sheet's view model (`TownCrierApp.swift`'s
+  /// `.sheet(item: $coordinator.detailApplication)`). Configuration depends on
+  /// ``isDetailApplicationAnonymous`` (GH#879 Phase 2): the anonymous path gets
+  /// no Save/saved-state and refreshes via the by-slug read; the authed path is
+  /// unchanged. Falls back to the authed configuration if no anonymous
+  /// repository was injected.
+  public func makeApplicationDetailViewModel(
+    application: PlanningApplication
+  ) -> ApplicationDetailViewModel {
+    let viewModel: ApplicationDetailViewModel
+    if isDetailApplicationAnonymous, let anonymousApplicationDetailRepository {
+      viewModel = ApplicationDetailViewModel(
+        application: application,
+        anonymousApplicationDetailRepository: anonymousApplicationDetailRepository
+      )
+    } else {
+      viewModel = ApplicationDetailViewModel(
+        application: application,
+        savedApplicationRepository: savedApplicationRepository,
+        planningApplicationRepository: repository
+      )
+    }
+    viewModel.onDismiss = { [weak self] in
+      self?.detailApplication = nil
+    }
+    // Review-prompt value moments (GH #628): a portal tap-through and a save are
+    // both genuine engagement peaks. The save callback fires only on a
+    // successful false→true save (the view model guarantees this).
+    viewModel.onOpenPortal = { [weak self] _ in
+      self?.reviewPromptTracker?.record(.tappedPortal)
+    }
+    viewModel.onSaved = { [weak self] in
+      self?.reviewPromptTracker?.record(.savedApplication)
+    }
+    viewModel.onRequestSignUp = { [weak self] in
+      self?.onRequestSignUp?()
+    }
+    return viewModel
   }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
@@ -9,6 +9,11 @@ public final class AppCoordinator: ObservableObject {
   static let logger = Logger(subsystem: "uk.towncrierapp", category: "AppCoordinator")
 
   @Published public var detailApplication: PlanningApplication?
+  /// True when `detailApplication` was resolved via the anonymous
+  /// (no-session) path (GH#879 Phase 2), so `makeApplicationDetailViewModel`
+  /// builds the no-Save/sign-up-CTA/by-slug-refresh configuration. Internal
+  /// (not private) so AppCoordinator+Detail can set it.
+  var isDetailApplicationAnonymous = false
   @Published public var deepLinkError: DomainError?
   @Published public var presentedLegalDocument: LegalDocumentType?
   @Published public var isManageSubscriptionPresented = false
@@ -58,6 +63,13 @@ public final class AppCoordinator: ObservableObject {
   // nothing. Internal (not private) so the AppCoordinator+Onboarding
   // extension can read it.
   let anonymousBrowseStateRepository: AnonymousBrowseStateRepository?
+  // Anonymous share-link / in-app detail fetch (GH#879 Phase 2). Optional so
+  // existing call sites/tests inject nothing. Internal so AppCoordinator+Detail
+  // can read it.
+  let anonymousApplicationDetailRepository: AnonymousApplicationDetailRepository?
+  /// Fired by the anonymous detail CTA (GH#879 Phase 2) — wired by the
+  /// composition root to the same Auth0 entry point every sign-up surface uses.
+  public var onRequestSignUp: (() -> Void)?
   // Single live source of truth for the appearance preference (GH#878),
   // shared with the anonymous welcome screen. Optional so existing call
   // sites/tests that don't exercise appearance inject nothing — forwarded
@@ -72,7 +84,8 @@ public final class AppCoordinator: ObservableObject {
   let geocoder: PostcodeGeocoder?
   private let appVersionProvider: AppVersionProvider
   private let versionConfigService: VersionConfigService
-  private let savedApplicationRepository: SavedApplicationRepository?
+  // Internal (not private) so the AppCoordinator+Detail extension can read it.
+  let savedApplicationRepository: SavedApplicationRepository?
   let offerCodeService: OfferCodeService?
   private let tierCache: UserDefaults
   let notificationStateRepository: NotificationStateRepository?
@@ -124,7 +137,8 @@ public final class AppCoordinator: ObservableObject {
     badgeSetter: BadgeSetting? = nil,
     reviewPromptTracker: ReviewPromptTracker? = nil,
     anonymousBrowseStateRepository: AnonymousBrowseStateRepository? = nil,
-    appearanceStore: AppearanceStore? = nil
+    appearanceStore: AppearanceStore? = nil,
+    anonymousApplicationDetailRepository: AnonymousApplicationDetailRepository? = nil
   ) {
     self.repository = repository
     self.authService = authService
@@ -154,6 +168,7 @@ public final class AppCoordinator: ObservableObject {
     self.reviewPromptTracker = reviewPromptTracker
     self.anonymousBrowseStateRepository = anonymousBrowseStateRepository
     self.appearanceStore = appearanceStore
+    self.anonymousApplicationDetailRepository = anonymousApplicationDetailRepository
 
     // Restore the last successfully resolved tier so that paying users
     // retain feature access immediately, even before the live resolution
@@ -283,29 +298,6 @@ public final class AppCoordinator: ObservableObject {
       versionConfigService: versionConfigService,
       appVersionProvider: appVersionProvider
     )
-  }
-
-  public func makeApplicationDetailViewModel(
-    application: PlanningApplication
-  ) -> ApplicationDetailViewModel {
-    let viewModel = ApplicationDetailViewModel(
-      application: application,
-      savedApplicationRepository: savedApplicationRepository,
-      planningApplicationRepository: repository
-    )
-    viewModel.onDismiss = { [weak self] in
-      self?.detailApplication = nil
-    }
-    // Review-prompt value moments (GH #628): a portal tap-through and a save are
-    // both genuine engagement peaks. The save callback fires only on a
-    // successful false→true save (the view model guarantees this).
-    viewModel.onOpenPortal = { [weak self] _ in
-      self?.reviewPromptTracker?.record(.tappedPortal)
-    }
-    viewModel.onSaved = { [weak self] in
-      self?.reviewPromptTracker?.record(.savedApplication)
-    }
-    return viewModel
   }
 
   // MARK: - Subscription Tier Resolution

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousApplicationSummaryView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousApplicationSummaryView.swift
@@ -3,12 +3,13 @@ import TownCrierDomain
 
 /// A reduced-feature bottom sheet showing a preview of a tapped pin on the
 /// anonymous map (GH#868 Phase 3). Unlike the authenticated
-/// `ApplicationSummarySheet`, there is no save affordance and no "View full
-/// details" — any deeper look routes to sign-up instead, since full detail and
-/// saving both require an account.
+/// `ApplicationSummarySheet`, there is no save affordance — saving requires
+/// an account — but "View full details" presents the full detail screen with
+/// no sign-up gate (GH#879 Phase 2): the anonymous map already holds the full
+/// `PlanningApplication`, so no network call is needed either.
 struct AnonymousApplicationSummaryView: View {
   let application: PlanningApplication
-  let onSignUp: () -> Void
+  let onViewFullDetails: () -> Void
 
   var body: some View {
     VStack(alignment: .leading, spacing: TCSpacing.medium) {
@@ -33,14 +34,14 @@ struct AnonymousApplicationSummaryView: View {
         .foregroundStyle(Color.tcTextTertiary)
 
       PrimaryButton {
-        onSignUp()
+        onViewFullDetails()
       } label: {
         HStack {
-          Image(systemName: "bell.badge")
-          Text("Create free account for full details")
+          Image(systemName: "doc.text.magnifyingglass")
+          Text("View full details")
         }
       }
-      .accessibilityLabel("Create free account for full details")
+      .accessibilityLabel("View full details")
     }
     .padding(TCSpacing.medium)
     .frame(maxWidth: .infinity, alignment: .leading)

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousBrowseCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousBrowseCoordinator.swift
@@ -43,6 +43,11 @@ public final class AnonymousBrowseCoordinator: ObservableObject {
   /// to `loginViewModel.login()`.
   public var onRequestSignIn: (() -> Void)?
 
+  /// Fired by the anonymous map's "View full details" handoff (GH#879 Phase
+  /// 2). Wired by the composition root to present the shared root detail
+  /// sheet in anonymous mode (`AppCoordinator.showAnonymousApplicationDetail`).
+  public var onShowApplicationDetail: ((PlanningApplication) -> Void)?
+
   public init(
     geocoder: PostcodeGeocoder,
     stateRepository: AnonymousBrowseStateRepository,
@@ -105,6 +110,9 @@ public final class AnonymousBrowseCoordinator: ObservableObject {
       radiusMetres: state.radiusMetres)
     viewModel.onRequestSignUp = { [weak self] in self?.onRequestSignIn?() }
     viewModel.onRadiusChanged = { [weak self] radius in self?.persistRadius(radius) }
+    viewModel.onShowApplicationDetail = { [weak self] application in
+      self?.onShowApplicationDetail?(application)
+    }
     return viewModel
   }
 

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMapView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMapView.swift
@@ -64,12 +64,14 @@ public struct AnonymousMapView: View {
       item: Binding(
         get: { viewModel.selectedApplication },
         set: { _ in viewModel.clearSelection() }
-      )
-    ) { application in
-      AnonymousApplicationSummaryView(application: application) {
-        viewModel.requestSignUp()
+      ),
+      onDismiss: { viewModel.presentPendingDetailIfNeeded() },
+      content: { application in
+        AnonymousApplicationSummaryView(application: application) {
+          viewModel.requestFullDetail()
+        }
       }
-    }
+    )
     // Disambiguation list for a coincident ("stacked") cluster tap (GH#877).
     // Its `onDismiss` presents the chosen row's summary, so the list always
     // finishes dismissing before the summary appears — the two `.sheet`s are

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMapViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMapViewModel.swift
@@ -26,6 +26,13 @@ public final class AnonymousMapViewModel: ObservableObject, ErrorHandlingViewMod
   /// the list and the summary are never on screen at once (SwiftUI's
   /// two-sheets race) — mirrors ``MapViewModel``'s handoff.
   @Published public private(set) var pendingSummaryApplication: PlanningApplication?
+  /// The application whose full detail screen should present once the
+  /// summary sheet has finished dismissing (GH#879 Phase 2). Set by
+  /// ``requestFullDetail()`` and consumed by ``presentPendingDetailIfNeeded()``
+  /// from the summary sheet's `onDismiss`, so the summary and the detail
+  /// sheet are never on screen at once — mirrors ``MapViewModel``'s
+  /// `pendingDetailApplication` handoff.
+  @Published public private(set) var pendingDetailApplication: PlanningApplication?
   @Published public private(set) var centreLat: Double
   @Published public private(set) var centreLon: Double
   @Published public private(set) var radiusMetres: Double
@@ -62,10 +69,15 @@ public final class AnonymousMapViewModel: ObservableObject, ErrorHandlingViewMod
   private let debounceNanoseconds: UInt64
   private var pendingRegionChangeTask: Task<Void, Never>?
 
-  /// Fired when the user takes any action deeper than the pin summary preview
-  /// (full detail, save) or taps the CTA banner — the anonymous map has no
-  /// such features itself, so every one of them routes to sign-up instead.
+  /// Fired by the persistent CTA banner's "Create account"/"Sign in" buttons
+  /// (full detail no longer requires an account — GH#879 Phase 2 replaced the
+  /// summary sheet's own sign-up handoff with ``onShowApplicationDetail``).
   public var onRequestSignUp: (() -> Void)?
+  /// Fired by ``presentPendingDetailIfNeeded()`` once the summary sheet has
+  /// dismissed, handing the full application to the coordinator to present
+  /// the detail screen (GH#879 Phase 2) — no network call, the anonymous map
+  /// already holds the full `PlanningApplication` from `near-point`.
+  public var onShowApplicationDetail: ((PlanningApplication) -> Void)?
 
   /// Fired whenever the live radius picker changes, so the coordinator can
   /// persist the chosen radius into `AnonymousBrowseState` ahead of the
@@ -186,11 +198,33 @@ public final class AnonymousMapViewModel: ObservableObject, ErrorHandlingViewMod
     stackedApplications = nil
   }
 
-  /// Any deeper touch than the summary preview (full detail, save) or the CTA
-  /// banner itself routes to sign-up — the anonymous map has none of those
-  /// features.
+  /// The CTA banner itself routes to sign-up — full detail no longer does
+  /// (GH#879 Phase 2).
   public func requestSignUp() {
     onRequestSignUp?()
+  }
+
+  /// Requests the full detail screen for the currently selected application
+  /// (GH#879 Phase 2). Stashes the selection as `pendingDetailApplication`
+  /// and clears `selectedApplication`, which dismisses the summary sheet.
+  /// The map view's sheet `onDismiss` then calls
+  /// ``presentPendingDetailIfNeeded()`` so the detail screen opens only
+  /// after the summary has gone — never two sheets at once. No-op when
+  /// nothing is selected. Mirrors ``MapViewModel/requestFullDetail()``.
+  public func requestFullDetail() {
+    guard let selected = selectedApplication else { return }
+    pendingDetailApplication = selected
+    selectedApplication = nil
+  }
+
+  /// Presents any pending detail application via ``onShowApplicationDetail``,
+  /// clearing the pending slot first so it fires exactly once. Invoked from
+  /// the summary sheet's `onDismiss`. No-op when nothing is pending (e.g. the
+  /// user swiped the summary away instead of tapping "View full details").
+  public func presentPendingDetailIfNeeded() {
+    guard let pending = pendingDetailApplication else { return }
+    pendingDetailApplication = nil
+    onShowApplicationDetail?(pending)
   }
 
   /// Updates the live radius picker, clamping to

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationDetail/ApplicationDetailView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationDetail/ApplicationDetailView.swift
@@ -39,6 +39,10 @@ public struct ApplicationDetailView: View {
         if viewModel.hasPortalUrl {
           portalButton
         }
+
+        if viewModel.showsSignUpCTA {
+          signUpCTA
+        }
       }
       .padding(TCSpacing.medium)
     }
@@ -145,6 +149,40 @@ public struct ApplicationDetailView: View {
         Text("View on Council Portal")
       }
     }
+  }
+
+  // MARK: - Sign-Up CTA (GH#879 Phase 2)
+
+  /// Replaces the Save toolbar affordance for an anonymously-viewed
+  /// application. Reuses ``AccountCTABanner/Copy`` so the wording never drifts
+  /// from the anonymous map's CTA — a deliberate product/legal choice
+  /// (never say "instant") — while laying out for this screen's already-padded
+  /// scroll content rather than the banner's bottom-safe-area pinning.
+  private var signUpCTA: some View {
+    VStack(alignment: .leading, spacing: TCSpacing.small) {
+      Text(AccountCTABanner.Copy.headline)
+        .font(TCTypography.headline)
+        .foregroundStyle(Color.tcTextPrimary)
+
+      Text(AccountCTABanner.Copy.subline)
+        .font(TCTypography.body)
+        .foregroundStyle(Color.tcTextSecondary)
+
+      HStack(spacing: TCSpacing.medium) {
+        PrimaryButton(AccountCTABanner.Copy.createAccount) {
+          viewModel.requestSignUp()
+        }
+
+        Button(AccountCTABanner.Copy.signIn) {
+          viewModel.requestSignUp()
+        }
+        .font(TCTypography.bodyEmphasis)
+        .foregroundStyle(Color.tcTextSecondary)
+      }
+    }
+    .padding(TCSpacing.medium)
+    .background(Color.tcSurfaceElevated)
+    .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.large))
   }
 
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationDetail/ApplicationDetailViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationDetail/ApplicationDetailViewModel.swift
@@ -74,10 +74,22 @@ public final class ApplicationDetailViewModel: ObservableObject {
   /// Fired only on a successful false→true save (never on unsave or failure).
   /// Drives the review-prompt `savedApplication` signal (GH #628).
   public var onSaved: (() -> Void)?
+  /// Fired by the anonymous sign-up CTA (GH#879 Phase 2), in place of the
+  /// Save affordance. Wired by the coordinator to the app's single Auth0
+  /// entry point, the same one every other sign-up/sign-in surface uses.
+  public var onRequestSignUp: (() -> Void)?
 
   /// Whether the save/unsave action is available (repository was provided).
   public var canSave: Bool {
     savedApplicationRepository != nil
+  }
+
+  /// Whether the anonymous sign-up CTA should replace the Save affordance
+  /// (GH#879 Phase 2) — true exactly when this view model was built for the
+  /// anonymous detail path (an ``AnonymousApplicationDetailRepository`` was
+  /// injected instead of the authed save/refresh repositories).
+  public var showsSignUpCTA: Bool {
+    anonymousApplicationDetailRepository != nil
   }
 
   public var hasPortalUrl: Bool {
@@ -90,6 +102,11 @@ public final class ApplicationDetailViewModel: ObservableObject {
 
   private let savedApplicationRepository: SavedApplicationRepository?
   private let planningApplicationRepository: PlanningApplicationRepository?
+  /// The anonymous (no-session) by-slug refresh path (GH#879 Phase 2).
+  /// Mutually driving with `planningApplicationRepository` in ``refresh()``:
+  /// when present, it takes precedence — a view model is only ever built for
+  /// one path or the other by the coordinator's factory.
+  private let anonymousApplicationDetailRepository: AnonymousApplicationDetailRepository?
 
   /// Re-entrancy guard for ``refresh()``. The detail sheet's `.task` can fire
   /// repeatedly for a single open — alongside scenePhase changes or a
@@ -105,11 +122,13 @@ public final class ApplicationDetailViewModel: ObservableObject {
     application: PlanningApplication,
     savedApplicationRepository: SavedApplicationRepository? = nil,
     planningApplicationRepository: PlanningApplicationRepository? = nil,
+    anonymousApplicationDetailRepository: AnonymousApplicationDetailRepository? = nil,
     isSaved: Bool = false
   ) {
     self.application = application
     self.savedApplicationRepository = savedApplicationRepository
     self.planningApplicationRepository = planningApplicationRepository
+    self.anonymousApplicationDetailRepository = anonymousApplicationDetailRepository
     self.isSaved = isSaved
   }
 
@@ -134,21 +153,40 @@ public final class ApplicationDetailViewModel: ObservableObject {
     }
   }
 
-  /// Re-fetches the application by id and replaces the cached payload on
-  /// success. Silent on failure — the cached payload remains visible. Required
-  /// to keep saved-row snapshots fresh on the server even though the sheet
-  /// presents the cached payload synchronously (bd tc-sslz, tc-udby).
-  /// No-op if no `PlanningApplicationRepository` was injected.
+  /// Re-fetches the application and replaces the cached payload on success.
+  /// Silent on failure — the cached payload remains visible.
+  ///
+  /// Two mutually-exclusive paths, chosen by which repository the
+  /// coordinator's factory injected: the authed by-id read (required to keep
+  /// saved-row snapshots fresh on the server, bd tc-sslz/tc-udby), or the
+  /// anonymous by-slug read (GH#879 Phase 2), which is skipped silently when
+  /// the cached application carries no authority slug — refreshing a
+  /// slug-less payload by slug is meaningless. No-op if neither repository
+  /// was injected.
   public func refresh() async {
-    guard let repository = planningApplicationRepository else { return }
     // Drop re-entrant calls while a refresh is already running so a single
-    // detail open issues at most one per-id fetch (bd tc-eum5). The flag is
-    // read and set synchronously before any `await`, so a second call
-    // scheduled on the same actor sees it set and returns immediately.
+    // detail open issues at most one fetch (bd tc-eum5). The flag is read
+    // and set synchronously before any `await`, so a second call scheduled
+    // on the same actor sees it set and returns immediately.
     guard !isRefreshInFlight else { return }
     isRefreshInFlight = true
     defer { isRefreshInFlight = false }
 
+    if let anonymousApplicationDetailRepository {
+      guard let slug = application.authority.slug else { return }
+      do {
+        let fresh = try await anonymousApplicationDetailRepository.fetchApplication(
+          bySlug: slug, ref: application.id.name)
+        if fresh != application {
+          application = fresh
+        }
+      } catch {
+        // Silent on failure — keep the cached payload visible.
+      }
+      return
+    }
+
+    guard let repository = planningApplicationRepository else { return }
     do {
       let fresh = try await repository.fetchApplication(by: applicationId)
       if fresh != application {
@@ -166,6 +204,11 @@ public final class ApplicationDetailViewModel: ObservableObject {
 
   public func dismiss() {
     onDismiss?()
+  }
+
+  /// Invokes the anonymous sign-up CTA (GH#879 Phase 2).
+  public func requestSignUp() {
+    onRequestSignUp?()
   }
 
   /// Toggles the saved state, calling the repository to persist the change.

--- a/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
+++ b/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
@@ -80,6 +80,11 @@ struct TownCrierApp: App {
     let anonymousApiClient = AnonymousURLSessionAPIClient(baseURL: apiBaseURL)
     let anonymousApplicationsRepository = APIAnonymousApplicationsRepository(
       apiClient: anonymousApiClient)
+    // Anonymous full detail + share-link fix (GH#879 Phase 2): backs both a
+    // signed-out share Universal Link and the anonymous map/summary sheet's
+    // "View full details".
+    let anonymousApplicationDetailRepository = APIAnonymousApplicationDetailRepository(
+      apiClient: anonymousApiClient)
 
     let savedApplicationRepository = APISavedApplicationRepository(apiClient: apiClient)
     let notificationStateRepository = APINotificationStateRepository(apiClient: apiClient)
@@ -112,7 +117,8 @@ struct TownCrierApp: App {
       badgeSetter: UIApplicationBadgeSetter(),
       reviewPromptTracker: reviewPromptTracker,
       anonymousBrowseStateRepository: anonymousBrowseStateRepository,
-      appearanceStore: sharedAppearanceStore
+      appearanceStore: sharedAppearanceStore,
+      anonymousApplicationDetailRepository: anonymousApplicationDetailRepository
     )
     reviewRequester.coordinator = appCoordinator  // weak; coordinator owns the tracker
     _coordinator = StateObject(wrappedValue: appCoordinator)
@@ -132,7 +138,11 @@ struct TownCrierApp: App {
     // Anonymous browse mode (GH#868 Phase 3): both "I already have an
     // account" on the welcome screen and the map's CTA banner funnel into the
     // same single sign-up/sign-in entry point the rest of the app uses —
-    // Auth0's hosted Universal Login handles both in one flow.
+    // Auth0's hosted Universal Login handles both in one flow. The anonymous
+    // detail screen's sign-up CTA (GH#879 Phase 2) uses the same entry point.
+    appCoordinator.onRequestSignUp = {
+      Task { @MainActor in await loginVM.login() }
+    }
     let anonymousCoordinator = AnonymousBrowseCoordinator(
       geocoder: anonymousGeocoder,
       stateRepository: anonymousBrowseStateRepository,
@@ -141,6 +151,12 @@ struct TownCrierApp: App {
     )
     anonymousCoordinator.onRequestSignIn = {
       Task { @MainActor in await loginVM.login() }
+    }
+    // "View full details" on the anonymous map/summary sheet presents the
+    // shared root detail sheet in anonymous mode (GH#879 Phase 2) — no
+    // network call, the anonymous map already holds the full application.
+    anonymousCoordinator.onShowApplicationDetail = { [weak appCoordinator] application in
+      appCoordinator?.showAnonymousApplicationDetail(application)
     }
     _anonymousBrowseCoordinator = StateObject(wrappedValue: anonymousCoordinator)
 

--- a/mobile/ios/town-crier-tests/Sources/Features/APIAnonymousApplicationDetailRepositoryTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APIAnonymousApplicationDetailRepositoryTests.swift
@@ -1,0 +1,115 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierData
+
+/// Wire tests for GH#879 Phase 2: the anonymous (no-session) detail read that
+/// backs a signed-out share Universal Link and the anonymous detail screen's
+/// stale-while-revalidate refresh.
+@Suite("APIAnonymousApplicationDetailRepository")
+struct APIAnonymousApplicationDetailRepositoryTests {
+
+  // MARK: - Helpers
+
+  private let baseURL = URL(string: "https://api-dev.towncrierapp.uk")!
+
+  private func makeSUT(
+    responses: [(Data, URLResponse)]
+  ) -> (APIAnonymousApplicationDetailRepository, StubHTTPTransport) {
+    let transport = StubHTTPTransport()
+    transport.responses = responses
+    let apiClient = AnonymousURLSessionAPIClient(baseURL: baseURL, transport: transport)
+    let sut = APIAnonymousApplicationDetailRepository(apiClient: apiClient)
+    return (sut, transport)
+  }
+
+  // swiftlint:disable force_unwrapping
+  private func httpResponse(statusCode: Int) -> HTTPURLResponse {
+    HTTPURLResponse(url: baseURL, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
+  }
+  // swiftlint:enable force_unwrapping
+
+  private let successJSON = """
+    {
+        "name": "Kingston/25/02755/CLC",
+        "uid": "app-003",
+        "areaName": "Kingston upon Thames",
+        "areaId": 789,
+        "authoritySlug": "kingston",
+        "address": "1 Market Place, Kingston, KT1 1JS",
+        "postcode": "KT1 1JS",
+        "description": "Certificate of lawfulness",
+        "appType": "Full",
+        "appState": "Undecided",
+        "appSize": null,
+        "startDate": "2026-02-01",
+        "decidedDate": null,
+        "consultedDate": null,
+        "longitude": null,
+        "latitude": null,
+        "url": null,
+        "link": null,
+        "lastDifferent": "2026-02-01T00:00:00+00:00"
+    }
+    """
+
+  // MARK: - fetchApplication(bySlug:ref:)
+
+  @Test("fetchApplication(bySlug:) sends GET /v1/applications/by-slug/{slug}/{ref} with no Authorization header")
+  func fetchApplicationBySlug_sendsCorrectRequest() async throws {
+    let (sut, transport) = makeSUT(
+      responses: [(Data(successJSON.utf8), httpResponse(statusCode: 200))])
+
+    let app = try await sut.fetchApplication(bySlug: "kingston", ref: "Kingston/25/02755/CLC")
+
+    #expect(transport.requests.count == 1)
+    let request = transport.requests[0]
+    #expect(request.httpMethod == "GET")
+    #expect(request.value(forHTTPHeaderField: "Authorization") == nil)
+    // The ref's slashes pass through into the path verbatim, exactly like the
+    // authed by-slug read interpolates `ref`.
+    #expect(
+      request.url?.path().contains("/v1/applications/by-slug/kingston/Kingston/25/02755/CLC")
+        == true)
+    #expect(app.id == PlanningApplicationId(authority: "789", name: "Kingston/25/02755/CLC"))
+    #expect(app.authority.slug == "kingston")
+  }
+
+  @Test("fetchApplication(bySlug:) with 404 throws applicationNotFound")
+  func fetchApplicationBySlug_notFound_throwsApplicationNotFound() async throws {
+    let (sut, _) = makeSUT(responses: [(Data("null".utf8), httpResponse(statusCode: 404))])
+
+    await #expect(
+      throws: DomainError.applicationNotFound(
+        PlanningApplicationId(authority: "kingston", name: "Kingston/25/GONE"))
+    ) {
+      _ = try await sut.fetchApplication(bySlug: "kingston", ref: "Kingston/25/GONE")
+    }
+  }
+
+  @Test("fetchApplication(bySlug:) with server error throws serverError not networkUnavailable")
+  func fetchApplicationBySlug_serverError_throwsServerError() async throws {
+    let (sut, _) = makeSUT(responses: [
+      (Data("Internal Server Error".utf8), httpResponse(statusCode: 500))
+    ])
+
+    await #expect(
+      throws: DomainError.serverError(statusCode: 500, message: "Internal Server Error")
+    ) {
+      _ = try await sut.fetchApplication(bySlug: "kingston", ref: "Kingston/25/02755/CLC")
+    }
+  }
+
+  @Test("fetchApplication(bySlug:) with network error throws networkUnavailable")
+  func fetchApplicationBySlug_networkError_throwsNetworkUnavailable() async throws {
+    let transport = StubHTTPTransport()
+    transport.error = URLError(.notConnectedToInternet)
+    let apiClient = AnonymousURLSessionAPIClient(baseURL: baseURL, transport: transport)
+    let sut = APIAnonymousApplicationDetailRepository(apiClient: apiClient)
+
+    await #expect(throws: DomainError.networkUnavailable) {
+      _ = try await sut.fetchApplication(bySlug: "kingston", ref: "Kingston/25/02755/CLC")
+    }
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/APIAnonymousApplicationDetailRepositoryTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APIAnonymousApplicationDetailRepositoryTests.swift
@@ -12,6 +12,7 @@ struct APIAnonymousApplicationDetailRepositoryTests {
 
   // MARK: - Helpers
 
+  // swiftlint:disable:next force_unwrapping
   private let baseURL = URL(string: "https://api-dev.towncrierapp.uk")!
 
   private func makeSUT(

--- a/mobile/ios/town-crier-tests/Sources/Features/APIAnonymousApplicationsRepositoryTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APIAnonymousApplicationsRepositoryTests.swift
@@ -96,6 +96,46 @@ struct APIAnonymousApplicationsRepositoryTests {
     #expect(app.location == expectedLocation)
   }
 
+  @Test("fetchNearby maps the additive authoritySlug field onto the authority when present")
+  func fetchNearby_mapsAuthoritySlug_whenPresent() async throws {
+    // GH#879 Phase 1 (#880): near-point now emits authoritySlug per result,
+    // reusing the same PlanningApplicationDTO/toDomain() mapping the by-id
+    // and by-slug detail reads already exercise — no separate mapping
+    // needed on the iOS side. This is the confirming test for that finding.
+    let json = """
+      [
+          {
+              "name": "Kingston/25/02755/CLC",
+              "uid": "app-003",
+              "areaName": "Kingston upon Thames",
+              "areaId": 789,
+              "authoritySlug": "kingston",
+              "address": "1 Market Place, Kingston, KT1 1JS",
+              "postcode": "KT1 1JS",
+              "description": "Certificate of lawfulness",
+              "appType": "Full",
+              "appState": "Undecided",
+              "appSize": null,
+              "startDate": "2026-02-01",
+              "decidedDate": null,
+              "consultedDate": null,
+              "longitude": null,
+              "latitude": null,
+              "url": null,
+              "link": null,
+              "lastDifferent": "2026-02-01T00:00:00+00:00"
+          }
+      ]
+      """
+    let (sut, _) = makeSUT(responses: [(Data(json.utf8), httpResponse(statusCode: 200))])
+
+    let result = try await sut.fetchNearby(
+      latitude: 52.2053, longitude: 0.1218, radiusMetres: 2000, limit: 200)
+
+    #expect(result.count == 1)
+    #expect(result[0].authority.slug == "kingston")
+  }
+
   @Test("fetchNearby with network error throws networkUnavailable")
   func fetchNearby_networkError_throwsNetworkUnavailable() async throws {
     let transport = StubHTTPTransport()

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousApplicationSummaryViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousApplicationSummaryViewTests.swift
@@ -11,10 +11,10 @@ struct AnonymousApplicationSummaryViewTests {
     _ = sut.body
   }
 
-  @Test func onSignUp_invokedByCaller() {
+  @Test func onViewFullDetails_invokedByCaller() {
     var invoked = false
     let sut = AnonymousApplicationSummaryView(application: .pendingReview) { invoked = true }
-    sut.onSignUp()
+    sut.onViewFullDetails()
     #expect(invoked)
   }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousBrowseCoordinatorTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousBrowseCoordinatorTests.swift
@@ -109,6 +109,20 @@ struct AnonymousBrowseCoordinatorTests {
     #expect(requested)
   }
 
+  // MARK: - View full details handoff (GH#879 Phase 2)
+
+  @Test func mapViewModel_onShowApplicationDetail_invokesCoordinatorCallback() {
+    let (sut, _, _, _) = makeSUT(persistedState: testState)
+    var captured: [PlanningApplication] = []
+    sut.onShowApplicationDetail = { captured.append($0) }
+
+    sut.mapViewModel?.selectApplication(.pendingReview)
+    sut.mapViewModel?.requestFullDetail()
+    sut.mapViewModel?.presentPendingDetailIfNeeded()
+
+    #expect(captured == [.pendingReview])
+  }
+
   // MARK: - Live radius picker persistence (GH#868 Phase 3 refinement)
 
   @Test func mapViewModel_radiusChange_persistsUpdatedStateWithSamePostcodeAndCoordinate() {

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousMapViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousMapViewModelTests.swift
@@ -282,4 +282,49 @@ struct AnonymousMapViewModelTests {
 
     #expect(sut.stackedApplications == nil)
   }
+
+  // MARK: - View full details (GH#879 Phase 2)
+
+  @Test func requestFullDetail_stashesSelectionAsPendingAndClearsSelection() {
+    let (sut, _) = makeSUT()
+    sut.selectApplication(.pendingReview)
+
+    sut.requestFullDetail()
+
+    #expect(sut.pendingDetailApplication == .pendingReview)
+    #expect(sut.selectedApplication == nil)
+  }
+
+  @Test func requestFullDetail_isNoOp_whenNothingSelected() {
+    let (sut, _) = makeSUT()
+
+    sut.requestFullDetail()
+
+    #expect(sut.pendingDetailApplication == nil)
+  }
+
+  @Test func presentPendingDetailIfNeeded_firesCallbackOnceWithPendingApplication() {
+    let (sut, _) = makeSUT()
+    sut.selectApplication(.pendingReview)
+    sut.requestFullDetail()
+
+    var captured: [PlanningApplication] = []
+    sut.onShowApplicationDetail = { captured.append($0) }
+
+    sut.presentPendingDetailIfNeeded()
+    sut.presentPendingDetailIfNeeded()
+
+    #expect(captured == [.pendingReview])
+    #expect(sut.pendingDetailApplication == nil)
+  }
+
+  @Test func presentPendingDetailIfNeeded_noOpWhenNothingPending() {
+    let (sut, _) = makeSUT()
+    var captured: [PlanningApplication] = []
+    sut.onShowApplicationDetail = { captured.append($0) }
+
+    sut.presentPendingDetailIfNeeded()
+
+    #expect(captured.isEmpty)
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorAnonymousDetailTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorAnonymousDetailTests.swift
@@ -39,6 +39,20 @@ struct AppCoordinatorAnonymousDetailTests {
     return (coordinator, planningSpy, anonSpy, authSpy)
   }
 
+  /// Carries an authority slug, unlike `.permitted`/`.rejected` — required for
+  /// exercising `refresh()`'s by-slug read.
+  private var kingstonApplication: PlanningApplication {
+    PlanningApplication(
+      id: PlanningApplicationId(authority: "789", name: "Kingston/25/02755/CLC"),
+      reference: ApplicationReference("Kingston/25/02755/CLC"),
+      authority: LocalAuthority(code: "789", name: "Kingston upon Thames", slug: "kingston"),
+      status: .undecided,
+      receivedDate: Date(timeIntervalSince1970: 1_700_000_000),
+      description: "Certificate of lawfulness",
+      address: "1 Market Place, Kingston, KT1 1JS"
+    )
+  }
+
   // MARK: - Share link routing
 
   @Test func showApplicationDetailBySlug_noSession_usesAnonymousRepository() async {
@@ -117,12 +131,14 @@ struct AppCoordinatorAnonymousDetailTests {
 
   @Test func makeApplicationDetailViewModel_afterAnonymousShareLink_refreshUsesAnonymousRepository() async {
     let (sut, _, anonSpy, _) = makeSUT(hasSession: false)
-    anonSpy.fetchApplicationBySlugResult = .success(.permitted)
+    // `kingstonApplication` carries an authority slug — required for
+    // refresh()'s by-slug read; the other fixtures (.permitted, etc.) don't.
+    anonSpy.fetchApplicationBySlugResult = .success(kingstonApplication)
     sut.showApplicationDetail(bySlug: "kingston", ref: "Kingston/25/02755/CLC")
     await sut.waitForPendingDetailLoad()
     anonSpy.fetchApplicationBySlugResult = .success(.rejected)
 
-    let vm = sut.makeApplicationDetailViewModel(application: .permitted)
+    let vm = sut.makeApplicationDetailViewModel(application: kingstonApplication)
     await vm.refresh()
 
     #expect(anonSpy.fetchApplicationBySlugCalls.count == 2)

--- a/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorAnonymousDetailTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorAnonymousDetailTests.swift
@@ -1,0 +1,191 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+/// GH#879 Phase 2: a signed-out tap on a share Universal Link, or the
+/// anonymous map/summary sheet's "View full details", must present the
+/// detail sheet without ever surfacing the authed repository's
+/// `sessionExpired` error, and the resulting view model must be configured
+/// for anonymous mode (no Save, sign-up CTA, by-slug refresh).
+@Suite("AppCoordinator — anonymous detail (GH#879 Phase 2)")
+@MainActor
+struct AppCoordinatorAnonymousDetailTests {
+  private func makeSUT(
+    hasSession: Bool,
+    savedApplicationRepository: SavedApplicationRepository? = nil
+  ) -> (
+    AppCoordinator, SpyPlanningApplicationRepository, SpyAnonymousApplicationDetailRepository,
+    SpyAuthenticationService
+  ) {
+    let planningSpy = SpyPlanningApplicationRepository()
+    let anonSpy = SpyAnonymousApplicationDetailRepository()
+    let authSpy = SpyAuthenticationService()
+    authSpy.currentSessionResult = hasSession ? .valid : nil
+    let coordinator = AppCoordinator(
+      repository: planningSpy,
+      authService: authSpy,
+      subscriptionService: SpySubscriptionService(),
+      userProfileRepository: SpyUserProfileRepository(),
+      watchZoneRepository: SpyWatchZoneRepository(),
+      onboardingRepository: SpyOnboardingRepository(),
+      notificationService: SpyNotificationService(),
+      appVersionProvider: SpyAppVersionProvider(),
+      versionConfigService: SpyVersionConfigService(),
+      savedApplicationRepository: savedApplicationRepository,
+      anonymousApplicationDetailRepository: anonSpy
+    )
+    return (coordinator, planningSpy, anonSpy, authSpy)
+  }
+
+  // MARK: - Share link routing
+
+  @Test func showApplicationDetailBySlug_noSession_usesAnonymousRepository() async {
+    let (sut, planningSpy, anonSpy, _) = makeSUT(hasSession: false)
+    anonSpy.fetchApplicationBySlugResult = .success(.permitted)
+
+    sut.showApplicationDetail(bySlug: "kingston", ref: "Kingston/25/02755/CLC")
+    await sut.waitForPendingDetailLoad()
+
+    #expect(sut.detailApplication == .permitted)
+    #expect(
+      anonSpy.fetchApplicationBySlugCalls == [
+        .init(authoritySlug: "kingston", ref: "Kingston/25/02755/CLC")
+      ])
+    #expect(planningSpy.fetchApplicationBySlugCalls.isEmpty)
+    // The bug this fixes: no session must never surface sessionExpired.
+    #expect(sut.deepLinkError == nil)
+  }
+
+  @Test func showApplicationDetailBySlug_withSession_usesAuthedRepository() async {
+    let (sut, planningSpy, anonSpy, _) = makeSUT(hasSession: true)
+    planningSpy.fetchApplicationBySlugResult = .success(.permitted)
+
+    sut.showApplicationDetail(bySlug: "kingston", ref: "Kingston/25/02755/CLC")
+    await sut.waitForPendingDetailLoad()
+
+    #expect(sut.detailApplication == .permitted)
+    #expect(
+      planningSpy.fetchApplicationBySlugCalls == [
+        .init(authoritySlug: "kingston", ref: "Kingston/25/02755/CLC")
+      ])
+    #expect(anonSpy.fetchApplicationBySlugCalls.isEmpty)
+  }
+
+  @Test func showApplicationDetailBySlug_noSessionNoAnonymousRepositoryInjected_fallsBackToAuthedRepository()
+    async {
+    // Defensive fallback for a coordinator built without the anonymous
+    // repository (e.g. an older/incomplete composition root) — preserves
+    // today's behaviour rather than silently doing nothing.
+    let planningSpy = SpyPlanningApplicationRepository()
+    planningSpy.fetchApplicationBySlugResult = .success(.permitted)
+    let authSpy = SpyAuthenticationService()
+    authSpy.currentSessionResult = nil
+    let sut = AppCoordinator(
+      repository: planningSpy,
+      authService: authSpy,
+      subscriptionService: SpySubscriptionService(),
+      userProfileRepository: SpyUserProfileRepository(),
+      watchZoneRepository: SpyWatchZoneRepository(),
+      onboardingRepository: SpyOnboardingRepository(),
+      notificationService: SpyNotificationService(),
+      appVersionProvider: SpyAppVersionProvider(),
+      versionConfigService: SpyVersionConfigService()
+    )
+
+    sut.showApplicationDetail(bySlug: "kingston", ref: "Kingston/25/02755/CLC")
+    await sut.waitForPendingDetailLoad()
+
+    #expect(sut.detailApplication == .permitted)
+    #expect(planningSpy.fetchApplicationBySlugCalls.count == 1)
+  }
+
+  // MARK: - makeApplicationDetailViewModel configuration
+
+  @Test func makeApplicationDetailViewModel_afterAnonymousShareLink_hidesSaveAndShowsSignUpCTA() async {
+    let (sut, _, anonSpy, _) = makeSUT(hasSession: false)
+    anonSpy.fetchApplicationBySlugResult = .success(.permitted)
+    sut.showApplicationDetail(bySlug: "kingston", ref: "Kingston/25/02755/CLC")
+    await sut.waitForPendingDetailLoad()
+
+    let vm = sut.makeApplicationDetailViewModel(application: .permitted)
+
+    #expect(!vm.canSave)
+    #expect(vm.showsSignUpCTA)
+  }
+
+  @Test func makeApplicationDetailViewModel_afterAnonymousShareLink_refreshUsesAnonymousRepository() async {
+    let (sut, _, anonSpy, _) = makeSUT(hasSession: false)
+    anonSpy.fetchApplicationBySlugResult = .success(.permitted)
+    sut.showApplicationDetail(bySlug: "kingston", ref: "Kingston/25/02755/CLC")
+    await sut.waitForPendingDetailLoad()
+    anonSpy.fetchApplicationBySlugResult = .success(.rejected)
+
+    let vm = sut.makeApplicationDetailViewModel(application: .permitted)
+    await vm.refresh()
+
+    #expect(anonSpy.fetchApplicationBySlugCalls.count == 2)
+  }
+
+  @Test func makeApplicationDetailViewModel_afterAuthedShareLink_keepsAuthedBehaviour() async {
+    let savedSpy = SpySavedApplicationRepository()
+    let (sut, planningSpy, _, _) = makeSUT(hasSession: true, savedApplicationRepository: savedSpy)
+    planningSpy.fetchApplicationBySlugResult = .success(.permitted)
+    sut.showApplicationDetail(bySlug: "kingston", ref: "Kingston/25/02755/CLC")
+    await sut.waitForPendingDetailLoad()
+
+    let vm = sut.makeApplicationDetailViewModel(application: .permitted)
+
+    #expect(vm.canSave)
+    #expect(!vm.showsSignUpCTA)
+  }
+
+  // MARK: - showAnonymousApplicationDetail (in-app "View full details")
+
+  @Test func showAnonymousApplicationDetail_setsDetailSynchronously() {
+    let (sut, _, _, _) = makeSUT(hasSession: false)
+
+    sut.showAnonymousApplicationDetail(.permitted)
+
+    #expect(sut.detailApplication == .permitted)
+  }
+
+  @Test func makeApplicationDetailViewModel_afterShowAnonymousApplicationDetail_hidesSaveAndShowsSignUpCTA() {
+    let (sut, _, _, _) = makeSUT(hasSession: false)
+    sut.showAnonymousApplicationDetail(.permitted)
+
+    let vm = sut.makeApplicationDetailViewModel(application: .permitted)
+
+    #expect(!vm.canSave)
+    #expect(vm.showsSignUpCTA)
+  }
+
+  @Test func makeApplicationDetailViewModel_afterAuthedShowApplicationDetail_neverShowsSignUpCTA() {
+    // Regression guard: a stale anonymous flag from a prior anonymous
+    // session must never leak into an authed detail open.
+    let savedSpy = SpySavedApplicationRepository()
+    let (sut, _, _, _) = makeSUT(hasSession: true, savedApplicationRepository: savedSpy)
+    sut.showAnonymousApplicationDetail(.pendingReview)
+
+    sut.showApplicationDetail(.permitted)
+    let vm = sut.makeApplicationDetailViewModel(application: .permitted)
+
+    #expect(vm.canSave)
+    #expect(!vm.showsSignUpCTA)
+  }
+
+  // MARK: - Sign-up CTA callback wiring
+
+  @Test func makeApplicationDetailViewModel_requestSignUp_invokesCoordinatorOnRequestSignUp() {
+    let (sut, _, _, _) = makeSUT(hasSession: false)
+    var invoked = false
+    sut.onRequestSignUp = { invoked = true }
+    sut.showAnonymousApplicationDetail(.permitted)
+    let vm = sut.makeApplicationDetailViewModel(application: .permitted)
+
+    vm.requestSignUp()
+
+    #expect(invoked)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/ApplicationDetailViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ApplicationDetailViewModelTests.swift
@@ -215,4 +215,116 @@ struct ApplicationDetailViewModelTests {
 
     #expect(sut.shareURL == nil)
   }
+
+  // MARK: - Anonymous mode (GH#879 Phase 2)
+
+  private var kingstonApplication: PlanningApplication {
+    PlanningApplication(
+      id: PlanningApplicationId(authority: "789", name: "Kingston/25/02755/CLC"),
+      reference: ApplicationReference("Kingston/25/02755/CLC"),
+      authority: LocalAuthority(code: "789", name: "Kingston upon Thames", slug: "kingston"),
+      status: .undecided,
+      receivedDate: Date(timeIntervalSince1970: 1_700_000_000),
+      description: "Certificate of lawfulness",
+      address: "1 Market Place, Kingston, KT1 1JS"
+    )
+  }
+
+  @Test func showsSignUpCTA_isTrue_whenAnonymousRepositoryInjected() {
+    let sut = ApplicationDetailViewModel(
+      application: .pendingReview,
+      anonymousApplicationDetailRepository: SpyAnonymousApplicationDetailRepository()
+    )
+
+    #expect(sut.showsSignUpCTA)
+  }
+
+  @Test func showsSignUpCTA_isFalse_byDefault() {
+    let sut = ApplicationDetailViewModel(application: .pendingReview)
+
+    #expect(!sut.showsSignUpCTA)
+  }
+
+  @Test func canSave_isFalse_inAnonymousMode() {
+    // Anonymous construction never injects a SavedApplicationRepository, so
+    // Save stays hidden regardless of the anonymous repository being present.
+    let sut = ApplicationDetailViewModel(
+      application: .pendingReview,
+      anonymousApplicationDetailRepository: SpyAnonymousApplicationDetailRepository()
+    )
+
+    #expect(!sut.canSave)
+  }
+
+  @Test func loadSavedState_isNoOp_inAnonymousMode() async {
+    // No SavedApplicationRepository is injected in anonymous mode, so this
+    // stays a no-op exactly like the existing "no repository" case.
+    let sut = ApplicationDetailViewModel(
+      application: .pendingReview,
+      anonymousApplicationDetailRepository: SpyAnonymousApplicationDetailRepository()
+    )
+
+    await sut.loadSavedState()
+
+    #expect(!sut.isSaved)
+  }
+
+  @Test func requestSignUp_invokesOnRequestSignUpCallback() {
+    let sut = ApplicationDetailViewModel(application: .pendingReview)
+    var invoked = false
+    sut.onRequestSignUp = { invoked = true }
+
+    sut.requestSignUp()
+
+    #expect(invoked)
+  }
+
+  @Test func refresh_inAnonymousMode_callsAnonymousRepositoryBySlug() async {
+    let anonSpy = SpyAnonymousApplicationDetailRepository()
+    anonSpy.fetchApplicationBySlugResult = .success(.permitted)
+    let sut = ApplicationDetailViewModel(
+      application: kingstonApplication,
+      anonymousApplicationDetailRepository: anonSpy
+    )
+
+    await sut.refresh()
+
+    #expect(
+      anonSpy.fetchApplicationBySlugCalls == [
+        .init(authoritySlug: "kingston", ref: "Kingston/25/02755/CLC")
+      ])
+    #expect(sut.reference == "2026/0099")
+  }
+
+  @Test func refresh_inAnonymousMode_skipsSilently_whenApplicationHasNoSlug() async {
+    // `.pendingReview` carries no authority slug — refreshing it by-slug would
+    // be meaningless, so the anonymous repository must never be called.
+    let anonSpy = SpyAnonymousApplicationDetailRepository()
+    let sut = ApplicationDetailViewModel(
+      application: .pendingReview,
+      anonymousApplicationDetailRepository: anonSpy
+    )
+
+    await sut.refresh()
+
+    #expect(anonSpy.fetchApplicationBySlugCalls.isEmpty)
+    #expect(sut.reference == "2026/0042")
+  }
+
+  @Test func refresh_inAnonymousMode_doesNotCallPlanningApplicationRepository() async {
+    // Guards against a future regression where both repositories are
+    // injected and the authed by-id path fires instead of the by-slug one.
+    let planningSpy = SpyPlanningApplicationRepository()
+    let anonSpy = SpyAnonymousApplicationDetailRepository()
+    anonSpy.fetchApplicationBySlugResult = .success(.permitted)
+    let sut = ApplicationDetailViewModel(
+      application: kingstonApplication,
+      planningApplicationRepository: planningSpy,
+      anonymousApplicationDetailRepository: anonSpy
+    )
+
+    await sut.refresh()
+
+    #expect(planningSpy.fetchApplicationCalls.isEmpty)
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/ApplicationDetailViewSignUpCTATests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ApplicationDetailViewSignUpCTATests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+/// GH#879 Phase 2: the anonymous detail screen replaces the Save affordance
+/// with a sign-up CTA.
+@Suite("ApplicationDetailView — sign-up CTA")
+@MainActor
+struct ApplicationDetailViewSignUpCTATests {
+
+  @Test("view renders when the view model is in anonymous mode")
+  func construction_inAnonymousMode_rendersWithoutCrashing() {
+    let vm = ApplicationDetailViewModel(
+      application: .pendingReview,
+      anonymousApplicationDetailRepository: SpyAnonymousApplicationDetailRepository()
+    )
+    let view = ApplicationDetailView(viewModel: vm)
+
+    _ = view.body
+  }
+
+  @Test("anonymous view model hides Save and shows the sign-up CTA")
+  func anonymousViewModel_hidesSaveAndShowsSignUpCTA() {
+    let vm = ApplicationDetailViewModel(
+      application: .pendingReview,
+      anonymousApplicationDetailRepository: SpyAnonymousApplicationDetailRepository()
+    )
+
+    #expect(!vm.canSave)
+    #expect(vm.showsSignUpCTA)
+  }
+
+  @Test("authed view model with a save repository never shows the sign-up CTA")
+  func authedViewModel_neverShowsSignUpCTA() {
+    let vm = ApplicationDetailViewModel(
+      application: .pendingReview,
+      savedApplicationRepository: SpySavedApplicationRepository()
+    )
+
+    #expect(vm.canSave)
+    #expect(!vm.showsSignUpCTA)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/CompositionRootTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/CompositionRootTests.swift
@@ -206,6 +206,47 @@ struct CompositionRootTests {
     #expect(anonymousCoordinator.screen == .welcome)
   }
 
+  // MARK: - Anonymous detail (GH#879 Phase 2)
+
+  @Test func anonymousApplicationDetailRepositoryInitialises() {
+    // Mirrors TownCrierApp.init()'s anonymous-detail wiring with real
+    // concrete types.
+    // swiftlint:disable:next force_unwrapping
+    let apiBaseURL = URL(string: "https://api.towncrierapp.uk")!
+    let anonymousApiClient = AnonymousURLSessionAPIClient(baseURL: apiBaseURL)
+    let repository = APIAnonymousApplicationDetailRepository(apiClient: anonymousApiClient)
+
+    #expect(type(of: repository) == APIAnonymousApplicationDetailRepository.self)
+  }
+
+  @Test func coordinatorAcceptsAnonymousApplicationDetailRepository() {
+    let authService = Auth0AuthenticationService(config: makeTestAuth0Config())
+    // swiftlint:disable:next force_unwrapping
+    let apiBaseURL = URL(string: "https://api.towncrierapp.uk")!
+    let apiClient = URLSessionAPIClient(baseURL: apiBaseURL, authService: authService)
+    let anonymousApiClient = AnonymousURLSessionAPIClient(baseURL: apiBaseURL)
+
+    let coordinator = AppCoordinator(
+      repository: APIPlanningApplicationRepository(apiClient: apiClient),
+      authService: authService,
+      subscriptionService: StoreKitSubscriptionService(),
+      userProfileRepository: APIUserProfileRepository(apiClient: apiClient),
+      watchZoneRepository: APIWatchZoneRepository(apiClient: apiClient),
+      onboardingRepository: UserDefaultsOnboardingRepository(),
+      notificationService: CompositeNotificationService(
+        permissionProvider: SpyNotificationPermissionProvider(),
+        apiService: APINotificationService(apiClient: apiClient),
+        remoteRegistrar: SpyRemoteNotificationRegistering()
+      ),
+      appVersionProvider: BundleAppVersionProvider(),
+      versionConfigService: APIVersionConfigService(baseURL: apiBaseURL),
+      anonymousApplicationDetailRepository: APIAnonymousApplicationDetailRepository(
+        apiClient: anonymousApiClient)
+    )
+
+    #expect(coordinator.detailApplication == nil)
+  }
+
   @Test func coordinatorAcceptsAnonymousBrowseStateRepository() {
     let authService = Auth0AuthenticationService(config: makeTestAuth0Config())
     // swiftlint:disable:next force_unwrapping

--- a/mobile/ios/town-crier-tests/Sources/Spies/SpyAnonymousApplicationDetailRepository.swift
+++ b/mobile/ios/town-crier-tests/Sources/Spies/SpyAnonymousApplicationDetailRepository.swift
@@ -1,0 +1,19 @@
+import TownCrierDomain
+
+final class SpyAnonymousApplicationDetailRepository: AnonymousApplicationDetailRepository,
+  @unchecked Sendable {
+  struct RecordedBySlugRequest: Sendable, Equatable {
+    let authoritySlug: String
+    let ref: String
+  }
+
+  private(set) var fetchApplicationBySlugCalls: [RecordedBySlugRequest] = []
+  var fetchApplicationBySlugResult: Result<PlanningApplication, Error> = .success(.pendingReview)
+
+  func fetchApplication(bySlug authoritySlug: String, ref: String) async throws
+    -> PlanningApplication {
+    fetchApplicationBySlugCalls.append(
+      RecordedBySlugRequest(authoritySlug: authoritySlug, ref: ref))
+    return try fetchApplicationBySlugResult.get()
+  }
+}


### PR DESCRIPTION
## Changes
- Signed-out share links now fetch via a new `AnonymousApplicationDetailRepository` (over `AnonymousURLSessionAPIClient`, hitting the already-public by-slug endpoint) instead of dying on the authed client's pre-HTTP session guard — the misleading "Session Expired" alert for users who never had a session is gone. Signed-in sessions keep today's authed path (read-state marking, by-id refresh-on-tap) exactly (GH #879 Phase 2, bead tc-hq9h7.2).
- The detail sheet gains an anonymous mode via the coordinator factory: Save hidden, saved-state skipped, `refresh()` via the anonymous by-slug read (skipped silently when no slug), and a sign-up CTA row reusing the `AccountCTABanner` copy (never "instant").
- The anonymous map's summary sheet button becomes "View full details", presenting the full detail screen from the already-loaded application — no network on open; near-point's `authoritySlug` (PR #880) decodes through the existing DTO (confirmed by a new positive-case test).
- Sim-verified live on dev (Birmingham): summary→detail handoff, no Save affordance, CTA copy, share sheet with share.towncrierapp.uk URL, in-app portal view, Auth0 trigger from the CTA, clean dismissal. The inbound universal-link leg is unit-tested (not deliverable on simulator).

Release-Note: Opening a shared application link now works without an account, and you can read full application details before signing up.

---
*Auto-shipped via ship skill*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ApYCEogBeZYu7UP4LEouyW