### PR TITLE
feat(ios): anonymous tab shell — Applications, Map, slimmed Settings (#879 Phase 3)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AccountCTABanner.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AccountCTABanner.swift
@@ -48,3 +48,32 @@ public struct AccountCTABanner: View {
     .padding(.bottom, TCSpacing.small)
   }
 }
+
+extension View {
+  /// Pins ``AccountCTABanner`` above this content's bottom safe area
+  /// (GH#879 Phase 3). Apply INSIDE each tab's content in
+  /// `AnonymousMainTabView` — never on the enclosing `TabView` itself.
+  ///
+  /// `.safeAreaInset(edge: .bottom)` applied directly to a `TabView` insets
+  /// against the *window's* bottom edge rather than the safe area above the
+  /// tab bar, drawing the banner over the tab bar and swallowing taps on the
+  /// other tabs — a real, reproducible SwiftUI layout defect confirmed via
+  /// live simulator verification, not a simulator artifact. Applying the
+  /// same modifier to a tab's own content instead works correctly, because
+  /// that content's bottom edge is already the boundary just above the tab
+  /// bar — mirrors the pre-Phase-3 `AnonymousMapView`, which hosted this
+  /// exact banner inside its own content and stacked correctly.
+  ///
+  /// Using `.safeAreaInset` (rather than a manual `ZStack` overlay) also
+  /// means scrollable content — the Applications list — automatically
+  /// reserves space for the banner, so its last row is never permanently
+  /// hidden behind it.
+  func accountCTABanner(
+    onCreateAccount: @escaping () -> Void,
+    onSignIn: @escaping () -> Void
+  ) -> some View {
+    safeAreaInset(edge: .bottom) {
+      AccountCTABanner(onCreateAccount: onCreateAccount, onSignIn: onSignIn)
+    }
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousApplicationListView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousApplicationListView.swift
@@ -1,0 +1,72 @@
+import SwiftUI
+import TownCrierDomain
+
+/// The anonymous (pre-signup) Applications tab (GH#879 Phase 3): a single
+/// nearest-first page of planning applications, reusing the same
+/// ``ApplicationListRow`` the authenticated Applications tab uses. No
+/// sort/filter chips (pre-resolved: v1 is nearest-first only) and no zone
+/// picker — the anonymous session has exactly one area, seeded from the
+/// postcode entered before this screen.
+public struct AnonymousApplicationListView: View {
+  @StateObject private var viewModel: AnonymousApplicationListViewModel
+
+  public init(viewModel: AnonymousApplicationListViewModel) {
+    _viewModel = StateObject(wrappedValue: viewModel)
+  }
+
+  public var body: some View {
+    List {
+      contentRows
+    }
+    .listStyle(.plain)
+    .scrollContentBackground(.hidden)
+    .background(Color.tcBackground)
+    .navigationTitle("Applications")
+    #if os(iOS)
+      .navigationBarTitleDisplayMode(.large)
+    #endif
+    .task {
+      await viewModel.loadApplications()
+    }
+    .refreshable {
+      await viewModel.loadApplications()
+    }
+  }
+
+  @ViewBuilder
+  private var contentRows: some View {
+    if viewModel.isLoading && viewModel.applications.isEmpty {
+      ListSkeletonView()
+        .listRowSeparator(.hidden)
+        .listRowInsets(EdgeInsets())
+        .listRowBackground(Color.tcBackground)
+    } else if let error = viewModel.error {
+      ErrorStateView(error: error) {
+        await viewModel.loadApplications()
+      }
+      .frame(maxWidth: .infinity)
+      .listRowSeparator(.hidden)
+      .listRowInsets(EdgeInsets())
+      .listRowBackground(Color.tcBackground)
+    } else if viewModel.isEmpty {
+      EmptyStateView(
+        icon: "doc.text.magnifyingglass",
+        title: "No Applications Nearby",
+        description: "No planning applications found within your chosen area yet."
+      )
+      .frame(maxWidth: .infinity)
+      .listRowSeparator(.hidden)
+      .listRowInsets(EdgeInsets())
+      .listRowBackground(Color.tcBackground)
+    } else {
+      ForEach(viewModel.applications) { application in
+        ApplicationListRow(application: application)
+          .listRowBackground(Color.tcSurface)
+          .contentShape(Rectangle())
+          .onTapGesture {
+            viewModel.selectApplication(application)
+          }
+      }
+    }
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousApplicationListViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousApplicationListViewModel.swift
@@ -1,0 +1,69 @@
+import Foundation
+import TownCrierDomain
+
+/// Drives the anonymous (pre-signup) Applications tab (GH#879 Phase 3): a
+/// single nearest-first page of planning applications near the stored
+/// coordinate, over the same ``AnonymousApplicationsRepository`` the
+/// anonymous map already uses. Deliberately reduced versus the authenticated
+/// ``ApplicationListViewModel`` — no sort/filter chips, no infinite scroll,
+/// no watch zone — matching the pre-resolved v1 scope decision (nearest-first
+/// only; parity can follow if anonymous usage justifies it).
+@MainActor
+public final class AnonymousApplicationListViewModel: ObservableObject, ErrorHandlingViewModel {
+  @Published public private(set) var applications: [PlanningApplication] = []
+  @Published public private(set) var isLoading = false
+  @Published public internal(set) var error: DomainError?
+
+  /// Mirrors ``AnonymousMapViewModel/defaultLimit`` — `near-point` returns at
+  /// most this many results in nearest-first order; the anonymous list is a
+  /// single bounded page, as the repository protocol is designed for.
+  public static let defaultLimit = AnonymousMapViewModel.defaultLimit
+
+  private let repository: AnonymousApplicationsRepository
+  private let coordinate: Coordinate
+  private let radiusMetres: Double
+
+  /// Fired when a row is tapped, handing the already-loaded application
+  /// straight to the coordinator — the established GH#879 Phase 2 handoff
+  /// (``AnonymousBrowseCoordinator/onShowApplicationDetail`` ->
+  /// `AppCoordinator.showAnonymousApplicationDetail`). No network call: the
+  /// row's `PlanningApplication` came from this same `fetchNearby` response.
+  public var onShowApplicationDetail: ((PlanningApplication) -> Void)?
+
+  public var isEmpty: Bool {
+    applications.isEmpty && error == nil && !isLoading
+  }
+
+  public init(
+    repository: AnonymousApplicationsRepository,
+    coordinate: Coordinate,
+    radiusMetres: Double
+  ) {
+    self.repository = repository
+    self.coordinate = coordinate
+    self.radiusMetres = radiusMetres
+  }
+
+  /// Fetches (or re-fetches, for pull-to-refresh) one nearest-first page at
+  /// the seeded coordinate/radius, replacing whatever was previously loaded.
+  public func loadApplications() async {
+    isLoading = true
+    error = nil
+    do {
+      applications = try await repository.fetchNearby(
+        latitude: coordinate.latitude,
+        longitude: coordinate.longitude,
+        radiusMetres: radiusMetres,
+        limit: Self.defaultLimit
+      )
+    } catch {
+      applications = []
+      handleError(error)
+    }
+    isLoading = false
+  }
+
+  public func selectApplication(_ application: PlanningApplication) {
+    onShowApplicationDetail?(application)
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousBrowseCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousBrowseCoordinator.swift
@@ -18,24 +18,46 @@ public final class AnonymousBrowseCoordinator: ObservableObject {
   public enum Screen: Equatable, Sendable {
     case welcome
     case postcodeEntry
+    /// The anonymous tab shell — Applications, Map, Settings (GH#879 Phase
+    /// 3; Zones arrives in Phase 4). Replaces the bare map as the
+    /// post-postcode destination.
+    case tabs
+  }
+
+  /// The anonymous tab shell's tabs (GH#879 Phase 3). Deliberately no
+  /// `.saved` case — saving is account-bound (ADR 0035) and stays the
+  /// conversion pitch; no `.zones` case yet — device-local zones arrive in
+  /// Phase 4.
+  public enum Tab: Hashable, Sendable {
+    case applications
     case map
+    case settings
   }
 
   @Published public private(set) var screen: Screen
   @Published public private(set) var mapViewModel: AnonymousMapViewModel?
+  /// Selected tab on the tab shell; bound to its `TabView`.
+  @Published public var selectedTab: Tab = .applications
 
   private let geocoder: PostcodeGeocoder
   private let stateRepository: AnonymousBrowseStateRepository
   private let applicationsRepository: AnonymousApplicationsRepository
   /// The state backing the current map session, kept in sync with the live
   /// radius picker so a slider drag re-persists the postcode/coordinate
-  /// alongside the newly chosen radius (GH#868 Phase 3 refinement).
+  /// alongside the newly chosen radius (GH#868 Phase 3 refinement). Also the
+  /// source for the Applications tab's list view model (GH#879 Phase 3).
   private var currentState: AnonymousBrowseState?
   /// Single live source of truth for the appearance preference (GH#878),
   /// shared with `SettingsViewModel` — injected by the composition root so
   /// the welcome screen's appearance control and the root
   /// `.preferredColorScheme` observe the exact same instance.
   private let appearanceStore: AppearanceStore
+  /// Backs the anonymous Settings tab's "Version" row (GH#879 Phase 3).
+  /// Required (no default): unlike `appearanceStore`, no concrete
+  /// implementation lives in this package — `town-crier-presentation`
+  /// deliberately does not depend on `town-crier-data` — so the composition
+  /// root must inject one, mirroring `AppCoordinator.init`.
+  private let appVersionProvider: AppVersionProvider
 
   /// Fired by "I already have an account", the postcode-entry back button's
   /// sibling CTA paths, and the map's CTA banner / deeper-action taps — all
@@ -48,24 +70,41 @@ public final class AnonymousBrowseCoordinator: ObservableObject {
   /// sheet in anonymous mode (`AppCoordinator.showAnonymousApplicationDetail`).
   public var onShowApplicationDetail: ((PlanningApplication) -> Void)?
 
+  /// Fired by the anonymous Settings tab's "Privacy Policy" row (GH#879
+  /// Phase 3). Wired by the composition root to the shared
+  /// `AppCoordinator.showPrivacyPolicy()` — legal documents are loaded from a
+  /// bundled JSON resource with no network/auth dependency, so both the
+  /// authed and anonymous surfaces can safely reuse the same presentation
+  /// mechanism on the always-present `AppCoordinator` instance.
+  public var onShowPrivacyPolicy: (() -> Void)?
+  /// Fired by the anonymous Settings tab's "Terms of Service" row (GH#879
+  /// Phase 3). See ``onShowPrivacyPolicy``.
+  public var onShowTermsOfService: (() -> Void)?
+  /// Fired by the anonymous Settings tab's "Rate the App" row (GH#879 Phase
+  /// 3). Wired by the composition root to the shared
+  /// `AppCoordinator.rateApp()`.
+  public var onRateApp: (() -> Void)?
+
   public init(
     geocoder: PostcodeGeocoder,
     stateRepository: AnonymousBrowseStateRepository,
     applicationsRepository: AnonymousApplicationsRepository,
-    appearanceStore: AppearanceStore? = nil
+    appearanceStore: AppearanceStore? = nil,
+    appVersionProvider: AppVersionProvider
   ) {
     self.geocoder = geocoder
     self.stateRepository = stateRepository
     self.applicationsRepository = applicationsRepository
     self.appearanceStore = appearanceStore ?? AppearanceStore()
+    self.appVersionProvider = appVersionProvider
     self.screen = .welcome
     self.mapViewModel = nil
 
     // Relaunch persistence (GH#868 Phase 3.5): a saved anonymous session
-    // routes straight to the map, never back through welcome.
+    // routes straight to the tab shell, never back through welcome.
     if let state = stateRepository.load() {
       currentState = state
-      screen = .map
+      screen = .tabs
       mapViewModel = makeMapViewModel(state: state)
     }
   }
@@ -86,21 +125,72 @@ public final class AnonymousBrowseCoordinator: ObservableObject {
       guard let self else { return }
       currentState = state
       mapViewModel = makeMapViewModel(state: state)
-      screen = .map
+      screen = .tabs
     }
     return viewModel
   }
 
   /// Returns the flow to its zero state and clears any persisted anonymous
   /// session — called on sign-out (GH#868 Phase 3.6), a deliberate return to
-  /// the welcome screen rather than back to the anonymous map. Idempotent:
-  /// safe to call even when nothing was ever persisted (e.g. a user who was
-  /// never anonymous before signing in).
+  /// the welcome screen rather than back to the anonymous tab shell.
+  /// Idempotent: safe to call even when nothing was ever persisted (e.g. a
+  /// user who was never anonymous before signing in).
   public func reset() {
     stateRepository.clear()
     currentState = nil
     mapViewModel = nil
     screen = .welcome
+  }
+
+  // MARK: - Tab shell factories (GH#879 Phase 3)
+
+  /// Builds the Applications tab's list view model, sourced from the same
+  /// coordinate/radius the map preview uses. Returns `nil` only in the
+  /// practically-unreachable case the tab shell renders before postcode
+  /// resolution has completed — `screen` only transitions to `.tabs` once
+  /// `currentState` (and `mapViewModel`) are both set.
+  public func makeApplicationListViewModel() -> AnonymousApplicationListViewModel? {
+    guard let state = currentState else { return nil }
+    let viewModel = AnonymousApplicationListViewModel(
+      repository: applicationsRepository,
+      coordinate: state.coordinate,
+      radiusMetres: state.radiusMetres)
+    viewModel.onShowApplicationDetail = { [weak self] application in
+      self?.onShowApplicationDetail?(application)
+    }
+    return viewModel
+  }
+
+  /// Builds the Settings tab's view model, sharing the same live
+  /// ``AppearanceStore`` instance the welcome screen and (once signed in)
+  /// `SettingsViewModel` observe.
+  public func makeSettingsViewModel() -> AnonymousSettingsViewModel {
+    AnonymousSettingsViewModel(
+      appearanceStore: appearanceStore, appVersionProvider: appVersionProvider)
+  }
+
+  /// "Create free account" / "Sign in" — both routes into the same Auth0
+  /// entry point every sign-up surface in the app uses. Called directly by
+  /// `AnonymousMainTabView`'s CTA banner and by `AnonymousSettingsView`'s
+  /// create-account section (mirrors `MainTabView` calling
+  /// `coordinator.showSettings()` directly).
+  public func requestSignIn() {
+    onRequestSignIn?()
+  }
+
+  /// "Privacy Policy" row on the anonymous Settings tab.
+  public func showPrivacyPolicy() {
+    onShowPrivacyPolicy?()
+  }
+
+  /// "Terms of Service" row on the anonymous Settings tab.
+  public func showTermsOfService() {
+    onShowTermsOfService?()
+  }
+
+  /// "Rate the App" row on the anonymous Settings tab.
+  public func requestRateApp() {
+    onRateApp?()
   }
 
   private func makeMapViewModel(state: AnonymousBrowseState) -> AnonymousMapViewModel {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousBrowseCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousBrowseCoordinator.swift
@@ -27,8 +27,9 @@ public final class AnonymousBrowseCoordinator: ObservableObject {
   /// The anonymous tab shell's tabs (GH#879 Phase 3). Deliberately no
   /// `.saved` case — saving is account-bound (ADR 0035) and stays the
   /// conversion pitch; no `.zones` case yet — device-local zones arrive in
-  /// Phase 4.
-  public enum Tab: Hashable, Sendable {
+  /// Phase 4. `CaseIterable` so tests can assert the tab set is exactly
+  /// these three, with no silent additions.
+  public enum Tab: Hashable, CaseIterable, Sendable {
     case applications
     case map
     case settings

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousBrowseView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousBrowseView.swift
@@ -18,10 +18,8 @@ public struct AnonymousBrowseView: View {
         WelcomeView(viewModel: coordinator.makeWelcomeViewModel())
       case .postcodeEntry:
         AnonymousPostcodeEntryView(viewModel: coordinator.makePostcodeEntryViewModel())
-      case .map:
-        if let mapViewModel = coordinator.mapViewModel {
-          AnonymousMapView(viewModel: mapViewModel)
-        }
+      case .tabs:
+        AnonymousMainTabView(coordinator: coordinator)
       }
     }
   }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMainTabView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMainTabView.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+
+/// The anonymous (pre-signup) tab shell (GH#879 Phase 3), parallel to the
+/// authenticated `MainTabView` (`town-crier-app/Sources/MainTabView.swift`):
+/// three tabs — Applications, Map, Settings. No Saved tab (saving is
+/// account-bound, ADR 0035); no Zones tab yet (device-local zones arrive in
+/// Phase 4). Replaces the bare `AnonymousMapView` as the post-postcode
+/// destination, and as what a persisted anonymous session relaunches into.
+///
+/// The persistent ``AccountCTABanner`` is hosted exactly once here, above the
+/// tab bar via `.safeAreaInset(edge: .bottom)` (the same "content pinned
+/// above the tab bar" pattern used for mini-players), so it appears over
+/// Applications and Map without each tab's own view needing to know about
+/// it. It is hidden on Settings — Settings already has its own prominent
+/// "Create free account" section, so a second copy of the same pitch would
+/// be redundant clutter (design-language: calm clarity, one hero element per
+/// screen).
+public struct AnonymousMainTabView: View {
+  @ObservedObject var coordinator: AnonymousBrowseCoordinator
+
+  public init(coordinator: AnonymousBrowseCoordinator) {
+    self.coordinator = coordinator
+  }
+
+  public var body: some View {
+    TabView(selection: $coordinator.selectedTab) {
+      applicationsTab
+      mapTab
+      settingsTab
+    }
+    .tint(Color.tcAmber)
+    .safeAreaInset(edge: .bottom) {
+      if coordinator.selectedTab != .settings {
+        AccountCTABanner(
+          onCreateAccount: { coordinator.requestSignIn() },
+          onSignIn: { coordinator.requestSignIn() }
+        )
+      }
+    }
+  }
+
+  // MARK: - Tabs
+
+  @ViewBuilder
+  private var applicationsTab: some View {
+    NavigationStack {
+      if let listViewModel = coordinator.makeApplicationListViewModel() {
+        AnonymousApplicationListView(viewModel: listViewModel)
+      }
+    }
+    .tabItem {
+      Label("Applications", systemImage: "doc.text.magnifyingglass")
+    }
+    .tag(AnonymousBrowseCoordinator.Tab.applications)
+  }
+
+  @ViewBuilder
+  private var mapTab: some View {
+    NavigationStack {
+      if let mapViewModel = coordinator.mapViewModel {
+        AnonymousMapView(viewModel: mapViewModel)
+          .navigationTitle("Map")
+          #if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+          #endif
+      }
+    }
+    .tabItem {
+      Label("Map", systemImage: "map")
+    }
+    .tag(AnonymousBrowseCoordinator.Tab.map)
+  }
+
+  private var settingsTab: some View {
+    NavigationStack {
+      AnonymousSettingsView(
+        viewModel: coordinator.makeSettingsViewModel(),
+        onCreateAccount: { coordinator.requestSignIn() },
+        onSignIn: { coordinator.requestSignIn() },
+        onPrivacyPolicy: { coordinator.showPrivacyPolicy() },
+        onTermsOfService: { coordinator.showTermsOfService() },
+        onRateApp: { coordinator.requestRateApp() }
+      )
+    }
+    .tabItem {
+      Label("Settings", systemImage: "gearshape")
+    }
+    .tag(AnonymousBrowseCoordinator.Tab.settings)
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMainTabView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMainTabView.swift
@@ -7,14 +7,18 @@ import SwiftUI
 /// Phase 4). Replaces the bare `AnonymousMapView` as the post-postcode
 /// destination, and as what a persisted anonymous session relaunches into.
 ///
-/// The persistent ``AccountCTABanner`` is hosted exactly once here, above the
-/// tab bar via `.safeAreaInset(edge: .bottom)` (the same "content pinned
-/// above the tab bar" pattern used for mini-players), so it appears over
-/// Applications and Map without each tab's own view needing to know about
-/// it. It is hidden on Settings — Settings already has its own prominent
-/// "Create free account" section, so a second copy of the same pitch would
-/// be redundant clutter (design-language: calm clarity, one hero element per
-/// screen).
+/// The persistent ``AccountCTABanner`` appears over Applications and Map via
+/// the shared `View.accountCTABanner(onCreateAccount:onSignIn:)` modifier,
+/// applied INSIDE each of those tabs' own content — never on this `TabView`
+/// itself. Hosting it at the `TabView` level was tried first and found, via
+/// live simulator verification, to draw the banner over the tab bar
+/// (`.safeAreaInset(edge: .bottom)` on a `TabView` insets against the
+/// *window's* bottom edge, not the safe area above the tab bar), making
+/// Map/Settings entirely unreachable — see `AccountCTABanner.swift` for the
+/// full writeup. It is omitted on Settings — Settings already has its own
+/// prominent "Create free account" section, so a second copy of the same
+/// pitch would be redundant clutter (design-language: calm clarity, one
+/// hero element per screen).
 public struct AnonymousMainTabView: View {
   @ObservedObject var coordinator: AnonymousBrowseCoordinator
 
@@ -29,14 +33,6 @@ public struct AnonymousMainTabView: View {
       settingsTab
     }
     .tint(Color.tcAmber)
-    .safeAreaInset(edge: .bottom) {
-      if coordinator.selectedTab != .settings {
-        AccountCTABanner(
-          onCreateAccount: { coordinator.requestSignIn() },
-          onSignIn: { coordinator.requestSignIn() }
-        )
-      }
-    }
   }
 
   // MARK: - Tabs
@@ -46,6 +42,10 @@ public struct AnonymousMainTabView: View {
     NavigationStack {
       if let listViewModel = coordinator.makeApplicationListViewModel() {
         AnonymousApplicationListView(viewModel: listViewModel)
+          .accountCTABanner(
+            onCreateAccount: { coordinator.requestSignIn() },
+            onSignIn: { coordinator.requestSignIn() }
+          )
       }
     }
     .tabItem {
@@ -63,6 +63,10 @@ public struct AnonymousMainTabView: View {
           #if os(iOS)
             .navigationBarTitleDisplayMode(.inline)
           #endif
+          .accountCTABanner(
+            onCreateAccount: { coordinator.requestSignIn() },
+            onSignIn: { coordinator.requestSignIn() }
+          )
       }
     }
     .tabItem {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMapView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMapView.swift
@@ -2,16 +2,19 @@ import MapKit
 import SwiftUI
 import TownCrierDomain
 
-/// The anonymous (pre-signup) map (GH#868 Phase 3) — the only screen in
-/// anonymous mode: no tab bar, no list, no settings. Centred on the stored
-/// coordinate, fetches pins via ``AnonymousMapViewModel``, clusters them
-/// on-device (GH#868 Phase 3 refinement), and pins a persistent
-/// ``AccountCTABanner`` — with a live monitoring-radius picker above it — over
-/// the bottom safe area. A pin tap shows a reduced-feature summary preview; a
-/// cluster tap zooms in, unless its members are coincident (same address),
-/// in which case it opens a ``StackedApplicationsSheet`` disambiguation list
-/// instead (GH#877); anything deeper than the summary preview routes to
-/// sign-up.
+/// The Map tab of the anonymous (pre-signup) tab shell (GH#868 Phase 3;
+/// promoted from the sole anonymous screen to a tab in GH#879 Phase 3).
+/// Centred on the stored coordinate, fetches pins via
+/// ``AnonymousMapViewModel``, clusters them on-device (GH#868 Phase 3
+/// refinement), and pins a live monitoring-radius picker over the bottom
+/// safe area. The persistent ``AccountCTABanner`` is hosted once by
+/// `AnonymousMainTabView` above the tab bar (GH#879 Phase 3) rather than
+/// here, so it appears over every tab, not just this one. A pin tap shows a
+/// reduced-feature summary preview; a cluster tap zooms in, unless its
+/// members are coincident (same address), in which case it opens a
+/// ``StackedApplicationsSheet`` disambiguation list instead (GH#877);
+/// anything deeper than the summary preview presents the full detail screen
+/// (GH#879 Phase 2).
 ///
 /// On iOS, pins render via ``AnonymousClusteredMapView`` (`MKMapView` +
 /// MapKit's built-in client-side clustering — near-point returns at most 200
@@ -43,13 +46,7 @@ public struct AnonymousMapView: View {
   public var body: some View {
     ZStack(alignment: .bottom) {
       mapBody
-      VStack(spacing: TCSpacing.small) {
-        radiusPickerCard
-        AccountCTABanner(
-          onCreateAccount: { viewModel.requestSignUp() },
-          onSignIn: { viewModel.requestSignUp() }
-        )
-      }
+      radiusPickerCard
     }
     .background(Color.tcBackground)
     .task { await viewModel.loadInitial() }
@@ -116,6 +113,7 @@ public struct AnonymousMapView: View {
     .background(Color.tcSurfaceElevated)
     .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.large))
     .padding(.horizontal, TCSpacing.medium)
+    .padding(.bottom, TCSpacing.small)
   }
 
   // MARK: - Map body

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousPostcodeEntryViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousPostcodeEntryViewModel.swift
@@ -6,7 +6,7 @@ import TownCrierDomain
 /// device-side ``PostcodesIOGeocoder`` in production — never `/v1/geocode`,
 /// which requires a session), persists the resolved
 /// ``AnonymousBrowseState``, and hands it to ``AnonymousBrowseCoordinator``
-/// via ``onResolved`` to advance to the map.
+/// via ``onResolved`` to advance to the tab shell (GH#879 Phase 3).
 @MainActor
 public final class AnonymousPostcodeEntryViewModel: ObservableObject, ErrorHandlingViewModel {
   @Published public var postcodeInput: String = ""
@@ -19,7 +19,8 @@ public final class AnonymousPostcodeEntryViewModel: ObservableObject, ErrorHandl
   /// Fired when the user taps "Back" — the coordinator returns to welcome.
   public var onBack: (() -> Void)?
   /// Fired once postcode entry has resolved and persisted a state — the
-  /// coordinator builds the map and advances the flow.
+  /// coordinator builds the map view model and advances the flow to the tab
+  /// shell.
   public var onResolved: ((AnonymousBrowseState) -> Void)?
 
   public init(geocoder: PostcodeGeocoder, stateRepository: AnonymousBrowseStateRepository) {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousSettingsView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousSettingsView.swift
@@ -1,0 +1,164 @@
+import SwiftUI
+import TownCrierDomain
+
+/// The anonymous (pre-signup) Settings tab (GH#879 Phase 3). Exposes
+/// exactly: a "Create free account" / "Sign in" section, Appearance, Data
+/// Attribution, Legal (Privacy Policy + Terms of Service), and About (Rate
+/// the App + Version). MUST NOT render account info, notification
+/// preferences, subscription, data export, sign out, or delete account —
+/// there is no such data to show `AnonymousSettingsViewModel` at all.
+///
+/// Row/section chrome is shared with the authenticated `SettingsView` via
+/// `SettingsRowStyling`. Navigation (sign-up entry, legal document
+/// presentation, App Store review) is decided by the coordinator, passed in
+/// as closures — mirrors `SettingsView`'s own closure-injection shape.
+public struct AnonymousSettingsView: View {
+  @StateObject private var viewModel: AnonymousSettingsViewModel
+  private let onCreateAccount: () -> Void
+  private let onSignIn: () -> Void
+  private let onPrivacyPolicy: () -> Void
+  private let onTermsOfService: () -> Void
+  private let onRateApp: () -> Void
+
+  public init(
+    viewModel: AnonymousSettingsViewModel,
+    onCreateAccount: @escaping () -> Void,
+    onSignIn: @escaping () -> Void,
+    onPrivacyPolicy: @escaping () -> Void,
+    onTermsOfService: @escaping () -> Void,
+    onRateApp: @escaping () -> Void
+  ) {
+    _viewModel = StateObject(wrappedValue: viewModel)
+    self.onCreateAccount = onCreateAccount
+    self.onSignIn = onSignIn
+    self.onPrivacyPolicy = onPrivacyPolicy
+    self.onTermsOfService = onTermsOfService
+    self.onRateApp = onRateApp
+  }
+
+  // MARK: - Test-only seams
+  //
+  // Mirror `SettingsView`'s test-only seams: invoke a callback as if the
+  // user had tapped the corresponding row, verifiable without ViewInspector
+  // or UI-level automation.
+
+  public func requestCreateAccount() { onCreateAccount() }
+  public func requestSignIn() { onSignIn() }
+  public func requestPrivacyPolicy() { onPrivacyPolicy() }
+  public func requestTermsOfService() { onTermsOfService() }
+  public func requestRateApp() { onRateApp() }
+
+  public var body: some View {
+    List {
+      createAccountSection
+      appearanceSection
+      attributionSection
+      legalSection
+      aboutSection
+    }
+    .scrollContentBackground(.hidden)
+    .background(Color.tcBackground)
+    .navigationTitle("Settings")
+  }
+
+  // MARK: - Create account
+
+  private var createAccountSection: some View {
+    Section {
+      Button {
+        onCreateAccount()
+      } label: {
+        Text("Create free account")
+          .font(TCTypography.bodyEmphasis)
+          .foregroundStyle(Color.tcAmber)
+      }
+      Button {
+        onSignIn()
+      } label: {
+        Text("Sign in")
+          .font(TCTypography.body)
+          .foregroundStyle(Color.tcTextPrimary)
+      }
+    } header: {
+      Text("Account")
+        .font(TCTypography.captionEmphasis)
+    } footer: {
+      Text(
+        "Create a free account to save applications, set up alerts, and manage watch zones."
+      )
+      .font(TCTypography.caption)
+      .foregroundStyle(Color.tcTextSecondary)
+    }
+  }
+
+  // MARK: - Appearance
+
+  private var appearanceSection: some View {
+    Section {
+      Picker(selection: $viewModel.appearanceMode) {
+        ForEach(AppearanceMode.allCases, id: \.self) { mode in
+          Text(mode.displayName).tag(mode)
+        }
+      } label: {
+        Label("Appearance", systemImage: "paintbrush")
+          .font(TCTypography.body)
+          .foregroundStyle(Color.tcTextPrimary)
+      }
+    } header: {
+      Text("Appearance")
+        .font(TCTypography.captionEmphasis)
+    }
+  }
+
+  // MARK: - Attribution
+
+  private var attributionSection: some View {
+    Section {
+      ForEach(viewModel.attributionItems, id: \.name) { item in
+        VStack(alignment: .leading, spacing: TCSpacing.extraSmall) {
+          Text(item.name)
+            .font(TCTypography.bodyEmphasis)
+            .foregroundStyle(Color.tcTextPrimary)
+          SettingsRowStyling.settingCaption(item.detail)
+        }
+      }
+    } header: {
+      Text("Data Attribution")
+        .font(TCTypography.captionEmphasis)
+    }
+  }
+
+  // MARK: - Legal
+
+  private var legalSection: some View {
+    Section {
+      SettingsRowStyling.navigationRow("Privacy Policy", systemImage: "hand.raised") {
+        onPrivacyPolicy()
+      }
+      SettingsRowStyling.navigationRow("Terms of Service", systemImage: "doc.text") {
+        onTermsOfService()
+      }
+    } header: {
+      Text("Legal")
+        .font(TCTypography.captionEmphasis)
+    }
+  }
+
+  // MARK: - About
+
+  private var aboutSection: some View {
+    Section {
+      SettingsRowStyling.navigationRow("Rate the App", systemImage: "star") {
+        onRateApp()
+      }
+      HStack {
+        SettingsRowStyling.settingLabel("Version")
+        Spacer()
+        SettingsRowStyling.settingCaption(viewModel.appVersion)
+      }
+    } header: {
+      Text("About")
+        .font(TCTypography.captionEmphasis)
+    }
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousSettingsViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousSettingsViewModel.swift
@@ -1,0 +1,53 @@
+import Combine
+import Foundation
+import TownCrierDomain
+
+/// The anonymous (pre-signup) Settings tab's ViewModel (GH#879 Phase 3): a
+/// deliberately small, distinct type from the authenticated
+/// `SettingsViewModel` rather than a shared abstraction over the two — it has
+/// no `AuthenticationService`, `SubscriptionService`, or
+/// `UserProfileRepository` dependency at all, so account info, notification
+/// preferences, subscription state, data export, sign-out, and account
+/// deletion structurally cannot appear on this screen: there is no data
+/// behind them.
+///
+/// Exposes exactly what an anonymous user's Settings needs: the shared
+/// appearance preference (GH#878), the app version, and the same data
+/// attribution rows the authenticated screen shows.
+@MainActor
+public final class AnonymousSettingsViewModel: ObservableObject {
+  private let appearanceStore: AppearanceStore
+  private let appVersionProvider: AppVersionProvider
+  // Forwards the shared store's own `objectWillChange` into this ViewModel's
+  // — without this, `AnonymousSettingsView` (which observes `self`, not the
+  // store directly) never re-renders when the mode changes from elsewhere
+  // (e.g. the welcome screen) — mirrors `SettingsViewModel`/`WelcomeViewModel`.
+  private var appearanceStoreSubscription: AnyCancellable?
+
+  public init(appearanceStore: AppearanceStore, appVersionProvider: AppVersionProvider) {
+    self.appearanceStore = appearanceStore
+    self.appVersionProvider = appVersionProvider
+    appearanceStoreSubscription = appearanceStore.objectWillChange.sink { [weak self] in
+      self?.objectWillChange.send()
+    }
+  }
+
+  /// The currently active appearance mode — a live read-through to the
+  /// shared ``AppearanceStore`` (GH#878), never a separate copy. Bound by the
+  /// Settings picker via `$viewModel.appearanceMode`.
+  public var appearanceMode: AppearanceMode {
+    get { appearanceStore.appearanceMode }
+    set { appearanceStore.appearanceMode = newValue }
+  }
+
+  public var appVersion: String {
+    "\(appVersionProvider.version) (\(appVersionProvider.buildNumber))"
+  }
+
+  /// Same content as the authenticated `SettingsViewModel.attributionItems`
+  /// — both read from the single shared ``AttributionItem/standard`` set so
+  /// the two surfaces cannot drift apart.
+  public var attributionItems: [AttributionItem] {
+    AttributionItem.standard
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Settings/AttributionItem.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Settings/AttributionItem.swift
@@ -12,3 +12,29 @@ public struct AttributionItem: Equatable, Sendable {
     self.url = url
   }
 }
+
+extension AttributionItem {
+  /// Standard data-source attribution rows shown in both the authenticated
+  /// Settings screen and the anonymous Settings tab (GH#879 Phase 3) — kept
+  /// in one place so the two surfaces cannot drift apart.
+  public static let standard: [AttributionItem] = [
+    AttributionItem(
+      name: "PlanIt",
+      detail: "Planning application data",
+      url: URL(string: "https://www.planit.org.uk")
+    ),
+    AttributionItem(
+      name: "Crown Copyright",
+      detail: "Contains public sector information"
+    ),
+    AttributionItem(
+      name: "Ordnance Survey",
+      detail: "Mapping data"
+    ),
+    AttributionItem(
+      name: "Apple Maps",
+      detail: "Map rendering and geocoding",
+      url: URL(string: "https://www.apple.com/maps/")
+    ),
+  ]
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Settings/SettingsRowStyling.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Settings/SettingsRowStyling.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+/// Shared row/section styling helpers for Settings-style `List` screens.
+/// Extracted (GH#879 Phase 3) so `SettingsView` (authenticated) and
+/// `AnonymousSettingsView` render identical row chrome without duplicating
+/// the same private helper methods across both files.
+enum SettingsRowStyling {
+  /// A label-value row: primary-styled label on the left, secondary-styled
+  /// value on the right.
+  static func settingRow(label: String, value: String) -> some View {
+    HStack {
+      settingLabel(label)
+      Spacer()
+      settingValue(value)
+    }
+  }
+
+  /// Body text styled as a setting label (primary foreground).
+  static func settingLabel(_ text: String) -> some View {
+    Text(text)
+      .font(TCTypography.body)
+      .foregroundStyle(Color.tcTextPrimary)
+  }
+
+  /// Body text styled as a setting value (secondary foreground).
+  static func settingValue(_ text: String) -> some View {
+    Text(text)
+      .font(TCTypography.body)
+      .foregroundStyle(Color.tcTextSecondary)
+  }
+
+  /// Caption text styled for metadata (secondary foreground).
+  static func settingCaption(_ text: String) -> some View {
+    Text(text)
+      .font(TCTypography.caption)
+      .foregroundStyle(Color.tcTextSecondary)
+  }
+
+  /// A tappable row with a label, SF Symbol icon, and trailing chevron
+  /// disclosure indicator.
+  static func navigationRow(
+    _ title: String, systemImage: String, action: @escaping () -> Void
+  ) -> some View {
+    Button(action: action) {
+      HStack {
+        Label(title, systemImage: systemImage)
+          .font(TCTypography.body)
+          .foregroundStyle(Color.tcTextPrimary)
+        Spacer()
+        settingChevron
+      }
+    }
+  }
+
+  /// Trailing chevron indicator for navigation rows.
+  static var settingChevron: some View {
+    Image(systemName: "chevron.right")
+      .font(.system(.caption))
+      .foregroundStyle(Color.tcTextTertiary)
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Settings/SettingsRowStyling.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Settings/SettingsRowStyling.swift
@@ -4,6 +4,10 @@ import SwiftUI
 /// Extracted (GH#879 Phase 3) so `SettingsView` (authenticated) and
 /// `AnonymousSettingsView` render identical row chrome without duplicating
 /// the same private helper methods across both files.
+/// `@MainActor` because the CI toolchain treats `Spacer.init(minLength:)` as
+/// main-actor-isolated; every call site is a `View.body`, so this adds no
+/// constraint in practice.
+@MainActor
 enum SettingsRowStyling {
   /// A label-value row: primary-styled label on the left, secondary-styled
   /// value on the right.

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Settings/SettingsView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Settings/SettingsView.swift
@@ -104,72 +104,26 @@ public struct SettingsView: View {
   }
 
   // MARK: - Helpers
-
-  /// A label-value row: primary-styled label on the left, secondary-styled value on the right.
-  private func settingRow(label: String, value: String) -> some View {
-    HStack {
-      settingLabel(label)
-      Spacer()
-      settingValue(value)
-    }
-  }
-
-  /// Body text styled as a setting label (primary foreground).
-  private func settingLabel(_ text: String) -> some View {
-    Text(text)
-      .font(TCTypography.body)
-      .foregroundStyle(Color.tcTextPrimary)
-  }
-
-  /// Body text styled as a setting value (secondary foreground).
-  private func settingValue(_ text: String) -> some View {
-    Text(text)
-      .font(TCTypography.body)
-      .foregroundStyle(Color.tcTextSecondary)
-  }
-
-  /// Caption text styled for metadata (secondary foreground).
-  private func settingCaption(_ text: String) -> some View {
-    Text(text)
-      .font(TCTypography.caption)
-      .foregroundStyle(Color.tcTextSecondary)
-  }
-
-  /// A tappable row with a label, SF Symbol icon, and trailing chevron disclosure indicator.
-  private func navigationRow(
-    _ title: String, systemImage: String, action: @escaping () -> Void
-  ) -> some View {
-    Button(action: action) {
-      HStack {
-        Label(title, systemImage: systemImage)
-          .font(TCTypography.body)
-          .foregroundStyle(Color.tcTextPrimary)
-        Spacer()
-        settingChevron
-      }
-    }
-  }
-
-  /// Trailing chevron indicator for navigation rows.
-  private var settingChevron: some View {
-    Image(systemName: "chevron.right")
-      .font(.system(.caption))
-      .foregroundStyle(Color.tcTextTertiary)
-  }
+  //
+  // Row/section chrome (`settingRow`, `settingLabel`, `settingValue`,
+  // `settingCaption`, `navigationRow`, `settingChevron`) lives in
+  // `SettingsRowStyling`, shared with `AnonymousSettingsView` (GH#879 Phase 3)
+  // so the two Settings surfaces render identical row chrome with no
+  // duplicated helpers.
 
   // MARK: - Account
 
   private var accountSection: some View {
     Section {
       if let email = viewModel.userEmail {
-        settingRow(label: "Email", value: email)
+        SettingsRowStyling.settingRow(label: "Email", value: email)
 
         if let name = viewModel.userName {
-          settingRow(label: "Name", value: name)
+          SettingsRowStyling.settingRow(label: "Name", value: name)
         }
 
         if let method = viewModel.authMethod {
-          settingRow(label: "Sign-in Method", value: method.displayName)
+          SettingsRowStyling.settingRow(label: "Sign-in Method", value: method.displayName)
         }
       }
     } header: {
@@ -201,7 +155,7 @@ public struct SettingsView: View {
 
   private var notificationSection: some View {
     Section {
-      navigationRow("Notification Preferences", systemImage: "bell") {
+      SettingsRowStyling.navigationRow("Notification Preferences", systemImage: "bell") {
         onNotificationPreferences?()
       }
     } header: {
@@ -215,7 +169,7 @@ public struct SettingsView: View {
   private var subscriptionSection: some View {
     Section {
       HStack {
-        settingLabel("Current Plan")
+        SettingsRowStyling.settingLabel("Current Plan")
         Spacer()
         HStack(spacing: TCSpacing.extraSmall) {
           Text(viewModel.subscriptionTier.rawValue.capitalized)
@@ -229,12 +183,12 @@ public struct SettingsView: View {
         }
       }
 
-      navigationRow("Manage Subscription", systemImage: "creditcard") {
+      SettingsRowStyling.navigationRow("Manage Subscription", systemImage: "creditcard") {
         onManageSubscription?()
       }
 
       if onRedeemOfferCode != nil {
-        navigationRow("Redeem Offer Code", systemImage: "ticket") {
+        SettingsRowStyling.navigationRow("Redeem Offer Code", systemImage: "ticket") {
           onRedeemOfferCode?()
         }
       }
@@ -253,7 +207,7 @@ public struct SettingsView: View {
           Text(item.name)
             .font(TCTypography.bodyEmphasis)
             .foregroundStyle(Color.tcTextPrimary)
-          settingCaption(item.detail)
+          SettingsRowStyling.settingCaption(item.detail)
         }
       }
     } header: {
@@ -266,11 +220,11 @@ public struct SettingsView: View {
 
   private var legalSection: some View {
     Section {
-      navigationRow("Privacy Policy", systemImage: "hand.raised") {
+      SettingsRowStyling.navigationRow("Privacy Policy", systemImage: "hand.raised") {
         onPrivacyPolicy?()
       }
 
-      navigationRow("Terms of Service", systemImage: "doc.text") {
+      SettingsRowStyling.navigationRow("Terms of Service", systemImage: "doc.text") {
         onTermsOfService?()
       }
 
@@ -296,7 +250,7 @@ public struct SettingsView: View {
         if viewModel.isExporting {
           ProgressView()
         } else {
-          settingChevron
+          SettingsRowStyling.settingChevron
         }
       }
     }
@@ -331,14 +285,14 @@ public struct SettingsView: View {
 
   private var appInfoSection: some View {
     Section {
-      navigationRow("Rate the App", systemImage: "star") {
+      SettingsRowStyling.navigationRow("Rate the App", systemImage: "star") {
         onRateApp?()
       }
 
       HStack {
-        settingLabel("Version")
+        SettingsRowStyling.settingLabel("Version")
         Spacer()
-        settingCaption(viewModel.appVersion)
+        SettingsRowStyling.settingCaption(viewModel.appVersion)
       }
     } header: {
       Text("About")

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Settings/SettingsViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Settings/SettingsViewModel.swift
@@ -93,26 +93,7 @@ public final class SettingsViewModel: ObservableObject, ErrorHandlingViewModel {
   }
 
   public var attributionItems: [AttributionItem] {
-    [
-      AttributionItem(
-        name: "PlanIt",
-        detail: "Planning application data",
-        url: URL(string: "https://www.planit.org.uk")
-      ),
-      AttributionItem(
-        name: "Crown Copyright",
-        detail: "Contains public sector information"
-      ),
-      AttributionItem(
-        name: "Ordnance Survey",
-        detail: "Mapping data"
-      ),
-      AttributionItem(
-        name: "Apple Maps",
-        detail: "Map rendering and geocoding",
-        url: URL(string: "https://www.apple.com/maps/")
-      ),
-    ]
+    AttributionItem.standard
   }
 
   public func load() async {

--- a/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
+++ b/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
@@ -147,7 +147,8 @@ struct TownCrierApp: App {
       geocoder: anonymousGeocoder,
       stateRepository: anonymousBrowseStateRepository,
       applicationsRepository: anonymousApplicationsRepository,
-      appearanceStore: sharedAppearanceStore
+      appearanceStore: sharedAppearanceStore,
+      appVersionProvider: appVersionProvider
     )
     anonymousCoordinator.onRequestSignIn = {
       Task { @MainActor in await loginVM.login() }
@@ -157,6 +158,21 @@ struct TownCrierApp: App {
     // network call, the anonymous map already holds the full application.
     anonymousCoordinator.onShowApplicationDetail = { [weak appCoordinator] application in
       appCoordinator?.showAnonymousApplicationDetail(application)
+    }
+    // The anonymous Settings tab's Legal/Rate-the-App rows (GH#879 Phase 3)
+    // reuse the always-present `AppCoordinator`'s existing mechanisms rather
+    // than duplicating them: legal documents load from a bundled JSON
+    // resource with no network/auth dependency, and "Rate the App" only ever
+    // opens a static App Store URL — both are safe to share verbatim between
+    // the authed and anonymous surfaces.
+    anonymousCoordinator.onShowPrivacyPolicy = { [weak appCoordinator] in
+      appCoordinator?.showPrivacyPolicy()
+    }
+    anonymousCoordinator.onShowTermsOfService = { [weak appCoordinator] in
+      appCoordinator?.showTermsOfService()
+    }
+    anonymousCoordinator.onRateApp = { [weak appCoordinator] in
+      appCoordinator?.rateApp()
     }
     _anonymousBrowseCoordinator = StateObject(wrappedValue: anonymousCoordinator)
 
@@ -206,12 +222,24 @@ struct TownCrierApp: App {
           // session always wins outright (above); otherwise
           // AnonymousBrowseCoordinator itself resolves the remaining two
           // states — persisted anonymous browse state routes straight to the
-          // map, anything else starts at the welcome screen. `LoginView`
+          // tab shell, anything else starts at the welcome screen. `LoginView`
           // still exists and is reached from there via "I already have an
           // account", which calls `loginViewModel.login()` directly (Auth0's
           // hosted Universal Login), the same single entry point sign-up and
           // sign-in both use.
+          //
+          // The legal-document sheet and App Store review modifier
+          // (GH#879 Phase 3) mount here too — mutually exclusive with
+          // `MainTabView`'s own copies inside `authenticatedRootView` above,
+          // since only one branch of this `Group` is ever in the tree at a
+          // time, so `coordinator`'s flags can never be observed twice.
           AnonymousBrowseView(coordinator: anonymousBrowseCoordinator)
+            .sheet(item: $coordinator.presentedLegalDocument) { documentType in
+              NavigationStack {
+                LegalDocumentView(viewModel: LegalDocumentViewModel(documentType: documentType))
+              }
+            }
+            .openingAppStoreReview(when: coordinator)
         }
       }
       // Session-restore on cold launch: previously lived in `LoginView`'s own

--- a/mobile/ios/town-crier-tests/Sources/Features/AccountCTABannerHostingTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AccountCTABannerHostingTests.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+import Testing
+
+@testable import TownCrierPresentation
+
+/// Regression coverage for the tab-shell CTA banner defect found by live
+/// simulator verification (tc-hq9h7.3 fix): `.safeAreaInset(edge: .bottom)`
+/// applied directly to a `TabView` insets against the *window's* bottom
+/// edge, drawing the banner over the tab bar and swallowing taps on the
+/// other tabs. The fix is `View.accountCTABanner(onCreateAccount:onSignIn:)`
+/// — applied INSIDE each tab's content instead, mirroring the pre-Phase-3
+/// `AnonymousMapView`, which hosted this exact banner inside its own content
+/// and stacked correctly above the tab bar.
+///
+/// SwiftUI view trees aren't introspectable in this codebase (no
+/// ViewInspector), so this is a construction/render smoke test — the
+/// meaningful regression guard is architectural: `AnonymousMainTabView` has
+/// no `.safeAreaInset` call on its `TabView` at all; every tab that wants
+/// the banner applies this modifier to its own content.
+@Suite("View.accountCTABanner")
+@MainActor
+struct AccountCTABannerHostingTests {
+  @Test func body_renders_onArbitraryContent() {
+    let sut = ProbeContent()
+
+    _ = sut.body
+  }
+}
+
+/// A minimal custom `View` applying the modifier under test. SwiftUI's
+/// `.safeAreaInset` produces a primitive `ModifiedContent` whose own `.body`
+/// traps if evaluated directly (it's rendered natively, not via a
+/// user-defined `body`) — calling `.body` on a custom `View` struct that
+/// merely *returns* that content, as every other body-render smoke test in
+/// this suite does, is the safe pattern.
+private struct ProbeContent: View {
+  var body: some View {
+    Text("tab content")
+      .accountCTABanner(onCreateAccount: {}, onSignIn: {})
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousApplicationListViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousApplicationListViewModelTests.swift
@@ -1,0 +1,116 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+/// GH#879 Phase 3: the anonymous Applications tab's list ViewModel — a
+/// single nearest-first page over `AnonymousApplicationsRepository`, no
+/// sort/filter chips (pre-resolved: v1 is nearest-first only).
+@Suite("AnonymousApplicationListViewModel")
+@MainActor
+struct AnonymousApplicationListViewModelTests {
+  private func makeSUT(
+    coordinate: Coordinate = .cambridge,
+    radiusMetres: Double = 2000
+  ) -> (AnonymousApplicationListViewModel, SpyAnonymousApplicationsRepository) {
+    let repository = SpyAnonymousApplicationsRepository()
+    let sut = AnonymousApplicationListViewModel(
+      repository: repository,
+      coordinate: coordinate,
+      radiusMetres: radiusMetres
+    )
+    return (sut, repository)
+  }
+
+  // MARK: - loadApplications
+
+  @Test func loadApplications_fetchesNearestFirstAtSeededCoordinateAndRadius() async {
+    let (sut, repository) = makeSUT(coordinate: .cambridge, radiusMetres: 1500)
+    repository.fetchNearbyResult = .success([.pendingReview, .permitted])
+
+    await sut.loadApplications()
+
+    #expect(repository.fetchNearbyCalls.count == 1)
+    let call = repository.fetchNearbyCalls[0]
+    #expect(call.latitude == Coordinate.cambridge.latitude)
+    #expect(call.longitude == Coordinate.cambridge.longitude)
+    #expect(call.radiusMetres == 1500)
+    #expect(call.limit == AnonymousApplicationListViewModel.defaultLimit)
+    #expect(sut.applications == [.pendingReview, .permitted])
+  }
+
+  @Test func loadApplications_setsIsLoadingFalseAfterCompletion() async {
+    let (sut, _) = makeSUT()
+
+    #expect(!sut.isLoading)
+    await sut.loadApplications()
+    #expect(!sut.isLoading)
+  }
+
+  @Test func loadApplications_failure_setsError() async {
+    let (sut, repository) = makeSUT()
+    repository.fetchNearbyResult = .failure(DomainError.networkUnavailable)
+
+    await sut.loadApplications()
+
+    #expect(sut.applications.isEmpty)
+    #expect(sut.error == .networkUnavailable)
+  }
+
+  /// Pull-to-refresh calls the same `loadApplications()` entry point — a
+  /// second successful fetch replaces the previously loaded rows.
+  @Test func loadApplications_calledAgain_replacesPreviousApplications() async {
+    let (sut, repository) = makeSUT()
+    repository.fetchNearbyResult = .success([.pendingReview])
+    await sut.loadApplications()
+    #expect(sut.applications == [.pendingReview])
+
+    repository.fetchNearbyResult = .success([.permitted])
+    await sut.loadApplications()
+
+    #expect(sut.applications == [.permitted])
+    #expect(repository.fetchNearbyCalls.count == 2)
+  }
+
+  // MARK: - isEmpty
+
+  @Test func isEmpty_trueWhenNoApplicationsNoErrorNotLoading() async {
+    let (sut, repository) = makeSUT()
+    repository.fetchNearbyResult = .success([])
+
+    await sut.loadApplications()
+
+    #expect(sut.isEmpty)
+  }
+
+  @Test func isEmpty_falseWhenApplicationsPresent() async {
+    let (sut, repository) = makeSUT()
+    repository.fetchNearbyResult = .success([.pendingReview])
+
+    await sut.loadApplications()
+
+    #expect(!sut.isEmpty)
+  }
+
+  @Test func isEmpty_falseWhenErrorPresent() async {
+    let (sut, repository) = makeSUT()
+    repository.fetchNearbyResult = .failure(DomainError.networkUnavailable)
+
+    await sut.loadApplications()
+
+    #expect(!sut.isEmpty)
+  }
+
+  // MARK: - Row selection -> detail handoff (GH#879 Phase 2 established handoff)
+
+  @Test func selectApplication_invokesOnShowApplicationDetail() {
+    let (sut, _) = makeSUT()
+    var captured: [PlanningApplication] = []
+    sut.onShowApplicationDetail = { captured.append($0) }
+
+    sut.selectApplication(.pendingReview)
+
+    #expect(captured == [.pendingReview])
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousApplicationListViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousApplicationListViewTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+@Suite("AnonymousApplicationListView")
+@MainActor
+struct AnonymousApplicationListViewTests {
+  private func makeViewModel(
+    coordinate: Coordinate = .cambridge, radiusMetres: Double = 2000
+  ) -> (AnonymousApplicationListViewModel, SpyAnonymousApplicationsRepository) {
+    let repository = SpyAnonymousApplicationsRepository()
+    let viewModel = AnonymousApplicationListViewModel(
+      repository: repository, coordinate: coordinate, radiusMetres: radiusMetres)
+    return (viewModel, repository)
+  }
+
+  @Test func body_renders_whenEmpty() {
+    let (viewModel, _) = makeViewModel()
+    let sut = AnonymousApplicationListView(viewModel: viewModel)
+
+    _ = sut.body
+  }
+
+  @Test func body_renders_withApplicationsLoaded() async {
+    let (viewModel, repository) = makeViewModel()
+    repository.fetchNearbyResult = .success([.pendingReview, .permitted])
+    await viewModel.loadApplications()
+    let sut = AnonymousApplicationListView(viewModel: viewModel)
+
+    _ = sut.body
+  }
+
+  @Test func body_renders_withErrorState() async {
+    let (viewModel, repository) = makeViewModel()
+    repository.fetchNearbyResult = .failure(DomainError.networkUnavailable)
+    await viewModel.loadApplications()
+    let sut = AnonymousApplicationListView(viewModel: viewModel)
+
+    _ = sut.body
+  }
+
+  @Test func rowTap_invokesOnShowApplicationDetail() {
+    let (viewModel, _) = makeViewModel()
+    var captured: [PlanningApplication] = []
+    viewModel.onShowApplicationDetail = { captured.append($0) }
+
+    // Mirrors the row's `.onTapGesture` wiring — the tap gesture itself is
+    // not exercisable without UI-level automation, so this asserts the same
+    // ViewModel call the gesture invokes (mirrors `ApplicationListView`'s
+    // reliance on `selectApplication` at the ViewModel level).
+    viewModel.selectApplication(.pendingReview)
+
+    #expect(captured == [.pendingReview])
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousBrowseCoordinatorTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousBrowseCoordinatorTests.swift
@@ -207,6 +207,13 @@ struct AnonymousBrowseCoordinatorTests {
     #expect(sut.selectedTab == .applications)
   }
 
+  /// The tab set is exactly Applications/Map/Settings (Zones arrives in
+  /// Phase 4) — no Saved tab, deliberately (saving is account-bound).
+  @Test func tab_allCases_isExactlyApplicationsMapSettings() {
+    #expect(
+      AnonymousBrowseCoordinator.Tab.allCases == [.applications, .map, .settings])
+  }
+
   @Test func makeApplicationListViewModel_afterPostcodeResolved_seedsFromCurrentState() {
     let (sut, _, _, _) = makeSUT(persistedState: testState)
 

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousBrowseCoordinatorTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousBrowseCoordinatorTests.swift
@@ -22,7 +22,8 @@ struct AnonymousBrowseCoordinatorTests {
       geocoder: geocoder,
       stateRepository: stateRepository,
       applicationsRepository: applicationsRepository,
-      appearanceStore: appearanceStore
+      appearanceStore: appearanceStore,
+      appVersionProvider: SpyAppVersionProvider()
     )
     return (sut, geocoder, stateRepository, applicationsRepository)
   }
@@ -41,10 +42,10 @@ struct AnonymousBrowseCoordinatorTests {
     #expect(sut.mapViewModel == nil)
   }
 
-  @Test func init_withPersistedState_startsAtMap() {
+  @Test func init_withPersistedState_startsAtTabs() {
     let (sut, _, _, _) = makeSUT(persistedState: testState)
 
-    #expect(sut.screen == .map)
+    #expect(sut.screen == .tabs)
     #expect(sut.mapViewModel != nil)
     #expect(sut.mapViewModel?.centreLat == Coordinate.cambridge.latitude)
   }
@@ -71,9 +72,9 @@ struct AnonymousBrowseCoordinatorTests {
     #expect(requested)
   }
 
-  // MARK: - Postcode entry -> map / back
+  // MARK: - Postcode entry -> tab shell / back
 
-  @Test func postcodeEntryViewModel_onResolved_advancesToMap() {
+  @Test func postcodeEntryViewModel_onResolved_advancesToTabs() {
     let (sut, _, _, _) = makeSUT()
     let postcodeVM = sut.makePostcodeEntryViewModel()
 
@@ -82,7 +83,7 @@ struct AnonymousBrowseCoordinatorTests {
     // view model's own geocode/persist behaviour (covered separately).
     postcodeVM.onResolved?(testState)
 
-    #expect(sut.screen == .map)
+    #expect(sut.screen == .tabs)
     #expect(sut.mapViewModel != nil)
   }
 
@@ -189,12 +190,98 @@ struct AnonymousBrowseCoordinatorTests {
 
   @Test func reset_clearsStateAndReturnsToWelcome() {
     let (sut, _, stateRepository, _) = makeSUT(persistedState: testState)
-    #expect(sut.screen == .map)
+    #expect(sut.screen == .tabs)
 
     sut.reset()
 
     #expect(stateRepository.clearCallCount == 1)
     #expect(sut.screen == .welcome)
     #expect(sut.mapViewModel == nil)
+  }
+
+  // MARK: - Tab shell (GH#879 Phase 3)
+
+  @Test func selectedTab_defaultsToApplications() {
+    let (sut, _, _, _) = makeSUT(persistedState: testState)
+
+    #expect(sut.selectedTab == .applications)
+  }
+
+  @Test func makeApplicationListViewModel_afterPostcodeResolved_seedsFromCurrentState() {
+    let (sut, _, _, _) = makeSUT(persistedState: testState)
+
+    let viewModel = sut.makeApplicationListViewModel()
+
+    #expect(viewModel != nil)
+  }
+
+  @Test func makeApplicationListViewModel_beforePostcodeResolved_returnsNil() {
+    let (sut, _, _, _) = makeSUT()
+
+    #expect(sut.makeApplicationListViewModel() == nil)
+  }
+
+  @Test func applicationListViewModel_onShowApplicationDetail_invokesCoordinatorCallback() {
+    let (sut, _, _, applicationsRepository) = makeSUT(persistedState: testState)
+    applicationsRepository.fetchNearbyResult = .success([.pendingReview])
+    var captured: [PlanningApplication] = []
+    sut.onShowApplicationDetail = { captured.append($0) }
+    let listViewModel = sut.makeApplicationListViewModel()
+
+    listViewModel?.selectApplication(.pendingReview)
+
+    #expect(captured == [.pendingReview])
+  }
+
+  @Test func makeSettingsViewModel_usesTheInjectedAppearanceStore() {
+    let defaults = UserDefaults(suiteName: UUID().uuidString)
+    // swiftlint:disable:next force_unwrapping
+    let appearanceStore = AppearanceStore(defaults: defaults!)
+    appearanceStore.appearanceMode = .oledDark
+    let (sut, _, _, _) = makeSUT(appearanceStore: appearanceStore)
+
+    let settingsVM = sut.makeSettingsViewModel()
+
+    #expect(settingsVM.appearanceMode == .oledDark)
+  }
+
+  @Test func requestSignIn_invokesOnRequestSignIn() {
+    let (sut, _, _, _) = makeSUT()
+    var requested = false
+    sut.onRequestSignIn = { requested = true }
+
+    sut.requestSignIn()
+
+    #expect(requested)
+  }
+
+  @Test func showPrivacyPolicy_invokesOnShowPrivacyPolicy() {
+    let (sut, _, _, _) = makeSUT()
+    var invoked = false
+    sut.onShowPrivacyPolicy = { invoked = true }
+
+    sut.showPrivacyPolicy()
+
+    #expect(invoked)
+  }
+
+  @Test func showTermsOfService_invokesOnShowTermsOfService() {
+    let (sut, _, _, _) = makeSUT()
+    var invoked = false
+    sut.onShowTermsOfService = { invoked = true }
+
+    sut.showTermsOfService()
+
+    #expect(invoked)
+  }
+
+  @Test func requestRateApp_invokesOnRateApp() {
+    let (sut, _, _, _) = makeSUT()
+    var invoked = false
+    sut.onRateApp = { invoked = true }
+
+    sut.requestRateApp()
+
+    #expect(invoked)
   }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousBrowseViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousBrowseViewTests.swift
@@ -15,7 +15,8 @@ struct AnonymousBrowseViewTests {
     return AnonymousBrowseCoordinator(
       geocoder: SpyPostcodeGeocoder(),
       stateRepository: stateRepository,
-      applicationsRepository: SpyAnonymousApplicationsRepository()
+      applicationsRepository: SpyAnonymousApplicationsRepository(),
+      appVersionProvider: SpyAppVersionProvider()
     )
   }
 
@@ -31,7 +32,7 @@ struct AnonymousBrowseViewTests {
     _ = sut.body
   }
 
-  @Test func body_renders_atMap() throws {
+  @Test func body_renders_atTabs() throws {
     let state = AnonymousBrowseState(
       postcode: try Postcode("CB1 2AD"), coordinate: .cambridge, createdAt: Date())
     let sut = AnonymousBrowseView(coordinator: makeCoordinator(persistedState: state))

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousMainTabViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousMainTabViewTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+/// GH#879 Phase 3 acceptance criteria: post-postcode routing lands on the
+/// tab shell with exactly Applications/Map/Settings, and the CTA banner
+/// (tested directly in `AccountCTABannerTests`) is reachable from Applications
+/// and Map.
+@Suite("AnonymousMainTabView")
+@MainActor
+struct AnonymousMainTabViewTests {
+  private func makeCoordinator() throws -> AnonymousBrowseCoordinator {
+    let stateRepository = SpyAnonymousBrowseStateRepository()
+    stateRepository.loadResult = AnonymousBrowseState(
+      postcode: try Postcode("CB1 2AD"), coordinate: .cambridge, createdAt: Date())
+    return AnonymousBrowseCoordinator(
+      geocoder: SpyPostcodeGeocoder(),
+      stateRepository: stateRepository,
+      applicationsRepository: SpyAnonymousApplicationsRepository(),
+      appVersionProvider: SpyAppVersionProvider()
+    )
+  }
+
+  @Test func body_renders_onApplicationsTab() throws {
+    let coordinator = try makeCoordinator()
+    coordinator.selectedTab = .applications
+    let sut = AnonymousMainTabView(coordinator: coordinator)
+
+    _ = sut.body
+  }
+
+  @Test func body_renders_onMapTab() throws {
+    let coordinator = try makeCoordinator()
+    coordinator.selectedTab = .map
+    let sut = AnonymousMainTabView(coordinator: coordinator)
+
+    _ = sut.body
+  }
+
+  @Test func body_renders_onSettingsTab() throws {
+    let coordinator = try makeCoordinator()
+    coordinator.selectedTab = .settings
+    let sut = AnonymousMainTabView(coordinator: coordinator)
+
+    _ = sut.body
+  }
+
+  /// `AnonymousBrowseView` routes `.tabs` straight to this view — proven at
+  /// the coordinator level (`AnonymousBrowseCoordinatorTests`); this
+  /// confirms the view itself renders once the coordinator has resolved a
+  /// postcode (map view model + current state both set).
+  @Test func body_renders_immediatelyAfterPostcodeResolution() throws {
+    let stateRepository = SpyAnonymousBrowseStateRepository()
+    let coordinator = AnonymousBrowseCoordinator(
+      geocoder: SpyPostcodeGeocoder(),
+      stateRepository: stateRepository,
+      applicationsRepository: SpyAnonymousApplicationsRepository(),
+      appVersionProvider: SpyAppVersionProvider()
+    )
+    let postcodeVM = coordinator.makePostcodeEntryViewModel()
+    postcodeVM.onResolved?(
+      AnonymousBrowseState(
+        postcode: try Postcode("CB1 2AD"), coordinate: .cambridge, createdAt: Date()))
+    #expect(coordinator.screen == .tabs)
+
+    let sut = AnonymousMainTabView(coordinator: coordinator)
+
+    _ = sut.body
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousSettingsViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousSettingsViewModelTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+/// GH#879 Phase 3: the anonymous Settings tab's ViewModel — deliberately a
+/// distinct, much smaller type than the authenticated `SettingsViewModel`
+/// rather than a shared abstraction. It has no `AuthenticationService`,
+/// `SubscriptionService`, or `UserProfileRepository` dependency at all, which
+/// is itself the structural guarantee that account info, notification
+/// preferences, subscription state, data export, sign-out, and account
+/// deletion can never appear on this screen — there is no data behind them.
+@Suite("AnonymousSettingsViewModel")
+@MainActor
+struct AnonymousSettingsViewModelTests {
+  private func makeSUT(
+    version: String = "1.0.0",
+    buildNumber: String = "42",
+    defaults: UserDefaults? = nil
+  ) -> (AnonymousSettingsViewModel, AppearanceStore, SpyAppVersionProvider) {
+    // swiftlint:disable:next force_unwrapping
+    let store = AppearanceStore(defaults: defaults ?? UserDefaults(suiteName: UUID().uuidString)!)
+    let versionProvider = SpyAppVersionProvider()
+    versionProvider.version = version
+    versionProvider.buildNumber = buildNumber
+    let sut = AnonymousSettingsViewModel(
+      appearanceStore: store, appVersionProvider: versionProvider)
+    return (sut, store, versionProvider)
+  }
+
+  // MARK: - Appearance (shared live source, GH#878)
+
+  @Test func appearanceMode_readsThroughToSharedStore() {
+    let (sut, store, _) = makeSUT()
+    store.appearanceMode = .oledDark
+
+    #expect(sut.appearanceMode == .oledDark)
+  }
+
+  @Test func appearanceMode_setter_writesThroughToSharedStore() {
+    let (sut, store, _) = makeSUT()
+
+    sut.appearanceMode = .dark
+
+    #expect(store.appearanceMode == .dark)
+  }
+
+  // MARK: - App version
+
+  @Test func appVersion_formatsVersionAndBuildNumber() {
+    let (sut, _, _) = makeSUT(version: "2.3.0", buildNumber: "77")
+
+    #expect(sut.appVersion == "2.3.0 (77)")
+  }
+
+  // MARK: - Data attribution — same content as the authed screen
+
+  @Test func attributionItems_matchesTheSharedStandardSet() {
+    let (sut, _, _) = makeSUT()
+
+    #expect(sut.attributionItems == AttributionItem.standard)
+  }
+
+  // MARK: - No account-bound state (GH#879 Phase 3 acceptance criteria)
+
+  @Test func viewModel_exposesNoAccountBoundStoredProperties() {
+    let (sut, _, _) = makeSUT()
+    let forbiddenSubstrings = [
+      "userEmail", "userName", "authMethod", "subscriptionTier", "isTrialPeriod",
+      "isExporting", "exportFileURL", "exportErrorMessage", "isShowingDeleteConfirmation",
+      "onLogout",
+    ]
+
+    let labels = Mirror(reflecting: sut).children.compactMap(\.label)
+
+    #expect(
+      labels.allSatisfy { label in
+        !forbiddenSubstrings.contains { label.localizedCaseInsensitiveContains($0) }
+      })
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousSettingsViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousSettingsViewTests.swift
@@ -1,0 +1,116 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+/// GH#879 Phase 3: the anonymous Settings tab. Exposes exactly:
+/// Create-account, Appearance, Data Attribution, Legal, About (Rate the App
+/// + Version). MUST NOT render: account info, notification preferences,
+/// subscription, export-your-data, sign out, delete account — enforced
+/// structurally by `AnonymousSettingsView.init` and `AnonymousSettingsViewModel`
+/// having no parameters/properties for any of those (see
+/// `AnonymousSettingsViewModelTests.viewModel_exposesNoAccountBoundStoredProperties`).
+@Suite("AnonymousSettingsView")
+@MainActor
+struct AnonymousSettingsViewTests {
+  private func makeViewModel() -> AnonymousSettingsViewModel {
+    // swiftlint:disable:next force_unwrapping
+    let store = AppearanceStore(defaults: UserDefaults(suiteName: UUID().uuidString)!)
+    return AnonymousSettingsViewModel(
+      appearanceStore: store, appVersionProvider: SpyAppVersionProvider())
+  }
+
+  @Test func body_renders() {
+    let sut = AnonymousSettingsView(
+      viewModel: makeViewModel(),
+      onCreateAccount: {},
+      onSignIn: {},
+      onPrivacyPolicy: {},
+      onTermsOfService: {},
+      onRateApp: {}
+    )
+
+    _ = sut.body
+  }
+
+  @Test func createAccountTap_invokesOnCreateAccount() {
+    var invoked = false
+    let sut = AnonymousSettingsView(
+      viewModel: makeViewModel(),
+      onCreateAccount: { invoked = true },
+      onSignIn: {},
+      onPrivacyPolicy: {},
+      onTermsOfService: {},
+      onRateApp: {}
+    )
+
+    sut.requestCreateAccount()
+
+    #expect(invoked)
+  }
+
+  @Test func signInTap_invokesOnSignIn() {
+    var invoked = false
+    let sut = AnonymousSettingsView(
+      viewModel: makeViewModel(),
+      onCreateAccount: {},
+      onSignIn: { invoked = true },
+      onPrivacyPolicy: {},
+      onTermsOfService: {},
+      onRateApp: {}
+    )
+
+    sut.requestSignIn()
+
+    #expect(invoked)
+  }
+
+  @Test func privacyPolicyTap_invokesOnPrivacyPolicy() {
+    var invoked = false
+    let sut = AnonymousSettingsView(
+      viewModel: makeViewModel(),
+      onCreateAccount: {},
+      onSignIn: {},
+      onPrivacyPolicy: { invoked = true },
+      onTermsOfService: {},
+      onRateApp: {}
+    )
+
+    sut.requestPrivacyPolicy()
+
+    #expect(invoked)
+  }
+
+  @Test func termsOfServiceTap_invokesOnTermsOfService() {
+    var invoked = false
+    let sut = AnonymousSettingsView(
+      viewModel: makeViewModel(),
+      onCreateAccount: {},
+      onSignIn: {},
+      onPrivacyPolicy: {},
+      onTermsOfService: { invoked = true },
+      onRateApp: {}
+    )
+
+    sut.requestTermsOfService()
+
+    #expect(invoked)
+  }
+
+  @Test func rateAppTap_invokesOnRateApp() {
+    var invoked = false
+    let sut = AnonymousSettingsView(
+      viewModel: makeViewModel(),
+      onCreateAccount: {},
+      onSignIn: {},
+      onPrivacyPolicy: {},
+      onTermsOfService: {},
+      onRateApp: { invoked = true }
+    )
+
+    sut.requestRateApp()
+
+    #expect(invoked)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/CompositionRootTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/CompositionRootTests.swift
@@ -200,7 +200,8 @@ struct CompositionRootTests {
     let anonymousCoordinator = AnonymousBrowseCoordinator(
       geocoder: anonymousGeocoder,
       stateRepository: anonymousBrowseStateRepository,
-      applicationsRepository: anonymousApplicationsRepository
+      applicationsRepository: anonymousApplicationsRepository,
+      appVersionProvider: BundleAppVersionProvider()
     )
 
     #expect(anonymousCoordinator.screen == .welcome)


### PR DESCRIPTION
## Changes
- Anonymous mode graduates from a bare map to a three-tab shell (`AnonymousMainTabView`): Applications (nearest-first list over the public near-point endpoint, reusing `ApplicationListRow`, pull-to-refresh, rows open the Phase 2 anonymous detail), Map (existing anonymous map), and a slimmed Settings tab (GH #879 Phase 3, bead tc-hq9h7.3).
- Anonymous Settings: create-account section, Appearance picker (shared `AppearanceStore`), Data Attribution, Legal (bundled documents — no network), Rate the App, Version. Account-bound rows are structurally absent (Mirror-reflection test asserts the ViewModel can't expose them).
- `AccountCTABanner` hosted once per tab content via a shared `.accountCTABanner(...)` modifier on Applications and Map (not Settings). An earlier TabView-level `.safeAreaInset` hosting was caught by live sim verification rendering OVER the tab bar and swallowing its taps — fixed and covered by a hosting regression test.
- Sim-verified live on dev (two rounds): tab switching, last-row scroll clearance above the banner, #877 stacked-cluster regression, exact Settings section inventory, instant dark-mode restyle across the shell, legal docs, Auth0 from banner + Settings, relaunch persistence to the shell.

Release-Note: Browse nearby planning applications in a full list, map, and settings — all before creating an account.

---
*Auto-shipped via ship skill*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ApYCEogBeZYu7UP4LEouyW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Anonymous users now see a tabbed pre-signup experience with separate Applications, Map, and Settings tabs.
  * Added an anonymous Applications list with loading, empty, and error states, plus tap-to-open application details.
  * Added an anonymous Settings screen with appearance options, app version info, legal links, and rate-app access.
  * A persistent create-account/sign-in banner now appears within the anonymous browsing experience.

* **Bug Fixes**
  * Improved anonymous flow routing so returning users and postcode resolution now land in the tabbed experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->