### PR TITLE
feat(ios): anonymous device-local zones — Zones tab + zone-driven browsing (#879 Phase 4)

### DIFF
--- a/mobile/ios/packages/town-crier-data/Sources/AnonymousBrowse/UserDefaultsDeviceLocalZoneRepository.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/AnonymousBrowse/UserDefaultsDeviceLocalZoneRepository.swift
@@ -1,0 +1,134 @@
+import Foundation
+import TownCrierDomain
+
+/// Persists device-local (pre-signup) zones to UserDefaults as a JSON-encoded
+/// array (GH#879 Phase 4). Device-local, like
+/// ``UserDefaultsAnonymousBrowseStateRepository`` — reinstalling the app
+/// resets it.
+///
+/// Migration: the first time ``loadAll()`` is called (tracked by a one-shot
+/// flag, not "storage is currently empty" — so a user who later deletes
+/// every zone is never silently re-seeded), if there are no stored zones and
+/// a legacy ``AnonymousBrowseState`` exists, seeds zone 1 from it (name = its
+/// postcode string, centre/radius from the state) and makes it active.
+/// `AnonymousBrowseState` itself is left untouched —
+/// `AppCoordinator+Onboarding`'s post-signup prefill still reads it.
+public final class UserDefaultsDeviceLocalZoneRepository: DeviceLocalZoneRepository,
+  @unchecked Sendable {
+  private let defaults: UserDefaults
+  private let legacyStateRepository: AnonymousBrowseStateRepository?
+  private let zonesKey = "deviceLocalZones"
+  private let activeZoneIdKey = "deviceLocalZoneActiveId"
+  private let migrationKey = "deviceLocalZoneMigrationComplete"
+  private let decoder = JSONDecoder()
+  private let encoder = JSONEncoder()
+
+  public init(
+    defaults: UserDefaults = .standard,
+    legacyStateRepository: AnonymousBrowseStateRepository? = nil
+  ) {
+    self.defaults = defaults
+    self.legacyStateRepository = legacyStateRepository
+  }
+
+  public func loadAll() -> [DeviceLocalZone] {
+    migrateIfNeeded()
+    return storedZones()
+  }
+
+  public func save(_ zone: DeviceLocalZone) throws {
+    var zones = storedZones()
+    if let index = zones.firstIndex(where: { $0.id == zone.id }) {
+      zones[index] = zone
+    } else {
+      guard zones.count < DeviceLocalZone.maxZoneCount else {
+        throw DomainError.deviceLocalZoneLimitReached
+      }
+      zones.append(zone)
+    }
+    persist(zones)
+    if activeZoneId() == nil {
+      setActiveZoneId(zone.id)
+    }
+  }
+
+  public func delete(_ id: DeviceLocalZoneId) {
+    var zones = storedZones()
+    zones.removeAll { $0.id == id }
+    persist(zones)
+    if activeZoneId() == id {
+      setActiveZoneId(zones.first?.id)
+    }
+  }
+
+  public func activeZoneId() -> DeviceLocalZoneId? {
+    guard let value = defaults.string(forKey: activeZoneIdKey) else { return nil }
+    return DeviceLocalZoneId(value)
+  }
+
+  public func setActiveZoneId(_ id: DeviceLocalZoneId?) {
+    guard let id else {
+      defaults.removeObject(forKey: activeZoneIdKey)
+      return
+    }
+    defaults.set(id.value, forKey: activeZoneIdKey)
+  }
+
+  // MARK: - Migration
+
+  private func migrateIfNeeded() {
+    guard !defaults.bool(forKey: migrationKey) else { return }
+    defaults.set(true, forKey: migrationKey)
+    guard storedZones().isEmpty else { return }
+    guard let legacyState = legacyStateRepository?.load() else { return }
+    guard
+      let zone = try? DeviceLocalZone(
+        name: legacyState.postcode.value,
+        centre: legacyState.coordinate,
+        radiusMetres: legacyState.radiusMetres)
+    else { return }
+    persist([zone])
+    setActiveZoneId(zone.id)
+  }
+
+  // MARK: - Storage
+
+  private func storedZones() -> [DeviceLocalZone] {
+    guard let data = defaults.data(forKey: zonesKey) else { return [] }
+    guard let stored = try? decoder.decode([StoredZone].self, from: data) else { return [] }
+    return stored.compactMap { $0.toDomain() }
+  }
+
+  private func persist(_ zones: [DeviceLocalZone]) {
+    let stored = zones.map { StoredZone(zone: $0) }
+    guard let data = try? encoder.encode(stored) else { return }
+    defaults.set(data, forKey: zonesKey)
+  }
+
+  /// Flat, versionless wire shape for the persisted blob — deliberately not
+  /// `DeviceLocalZone` itself, so the domain type never needs to conform to
+  /// `Codable` (Domain stays free of persistence concerns).
+  private struct StoredZone: Codable {
+    let id: String
+    let name: String
+    let latitude: Double
+    let longitude: Double
+    let radiusMetres: Double
+
+    init(zone: DeviceLocalZone) {
+      id = zone.id.value
+      name = zone.name
+      latitude = zone.centre.latitude
+      longitude = zone.centre.longitude
+      radiusMetres = zone.radiusMetres
+    }
+
+    func toDomain() -> DeviceLocalZone? {
+      guard let centre = try? Coordinate(latitude: latitude, longitude: longitude) else {
+        return nil
+      }
+      return try? DeviceLocalZone(
+        id: DeviceLocalZoneId(id), name: name, centre: centre, radiusMetres: radiusMetres)
+    }
+  }
+}

--- a/mobile/ios/packages/town-crier-domain/Sources/Entities/DomainError.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/Entities/DomainError.swift
@@ -19,6 +19,12 @@ public enum DomainError: Error, Equatable, Sendable {
   case restoreFailed(String)
   case unexpected(String)
   case insufficientEntitlement(required: String)
+  /// Attempted to save a NEW device-local zone (GH#879 Phase 4) while already
+  /// at ``DeviceLocalZone/maxZoneCount``. Distinct from
+  /// `.insufficientEntitlement`: this is an on-device cap with no
+  /// subscription tier behind it, so the UI routes to a sign-up CTA rather
+  /// than the paywall.
+  case deviceLocalZoneLimitReached
 
   /// User-facing title for display in error states.
   public var userTitle: String {
@@ -39,6 +45,8 @@ public enum DomainError: Error, Equatable, Sendable {
       return "Not Found"
     case .insufficientEntitlement:
       return "Upgrade Required"
+    case .deviceLocalZoneLimitReached:
+      return "Area Limit Reached"
     case .invalidPostcode:
       return "Invalid Postcode"
     case .geocodingFailed:
@@ -71,6 +79,8 @@ public enum DomainError: Error, Equatable, Sendable {
       return "There was a problem with your purchase. Please try again."
     case .insufficientEntitlement:
       return "This feature is on a higher plan. Upgrade to use it."
+    case .deviceLocalZoneLimitReached:
+      return "You can save up to 3 areas on this device. Delete one, or create a free account."
     case .invalidPostcode(let raw):
       return "The postcode '\(raw)' doesn't look right. Please enter a valid UK postcode."
     case .geocodingFailed:
@@ -90,7 +100,8 @@ public enum DomainError: Error, Equatable, Sendable {
     case .authenticationFailed, .invalidPostcode,
       .invalidCoordinate, .invalidWatchZoneRadius, .invalidWatchZoneName,
       .invalidStatusTransition, .applicationNotFound, .notificationPermissionDenied,
-      .purchaseCancelled, .productNotFound, .insufficientEntitlement:
+      .purchaseCancelled, .productNotFound, .insufficientEntitlement,
+      .deviceLocalZoneLimitReached:
       return false
     }
   }

--- a/mobile/ios/packages/town-crier-domain/Sources/Protocols/DeviceLocalZoneRepository.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/Protocols/DeviceLocalZoneRepository.swift
@@ -1,0 +1,31 @@
+/// Persists device-local (pre-signup) zones (GH#879 Phase 4): up to
+/// ``DeviceLocalZone/maxZoneCount`` areas, entirely on-device — no server
+/// zone, no alerts. A distinct value object/repository pair from
+/// `WatchZone`/`WatchZoneRepository`: `WatchZone.authorityId` is
+/// server-resolved and unavailable to an anonymous session.
+public protocol DeviceLocalZoneRepository: Sendable {
+  /// All persisted zones, in the order they were created.
+  func loadAll() -> [DeviceLocalZone]
+
+  /// Persists `zone` — inserting it if `zone.id` is new, replacing the
+  /// existing entry in place if not. Throws
+  /// `DomainError.deviceLocalZoneLimitReached` when inserting a NEW zone
+  /// would exceed ``DeviceLocalZone/maxZoneCount``; editing an existing zone
+  /// is never blocked by the cap. The first zone ever saved (whether via this
+  /// call or the legacy-state migration) becomes the active zone
+  /// automatically.
+  func save(_ zone: DeviceLocalZone) throws
+
+  /// Removes the zone with `id`, if present. Idempotent. If the removed zone
+  /// was active, the active zone becomes the first remaining zone, or `nil`
+  /// if none remain.
+  func delete(_ id: DeviceLocalZoneId)
+
+  /// The currently active zone's id — the one driving the anonymous
+  /// Applications list query and the Map centre/radius — or `nil` if no zone
+  /// has ever been saved.
+  func activeZoneId() -> DeviceLocalZoneId?
+
+  /// Sets the active zone. Pass `nil` to clear it explicitly.
+  func setActiveZoneId(_ id: DeviceLocalZoneId?)
+}

--- a/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/DeviceLocalZone.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/DeviceLocalZone.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// A circular geographic area saved on-device before sign-up (GH#879 Phase
+/// 4): name, centre, radius. Deliberately NOT a ``WatchZone`` — that type
+/// requires a server-resolved `authorityId`, which an anonymous session has
+/// no way to obtain. No alerts, no server persistence: a device-local zone
+/// exists purely to drive the anonymous Applications list and Map while the
+/// user has no account.
+public struct DeviceLocalZone: Equatable, Hashable, Identifiable, Sendable {
+  public let id: DeviceLocalZoneId
+  public let name: String
+  public let centre: Coordinate
+  public let radiusMetres: Double
+
+  /// Matches the public `GET /v1/applications/near-point` endpoint's own
+  /// clamp — deliberately NOT the authed ``WatchZoneLimits`` tiers, since a
+  /// device-local zone has no subscription tier to key off.
+  public static let minRadiusMetres: Double = 100
+  public static let maxRadiusMetres: Double = 5000
+
+  /// The on-device cap. Matches the Personal tier's watch-zone quota so a
+  /// post-signup conversion is never an absurd "delete some of your areas
+  /// first" moment (GH#879 pre-resolved decision).
+  public static let maxZoneCount = 3
+
+  public init(
+    id: DeviceLocalZoneId = DeviceLocalZoneId(),
+    name: String,
+    centre: Coordinate,
+    radiusMetres: Double
+  ) throws {
+    let trimmed = name.trimmingCharacters(in: .whitespaces)
+    guard !trimmed.isEmpty else {
+      throw DomainError.invalidWatchZoneName
+    }
+    self.id = id
+    self.name = trimmed
+    self.centre = centre
+    self.radiusMetres = Self.clampRadius(radiusMetres)
+  }
+
+  /// Clamps `metres` to `[minRadiusMetres, maxRadiusMetres]`.
+  public static func clampRadius(_ metres: Double) -> Double {
+    min(max(metres, minRadiusMetres), maxRadiusMetres)
+  }
+}

--- a/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/DeviceLocalZoneId.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/DeviceLocalZoneId.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Unique identifier for a device-local zone (GH#879 Phase 4).
+public struct DeviceLocalZoneId: Equatable, Hashable, Sendable {
+  public let value: String
+
+  public init(_ value: String) {
+    self.value = value
+  }
+
+  public init() {
+    self.value = UUID().uuidString
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousApplicationListView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousApplicationListView.swift
@@ -4,9 +4,13 @@ import TownCrierDomain
 /// The anonymous (pre-signup) Applications tab (GH#879 Phase 3): a single
 /// nearest-first page of planning applications, reusing the same
 /// ``ApplicationListRow`` the authenticated Applications tab uses. No
-/// sort/filter chips (pre-resolved: v1 is nearest-first only) and no zone
-/// picker — the anonymous session has exactly one area, seeded from the
-/// postcode entered before this screen.
+/// sort/filter chips (pre-resolved: v1 is nearest-first only).
+///
+/// GH#879 Phase 4: when more than one device-local zone exists, a zone
+/// picker chip row appears above the list — mirroring the authed
+/// `ApplicationListView`'s zone chips (`ApplicationListView.swift:120-140`)
+/// but over ``DeviceLocalZone``. Switching the active zone re-fetches this
+/// list and re-centres the Map tab.
 public struct AnonymousApplicationListView: View {
   @StateObject private var viewModel: AnonymousApplicationListViewModel
 
@@ -16,6 +20,7 @@ public struct AnonymousApplicationListView: View {
 
   public var body: some View {
     List {
+      zonePickerRow
       contentRows
     }
     .listStyle(.plain)
@@ -30,6 +35,33 @@ public struct AnonymousApplicationListView: View {
     }
     .refreshable {
       await viewModel.loadApplications()
+    }
+  }
+
+  // MARK: - Zone picker (GH#879 Phase 4)
+
+  @ViewBuilder
+  private var zonePickerRow: some View {
+    if viewModel.showZonePicker {
+      ScrollView(.horizontal, showsIndicators: false) {
+        HStack(spacing: TCSpacing.small) {
+          ForEach(viewModel.zones) { zone in
+            CapsuleChipView(
+              label: zone.name,
+              isSelected: zone.id == viewModel.selectedZone?.id
+            ) {
+              Task {
+                await viewModel.selectZone(zone)
+              }
+            }
+          }
+        }
+        .padding(.horizontal, TCSpacing.medium)
+        .padding(.vertical, TCSpacing.small)
+      }
+      .listRowSeparator(.hidden)
+      .listRowInsets(EdgeInsets())
+      .listRowBackground(Color.tcBackground)
     }
   }
 

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousApplicationListViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousApplicationListViewModel.swift
@@ -2,17 +2,26 @@ import Foundation
 import TownCrierDomain
 
 /// Drives the anonymous (pre-signup) Applications tab (GH#879 Phase 3): a
-/// single nearest-first page of planning applications near the stored
-/// coordinate, over the same ``AnonymousApplicationsRepository`` the
-/// anonymous map already uses. Deliberately reduced versus the authenticated
-/// ``ApplicationListViewModel`` — no sort/filter chips, no infinite scroll,
-/// no watch zone — matching the pre-resolved v1 scope decision (nearest-first
-/// only; parity can follow if anonymous usage justifies it).
+/// single nearest-first page of planning applications, reusing the same
+/// ``ApplicationListRow`` the authenticated Applications tab uses. No
+/// sort/filter chips — matching the pre-resolved v1 scope decision
+/// (nearest-first only; parity can follow if anonymous usage justifies it).
+///
+/// GH#879 Phase 4: the query is now zone-driven. The persisted active
+/// ``DeviceLocalZone`` supplies the coordinate/radius; a zone picker mirrors
+/// the authed ``ApplicationListViewModel``'s pattern
+/// (`showZonePicker`/`zones`/`selectedZone`/`selectZone(_:)`), but over
+/// device-local zones instead of server-side watch zones.
+/// `fallbackCoordinate`/`fallbackRadiusMetres` back the query only in the
+/// practically-unreachable case no device-local zone exists at all (e.g.
+/// before the legacy-state migration has ever run).
 @MainActor
 public final class AnonymousApplicationListViewModel: ObservableObject, ErrorHandlingViewModel {
   @Published public private(set) var applications: [PlanningApplication] = []
   @Published public private(set) var isLoading = false
   @Published public internal(set) var error: DomainError?
+  @Published public private(set) var zones: [DeviceLocalZone] = []
+  @Published public private(set) var selectedZone: DeviceLocalZone?
 
   /// Mirrors ``AnonymousMapViewModel/defaultLimit`` — `near-point` returns at
   /// most this many results in nearest-first order; the anonymous list is a
@@ -20,8 +29,9 @@ public final class AnonymousApplicationListViewModel: ObservableObject, ErrorHan
   public static let defaultLimit = AnonymousMapViewModel.defaultLimit
 
   private let repository: AnonymousApplicationsRepository
-  private let coordinate: Coordinate
-  private let radiusMetres: Double
+  private let zoneRepository: DeviceLocalZoneRepository
+  private let fallbackCoordinate: Coordinate
+  private let fallbackRadiusMetres: Double
 
   /// Fired when a row is tapped, handing the already-loaded application
   /// straight to the coordinator — the established GH#879 Phase 2 handoff
@@ -30,30 +40,72 @@ public final class AnonymousApplicationListViewModel: ObservableObject, ErrorHan
   /// row's `PlanningApplication` came from this same `fetchNearby` response.
   public var onShowApplicationDetail: ((PlanningApplication) -> Void)?
 
+  /// Fired whenever the zone picker's selection changes (GH#879 Phase 4), so
+  /// the coordinator can re-centre the Map tab to match.
+  public var onActiveZoneChanged: ((DeviceLocalZone) -> Void)?
+
   public var isEmpty: Bool {
     applications.isEmpty && error == nil && !isLoading
   }
 
+  /// True when the picker should render — mirrors the authed
+  /// `ApplicationListViewModel.showZonePicker`: a single zone is no
+  /// meaningful choice.
+  public var showZonePicker: Bool {
+    zones.count > 1
+  }
+
   public init(
     repository: AnonymousApplicationsRepository,
-    coordinate: Coordinate,
-    radiusMetres: Double
+    zoneRepository: DeviceLocalZoneRepository,
+    fallbackCoordinate: Coordinate,
+    fallbackRadiusMetres: Double
   ) {
     self.repository = repository
-    self.coordinate = coordinate
-    self.radiusMetres = radiusMetres
+    self.zoneRepository = zoneRepository
+    self.fallbackCoordinate = fallbackCoordinate
+    self.fallbackRadiusMetres = fallbackRadiusMetres
   }
 
   /// Fetches (or re-fetches, for pull-to-refresh) one nearest-first page at
-  /// the seeded coordinate/radius, replacing whatever was previously loaded.
+  /// the active zone's coordinate/radius, replacing whatever was previously
+  /// loaded. Re-reads the zone list from the repository on every call so
+  /// edits made on the Zones tab are picked up without a separate refresh
+  /// signal.
   public func loadApplications() async {
+    isLoading = true
+    error = nil
+    refreshZones()
+    let (latitude, longitude, radiusMetres) = activeQueryLocation()
+    do {
+      applications = try await repository.fetchNearby(
+        latitude: latitude,
+        longitude: longitude,
+        radiusMetres: radiusMetres,
+        limit: Self.defaultLimit
+      )
+    } catch {
+      applications = []
+      handleError(error)
+    }
+    isLoading = false
+  }
+
+  /// Switches the active zone (a picker chip tap): persists the choice,
+  /// notifies ``onActiveZoneChanged`` so the Map tab re-centres, and
+  /// re-fetches the list at the new zone's coordinate/radius.
+  public func selectZone(_ zone: DeviceLocalZone) async {
+    selectedZone = zone
+    zoneRepository.setActiveZoneId(zone.id)
+    onActiveZoneChanged?(zone)
+
     isLoading = true
     error = nil
     do {
       applications = try await repository.fetchNearby(
-        latitude: coordinate.latitude,
-        longitude: coordinate.longitude,
-        radiusMetres: radiusMetres,
+        latitude: zone.centre.latitude,
+        longitude: zone.centre.longitude,
+        radiusMetres: zone.radiusMetres,
         limit: Self.defaultLimit
       )
     } catch {
@@ -65,5 +117,23 @@ public final class AnonymousApplicationListViewModel: ObservableObject, ErrorHan
 
   public func selectApplication(_ application: PlanningApplication) {
     onShowApplicationDetail?(application)
+  }
+
+  private func refreshZones() {
+    zones = zoneRepository.loadAll()
+    if let activeId = zoneRepository.activeZoneId() {
+      selectedZone = zones.first { $0.id == activeId } ?? zones.first
+    } else {
+      selectedZone = zones.first
+    }
+  }
+
+  private func activeQueryLocation() -> (
+    latitude: Double, longitude: Double, radiusMetres: Double
+  ) {
+    guard let zone = selectedZone else {
+      return (fallbackCoordinate.latitude, fallbackCoordinate.longitude, fallbackRadiusMetres)
+    }
+    return (zone.centre.latitude, zone.centre.longitude, zone.radiusMetres)
   }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousBrowseCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousBrowseCoordinator.swift
@@ -181,7 +181,7 @@ public final class AnonymousBrowseCoordinator: ObservableObject {
     // `AnonymousMapViewModel.updateActiveZone(_:)`'s own docs for the full
     // writeup).
     viewModel.onActiveZoneChanged = { [weak self] zone in
-      Task { await self?.mapViewModel?.updateActiveZone(zone) }
+      self?.mapViewModel?.updateActiveZone(zone)
     }
     return viewModel
   }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousBrowseCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousBrowseCoordinator.swift
@@ -171,11 +171,17 @@ public final class AnonymousBrowseCoordinator: ObservableObject {
       self?.onShowApplicationDetail?(application)
     }
     // Switching the active zone (a picker chip tap) re-centres the Map tab
-    // to match (GH#879 Phase 4 acceptance criteria) — rebuilding
-    // `mapViewModel` mirrors how a postcode/relaunch resolution already
-    // replaces it.
+    // to match (GH#879 Phase 4 acceptance criteria). Mutates the EXISTING
+    // `mapViewModel` in place via `updateActiveZone(_:)` rather than
+    // replacing the published property with a new instance — live simulator
+    // verification found that replacing it left the Map tab frozen on the
+    // previous zone until a full relaunch, because `AnonymousMapView` holds
+    // the view model in a `@StateObject`, which SwiftUI keeps bound to
+    // whichever instance was FIRST passed to it (see
+    // `AnonymousMapViewModel.updateActiveZone(_:)`'s own docs for the full
+    // writeup).
     viewModel.onActiveZoneChanged = { [weak self] zone in
-      self?.mapViewModel = self?.makeMapViewModel(zone: zone)
+      Task { await self?.mapViewModel?.updateActiveZone(zone) }
     }
     return viewModel
   }
@@ -229,25 +235,6 @@ public final class AnonymousBrowseCoordinator: ObservableObject {
       radiusMetres: state.radiusMetres)
     viewModel.onRequestSignUp = { [weak self] in self?.onRequestSignIn?() }
     viewModel.onRadiusChanged = { [weak self] radius in self?.persistRadius(radius) }
-    viewModel.onShowApplicationDetail = { [weak self] application in
-      self?.onShowApplicationDetail?(application)
-    }
-    return viewModel
-  }
-
-  /// Rebuilds the Map tab's view model centred on `zone` (GH#879 Phase 4),
-  /// used when the Applications tab's zone picker switches the active zone.
-  /// Deliberately does not wire `onRadiusChanged` the way
-  /// ``makeMapViewModel(state:)`` does: that persistence path writes into the
-  /// legacy `AnonymousBrowseState` for the onboarding-prefill seam, which is
-  /// out of scope for a zone-driven session — see `AnonymousMapView`'s radius
-  /// picker note for the follow-up this leaves open.
-  private func makeMapViewModel(zone: DeviceLocalZone) -> AnonymousMapViewModel {
-    let viewModel = AnonymousMapViewModel(
-      repository: applicationsRepository,
-      coordinate: zone.centre,
-      radiusMetres: zone.radiusMetres)
-    viewModel.onRequestSignUp = { [weak self] in self?.onRequestSignIn?() }
     viewModel.onShowApplicationDetail = { [weak self] application in
       self?.onShowApplicationDetail?(application)
     }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousBrowseCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousBrowseCoordinator.swift
@@ -18,20 +18,20 @@ public final class AnonymousBrowseCoordinator: ObservableObject {
   public enum Screen: Equatable, Sendable {
     case welcome
     case postcodeEntry
-    /// The anonymous tab shell — Applications, Map, Settings (GH#879 Phase
-    /// 3; Zones arrives in Phase 4). Replaces the bare map as the
-    /// post-postcode destination.
+    /// The anonymous tab shell — Applications, Map, Zones, Settings.
+    /// Replaces the bare map as the post-postcode destination.
     case tabs
   }
 
-  /// The anonymous tab shell's tabs (GH#879 Phase 3). Deliberately no
-  /// `.saved` case — saving is account-bound (ADR 0035) and stays the
-  /// conversion pitch; no `.zones` case yet — device-local zones arrive in
-  /// Phase 4. `CaseIterable` so tests can assert the tab set is exactly
-  /// these three, with no silent additions.
+  /// The anonymous tab shell's tabs, in display order (GH#879 Phase 3;
+  /// `.zones` added Phase 4). Deliberately no `.saved` case — saving is
+  /// account-bound (ADR 0035) and stays the conversion pitch. `CaseIterable`
+  /// so tests can assert the tab set is exactly these four, with no silent
+  /// additions.
   public enum Tab: Hashable, CaseIterable, Sendable {
     case applications
     case map
+    case zones
     case settings
   }
 
@@ -43,6 +43,11 @@ public final class AnonymousBrowseCoordinator: ObservableObject {
   private let geocoder: PostcodeGeocoder
   private let stateRepository: AnonymousBrowseStateRepository
   private let applicationsRepository: AnonymousApplicationsRepository
+  /// Backs the Zones tab (GH#879 Phase 4) and the Applications tab's
+  /// zone-driven query/picker. A distinct store from `stateRepository` — see
+  /// `DeviceLocalZoneRepository`'s own docs for the migration relationship
+  /// between the two.
+  private let deviceLocalZoneRepository: DeviceLocalZoneRepository
   /// The state backing the current map session, kept in sync with the live
   /// radius picker so a slider drag re-persists the postcode/coordinate
   /// alongside the newly chosen radius (GH#868 Phase 3 refinement). Also the
@@ -90,12 +95,14 @@ public final class AnonymousBrowseCoordinator: ObservableObject {
     geocoder: PostcodeGeocoder,
     stateRepository: AnonymousBrowseStateRepository,
     applicationsRepository: AnonymousApplicationsRepository,
+    deviceLocalZoneRepository: DeviceLocalZoneRepository,
     appearanceStore: AppearanceStore? = nil,
     appVersionProvider: AppVersionProvider
   ) {
     self.geocoder = geocoder
     self.stateRepository = stateRepository
     self.applicationsRepository = applicationsRepository
+    self.deviceLocalZoneRepository = deviceLocalZoneRepository
     self.appearanceStore = appearanceStore ?? AppearanceStore()
     self.appVersionProvider = appVersionProvider
     self.screen = .welcome
@@ -145,20 +152,41 @@ public final class AnonymousBrowseCoordinator: ObservableObject {
 
   // MARK: - Tab shell factories (GH#879 Phase 3)
 
-  /// Builds the Applications tab's list view model, sourced from the same
-  /// coordinate/radius the map preview uses. Returns `nil` only in the
-  /// practically-unreachable case the tab shell renders before postcode
-  /// resolution has completed — `screen` only transitions to `.tabs` once
-  /// `currentState` (and `mapViewModel`) are both set.
+  /// Builds the Applications tab's list view model. The active device-local
+  /// zone drives the query (GH#879 Phase 4); `state.coordinate`/
+  /// `state.radiusMetres` back it only as a fallback for the
+  /// practically-unreachable case no device-local zone exists at all.
+  /// Returns `nil` only in the practically-unreachable case the tab shell
+  /// renders before postcode resolution has completed — `screen` only
+  /// transitions to `.tabs` once `currentState` (and `mapViewModel`) are both
+  /// set.
   public func makeApplicationListViewModel() -> AnonymousApplicationListViewModel? {
     guard let state = currentState else { return nil }
     let viewModel = AnonymousApplicationListViewModel(
       repository: applicationsRepository,
-      coordinate: state.coordinate,
-      radiusMetres: state.radiusMetres)
+      zoneRepository: deviceLocalZoneRepository,
+      fallbackCoordinate: state.coordinate,
+      fallbackRadiusMetres: state.radiusMetres)
     viewModel.onShowApplicationDetail = { [weak self] application in
       self?.onShowApplicationDetail?(application)
     }
+    // Switching the active zone (a picker chip tap) re-centres the Map tab
+    // to match (GH#879 Phase 4 acceptance criteria) — rebuilding
+    // `mapViewModel` mirrors how a postcode/relaunch resolution already
+    // replaces it.
+    viewModel.onActiveZoneChanged = { [weak self] zone in
+      self?.mapViewModel = self?.makeMapViewModel(zone: zone)
+    }
+    return viewModel
+  }
+
+  /// Builds the Zones tab's view model (GH#879 Phase 4), sharing the same
+  /// anonymous `PostcodeGeocoder` instance postcode entry uses (never
+  /// `/v1/geocode`).
+  public func makeDeviceLocalZoneListViewModel() -> DeviceLocalZoneListViewModel {
+    let viewModel = DeviceLocalZoneListViewModel(
+      repository: deviceLocalZoneRepository, geocoder: geocoder)
+    viewModel.onRequestSignUp = { [weak self] in self?.onRequestSignIn?() }
     return viewModel
   }
 
@@ -201,6 +229,25 @@ public final class AnonymousBrowseCoordinator: ObservableObject {
       radiusMetres: state.radiusMetres)
     viewModel.onRequestSignUp = { [weak self] in self?.onRequestSignIn?() }
     viewModel.onRadiusChanged = { [weak self] radius in self?.persistRadius(radius) }
+    viewModel.onShowApplicationDetail = { [weak self] application in
+      self?.onShowApplicationDetail?(application)
+    }
+    return viewModel
+  }
+
+  /// Rebuilds the Map tab's view model centred on `zone` (GH#879 Phase 4),
+  /// used when the Applications tab's zone picker switches the active zone.
+  /// Deliberately does not wire `onRadiusChanged` the way
+  /// ``makeMapViewModel(state:)`` does: that persistence path writes into the
+  /// legacy `AnonymousBrowseState` for the onboarding-prefill seam, which is
+  /// out of scope for a zone-driven session — see `AnonymousMapView`'s radius
+  /// picker note for the follow-up this leaves open.
+  private func makeMapViewModel(zone: DeviceLocalZone) -> AnonymousMapViewModel {
+    let viewModel = AnonymousMapViewModel(
+      repository: applicationsRepository,
+      coordinate: zone.centre,
+      radiusMetres: zone.radiusMetres)
+    viewModel.onRequestSignUp = { [weak self] in self?.onRequestSignIn?() }
     viewModel.onShowApplicationDetail = { [weak self] application in
       self?.onShowApplicationDetail?(application)
     }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousClusteredMapView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousClusteredMapView.swift
@@ -15,6 +15,27 @@
   /// status-coloured single pin, `MKCircle` radius overlay) without touching
   /// that file — the anonymous surface is a deliberately reduced,
   /// self-contained screen (see `AnonymousMapView`'s header).
+  ///
+  /// GH#879 Phase 4 crash fix: live simulator verification found a
+  /// reproducible `SIGABRT` inside MapKit's own deferred clustering pass
+  /// (`-[MKMapView annotationContainer:requestAddingClusterForAnnotationViews:]`
+  /// → Objective-C message forwarding → `doesNotRecognizeSelector:`),
+  /// triggered by switching the active device-local zone (which replaces
+  /// the map's full pin set) in combination with tab switches and a radius
+  /// drag, or by rapid zone-switch/tab cycling. `updateUIView` previously
+  /// mutated MapKit's annotations/overlay/camera SYNCHRONOUSLY and
+  /// re-entrantly every time any of several `@Published` properties changed
+  /// — which could land while MapKit's own `NSTimer`-driven clustering pass
+  /// from a PRIOR mutation was still pending, messaging annotation views
+  /// that were mid-rebuild. `Coordinator.scheduleUpdate(_:)` now coalesces
+  /// bursts of `updateUIView` calls onto a single deferred application (one
+  /// actor hop later, via `Task { @MainActor in }`), reading the ViewModel's
+  /// state fresh when it runs — this breaks the direct re-entrant call
+  /// chain and collapses rapid churn to one mutation. The exact MapKit
+  /// internal timing this races against cannot be reproduced in
+  /// `swift test` (no `MKMapView`/`NSTimer` harness here, and this type is
+  /// UIKit-only / has no existing unit-test coverage) — verified via a
+  /// dispatched simulator re-run instead.
   @MainActor
   struct AnonymousClusteredMapView: UIViewRepresentable {
     /// Observed so `updateUIView` re-runs whenever the ViewModel publishes —
@@ -55,19 +76,27 @@
     }
 
     func updateUIView(_ mapView: MKMapView, context: Context) {
+      // Deferred + coalesced (GH#879 Phase 4 crash fix — see this file's
+      // header): mutating MapKit's annotation/overlay state SYNCHRONOUSLY
+      // and possibly re-entrantly from within `updateUIView` reproducibly
+      // crashed on-device inside MapKit's own deferred clustering pass
+      // (`-[MKAnnotationContainerView _updateClusterableAnnotationViews:...]`).
       let coordinator = context.coordinator
-      coordinator.syncAnnotations(on: mapView, desired: viewModel.applications)
-      coordinator.applyRadiusOverlay(
-        to: mapView,
-        anchor: viewModel.anchorCoordinate,
-        radius: viewModel.selectedRadiusMetres)
-      // Reframe only when the selected radius actually changed, so a pin
-      // refetch (pan/zoom exploring) never yanks the user's current viewport
-      // back — mirrors `ClusteredMapView.frameCameraIfZoneChanged`.
-      coordinator.reframeIfRadiusChanged(
-        on: mapView,
-        centre: Self.coordinate(for: viewModel.anchorCoordinate),
-        radius: viewModel.selectedRadiusMetres)
+      let currentViewModel = viewModel
+      coordinator.scheduleUpdate {
+        coordinator.syncAnnotations(on: mapView, desired: currentViewModel.applications)
+        coordinator.applyRadiusOverlay(
+          to: mapView,
+          anchor: currentViewModel.anchorCoordinate,
+          radius: currentViewModel.selectedRadiusMetres)
+        // Reframe only when the selected radius actually changed, so a pin
+        // refetch (pan/zoom exploring) never yanks the user's current
+        // viewport back — mirrors `ClusteredMapView.frameCameraIfZoneChanged`.
+        coordinator.reframeIfRadiusChanged(
+          on: mapView,
+          centre: Self.coordinate(for: currentViewModel.anchorCoordinate),
+          radius: currentViewModel.selectedRadiusMetres)
+      }
     }
 
     static func coordinate(for coordinate: Coordinate) -> CLLocationCoordinate2D {
@@ -92,6 +121,10 @@
     final class Coordinator: NSObject, MKMapViewDelegate {
       private let viewModel: AnonymousMapViewModel
 
+      /// Guards ``scheduleUpdate(_:)``'s coalescing — see this file's header
+      /// for the crash this fixes.
+      private var hasScheduledUpdate = false
+
       /// The radius the camera is currently framed on, so a pin refetch never
       /// reframes — only an actual radius-slider change does.
       private var framedRadius: Double?
@@ -102,6 +135,29 @@
 
       init(viewModel: AnonymousMapViewModel) {
         self.viewModel = viewModel
+      }
+
+      // MARK: - Update coalescing (GH#879 Phase 4 crash fix)
+
+      /// Coalesces bursts of `updateUIView` calls (a radius drag, a pin
+      /// refetch, an active-zone switch — several `@Published` properties
+      /// can change together in one shot, e.g.
+      /// `AnonymousMapViewModel.updateActiveZone(_:)`) onto a SINGLE
+      /// deferred application, one main-actor hop later, rather than
+      /// mutating MapKit's annotation/overlay/camera state synchronously
+      /// and possibly re-entrantly on every call — see this file's header
+      /// for the crash this closes. `apply` reads the ViewModel's state
+      /// fresh at the point it actually runs, so a coalesced burst always
+      /// applies the LATEST state, never a stale intermediate one; calls
+      /// arriving while one is already pending are simply dropped (the
+      /// pending one will pick up their state too).
+      func scheduleUpdate(_ apply: @escaping @MainActor () -> Void) {
+        guard !hasScheduledUpdate else { return }
+        hasScheduledUpdate = true
+        Task { @MainActor [weak self] in
+          self?.hasScheduledUpdate = false
+          apply()
+        }
       }
 
       // MARK: - Annotation diffing

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMainTabView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMainTabView.swift
@@ -2,10 +2,11 @@ import SwiftUI
 
 /// The anonymous (pre-signup) tab shell (GH#879 Phase 3), parallel to the
 /// authenticated `MainTabView` (`town-crier-app/Sources/MainTabView.swift`):
-/// three tabs — Applications, Map, Settings. No Saved tab (saving is
-/// account-bound, ADR 0035); no Zones tab yet (device-local zones arrive in
-/// Phase 4). Replaces the bare `AnonymousMapView` as the post-postcode
-/// destination, and as what a persisted anonymous session relaunches into.
+/// four tabs — Applications, Map, Zones, Settings (Zones added Phase 4,
+/// matching the authed shell's tab order and its `mappin.and.ellipse` icon).
+/// No Saved tab (saving is account-bound, ADR 0035). Replaces the bare
+/// `AnonymousMapView` as the post-postcode destination, and as what a
+/// persisted anonymous session relaunches into.
 ///
 /// The persistent ``AccountCTABanner`` appears over Applications and Map via
 /// the shared `View.accountCTABanner(onCreateAccount:onSignIn:)` modifier,
@@ -18,7 +19,10 @@ import SwiftUI
 /// full writeup. It is omitted on Settings — Settings already has its own
 /// prominent "Create free account" section, so a second copy of the same
 /// pitch would be redundant clutter (design-language: calm clarity, one
-/// hero element per screen).
+/// hero element per screen). It is likewise omitted on Zones: every zone row
+/// already carries its own alert-affordance CTA
+/// (``DeviceLocalZoneListView``), and a persistent banner on top of that
+/// would be the same redundant-clutter problem, not a new one.
 public struct AnonymousMainTabView: View {
   @ObservedObject var coordinator: AnonymousBrowseCoordinator
 
@@ -30,6 +34,7 @@ public struct AnonymousMainTabView: View {
     TabView(selection: $coordinator.selectedTab) {
       applicationsTab
       mapTab
+      zonesTab
       settingsTab
     }
     .tint(Color.tcAmber)
@@ -73,6 +78,17 @@ public struct AnonymousMainTabView: View {
       Label("Map", systemImage: "map")
     }
     .tag(AnonymousBrowseCoordinator.Tab.map)
+  }
+
+  @ViewBuilder
+  private var zonesTab: some View {
+    NavigationStack {
+      DeviceLocalZoneListView(viewModel: coordinator.makeDeviceLocalZoneListViewModel())
+    }
+    .tabItem {
+      Label("Zones", systemImage: "mappin.and.ellipse")
+    }
+    .tag(AnonymousBrowseCoordinator.Tab.zones)
   }
 
   private var settingsTab: some View {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMapView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMapView.swift
@@ -90,11 +90,24 @@ public struct AnonymousMapView: View {
   /// Live monitoring-radius `Slider`, mirroring `RadiusPickerStepView`'s
   /// paradigm (same `formatRadius` label, `tcAmber` tint) so the anonymous
   /// preview and the post-signup wizard feel like one continuous control.
+  ///
+  /// GH#879 Phase 4 screen-space note: this card previously stacked its
+  /// value label above the slider inside `TCSpacing.medium` padding on all
+  /// sides — combined with the CTA banner and tab bar, sim verification
+  /// found the three together ate roughly 45% of the Map screen. Collapsing
+  /// the label and slider onto a single row, with tighter vertical padding,
+  /// meaningfully reduces that footprint without losing the ability to
+  /// adjust the radius from the map. It still previews the free-tier zone
+  /// size for the onboarding handoff (`AnonymousBrowseState`) rather than
+  /// writing through to the active `DeviceLocalZone` — that deeper question
+  /// (tc-zagg4) was assessed as more than a small change for this bead.
   private var radiusPickerCard: some View {
-    VStack(spacing: TCSpacing.small) {
+    HStack(spacing: TCSpacing.small) {
       Text(formatRadius(viewModel.selectedRadiusMetres))
-        .font(TCTypography.bodyEmphasis)
+        .font(TCTypography.captionEmphasis)
         .foregroundStyle(Color.tcTextPrimary)
+        .frame(minWidth: 52, alignment: .leading)
+        .accessibilityHidden(true)
 
       Slider(
         value: Binding(
@@ -109,7 +122,8 @@ public struct AnonymousMapView: View {
       .accessibilityLabel("Monitoring radius")
       .accessibilityValue(formatRadius(viewModel.selectedRadiusMetres))
     }
-    .padding(TCSpacing.medium)
+    .padding(.horizontal, TCSpacing.medium)
+    .padding(.vertical, TCSpacing.small)
     .background(Color.tcSurfaceElevated)
     .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.large))
     .padding(.horizontal, TCSpacing.medium)

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMapViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMapViewModel.swift
@@ -59,11 +59,12 @@ public final class AnonymousMapViewModel: ObservableObject, ErrorHandlingViewMod
   public static let minSelectedRadiusMetres: Double = 100
   public static let maxSelectedRadiusMetres: Double = WatchZoneLimits(tier: .free).maxRadiusMetres
 
-  /// The postcode-resolved point the radius preview circle is drawn around
-  /// and the camera reframes to. Fixed for the view model's lifetime, unlike
-  /// `centreLat`/`centreLon`, which follow the viewport as the user pans/
-  /// zooms.
-  public let anchorCoordinate: Coordinate
+  /// The point the radius preview circle is drawn around and the camera
+  /// reframes to. Fixed across a `regionDidChange` pan/zoom (unlike
+  /// `centreLat`/`centreLon`, which follow the viewport) — but IS updated by
+  /// ``updateActiveZone(_:)`` when the active device-local zone changes
+  /// (GH#879 Phase 4), so it is `@Published private(set)`, not `let`.
+  @Published public private(set) var anchorCoordinate: Coordinate
 
   private let repository: AnonymousApplicationsRepository
   private let debounceNanoseconds: UInt64
@@ -238,5 +239,42 @@ public final class AnonymousMapViewModel: ObservableObject, ErrorHandlingViewMod
 
   private static func clampSelectedRadius(_ metres: Double) -> Double {
     min(max(metres, minSelectedRadiusMetres), maxSelectedRadiusMetres)
+  }
+
+  /// Re-centres this SAME view model on `zone` (GH#879 Phase 4 defect fix)
+  /// when the active device-local zone changes — e.g. a zone-picker chip tap
+  /// on the Applications tab. Deliberately mutates in place rather than the
+  /// coordinator replacing the whole `AnonymousMapViewModel` instance:
+  /// `AnonymousMapView` holds this object in a `@StateObject`, which SwiftUI
+  /// keeps bound to the FIRST instance passed to it — a same-position
+  /// `AnonymousMapView(viewModel:)` re-init with a NEW instance is silently
+  /// ignored, which is exactly what live simulator verification caught (the
+  /// map stayed on the previous zone until a full relaunch). Mutating
+  /// `@Published` state on the existing instance instead triggers a normal
+  /// SwiftUI re-render, and preserves any live pan/zoom camera state rather
+  /// than tearing the map view down.
+  ///
+  /// Cancels any in-flight debounced `regionDidChange` refetch first so a
+  /// stale pan/zoom fetch can never race this one and clobber the result.
+  /// Clears selection/stack state — those refer to pins from the OLD zone's
+  /// result set, about to be replaced.
+  public func updateActiveZone(_ zone: DeviceLocalZone) async {
+    pendingRegionChangeTask?.cancel()
+    pendingRegionChangeTask = nil
+    selectedApplication = nil
+    stackedApplications = nil
+    pendingSummaryApplication = nil
+    pendingDetailApplication = nil
+
+    centreLat = zone.centre.latitude
+    centreLon = zone.centre.longitude
+    anchorCoordinate = zone.centre
+    radiusMetres = zone.radiusMetres
+    selectedRadiusMetres = Self.clampSelectedRadius(zone.radiusMetres)
+
+    await fetch(
+      latitude: zone.centre.latitude,
+      longitude: zone.centre.longitude,
+      radiusMetres: zone.radiusMetres)
   }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMapViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMapViewModel.swift
@@ -69,6 +69,10 @@ public final class AnonymousMapViewModel: ObservableObject, ErrorHandlingViewMod
   private let repository: AnonymousApplicationsRepository
   private let debounceNanoseconds: UInt64
   private var pendingRegionChangeTask: Task<Void, Never>?
+  /// Debounces ``updateActiveZone(_:)``'s fetch the same way
+  /// `pendingRegionChangeTask` debounces `regionDidChange` (GH#879 Phase 4
+  /// crash fix — see that method's docs).
+  private var pendingActiveZoneTask: Task<Void, Never>?
 
   /// Fired by the persistent CTA banner's "Create account"/"Sign in" buttons
   /// (full detail no longer requires an account — GH#879 Phase 2 replaced the
@@ -117,6 +121,10 @@ public final class AnonymousMapViewModel: ObservableObject, ErrorHandlingViewMod
     self.radiusMetres = clampedRadius
 
     pendingRegionChangeTask?.cancel()
+    // Mutual exclusion with an in-flight active-zone update (GH#879 Phase
+    // 4): a pan/zoom and a zone switch racing each other must never both
+    // land — "last request wins" — see `updateActiveZone(_:)`'s docs.
+    pendingActiveZoneTask?.cancel()
     let debounceDuration = debounceNanoseconds
     pendingRegionChangeTask = Task { [weak self] in
       try? await Task.sleep(nanoseconds: debounceDuration)
@@ -254,13 +262,29 @@ public final class AnonymousMapViewModel: ObservableObject, ErrorHandlingViewMod
   /// SwiftUI re-render, and preserves any live pan/zoom camera state rather
   /// than tearing the map view down.
   ///
-  /// Cancels any in-flight debounced `regionDidChange` refetch first so a
-  /// stale pan/zoom fetch can never race this one and clobber the result.
-  /// Clears selection/stack state — those refer to pins from the OLD zone's
-  /// result set, about to be replaced.
-  public func updateActiveZone(_ zone: DeviceLocalZone) async {
+  /// Centre/anchor/radius update IMMEDIATELY (synchronously) so the camera
+  /// and radius overlay reframe as soon as the zone switches. The FETCH —
+  /// and therefore the full pin/annotation-set swap it produces — is
+  /// debounced the same way `regionDidChange` debounces a pan/zoom, and
+  /// mutually cancels any in-flight `regionDidChange`/`updateActiveZone`
+  /// fetch of the other kind. This is a crash fix (GH#879 Phase 4): live
+  /// simulator verification hit a MapKit-internal SIGABRT
+  /// (`-[MKMapView annotationContainer:requestAddingClusterForAnnotationViews:]`
+  /// → `doesNotRecognizeSelector:`) reproducibly when the active zone was
+  /// switched rapidly — MapKit's own deferred clustering pass cannot
+  /// tolerate the annotation set being replaced faster than it can settle.
+  /// Debouncing collapses a rapid run of zone switches to a single pin swap
+  /// for the LAST zone selected, rather than one overlapping swap per tap.
+  ///
+  /// Clears selection/stack state immediately (not debounced) — those refer
+  /// to pins from the OLD zone's result set, about to be replaced, and
+  /// leaving a stale summary/disambiguation sheet open over a map that has
+  /// already moved to a new area would be its own bug.
+  public func updateActiveZone(_ zone: DeviceLocalZone) {
     pendingRegionChangeTask?.cancel()
     pendingRegionChangeTask = nil
+    pendingActiveZoneTask?.cancel()
+
     selectedApplication = nil
     stackedApplications = nil
     pendingSummaryApplication = nil
@@ -272,9 +296,20 @@ public final class AnonymousMapViewModel: ObservableObject, ErrorHandlingViewMod
     radiusMetres = zone.radiusMetres
     selectedRadiusMetres = Self.clampSelectedRadius(zone.radiusMetres)
 
-    await fetch(
-      latitude: zone.centre.latitude,
-      longitude: zone.centre.longitude,
-      radiusMetres: zone.radiusMetres)
+    let debounceDuration = debounceNanoseconds
+    pendingActiveZoneTask = Task { [weak self] in
+      try? await Task.sleep(nanoseconds: debounceDuration)
+      guard !Task.isCancelled else { return }
+      await self?.fetch(
+        latitude: zone.centre.latitude,
+        longitude: zone.centre.longitude,
+        radiusMetres: zone.radiusMetres)
+    }
+  }
+
+  /// Test-only synchronisation: await the most recently scheduled debounced
+  /// active-zone refetch, mirroring ``waitForPendingRegionChangeRefetch()``.
+  public func waitForPendingActiveZoneUpdate() async {
+    await pendingActiveZoneTask?.value
   }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/DeviceLocalZoneEditorView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/DeviceLocalZoneEditorView.swift
@@ -1,0 +1,165 @@
+import SwiftUI
+import TownCrierDomain
+
+/// Create or edit a device-local zone: name → postcode entry → radius picker
+/// → map preview → save (GH#879 Phase 4).
+///
+/// Visual conventions mirror the authed `WatchZoneEditorView`, but this is a
+/// separate, simpler anonymous editor — no entitlement gate, no per-zone
+/// notification toggles (any alert affordance lives on the zone row, not
+/// here).
+public struct DeviceLocalZoneEditorView: View {
+  @StateObject private var viewModel: DeviceLocalZoneEditorViewModel
+  @Environment(\.dismiss) private var dismiss
+
+  public init(viewModel: DeviceLocalZoneEditorViewModel) {
+    _viewModel = StateObject(wrappedValue: viewModel)
+  }
+
+  public var body: some View {
+    NavigationStack {
+      Form {
+        nameSection
+        if viewModel.isPostcodeFieldVisible {
+          postcodeSection
+        }
+        if viewModel.geocodedCoordinate != nil {
+          radiusSection
+          mapPreviewSection
+        }
+        if let error = viewModel.error {
+          errorSection(error)
+        }
+      }
+      .navigationTitle(viewModel.isEditing ? "Edit Area" : "New Area")
+      #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+      #endif
+      .toolbar {
+        ToolbarItem(placement: .cancellationAction) {
+          Button("Cancel") { dismiss() }
+        }
+        ToolbarItem(placement: .confirmationAction) {
+          Button("Save") {
+            Task {
+              // Dismiss only on success. On a cap breach the list dismisses
+              // the sheet itself (via onRequestSignUp) and shows the sign-up
+              // CTA; on any other failure the editor stays open and shows
+              // the inline error.
+              if await viewModel.save() {
+                dismiss()
+              }
+            }
+          }
+          .disabled(
+            viewModel.geocodedCoordinate == nil || viewModel.isLoading
+              || viewModel.nameInput.trimmingCharacters(in: .whitespaces).isEmpty
+          )
+        }
+      }
+    }
+  }
+
+  private var nameSection: some View {
+    Section {
+      TextField("e.g. Home, Allotment", text: $viewModel.nameInput)
+        .autocorrectionDisabled()
+    } header: {
+      Text("Area Name")
+    } footer: {
+      Text("A friendly name to identify this area.")
+        .font(.system(.caption))
+        .foregroundStyle(Color.tcTextSecondary)
+    }
+  }
+
+  private var postcodeSection: some View {
+    Section {
+      HStack {
+        TextField("Postcode", text: $viewModel.postcodeInput)
+          .textContentType(.postalCode)
+          .autocorrectionDisabled()
+          #if os(iOS)
+            .textInputAutocapitalization(.characters)
+          #endif
+
+        if viewModel.isLoading {
+          ProgressView()
+        } else {
+          Button("Look up") {
+            Task { await viewModel.submitPostcode() }
+          }
+          .disabled(viewModel.postcodeInput.isEmpty)
+        }
+      }
+    } header: {
+      Text("Postcode")
+    } footer: {
+      Text("Enter a UK postcode to centre this area.")
+        .font(.system(.caption))
+        .foregroundStyle(Color.tcTextSecondary)
+    }
+  }
+
+  private var radiusSection: some View {
+    Section("Radius") {
+      VStack(alignment: .leading, spacing: TCSpacing.small) {
+        Text(formatRadius(viewModel.selectedRadiusMetres))
+          .font(TCTypography.bodyEmphasis)
+          .foregroundStyle(Color.tcTextPrimary)
+
+        Slider(
+          value: $viewModel.selectedRadiusMetres,
+          in: viewModel.minRadiusMetres...viewModel.maxRadiusMetres,
+          step: 100
+        )
+        .tint(Color.tcAmber)
+        .accessibilityLabel("Radius")
+        .accessibilityValue(formatRadius(viewModel.selectedRadiusMetres))
+
+        HStack {
+          Text(formatRadius(viewModel.minRadiusMetres))
+          Spacer()
+          Text(formatRadius(viewModel.maxRadiusMetres))
+        }
+        .font(TCTypography.caption)
+        .foregroundStyle(Color.tcTextSecondary)
+      }
+    }
+  }
+
+  @ViewBuilder
+  private var mapPreviewSection: some View {
+    if let coordinate = viewModel.geocodedCoordinate {
+      Section("Preview") {
+        ZoneMapPreview(
+          centre: coordinate,
+          radiusMetres: viewModel.selectedRadiusMetres,
+          strokeWidth: 2
+        )
+        .frame(height: 220)
+        .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.medium))
+        .listRowInsets(
+          EdgeInsets(
+            top: TCSpacing.small,
+            leading: TCSpacing.medium,
+            bottom: TCSpacing.small,
+            trailing: TCSpacing.medium
+          ))
+      }
+    }
+  }
+
+  private func errorSection(_ error: DomainError) -> some View {
+    Section {
+      Label {
+        Text(error.userMessage)
+          .font(.system(.body))
+          .foregroundStyle(Color.tcStatusRejected)
+      } icon: {
+        Image(systemName: "exclamationmark.triangle.fill")
+          .foregroundStyle(Color.tcStatusRejected)
+      }
+    }
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/DeviceLocalZoneEditorViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/DeviceLocalZoneEditorViewModel.swift
@@ -1,0 +1,113 @@
+import Foundation
+import TownCrierDomain
+
+/// Creates or edits a single device-local zone (GH#879 Phase 4): name,
+/// postcode entry geocoded client-side via `PostcodeGeocoder` — never
+/// `/v1/geocode` — and a radius clamped to
+/// `[DeviceLocalZone.minRadiusMetres, DeviceLocalZone.maxRadiusMetres]`.
+///
+/// Visual/interaction conventions mirror the authed `WatchZoneEditorViewModel`,
+/// but this is a distinct, simpler type — no tier, no entitlement gating, no
+/// per-zone notification toggles. Any alert affordance on a device-local zone
+/// is a sign-up CTA handled by the list, not the editor.
+@MainActor
+public final class DeviceLocalZoneEditorViewModel: ObservableObject, ErrorHandlingViewModel {
+  @Published public var nameInput: String = ""
+  @Published public var postcodeInput: String = ""
+  @Published public var selectedRadiusMetres: Double = 1000
+  @Published public private(set) var geocodedCoordinate: Coordinate?
+  @Published public private(set) var isLoading = false
+  @Published public internal(set) var error: DomainError?
+
+  var onSave: ((DeviceLocalZone) -> Void)?
+
+  /// Invoked when saving would exceed the on-device cap
+  /// (`DomainError.deviceLocalZoneLimitReached`) — the list dismisses the
+  /// editor and shows the sign-up CTA instead of an inline error.
+  public var onRequestSignUp: (() -> Void)?
+
+  public let isEditing: Bool
+  public let minRadiusMetres = DeviceLocalZone.minRadiusMetres
+  public let maxRadiusMetres = DeviceLocalZone.maxRadiusMetres
+
+  private let geocoder: PostcodeGeocoder
+  private let repository: DeviceLocalZoneRepository
+  private let existingId: DeviceLocalZoneId?
+
+  public init(
+    geocoder: PostcodeGeocoder,
+    repository: DeviceLocalZoneRepository,
+    editing zone: DeviceLocalZone? = nil
+  ) {
+    self.geocoder = geocoder
+    self.repository = repository
+    self.isEditing = zone != nil
+    self.existingId = zone?.id
+
+    if let zone {
+      self.nameInput = zone.name
+      self.selectedRadiusMetres = zone.radiusMetres
+      self.geocodedCoordinate = zone.centre
+    }
+  }
+
+  public var isPostcodeFieldVisible: Bool {
+    !isEditing
+  }
+
+  public func submitPostcode() async {
+    isLoading = true
+    error = nil
+
+    let postcode: Postcode
+    do {
+      postcode = try Postcode(postcodeInput)
+    } catch {
+      handleError(error)
+      isLoading = false
+      return
+    }
+
+    do {
+      geocodedCoordinate = try await geocoder.geocode(postcode)
+      if nameInput.trimmingCharacters(in: .whitespaces).isEmpty {
+        nameInput = postcode.value
+      }
+    } catch {
+      handleError(error)
+    }
+
+    isLoading = false
+  }
+
+  /// Persists the zone. Returns `true` on success so the View dismisses only
+  /// when the save actually succeeded.
+  ///
+  /// On a cap breach (`DomainError.deviceLocalZoneLimitReached`) routes to
+  /// the sign-up CTA via `onRequestSignUp` and leaves `error` unset; all
+  /// other failures set `error` so the inline error section is shown and the
+  /// editor stays open.
+  @discardableResult
+  public func save() async -> Bool {
+    guard let coordinate = geocodedCoordinate else { return false }
+    error = nil
+
+    do {
+      let zone = try DeviceLocalZone(
+        id: existingId ?? DeviceLocalZoneId(),
+        name: nameInput,
+        centre: coordinate,
+        radiusMetres: selectedRadiusMetres
+      )
+      try repository.save(zone)
+      onSave?(zone)
+      return true
+    } catch DomainError.deviceLocalZoneLimitReached {
+      onRequestSignUp?()
+      return false
+    } catch {
+      handleError(error)
+      return false
+    }
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/DeviceLocalZoneListView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/DeviceLocalZoneListView.swift
@@ -1,0 +1,126 @@
+import SwiftUI
+import TownCrierDomain
+
+/// The anonymous (pre-signup) Zones tab (GH#879 Phase 4): up to
+/// ``DeviceLocalZone/maxZoneCount`` device-local areas with create/edit/
+/// delete. Mirrors `WatchZoneListView`'s visual conventions, but every
+/// notification affordance and any attempt to add a 4th zone route to a
+/// sign-up CTA rather than a real quota/entitlement flow — device-local
+/// zones never deliver alerts.
+public struct DeviceLocalZoneListView: View {
+  @StateObject private var viewModel: DeviceLocalZoneListViewModel
+
+  public init(viewModel: DeviceLocalZoneListViewModel) {
+    _viewModel = StateObject(wrappedValue: viewModel)
+  }
+
+  public var body: some View {
+    List {
+      if viewModel.zones.isEmpty {
+        emptyState
+      } else {
+        ForEach(viewModel.zones) { zone in
+          DeviceLocalZoneRow(zone: zone) { viewModel.requestAlertsSignUp() }
+            .contentShape(Rectangle())
+            .onTapGesture { viewModel.editZone(zone) }
+        }
+        .onDelete { indexSet in
+          guard let index = indexSet.first else { return }
+          viewModel.deleteZone(viewModel.zones[index])
+        }
+      }
+    }
+    .scrollContentBackground(.hidden)
+    .background(Color.tcBackground)
+    .navigationTitle("Zones")
+    .toolbar {
+      ToolbarItem(placement: .primaryAction) {
+        Button {
+          viewModel.addZoneTapped()
+        } label: {
+          Image(systemName: "plus")
+        }
+        .accessibilityLabel("Add Area")
+      }
+    }
+    .task {
+      viewModel.load()
+    }
+    .sheet(item: $viewModel.editorTarget) { target in
+      DeviceLocalZoneEditorView(viewModel: viewModel.makeEditorViewModel(for: target))
+    }
+    .sheet(isPresented: $viewModel.isSignUpCTAPresented) {
+      DeviceLocalZoneSignUpCTAView(
+        onCreateAccount: { viewModel.confirmSignUp() },
+        onSignIn: { viewModel.confirmSignUp() },
+        onDismiss: { viewModel.dismissSignUpCTA() }
+      )
+      .selfSizingSheet()
+    }
+  }
+
+  private var emptyState: some View {
+    Section {
+      VStack(spacing: TCSpacing.medium) {
+        Image(systemName: "mappin.and.ellipse")
+          .font(.system(.largeTitle))
+          .foregroundStyle(Color.tcTextTertiary)
+        Text("No Areas Yet")
+          .font(.system(.headline).weight(.semibold))
+        Text("Add an area to see nearby planning applications.")
+          .font(.system(.body))
+          .foregroundStyle(Color.tcTextSecondary)
+          .multilineTextAlignment(.center)
+        Button {
+          viewModel.addZoneTapped()
+        } label: {
+          Text("Add Area")
+            .font(.system(.body).weight(.semibold))
+            .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.borderedProminent)
+        .tint(Color.tcAmber)
+      }
+      .padding(.vertical, TCSpacing.extraLarge)
+    }
+    .listRowBackground(Color.tcBackground)
+  }
+}
+
+private struct DeviceLocalZoneRow: View {
+  let zone: DeviceLocalZone
+  let onAlertTap: () -> Void
+
+  var body: some View {
+    HStack(spacing: TCSpacing.medium) {
+      ZoneMapPreview(centre: zone.centre, radiusMetres: zone.radiusMetres)
+        .frame(width: 56, height: 56)
+        .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.small))
+
+      VStack(alignment: .leading, spacing: TCSpacing.extraSmall) {
+        Text(zone.name)
+          .font(.system(.headline).weight(.semibold))
+        Text(formatRadius(zone.radiusMetres))
+          .font(.system(.caption))
+          .foregroundStyle(Color.tcTextSecondary)
+      }
+
+      Spacer()
+
+      // Any alert/notification affordance on a zone row is a sign-up CTA —
+      // device-local zones never deliver alerts (GH#879 Phase 4).
+      Button(action: onAlertTap) {
+        Image(systemName: "bell.slash")
+          .foregroundStyle(Color.tcTextTertiary)
+      }
+      .buttonStyle(.plain)
+      .accessibilityLabel("Alerts require a free account")
+
+      Image(systemName: "chevron.right")
+        .font(.system(.caption))
+        .foregroundStyle(Color.tcTextTertiary)
+    }
+    .padding(.vertical, TCSpacing.extraSmall)
+    .listRowBackground(Color.tcSurface)
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/DeviceLocalZoneListViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/DeviceLocalZoneListViewModel.swift
@@ -1,0 +1,110 @@
+import Foundation
+import TownCrierDomain
+
+/// Drives the anonymous (pre-signup) Zones tab (GH#879 Phase 4): up to
+/// ``DeviceLocalZone/maxZoneCount`` device-local areas with create/edit/
+/// delete. Deliberately has no notion of a real quota/entitlement flow —
+/// attempting to add a 4th zone, and tapping any per-row alert affordance,
+/// both route straight to a sign-up CTA (``isSignUpCTAPresented``).
+@MainActor
+public final class DeviceLocalZoneListViewModel: ObservableObject {
+  /// What the create/edit sheet should show. `Identifiable` so it binds
+  /// directly to `.sheet(item:)`.
+  public enum EditorTarget: Identifiable, Equatable {
+    case new
+    case edit(DeviceLocalZone)
+
+    public var id: String {
+      switch self {
+      case .new: return "new"
+      case .edit(let zone): return zone.id.value
+      }
+    }
+  }
+
+  @Published public private(set) var zones: [DeviceLocalZone] = []
+  @Published public var editorTarget: EditorTarget?
+  @Published public var isSignUpCTAPresented = false
+
+  private let repository: DeviceLocalZoneRepository
+  private let geocoder: PostcodeGeocoder
+
+  /// Fired when the user confirms the sign-up CTA (cap reached, or a
+  /// per-row alert affordance tapped). Wired by the coordinator to the same
+  /// single sign-up/sign-in entry point every anonymous CTA uses.
+  public var onRequestSignUp: (() -> Void)?
+
+  public init(repository: DeviceLocalZoneRepository, geocoder: PostcodeGeocoder) {
+    self.repository = repository
+    self.geocoder = geocoder
+  }
+
+  public var canAddZone: Bool {
+    zones.count < DeviceLocalZone.maxZoneCount
+  }
+
+  public func load() {
+    zones = repository.loadAll()
+  }
+
+  /// The "+" toolbar action and the empty state's "Add Area" button. Opens
+  /// the editor when there's still headroom; otherwise routes straight to
+  /// the sign-up CTA — never opens the editor just to reject the save.
+  public func addZoneTapped() {
+    if canAddZone {
+      editorTarget = .new
+    } else {
+      isSignUpCTAPresented = true
+    }
+  }
+
+  public func editZone(_ zone: DeviceLocalZone) {
+    editorTarget = .edit(zone)
+  }
+
+  public func deleteZone(_ zone: DeviceLocalZone) {
+    repository.delete(zone.id)
+    zones.removeAll { $0.id == zone.id }
+  }
+
+  /// Any alert/notification affordance on a zone row is a sign-up CTA —
+  /// device-local zones never deliver alerts (GH#879 Phase 4).
+  public func requestAlertsSignUp() {
+    isSignUpCTAPresented = true
+  }
+
+  public func dismissSignUpCTA() {
+    isSignUpCTAPresented = false
+  }
+
+  public func confirmSignUp() {
+    isSignUpCTAPresented = false
+    onRequestSignUp?()
+  }
+
+  public func dismissEditor() {
+    editorTarget = nil
+  }
+
+  /// Builds the editor view model for `target`, wiring its callbacks back
+  /// into this list: a successful save dismisses the editor and reloads the
+  /// zone list from the repository; a cap breach dismisses the editor and
+  /// shows the sign-up CTA instead of an inline error.
+  public func makeEditorViewModel(for target: EditorTarget) -> DeviceLocalZoneEditorViewModel {
+    let editingZone: DeviceLocalZone? = {
+      if case .edit(let zone) = target { return zone }
+      return nil
+    }()
+    let viewModel = DeviceLocalZoneEditorViewModel(
+      geocoder: geocoder, repository: repository, editing: editingZone)
+    viewModel.onSave = { [weak self] _ in
+      self?.editorTarget = nil
+      self?.load()
+    }
+    viewModel.onRequestSignUp = { [weak self] in
+      self?.editorTarget = nil
+      self?.isSignUpCTAPresented = true
+    }
+    return viewModel
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/DeviceLocalZoneSignUpCTAView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/DeviceLocalZoneSignUpCTAView.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+
+/// Sign-up CTA shown when an anonymous user hits the on-device zone cap
+/// (``DeviceLocalZone/maxZoneCount``) or taps a zone row's alert affordance
+/// (GH#879 Phase 4).
+///
+/// Copy is a deliberate product/legal decision, mirroring
+/// ``AccountCTABanner``'s rationale: pitches the account, never promises
+/// more on-device areas (the free tier is one server zone), and never says
+/// "instant" — instant alerts are a paid, server-enforced entitlement.
+public struct DeviceLocalZoneSignUpCTAView: View {
+  public enum Copy {
+    public static let headline = "Create a free account"
+    public static let subline =
+      "Get notified when things change in your areas, and keep them saved beyond this device."
+    public static let createAccount = "Create free account"
+    public static let signIn = "Sign in"
+    public static let notNow = "Not now"
+  }
+
+  private let onCreateAccount: () -> Void
+  private let onSignIn: () -> Void
+  private let onDismiss: () -> Void
+
+  public init(
+    onCreateAccount: @escaping () -> Void,
+    onSignIn: @escaping () -> Void,
+    onDismiss: @escaping () -> Void
+  ) {
+    self.onCreateAccount = onCreateAccount
+    self.onSignIn = onSignIn
+    self.onDismiss = onDismiss
+  }
+
+  public var body: some View {
+    VStack(spacing: TCSpacing.large) {
+      Spacer()
+        .frame(height: TCSpacing.medium)
+
+      Image(systemName: "bell.badge")
+        .font(.system(.largeTitle))
+        .foregroundStyle(Color.tcAmber)
+
+      Text(Copy.headline)
+        .font(TCTypography.displaySmall)
+        .foregroundStyle(Color.tcTextPrimary)
+
+      Text(Copy.subline)
+        .font(TCTypography.body)
+        .foregroundStyle(Color.tcTextSecondary)
+        .multilineTextAlignment(.center)
+        .padding(.horizontal, TCSpacing.medium)
+
+      Spacer()
+        .frame(height: TCSpacing.small)
+
+      PrimaryButton(Copy.createAccount, action: onCreateAccount)
+        .padding(.horizontal, TCSpacing.medium)
+
+      Button(action: onSignIn) {
+        Text(Copy.signIn)
+          .font(TCTypography.bodyEmphasis)
+          .foregroundStyle(Color.tcTextSecondary)
+      }
+      .frame(minHeight: 44)
+
+      Button(action: onDismiss) {
+        Text(Copy.notNow)
+          .font(TCTypography.body)
+          .foregroundStyle(Color.tcTextTertiary)
+      }
+      .frame(minHeight: 44)
+
+      Spacer()
+        .frame(height: TCSpacing.medium)
+    }
+    .padding(.horizontal, TCSpacing.medium)
+    .background(Color.tcSurfaceElevated)
+  }
+
+  // MARK: - Test Helpers
+
+  func simulateCreateAccountTap() {
+    onCreateAccount()
+  }
+
+  func simulateSignInTap() {
+    onSignIn()
+  }
+
+  func simulateDismissTap() {
+    onDismiss()
+  }
+}

--- a/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
+++ b/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
@@ -80,6 +80,11 @@ struct TownCrierApp: App {
     let anonymousApiClient = AnonymousURLSessionAPIClient(baseURL: apiBaseURL)
     let anonymousApplicationsRepository = APIAnonymousApplicationsRepository(
       apiClient: anonymousApiClient)
+    // Device-local zones (GH#879 Phase 4): up to 3 on-device areas, migrated
+    // from `anonymousBrowseStateRepository` on first load — see
+    // `UserDefaultsDeviceLocalZoneRepository`'s own docs.
+    let deviceLocalZoneRepository = UserDefaultsDeviceLocalZoneRepository(
+      legacyStateRepository: anonymousBrowseStateRepository)
     // Anonymous full detail + share-link fix (GH#879 Phase 2): backs both a
     // signed-out share Universal Link and the anonymous map/summary sheet's
     // "View full details".
@@ -147,6 +152,7 @@ struct TownCrierApp: App {
       geocoder: anonymousGeocoder,
       stateRepository: anonymousBrowseStateRepository,
       applicationsRepository: anonymousApplicationsRepository,
+      deviceLocalZoneRepository: deviceLocalZoneRepository,
       appearanceStore: sharedAppearanceStore,
       appVersionProvider: appVersionProvider
     )

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousApplicationListViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousApplicationListViewModelTests.swift
@@ -7,26 +7,44 @@ import TownCrierDomain
 /// GH#879 Phase 3: the anonymous Applications tab's list ViewModel — a
 /// single nearest-first page over `AnonymousApplicationsRepository`, no
 /// sort/filter chips (pre-resolved: v1 is nearest-first only).
+///
+/// GH#879 Phase 4: the active `DeviceLocalZone` now drives the query, with a
+/// zone picker mirroring the authed `ApplicationListViewModel`'s pattern.
+/// `fallbackCoordinate`/`fallbackRadiusMetres` back the query only in the
+/// practically-unreachable case no device-local zone exists at all.
 @Suite("AnonymousApplicationListViewModel")
 @MainActor
 struct AnonymousApplicationListViewModelTests {
   private func makeSUT(
-    coordinate: Coordinate = .cambridge,
-    radiusMetres: Double = 2000
-  ) -> (AnonymousApplicationListViewModel, SpyAnonymousApplicationsRepository) {
+    fallbackCoordinate: Coordinate = .cambridge,
+    fallbackRadiusMetres: Double = 2000,
+    zones: [DeviceLocalZone] = [],
+    activeZoneId: DeviceLocalZoneId? = nil
+  ) -> (AnonymousApplicationListViewModel, SpyAnonymousApplicationsRepository, SpyDeviceLocalZoneRepository) {
     let repository = SpyAnonymousApplicationsRepository()
+    let zoneRepository = SpyDeviceLocalZoneRepository()
+    zoneRepository.loadAllResult = zones
+    zoneRepository.activeZoneIdResult = activeZoneId
     let sut = AnonymousApplicationListViewModel(
       repository: repository,
-      coordinate: coordinate,
-      radiusMetres: radiusMetres
+      zoneRepository: zoneRepository,
+      fallbackCoordinate: fallbackCoordinate,
+      fallbackRadiusMetres: fallbackRadiusMetres
     )
-    return (sut, repository)
+    return (sut, repository, zoneRepository)
   }
 
-  // MARK: - loadApplications
+  private func makeZone(
+    name: String = "Home", radiusMetres: Double = 1500
+  ) throws -> DeviceLocalZone {
+    try DeviceLocalZone(name: name, centre: .cambridge, radiusMetres: radiusMetres)
+  }
 
-  @Test func loadApplications_fetchesNearestFirstAtSeededCoordinateAndRadius() async {
-    let (sut, repository) = makeSUT(coordinate: .cambridge, radiusMetres: 1500)
+  // MARK: - loadApplications, no device-local zones (fallback)
+
+  @Test func loadApplications_noZones_fetchesAtFallbackCoordinateAndRadius() async {
+    let (sut, repository, _) = makeSUT(
+      fallbackCoordinate: .cambridge, fallbackRadiusMetres: 1500, zones: [])
     repository.fetchNearbyResult = .success([.pendingReview, .permitted])
 
     await sut.loadApplications()
@@ -41,7 +59,7 @@ struct AnonymousApplicationListViewModelTests {
   }
 
   @Test func loadApplications_setsIsLoadingFalseAfterCompletion() async {
-    let (sut, _) = makeSUT()
+    let (sut, _, _) = makeSUT()
 
     #expect(!sut.isLoading)
     await sut.loadApplications()
@@ -49,7 +67,7 @@ struct AnonymousApplicationListViewModelTests {
   }
 
   @Test func loadApplications_failure_setsError() async {
-    let (sut, repository) = makeSUT()
+    let (sut, repository, _) = makeSUT()
     repository.fetchNearbyResult = .failure(DomainError.networkUnavailable)
 
     await sut.loadApplications()
@@ -61,7 +79,7 @@ struct AnonymousApplicationListViewModelTests {
   /// Pull-to-refresh calls the same `loadApplications()` entry point — a
   /// second successful fetch replaces the previously loaded rows.
   @Test func loadApplications_calledAgain_replacesPreviousApplications() async {
-    let (sut, repository) = makeSUT()
+    let (sut, repository, _) = makeSUT()
     repository.fetchNearbyResult = .success([.pendingReview])
     await sut.loadApplications()
     #expect(sut.applications == [.pendingReview])
@@ -76,7 +94,7 @@ struct AnonymousApplicationListViewModelTests {
   // MARK: - isEmpty
 
   @Test func isEmpty_trueWhenNoApplicationsNoErrorNotLoading() async {
-    let (sut, repository) = makeSUT()
+    let (sut, repository, _) = makeSUT()
     repository.fetchNearbyResult = .success([])
 
     await sut.loadApplications()
@@ -85,7 +103,7 @@ struct AnonymousApplicationListViewModelTests {
   }
 
   @Test func isEmpty_falseWhenApplicationsPresent() async {
-    let (sut, repository) = makeSUT()
+    let (sut, repository, _) = makeSUT()
     repository.fetchNearbyResult = .success([.pendingReview])
 
     await sut.loadApplications()
@@ -94,7 +112,7 @@ struct AnonymousApplicationListViewModelTests {
   }
 
   @Test func isEmpty_falseWhenErrorPresent() async {
-    let (sut, repository) = makeSUT()
+    let (sut, repository, _) = makeSUT()
     repository.fetchNearbyResult = .failure(DomainError.networkUnavailable)
 
     await sut.loadApplications()
@@ -105,12 +123,92 @@ struct AnonymousApplicationListViewModelTests {
   // MARK: - Row selection -> detail handoff (GH#879 Phase 2 established handoff)
 
   @Test func selectApplication_invokesOnShowApplicationDetail() {
-    let (sut, _) = makeSUT()
+    let (sut, _, _) = makeSUT()
     var captured: [PlanningApplication] = []
     sut.onShowApplicationDetail = { captured.append($0) }
 
     sut.selectApplication(.pendingReview)
 
     #expect(captured == [.pendingReview])
+  }
+
+  // MARK: - Zone-driven browsing (GH#879 Phase 4)
+
+  @Test func loadApplications_withActiveZone_fetchesAtZoneCoordinateAndRadius() async throws {
+    let zone = try makeZone(radiusMetres: 3000)
+    let (sut, repository, _) = makeSUT(
+      fallbackCoordinate: .cambridge,
+      fallbackRadiusMetres: 2000,
+      zones: [zone],
+      activeZoneId: zone.id)
+    repository.fetchNearbyResult = .success([])
+
+    await sut.loadApplications()
+
+    #expect(repository.fetchNearbyCalls.last?.radiusMetres == 3000)
+    #expect(sut.selectedZone == zone)
+  }
+
+  @Test func loadApplications_noActiveZoneIdSet_defaultsToFirstZone() async throws {
+    let zone = try makeZone()
+    let (sut, repository, _) = makeSUT(zones: [zone], activeZoneId: nil)
+    repository.fetchNearbyResult = .success([])
+
+    await sut.loadApplications()
+
+    #expect(sut.selectedZone == zone)
+  }
+
+  @Test func showZonePicker_false_whenZeroOrOneZone() async throws {
+    let (sutZero, repoZero, _) = makeSUT(zones: [])
+    repoZero.fetchNearbyResult = .success([])
+    await sutZero.loadApplications()
+    #expect(!sutZero.showZonePicker)
+
+    let zone = try makeZone()
+    let (sutOne, repoOne, _) = makeSUT(zones: [zone])
+    repoOne.fetchNearbyResult = .success([])
+    await sutOne.loadApplications()
+    #expect(!sutOne.showZonePicker)
+  }
+
+  @Test func showZonePicker_true_whenMultipleZones() async throws {
+    let (sut, repository, _) = makeSUT(
+      zones: [try makeZone(name: "One"), try makeZone(name: "Two")])
+    repository.fetchNearbyResult = .success([])
+
+    await sut.loadApplications()
+
+    #expect(sut.showZonePicker)
+  }
+
+  @Test func selectZone_persistsActiveZoneAndRefetches() async throws {
+    let zoneA = try makeZone(name: "A", radiusMetres: 1000)
+    let zoneB = try makeZone(name: "B", radiusMetres: 4000)
+    let (sut, repository, zoneRepository) = makeSUT(
+      zones: [zoneA, zoneB], activeZoneId: zoneA.id)
+    repository.fetchNearbyResult = .success([])
+    await sut.loadApplications()
+
+    repository.fetchNearbyResult = .success([.pendingReview])
+    await sut.selectZone(zoneB)
+
+    #expect(sut.selectedZone == zoneB)
+    #expect(zoneRepository.setActiveZoneIdCalls.last == zoneB.id)
+    #expect(repository.fetchNearbyCalls.last?.radiusMetres == 4000)
+    #expect(sut.applications == [.pendingReview])
+  }
+
+  @Test func selectZone_invokesOnActiveZoneChanged() async throws {
+    let zoneA = try makeZone(name: "A")
+    let zoneB = try makeZone(name: "B")
+    let (sut, repository, _) = makeSUT(zones: [zoneA, zoneB], activeZoneId: zoneA.id)
+    repository.fetchNearbyResult = .success([])
+    var changed: [DeviceLocalZone] = []
+    sut.onActiveZoneChanged = { changed.append($0) }
+
+    await sut.selectZone(zoneB)
+
+    #expect(changed == [zoneB])
   }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousApplicationListViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousApplicationListViewTests.swift
@@ -12,7 +12,10 @@ struct AnonymousApplicationListViewTests {
   ) -> (AnonymousApplicationListViewModel, SpyAnonymousApplicationsRepository) {
     let repository = SpyAnonymousApplicationsRepository()
     let viewModel = AnonymousApplicationListViewModel(
-      repository: repository, coordinate: coordinate, radiusMetres: radiusMetres)
+      repository: repository,
+      zoneRepository: SpyDeviceLocalZoneRepository(),
+      fallbackCoordinate: coordinate,
+      fallbackRadiusMetres: radiusMetres)
     return (viewModel, repository)
   }
 

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousApplicationListViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousApplicationListViewTests.swift
@@ -57,4 +57,48 @@ struct AnonymousApplicationListViewTests {
 
     #expect(captured == [.pendingReview])
   }
+
+  // MARK: - Zone picker chips (GH#879 Phase 4)
+
+  @Test func body_renders_withZonePickerVisible() async throws {
+    let (viewModel, repository) = makeViewModel()
+    let zoneRepository = SpyDeviceLocalZoneRepository()
+    zoneRepository.loadAllResult = [
+      try DeviceLocalZone(name: "Home", centre: .cambridge, radiusMetres: 1000),
+      try DeviceLocalZone(name: "Office", centre: .cambridge, radiusMetres: 1000),
+    ]
+    let vm = AnonymousApplicationListViewModel(
+      repository: repository,
+      zoneRepository: zoneRepository,
+      fallbackCoordinate: .cambridge,
+      fallbackRadiusMetres: 2000)
+    repository.fetchNearbyResult = .success([])
+    await vm.loadApplications()
+    #expect(vm.showZonePicker)
+    let sut = AnonymousApplicationListView(viewModel: vm)
+
+    _ = sut.body
+  }
+
+  @Test func chipTap_invokesSelectZone() async throws {
+    let (_, repository) = makeViewModel()
+    let zoneRepository = SpyDeviceLocalZoneRepository()
+    let zoneA = try DeviceLocalZone(name: "Home", centre: .cambridge, radiusMetres: 1000)
+    let zoneB = try DeviceLocalZone(name: "Office", centre: .cambridge, radiusMetres: 1000)
+    zoneRepository.loadAllResult = [zoneA, zoneB]
+    let vm = AnonymousApplicationListViewModel(
+      repository: repository,
+      zoneRepository: zoneRepository,
+      fallbackCoordinate: .cambridge,
+      fallbackRadiusMetres: 2000)
+    repository.fetchNearbyResult = .success([])
+    await vm.loadApplications()
+
+    // Mirrors the row-tap test above: the chip's tap gesture itself is not
+    // exercisable without UI-level automation, so this asserts the same
+    // ViewModel call the tap invokes.
+    await vm.selectZone(zoneB)
+
+    #expect(vm.selectedZone == zoneB)
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousBrowseCoordinatorTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousBrowseCoordinatorTests.swift
@@ -308,7 +308,16 @@ struct AnonymousBrowseCoordinatorTests {
     #expect(requested)
   }
 
-  @Test func applicationListViewModel_selectZone_reCentresMapViewModel() async throws {
+  /// Regression test for a live-simulator-verified defect: switching the
+  /// active zone on the Applications tab left the Map tab showing the
+  /// PREVIOUS zone until a full relaunch. Root cause: the coordinator was
+  /// replacing `mapViewModel` with a brand-new `AnonymousMapViewModel`
+  /// instance, but `AnonymousMapView` holds it in a `@StateObject` — SwiftUI
+  /// ignores a replaced constructor argument on an already-mounted view, so
+  /// the OLD instance kept rendering forever. The fix mutates the SAME
+  /// instance in place, so this test asserts identity is PRESERVED (not
+  /// replaced) alongside the updated centre/radius.
+  @Test func applicationListViewModel_selectZone_reCentresTheSameMapViewModelInstance() async throws {
     let (sut, _, _, applicationsRepository, deviceLocalZoneRepository) = makeSUT(
       persistedState: testState)
     applicationsRepository.fetchNearbyResult = .success([])
@@ -325,8 +334,9 @@ struct AnonymousBrowseCoordinatorTests {
 
     await listViewModel?.selectZone(zoneB)
 
-    #expect(sut.mapViewModel !== originalMapViewModel)
+    #expect(sut.mapViewModel === originalMapViewModel)
     #expect(sut.mapViewModel?.centreLat == zoneB.centre.latitude)
+    #expect(sut.mapViewModel?.anchorCoordinate == zoneB.centre)
     #expect(sut.mapViewModel?.radiusMetres == zoneB.radiusMetres)
   }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousBrowseCoordinatorTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousBrowseCoordinatorTests.swift
@@ -12,20 +12,22 @@ struct AnonymousBrowseCoordinatorTests {
     appearanceStore: AppearanceStore? = nil
   ) -> (
     AnonymousBrowseCoordinator, SpyPostcodeGeocoder, SpyAnonymousBrowseStateRepository,
-    SpyAnonymousApplicationsRepository
+    SpyAnonymousApplicationsRepository, SpyDeviceLocalZoneRepository
   ) {
     let geocoder = SpyPostcodeGeocoder()
     let stateRepository = SpyAnonymousBrowseStateRepository()
     stateRepository.loadResult = persistedState
     let applicationsRepository = SpyAnonymousApplicationsRepository()
+    let deviceLocalZoneRepository = SpyDeviceLocalZoneRepository()
     let sut = AnonymousBrowseCoordinator(
       geocoder: geocoder,
       stateRepository: stateRepository,
       applicationsRepository: applicationsRepository,
+      deviceLocalZoneRepository: deviceLocalZoneRepository,
       appearanceStore: appearanceStore,
       appVersionProvider: SpyAppVersionProvider()
     )
-    return (sut, geocoder, stateRepository, applicationsRepository)
+    return (sut, geocoder, stateRepository, applicationsRepository, deviceLocalZoneRepository)
   }
 
   private var testState: AnonymousBrowseState {
@@ -36,14 +38,14 @@ struct AnonymousBrowseCoordinatorTests {
   // MARK: - Initial screen
 
   @Test func init_withNoPersistedState_startsAtWelcome() {
-    let (sut, _, _, _) = makeSUT()
+    let (sut, _, _, _, _) = makeSUT()
 
     #expect(sut.screen == .welcome)
     #expect(sut.mapViewModel == nil)
   }
 
   @Test func init_withPersistedState_startsAtTabs() {
-    let (sut, _, _, _) = makeSUT(persistedState: testState)
+    let (sut, _, _, _, _) = makeSUT(persistedState: testState)
 
     #expect(sut.screen == .tabs)
     #expect(sut.mapViewModel != nil)
@@ -53,7 +55,7 @@ struct AnonymousBrowseCoordinatorTests {
   // MARK: - Welcome -> postcode entry
 
   @Test func welcomeViewModel_getStarted_advancesToPostcodeEntry() {
-    let (sut, _, _, _) = makeSUT()
+    let (sut, _, _, _, _) = makeSUT()
     let welcomeVM = sut.makeWelcomeViewModel()
 
     welcomeVM.getStarted()
@@ -62,7 +64,7 @@ struct AnonymousBrowseCoordinatorTests {
   }
 
   @Test func welcomeViewModel_signIn_invokesOnRequestSignIn() {
-    let (sut, _, _, _) = makeSUT()
+    let (sut, _, _, _, _) = makeSUT()
     var requested = false
     sut.onRequestSignIn = { requested = true }
     let welcomeVM = sut.makeWelcomeViewModel()
@@ -75,7 +77,7 @@ struct AnonymousBrowseCoordinatorTests {
   // MARK: - Postcode entry -> tab shell / back
 
   @Test func postcodeEntryViewModel_onResolved_advancesToTabs() {
-    let (sut, _, _, _) = makeSUT()
+    let (sut, _, _, _, _) = makeSUT()
     let postcodeVM = sut.makePostcodeEntryViewModel()
 
     // The coordinator wires `onResolved` when it builds the view model; invoke
@@ -88,7 +90,7 @@ struct AnonymousBrowseCoordinatorTests {
   }
 
   @Test func postcodeEntryViewModel_onBack_returnsToWelcome() {
-    let (sut, _, _, _) = makeSUT()
+    let (sut, _, _, _, _) = makeSUT()
     let welcomeVM = sut.makeWelcomeViewModel()
     welcomeVM.getStarted()
     let postcodeVM = sut.makePostcodeEntryViewModel()
@@ -101,7 +103,7 @@ struct AnonymousBrowseCoordinatorTests {
   // MARK: - Map sign-up handoff
 
   @Test func mapViewModel_requestSignUp_invokesOnRequestSignIn() {
-    let (sut, _, _, _) = makeSUT(persistedState: testState)
+    let (sut, _, _, _, _) = makeSUT(persistedState: testState)
     var requested = false
     sut.onRequestSignIn = { requested = true }
 
@@ -113,7 +115,7 @@ struct AnonymousBrowseCoordinatorTests {
   // MARK: - View full details handoff (GH#879 Phase 2)
 
   @Test func mapViewModel_onShowApplicationDetail_invokesCoordinatorCallback() {
-    let (sut, _, _, _) = makeSUT(persistedState: testState)
+    let (sut, _, _, _, _) = makeSUT(persistedState: testState)
     var captured: [PlanningApplication] = []
     sut.onShowApplicationDetail = { captured.append($0) }
 
@@ -127,7 +129,7 @@ struct AnonymousBrowseCoordinatorTests {
   // MARK: - Live radius picker persistence (GH#868 Phase 3 refinement)
 
   @Test func mapViewModel_radiusChange_persistsUpdatedStateWithSamePostcodeAndCoordinate() {
-    let (sut, _, stateRepository, _) = makeSUT(persistedState: testState)
+    let (sut, _, stateRepository, _, _) = makeSUT(persistedState: testState)
 
     sut.mapViewModel?.updateSelectedRadius(1500)
 
@@ -137,7 +139,7 @@ struct AnonymousBrowseCoordinatorTests {
   }
 
   @Test func postcodeEntryViewModel_onResolved_thenRadiusChange_persistsAgainstResolvedState() {
-    let (sut, _, stateRepository, _) = makeSUT()
+    let (sut, _, stateRepository, _, _) = makeSUT()
     let postcodeVM = sut.makePostcodeEntryViewModel()
     postcodeVM.onResolved?(testState)
 
@@ -155,7 +157,7 @@ struct AnonymousBrowseCoordinatorTests {
       createdAt: testState.createdAt
     )
 
-    let (sut, _, _, _) = makeSUT(persistedState: stateWithRadius)
+    let (sut, _, _, _, _) = makeSUT(persistedState: stateWithRadius)
 
     #expect(sut.mapViewModel?.selectedRadiusMetres == 1500)
   }
@@ -167,7 +169,7 @@ struct AnonymousBrowseCoordinatorTests {
     // swiftlint:disable:next force_unwrapping
     let appearanceStore = AppearanceStore(defaults: defaults!)
     appearanceStore.appearanceMode = .oledDark
-    let (sut, _, _, _) = makeSUT(appearanceStore: appearanceStore)
+    let (sut, _, _, _, _) = makeSUT(appearanceStore: appearanceStore)
 
     let welcomeVM = sut.makeWelcomeViewModel()
 
@@ -178,7 +180,7 @@ struct AnonymousBrowseCoordinatorTests {
     let defaults = UserDefaults(suiteName: UUID().uuidString)
     // swiftlint:disable:next force_unwrapping
     let appearanceStore = AppearanceStore(defaults: defaults!)
-    let (sut, _, _, _) = makeSUT(appearanceStore: appearanceStore)
+    let (sut, _, _, _, _) = makeSUT(appearanceStore: appearanceStore)
     let welcomeVM = sut.makeWelcomeViewModel()
 
     welcomeVM.selectAppearanceMode(.dark)
@@ -189,7 +191,7 @@ struct AnonymousBrowseCoordinatorTests {
   // MARK: - Reset (sign-out)
 
   @Test func reset_clearsStateAndReturnsToWelcome() {
-    let (sut, _, stateRepository, _) = makeSUT(persistedState: testState)
+    let (sut, _, stateRepository, _, _) = makeSUT(persistedState: testState)
     #expect(sut.screen == .tabs)
 
     sut.reset()
@@ -202,20 +204,20 @@ struct AnonymousBrowseCoordinatorTests {
   // MARK: - Tab shell (GH#879 Phase 3)
 
   @Test func selectedTab_defaultsToApplications() {
-    let (sut, _, _, _) = makeSUT(persistedState: testState)
+    let (sut, _, _, _, _) = makeSUT(persistedState: testState)
 
     #expect(sut.selectedTab == .applications)
   }
 
-  /// The tab set is exactly Applications/Map/Settings (Zones arrives in
-  /// Phase 4) — no Saved tab, deliberately (saving is account-bound).
-  @Test func tab_allCases_isExactlyApplicationsMapSettings() {
+  /// The tab set is exactly Applications/Map/Zones/Settings, in that order —
+  /// no Saved tab, deliberately (saving is account-bound).
+  @Test func tab_allCases_isExactlyApplicationsMapZonesSettings() {
     #expect(
-      AnonymousBrowseCoordinator.Tab.allCases == [.applications, .map, .settings])
+      AnonymousBrowseCoordinator.Tab.allCases == [.applications, .map, .zones, .settings])
   }
 
   @Test func makeApplicationListViewModel_afterPostcodeResolved_seedsFromCurrentState() {
-    let (sut, _, _, _) = makeSUT(persistedState: testState)
+    let (sut, _, _, _, _) = makeSUT(persistedState: testState)
 
     let viewModel = sut.makeApplicationListViewModel()
 
@@ -223,13 +225,13 @@ struct AnonymousBrowseCoordinatorTests {
   }
 
   @Test func makeApplicationListViewModel_beforePostcodeResolved_returnsNil() {
-    let (sut, _, _, _) = makeSUT()
+    let (sut, _, _, _, _) = makeSUT()
 
     #expect(sut.makeApplicationListViewModel() == nil)
   }
 
   @Test func applicationListViewModel_onShowApplicationDetail_invokesCoordinatorCallback() {
-    let (sut, _, _, applicationsRepository) = makeSUT(persistedState: testState)
+    let (sut, _, _, applicationsRepository, _) = makeSUT(persistedState: testState)
     applicationsRepository.fetchNearbyResult = .success([.pendingReview])
     var captured: [PlanningApplication] = []
     sut.onShowApplicationDetail = { captured.append($0) }
@@ -245,7 +247,7 @@ struct AnonymousBrowseCoordinatorTests {
     // swiftlint:disable:next force_unwrapping
     let appearanceStore = AppearanceStore(defaults: defaults!)
     appearanceStore.appearanceMode = .oledDark
-    let (sut, _, _, _) = makeSUT(appearanceStore: appearanceStore)
+    let (sut, _, _, _, _) = makeSUT(appearanceStore: appearanceStore)
 
     let settingsVM = sut.makeSettingsViewModel()
 
@@ -253,7 +255,7 @@ struct AnonymousBrowseCoordinatorTests {
   }
 
   @Test func requestSignIn_invokesOnRequestSignIn() {
-    let (sut, _, _, _) = makeSUT()
+    let (sut, _, _, _, _) = makeSUT()
     var requested = false
     sut.onRequestSignIn = { requested = true }
 
@@ -263,7 +265,7 @@ struct AnonymousBrowseCoordinatorTests {
   }
 
   @Test func showPrivacyPolicy_invokesOnShowPrivacyPolicy() {
-    let (sut, _, _, _) = makeSUT()
+    let (sut, _, _, _, _) = makeSUT()
     var invoked = false
     sut.onShowPrivacyPolicy = { invoked = true }
 
@@ -273,7 +275,7 @@ struct AnonymousBrowseCoordinatorTests {
   }
 
   @Test func showTermsOfService_invokesOnShowTermsOfService() {
-    let (sut, _, _, _) = makeSUT()
+    let (sut, _, _, _, _) = makeSUT()
     var invoked = false
     sut.onShowTermsOfService = { invoked = true }
 
@@ -283,12 +285,48 @@ struct AnonymousBrowseCoordinatorTests {
   }
 
   @Test func requestRateApp_invokesOnRateApp() {
-    let (sut, _, _, _) = makeSUT()
+    let (sut, _, _, _, _) = makeSUT()
     var invoked = false
     sut.onRateApp = { invoked = true }
 
     sut.requestRateApp()
 
     #expect(invoked)
+  }
+
+  // MARK: - Zones tab (GH#879 Phase 4)
+
+  @Test func makeDeviceLocalZoneListViewModel_requestSignUp_invokesOnRequestSignIn() {
+    let (sut, _, _, _, _) = makeSUT()
+    var requested = false
+    sut.onRequestSignIn = { requested = true }
+    let zonesVM = sut.makeDeviceLocalZoneListViewModel()
+
+    zonesVM.requestAlertsSignUp()
+    zonesVM.confirmSignUp()
+
+    #expect(requested)
+  }
+
+  @Test func applicationListViewModel_selectZone_reCentresMapViewModel() async throws {
+    let (sut, _, _, applicationsRepository, deviceLocalZoneRepository) = makeSUT(
+      persistedState: testState)
+    applicationsRepository.fetchNearbyResult = .success([])
+    let zoneA = try DeviceLocalZone(name: "A", centre: .cambridge, radiusMetres: 1000)
+    let zoneB = try DeviceLocalZone(
+      name: "B",
+      centre: try Coordinate(latitude: 51.5074, longitude: -0.1278),
+      radiusMetres: 3000)
+    deviceLocalZoneRepository.loadAllResult = [zoneA, zoneB]
+    deviceLocalZoneRepository.activeZoneIdResult = zoneA.id
+    let listViewModel = sut.makeApplicationListViewModel()
+    await listViewModel?.loadApplications()
+    let originalMapViewModel = sut.mapViewModel
+
+    await listViewModel?.selectZone(zoneB)
+
+    #expect(sut.mapViewModel !== originalMapViewModel)
+    #expect(sut.mapViewModel?.centreLat == zoneB.centre.latitude)
+    #expect(sut.mapViewModel?.radiusMetres == zoneB.radiusMetres)
   }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousBrowseViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousBrowseViewTests.swift
@@ -16,6 +16,7 @@ struct AnonymousBrowseViewTests {
       geocoder: SpyPostcodeGeocoder(),
       stateRepository: stateRepository,
       applicationsRepository: SpyAnonymousApplicationsRepository(),
+      deviceLocalZoneRepository: SpyDeviceLocalZoneRepository(),
       appVersionProvider: SpyAppVersionProvider()
     )
   }

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousMainTabViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousMainTabViewTests.swift
@@ -5,9 +5,9 @@ import TownCrierDomain
 @testable import TownCrierPresentation
 
 /// GH#879 Phase 3 acceptance criteria: post-postcode routing lands on the
-/// tab shell with exactly Applications/Map/Settings, and the CTA banner
-/// (tested directly in `AccountCTABannerTests`) is reachable from Applications
-/// and Map.
+/// tab shell with exactly Applications/Map/Zones/Settings, and the CTA
+/// banner (tested directly in `AccountCTABannerTests`) is reachable from
+/// Applications and Map.
 @Suite("AnonymousMainTabView")
 @MainActor
 struct AnonymousMainTabViewTests {
@@ -19,6 +19,7 @@ struct AnonymousMainTabViewTests {
       geocoder: SpyPostcodeGeocoder(),
       stateRepository: stateRepository,
       applicationsRepository: SpyAnonymousApplicationsRepository(),
+      deviceLocalZoneRepository: SpyDeviceLocalZoneRepository(),
       appVersionProvider: SpyAppVersionProvider()
     )
   }
@@ -34,6 +35,14 @@ struct AnonymousMainTabViewTests {
   @Test func body_renders_onMapTab() throws {
     let coordinator = try makeCoordinator()
     coordinator.selectedTab = .map
+    let sut = AnonymousMainTabView(coordinator: coordinator)
+
+    _ = sut.body
+  }
+
+  @Test func body_renders_onZonesTab() throws {
+    let coordinator = try makeCoordinator()
+    coordinator.selectedTab = .zones
     let sut = AnonymousMainTabView(coordinator: coordinator)
 
     _ = sut.body
@@ -57,6 +66,7 @@ struct AnonymousMainTabViewTests {
       geocoder: SpyPostcodeGeocoder(),
       stateRepository: stateRepository,
       applicationsRepository: SpyAnonymousApplicationsRepository(),
+      deviceLocalZoneRepository: SpyDeviceLocalZoneRepository(),
       appVersionProvider: SpyAppVersionProvider()
     )
     let postcodeVM = coordinator.makePostcodeEntryViewModel()

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousMapViewModelActiveZoneTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousMapViewModelActiveZoneTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+/// Split out of `AnonymousMapViewModelTests` (file-length discipline) —
+/// GH#879 Phase 4 defect fix: live simulator verification found that
+/// switching the active zone on the Applications tab left the Map tab
+/// frozen on the previous zone until a full relaunch. Root cause: the
+/// coordinator was replacing `AnonymousMapViewModel` wholesale, which
+/// `AnonymousMapView`'s `@StateObject` silently ignores (a replaced
+/// constructor argument on an already-mounted view is a no-op). The fix
+/// instead mutates a live instance via ``AnonymousMapViewModel/updateActiveZone(_:)``.
+@Suite("AnonymousMapViewModel — active-zone re-centring in place (GH#879 Phase 4)")
+@MainActor
+struct AnonymousMapViewModelActiveZoneTests {
+  private func makeSUT(
+    coordinate: Coordinate = .cambridge,
+    radiusMetres: Double = 2000
+  ) -> (AnonymousMapViewModel, SpyAnonymousApplicationsRepository) {
+    let repository = SpyAnonymousApplicationsRepository()
+    let sut = AnonymousMapViewModel(
+      repository: repository, coordinate: coordinate, radiusMetres: radiusMetres)
+    return (sut, repository)
+  }
+
+  private func makeZone(radiusMetres: Double = 3000) throws -> DeviceLocalZone {
+    try DeviceLocalZone(
+      name: "London",
+      centre: try Coordinate(latitude: 51.5074, longitude: -0.1278),
+      radiusMetres: radiusMetres
+    )
+  }
+
+  @Test func updateActiveZone_updatesCentreAndAnchorToZoneCentre() async throws {
+    let (sut, repository) = makeSUT(coordinate: .cambridge)
+    repository.fetchNearbyResult = .success([])
+    let zone = try makeZone()
+
+    await sut.updateActiveZone(zone)
+
+    #expect(sut.centreLat == zone.centre.latitude)
+    #expect(sut.centreLon == zone.centre.longitude)
+    #expect(sut.anchorCoordinate == zone.centre)
+  }
+
+  @Test func updateActiveZone_updatesRadiusMetresToZoneRadius() async throws {
+    let (sut, repository) = makeSUT(radiusMetres: 1000)
+    repository.fetchNearbyResult = .success([])
+    let zone = try makeZone(radiusMetres: 4000)
+
+    await sut.updateActiveZone(zone)
+
+    #expect(sut.radiusMetres == 4000)
+  }
+
+  @Test func updateActiveZone_clampsSelectedRadiusToFreeTierPreviewCap() async throws {
+    let (sut, repository) = makeSUT()
+    repository.fetchNearbyResult = .success([])
+    let zone = try makeZone(radiusMetres: 5000)
+
+    await sut.updateActiveZone(zone)
+
+    #expect(sut.selectedRadiusMetres == AnonymousMapViewModel.maxSelectedRadiusMetres)
+  }
+
+  @Test func updateActiveZone_refetchesApplicationsAtTheNewZonesCoordinateAndRadius() async throws {
+    let (sut, repository) = makeSUT(coordinate: .cambridge)
+    repository.fetchNearbyResult = .success([.pendingReview])
+    let zone = try makeZone(radiusMetres: 4000)
+
+    await sut.updateActiveZone(zone)
+
+    let call = repository.fetchNearbyCalls.last
+    #expect(call?.latitude == zone.centre.latitude)
+    #expect(call?.longitude == zone.centre.longitude)
+    #expect(call?.radiusMetres == 4000)
+    #expect(sut.applications == [.pendingReview])
+  }
+
+  @Test func updateActiveZone_clearsAnyPendingSelectionState() async throws {
+    let (sut, repository) = makeSUT()
+    repository.fetchNearbyResult = .success([])
+    sut.selectApplication(.pendingReview)
+    sut.selectStack([.pendingReview, .permitted])
+    let zone = try makeZone()
+
+    await sut.updateActiveZone(zone)
+
+    #expect(sut.selectedApplication == nil)
+    #expect(sut.stackedApplications == nil)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousMapViewModelActiveZoneTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousMapViewModelActiveZoneTests.swift
@@ -12,16 +12,29 @@ import TownCrierDomain
 /// `AnonymousMapView`'s `@StateObject` silently ignores (a replaced
 /// constructor argument on an already-mounted view is a no-op). The fix
 /// instead mutates a live instance via ``AnonymousMapViewModel/updateActiveZone(_:)``.
+///
+/// A second live-simulator-verified defect (crash) followed: switching
+/// zones rapidly could SIGABRT inside MapKit's own deferred clustering pass.
+/// `updateActiveZone(_:)`'s fetch (and therefore the annotation-set swap it
+/// drives) is now debounced the same way `regionDidChange` debounces a
+/// pan/zoom — proven here; the MapKit-internal timing itself is
+/// UIKit/on-sim-only and covered separately (see
+/// `AnonymousClusteredMapView`'s file header).
 @Suite("AnonymousMapViewModel — active-zone re-centring in place (GH#879 Phase 4)")
 @MainActor
 struct AnonymousMapViewModelActiveZoneTests {
   private func makeSUT(
     coordinate: Coordinate = .cambridge,
-    radiusMetres: Double = 2000
+    radiusMetres: Double = 2000,
+    debounceNanoseconds: UInt64 = 5_000_000
   ) -> (AnonymousMapViewModel, SpyAnonymousApplicationsRepository) {
     let repository = SpyAnonymousApplicationsRepository()
     let sut = AnonymousMapViewModel(
-      repository: repository, coordinate: coordinate, radiusMetres: radiusMetres)
+      repository: repository,
+      coordinate: coordinate,
+      radiusMetres: radiusMetres,
+      debounceNanoseconds: debounceNanoseconds
+    )
     return (sut, repository)
   }
 
@@ -33,44 +46,58 @@ struct AnonymousMapViewModelActiveZoneTests {
     )
   }
 
-  @Test func updateActiveZone_updatesCentreAndAnchorToZoneCentre() async throws {
-    let (sut, repository) = makeSUT(coordinate: .cambridge)
-    repository.fetchNearbyResult = .success([])
+  // MARK: - Immediate (non-debounced) state
+
+  @Test func updateActiveZone_updatesCentreAndAnchorToZoneCentreImmediately() throws {
+    let (sut, _) = makeSUT(coordinate: .cambridge)
     let zone = try makeZone()
 
-    await sut.updateActiveZone(zone)
+    sut.updateActiveZone(zone)
 
     #expect(sut.centreLat == zone.centre.latitude)
     #expect(sut.centreLon == zone.centre.longitude)
     #expect(sut.anchorCoordinate == zone.centre)
   }
 
-  @Test func updateActiveZone_updatesRadiusMetresToZoneRadius() async throws {
-    let (sut, repository) = makeSUT(radiusMetres: 1000)
-    repository.fetchNearbyResult = .success([])
+  @Test func updateActiveZone_updatesRadiusMetresToZoneRadiusImmediately() throws {
+    let (sut, _) = makeSUT(radiusMetres: 1000)
     let zone = try makeZone(radiusMetres: 4000)
 
-    await sut.updateActiveZone(zone)
+    sut.updateActiveZone(zone)
 
     #expect(sut.radiusMetres == 4000)
   }
 
-  @Test func updateActiveZone_clampsSelectedRadiusToFreeTierPreviewCap() async throws {
-    let (sut, repository) = makeSUT()
-    repository.fetchNearbyResult = .success([])
+  @Test func updateActiveZone_clampsSelectedRadiusToFreeTierPreviewCapImmediately() throws {
+    let (sut, _) = makeSUT()
     let zone = try makeZone(radiusMetres: 5000)
 
-    await sut.updateActiveZone(zone)
+    sut.updateActiveZone(zone)
 
     #expect(sut.selectedRadiusMetres == AnonymousMapViewModel.maxSelectedRadiusMetres)
   }
+
+  @Test func updateActiveZone_clearsAnyPendingSelectionStateImmediately() throws {
+    let (sut, _) = makeSUT()
+    sut.selectApplication(.pendingReview)
+    sut.selectStack([.pendingReview, .permitted])
+    let zone = try makeZone()
+
+    sut.updateActiveZone(zone)
+
+    #expect(sut.selectedApplication == nil)
+    #expect(sut.stackedApplications == nil)
+  }
+
+  // MARK: - Debounced fetch (crash fix: collapses rapid churn to one swap)
 
   @Test func updateActiveZone_refetchesApplicationsAtTheNewZonesCoordinateAndRadius() async throws {
     let (sut, repository) = makeSUT(coordinate: .cambridge)
     repository.fetchNearbyResult = .success([.pendingReview])
     let zone = try makeZone(radiusMetres: 4000)
 
-    await sut.updateActiveZone(zone)
+    sut.updateActiveZone(zone)
+    await sut.waitForPendingActiveZoneUpdate()
 
     let call = repository.fetchNearbyCalls.last
     #expect(call?.latitude == zone.centre.latitude)
@@ -79,16 +106,37 @@ struct AnonymousMapViewModelActiveZoneTests {
     #expect(sut.applications == [.pendingReview])
   }
 
-  @Test func updateActiveZone_clearsAnyPendingSelectionState() async throws {
+  @Test func updateActiveZone_rapidSuccessiveCalls_onlyTheLastZoneFetches() async throws {
     let (sut, repository) = makeSUT()
-    repository.fetchNearbyResult = .success([])
-    sut.selectApplication(.pendingReview)
-    sut.selectStack([.pendingReview, .permitted])
-    let zone = try makeZone()
+    repository.fetchNearbyResult = .success([.pendingReview])
+    let zoneA = try makeZone(radiusMetres: 1000)
+    let zoneB = try makeZone(radiusMetres: 4000)
 
-    await sut.updateActiveZone(zone)
+    sut.updateActiveZone(zoneA)
+    sut.updateActiveZone(zoneB)
+    await sut.waitForPendingActiveZoneUpdate()
 
-    #expect(sut.selectedApplication == nil)
-    #expect(sut.stackedApplications == nil)
+    #expect(repository.fetchNearbyCalls.count == 1)
+    #expect(repository.fetchNearbyCalls[0].radiusMetres == 4000)
+    // The final state reflects zone B throughout, not a stale zone A value.
+    #expect(sut.radiusMetres == 4000)
+    #expect(sut.anchorCoordinate == zoneB.centre)
+  }
+
+  @Test func updateActiveZone_cancelsAnInFlightRegionChangeFetch() async throws {
+    let (sut, repository) = makeSUT()
+    repository.fetchNearbyResult = .success([.permitted])
+    sut.regionDidChange(centreLat: 10, centreLon: 10, radiusMetres: 2000)
+    let zone = try makeZone(radiusMetres: 4000)
+
+    sut.updateActiveZone(zone)
+    await sut.waitForPendingRegionChangeRefetch()
+    await sut.waitForPendingActiveZoneUpdate()
+
+    // Only the zone update's fetch should have landed — the pan/zoom fetch
+    // was cancelled, so its `latitude: 10, longitude: 10` never overwrites
+    // the zone's coordinate.
+    #expect(repository.fetchNearbyCalls.count == 1)
+    #expect(repository.fetchNearbyCalls[0].radiusMetres == 4000)
   }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/CompositionRootTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/CompositionRootTests.swift
@@ -196,11 +196,14 @@ struct CompositionRootTests {
     let anonymousApplicationsRepository = APIAnonymousApplicationsRepository(
       apiClient: anonymousApiClient)
     let anonymousBrowseStateRepository = UserDefaultsAnonymousBrowseStateRepository()
+    let deviceLocalZoneRepository = UserDefaultsDeviceLocalZoneRepository(
+      legacyStateRepository: anonymousBrowseStateRepository)
 
     let anonymousCoordinator = AnonymousBrowseCoordinator(
       geocoder: anonymousGeocoder,
       stateRepository: anonymousBrowseStateRepository,
       applicationsRepository: anonymousApplicationsRepository,
+      deviceLocalZoneRepository: deviceLocalZoneRepository,
       appVersionProvider: BundleAppVersionProvider()
     )
 

--- a/mobile/ios/town-crier-tests/Sources/Features/DeviceLocalZoneEditorViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/DeviceLocalZoneEditorViewModelTests.swift
@@ -1,0 +1,201 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+/// GH#879 Phase 4: create/edit a single device-local zone — name, postcode
+/// entry geocoded client-side, radius clamped to
+/// `[DeviceLocalZone.minRadiusMetres, DeviceLocalZone.maxRadiusMetres]`.
+@Suite("DeviceLocalZoneEditorViewModel")
+@MainActor
+struct DeviceLocalZoneEditorViewModelTests {
+  private func makeSUT(
+    editing zone: DeviceLocalZone? = nil
+  ) -> (DeviceLocalZoneEditorViewModel, SpyPostcodeGeocoder, SpyDeviceLocalZoneRepository) {
+    let geocoder = SpyPostcodeGeocoder()
+    let repository = SpyDeviceLocalZoneRepository()
+    let sut = DeviceLocalZoneEditorViewModel(
+      geocoder: geocoder, repository: repository, editing: zone)
+    return (sut, geocoder, repository)
+  }
+
+  // MARK: - New zone
+
+  @Test func init_new_isNotEditing() {
+    let (sut, _, _) = makeSUT()
+
+    #expect(!sut.isEditing)
+    #expect(sut.isPostcodeFieldVisible)
+    #expect(sut.geocodedCoordinate == nil)
+  }
+
+  @Test func init_new_defaultRadiusIsWithinRange() {
+    let (sut, _, _) = makeSUT()
+
+    #expect(sut.selectedRadiusMetres >= DeviceLocalZone.minRadiusMetres)
+    #expect(sut.selectedRadiusMetres <= DeviceLocalZone.maxRadiusMetres)
+  }
+
+  @Test func radiusBounds_matchDeviceLocalZoneClamp() {
+    let (sut, _, _) = makeSUT()
+
+    #expect(sut.minRadiusMetres == DeviceLocalZone.minRadiusMetres)
+    #expect(sut.maxRadiusMetres == DeviceLocalZone.maxRadiusMetres)
+  }
+
+  // MARK: - Editing an existing zone
+
+  @Test func init_editing_seedsFieldsFromZone() throws {
+    let zone = try DeviceLocalZone(name: "Home", centre: .cambridge, radiusMetres: 1500)
+
+    let (sut, _, _) = makeSUT(editing: zone)
+
+    #expect(sut.isEditing)
+    #expect(!sut.isPostcodeFieldVisible)
+    #expect(sut.nameInput == "Home")
+    #expect(sut.selectedRadiusMetres == 1500)
+    #expect(sut.geocodedCoordinate == .cambridge)
+  }
+
+  // MARK: - Postcode submission
+
+  @Test func submitPostcode_validPostcode_setsGeocodedCoordinate() async throws {
+    let (sut, geocoder, _) = makeSUT()
+    geocoder.geocodeResult = .success(.cambridge)
+    sut.postcodeInput = "CB1 2AD"
+
+    await sut.submitPostcode()
+
+    #expect(sut.geocodedCoordinate == .cambridge)
+    #expect(sut.error == nil)
+  }
+
+  @Test func submitPostcode_emptyNameInput_defaultsNameToPostcode() async throws {
+    let (sut, geocoder, _) = makeSUT()
+    geocoder.geocodeResult = .success(.cambridge)
+    sut.postcodeInput = "CB1 2AD"
+
+    await sut.submitPostcode()
+
+    #expect(sut.nameInput == "CB1 2AD")
+  }
+
+  @Test func submitPostcode_existingNameInput_doesNotOverwriteName() async throws {
+    let (sut, geocoder, _) = makeSUT()
+    geocoder.geocodeResult = .success(.cambridge)
+    sut.nameInput = "My Custom Name"
+    sut.postcodeInput = "CB1 2AD"
+
+    await sut.submitPostcode()
+
+    #expect(sut.nameInput == "My Custom Name")
+  }
+
+  @Test func submitPostcode_invalidPostcode_setsError() async {
+    let (sut, _, _) = makeSUT()
+    sut.postcodeInput = "not a postcode"
+
+    await sut.submitPostcode()
+
+    #expect(sut.geocodedCoordinate == nil)
+    #expect(sut.error != nil)
+  }
+
+  @Test func submitPostcode_geocoderFailure_setsError() async {
+    let (sut, geocoder, _) = makeSUT()
+    geocoder.geocodeResult = .failure(DomainError.geocodingFailed("CB1 2AD"))
+    sut.postcodeInput = "CB1 2AD"
+
+    await sut.submitPostcode()
+
+    #expect(sut.geocodedCoordinate == nil)
+    #expect(sut.error == .geocodingFailed("CB1 2AD"))
+  }
+
+  // MARK: - Save
+
+  @Test func save_noGeocodedCoordinate_returnsFalse() async {
+    let (sut, _, repository) = makeSUT()
+
+    let result = await sut.save()
+
+    #expect(!result)
+    #expect(repository.saveCalls.isEmpty)
+  }
+
+  @Test func save_validZone_persistsAndReturnsTrue() async throws {
+    let (sut, geocoder, repository) = makeSUT()
+    geocoder.geocodeResult = .success(.cambridge)
+    sut.postcodeInput = "CB1 2AD"
+    await sut.submitPostcode()
+    sut.nameInput = "Home"
+    sut.selectedRadiusMetres = 2000
+
+    let result = await sut.save()
+
+    #expect(result)
+    #expect(repository.saveCalls.count == 1)
+    #expect(repository.saveCalls.first?.name == "Home")
+    #expect(repository.saveCalls.first?.radiusMetres == 2000)
+  }
+
+  @Test func save_invokesOnSaveWithTheSavedZone() async {
+    let (sut, geocoder, _) = makeSUT()
+    geocoder.geocodeResult = .success(.cambridge)
+    sut.postcodeInput = "CB1 2AD"
+    await sut.submitPostcode()
+    sut.nameInput = "Home"
+    var saved: DeviceLocalZone?
+    sut.onSave = { saved = $0 }
+
+    await sut.save()
+
+    #expect(saved?.name == "Home")
+  }
+
+  @Test func save_editingExistingZone_reusesTheSameId() async throws {
+    let zone = try DeviceLocalZone(name: "Home", centre: .cambridge, radiusMetres: 1000)
+    let (sut, _, repository) = makeSUT(editing: zone)
+    sut.nameInput = "Renamed"
+
+    await sut.save()
+
+    #expect(repository.saveCalls.first?.id == zone.id)
+    #expect(repository.saveCalls.first?.name == "Renamed")
+  }
+
+  @Test func save_repositoryThrowsLimitReached_invokesOnRequestSignUpAndReturnsFalse() async {
+    let (sut, geocoder, repository) = makeSUT()
+    geocoder.geocodeResult = .success(.cambridge)
+    sut.postcodeInput = "CB1 2AD"
+    await sut.submitPostcode()
+    sut.nameInput = "Home"
+    repository.saveError = DomainError.deviceLocalZoneLimitReached
+    var requested = false
+    sut.onRequestSignUp = { requested = true }
+
+    let result = await sut.save()
+
+    #expect(!result)
+    #expect(requested)
+    #expect(sut.error == nil)
+  }
+
+  @Test func save_repositoryThrowsOtherError_setsInlineErrorAndReturnsFalse() async {
+    let (sut, geocoder, repository) = makeSUT()
+    geocoder.geocodeResult = .success(.cambridge)
+    sut.postcodeInput = "CB1 2AD"
+    await sut.submitPostcode()
+    sut.nameInput = "Home"
+    repository.saveError = DomainError.networkUnavailable
+    var requested = false
+    sut.onRequestSignUp = { requested = true }
+
+    let result = await sut.save()
+
+    #expect(!result)
+    #expect(!requested)
+    #expect(sut.error == .networkUnavailable)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/DeviceLocalZoneEditorViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/DeviceLocalZoneEditorViewTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+@MainActor
+@Suite("DeviceLocalZoneEditorView")
+struct DeviceLocalZoneEditorViewTests {
+  private func makeViewModel(
+    editing zone: DeviceLocalZone? = nil
+  ) -> DeviceLocalZoneEditorViewModel {
+    DeviceLocalZoneEditorViewModel(
+      geocoder: SpyPostcodeGeocoder(),
+      repository: SpyDeviceLocalZoneRepository(),
+      editing: zone
+    )
+  }
+
+  @Test func body_renders_inCreateMode_withoutCoordinate() {
+    let vm = makeViewModel()
+    let sut = DeviceLocalZoneEditorView(viewModel: vm)
+    _ = sut.body
+  }
+
+  @Test func body_renders_inEditMode() throws {
+    let zone = try DeviceLocalZone(name: "Home", centre: .cambridge, radiusMetres: 1500)
+    let vm = makeViewModel(editing: zone)
+    let sut = DeviceLocalZoneEditorView(viewModel: vm)
+    _ = sut.body
+  }
+
+  @Test func body_renders_afterPostcodeGeocoded() async {
+    let vm = makeViewModel()
+    vm.postcodeInput = "CB1 2AD"
+    await vm.submitPostcode()
+    let sut = DeviceLocalZoneEditorView(viewModel: vm)
+    _ = sut.body
+  }
+
+  @Test func body_renders_withErrorState() async {
+    let vm = makeViewModel()
+    vm.postcodeInput = "not a postcode"
+    await vm.submitPostcode()
+    let sut = DeviceLocalZoneEditorView(viewModel: vm)
+    _ = sut.body
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/DeviceLocalZoneListViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/DeviceLocalZoneListViewModelTests.swift
@@ -1,0 +1,184 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+/// GH#879 Phase 4: the anonymous Zones tab — up to `DeviceLocalZone.maxZoneCount`
+/// device-local areas with create/edit/delete. Any alert affordance and any
+/// attempt to add a 4th zone route to the sign-up CTA rather than a real
+/// quota/entitlement flow.
+@Suite("DeviceLocalZoneListViewModel")
+@MainActor
+struct DeviceLocalZoneListViewModelTests {
+  private func makeSUT() -> (DeviceLocalZoneListViewModel, SpyDeviceLocalZoneRepository) {
+    let repository = SpyDeviceLocalZoneRepository()
+    let sut = DeviceLocalZoneListViewModel(repository: repository, geocoder: SpyPostcodeGeocoder())
+    return (sut, repository)
+  }
+
+  private func makeZone(name: String = "Home") throws -> DeviceLocalZone {
+    try DeviceLocalZone(name: name, centre: .cambridge, radiusMetres: 1000)
+  }
+
+  // MARK: - Load
+
+  @Test func load_populatesZonesFromRepository() throws {
+    let (sut, repository) = makeSUT()
+    repository.loadAllResult = [try makeZone(name: "One"), try makeZone(name: "Two")]
+
+    sut.load()
+
+    #expect(sut.zones.count == 2)
+  }
+
+  // MARK: - canAddZone
+
+  @Test func canAddZone_true_belowCap() throws {
+    let (sut, repository) = makeSUT()
+    repository.loadAllResult = [try makeZone(), try makeZone()]
+    sut.load()
+
+    #expect(sut.canAddZone)
+  }
+
+  @Test func canAddZone_false_atCap() throws {
+    let (sut, repository) = makeSUT()
+    repository.loadAllResult = [try makeZone(name: "1"), try makeZone(name: "2"), try makeZone(name: "3")]
+    sut.load()
+
+    #expect(!sut.canAddZone)
+  }
+
+  // MARK: - addZoneTapped
+
+  @Test func addZoneTapped_belowCap_opensNewEditor() {
+    let (sut, _) = makeSUT()
+    sut.load()
+
+    sut.addZoneTapped()
+
+    #expect(sut.editorTarget == .new)
+    #expect(!sut.isSignUpCTAPresented)
+  }
+
+  @Test func addZoneTapped_atCap_presentsSignUpCTA() throws {
+    let (sut, repository) = makeSUT()
+    repository.loadAllResult = [try makeZone(name: "1"), try makeZone(name: "2"), try makeZone(name: "3")]
+    sut.load()
+
+    sut.addZoneTapped()
+
+    #expect(sut.editorTarget == nil)
+    #expect(sut.isSignUpCTAPresented)
+  }
+
+  // MARK: - editZone
+
+  @Test func editZone_opensEditorForThatZone() throws {
+    let (sut, _) = makeSUT()
+    let zone = try makeZone()
+
+    sut.editZone(zone)
+
+    #expect(sut.editorTarget == .edit(zone))
+  }
+
+  // MARK: - deleteZone
+
+  @Test func deleteZone_removesFromRepositoryAndLocalList() throws {
+    let (sut, repository) = makeSUT()
+    let zone = try makeZone()
+    repository.loadAllResult = [zone]
+    sut.load()
+
+    sut.deleteZone(zone)
+
+    #expect(repository.deleteCalls == [zone.id])
+    #expect(sut.zones.isEmpty)
+  }
+
+  // MARK: - Alert affordance -> sign-up CTA
+
+  @Test func requestAlertsSignUp_presentsSignUpCTA() {
+    let (sut, _) = makeSUT()
+
+    sut.requestAlertsSignUp()
+
+    #expect(sut.isSignUpCTAPresented)
+  }
+
+  @Test func dismissSignUpCTA_clearsTheFlag() {
+    let (sut, _) = makeSUT()
+    sut.requestAlertsSignUp()
+
+    sut.dismissSignUpCTA()
+
+    #expect(!sut.isSignUpCTAPresented)
+  }
+
+  @Test func confirmSignUp_clearsTheFlagAndInvokesOnRequestSignUp() {
+    let (sut, _) = makeSUT()
+    sut.requestAlertsSignUp()
+    var requested = false
+    sut.onRequestSignUp = { requested = true }
+
+    sut.confirmSignUp()
+
+    #expect(!sut.isSignUpCTAPresented)
+    #expect(requested)
+  }
+
+  // MARK: - Editor dismissal / reload
+
+  @Test func dismissEditor_clearsEditorTarget() {
+    let (sut, _) = makeSUT()
+    sut.addZoneTapped()
+
+    sut.dismissEditor()
+
+    #expect(sut.editorTarget == nil)
+  }
+
+  @Test func makeEditorViewModel_forNew_isNotEditing() {
+    let (sut, _) = makeSUT()
+
+    let editorVM = sut.makeEditorViewModel(for: .new)
+
+    #expect(!editorVM.isEditing)
+  }
+
+  @Test func makeEditorViewModel_forEdit_seedsFromZone() throws {
+    let (sut, _) = makeSUT()
+    let zone = try makeZone(name: "Existing")
+
+    let editorVM = sut.makeEditorViewModel(for: .edit(zone))
+
+    #expect(editorVM.isEditing)
+    #expect(editorVM.nameInput == "Existing")
+  }
+
+  @Test func makeEditorViewModel_onSave_dismissesEditorAndReloadsZones() throws {
+    let (sut, repository) = makeSUT()
+    sut.addZoneTapped()
+    let editorVM = sut.makeEditorViewModel(for: .new)
+    let saved = try makeZone(name: "Saved")
+    repository.loadAllResult = [saved]
+
+    editorVM.onSave?(saved)
+
+    #expect(sut.editorTarget == nil)
+    #expect(sut.zones == [saved])
+  }
+
+  @Test func makeEditorViewModel_onRequestSignUp_dismissesEditorAndPresentsCTA() {
+    let (sut, _) = makeSUT()
+    sut.addZoneTapped()
+    let editorVM = sut.makeEditorViewModel(for: .new)
+
+    editorVM.onRequestSignUp?()
+
+    #expect(sut.editorTarget == nil)
+    #expect(sut.isSignUpCTAPresented)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/DeviceLocalZoneListViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/DeviceLocalZoneListViewTests.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+@Suite("DeviceLocalZoneListView")
+@MainActor
+struct DeviceLocalZoneListViewTests {
+  private func makeViewModel() -> (DeviceLocalZoneListViewModel, SpyDeviceLocalZoneRepository) {
+    let repository = SpyDeviceLocalZoneRepository()
+    let vm = DeviceLocalZoneListViewModel(repository: repository, geocoder: SpyPostcodeGeocoder())
+    return (vm, repository)
+  }
+
+  private func makeZone(name: String = "Home") throws -> DeviceLocalZone {
+    try DeviceLocalZone(name: name, centre: .cambridge, radiusMetres: 1000)
+  }
+
+  @Test func body_renders_whenNoZones() {
+    let (vm, _) = makeViewModel()
+    let sut = DeviceLocalZoneListView(viewModel: vm)
+    _ = sut.body
+  }
+
+  @Test func body_renders_withZones() throws {
+    let (vm, repository) = makeViewModel()
+    repository.loadAllResult = [try makeZone(name: "One"), try makeZone(name: "Two")]
+    vm.load()
+
+    let sut = DeviceLocalZoneListView(viewModel: vm)
+    _ = sut.body
+  }
+
+  @Test func body_renders_whenEditorPresented() {
+    let (vm, _) = makeViewModel()
+    vm.addZoneTapped()
+
+    let sut = DeviceLocalZoneListView(viewModel: vm)
+    _ = sut.body
+  }
+
+  @Test func body_renders_whenSignUpCTAPresented() throws {
+    let (vm, repository) = makeViewModel()
+    repository.loadAllResult = [
+      try makeZone(name: "1"), try makeZone(name: "2"), try makeZone(name: "3"),
+    ]
+    vm.load()
+    vm.addZoneTapped()
+
+    #expect(vm.isSignUpCTAPresented)
+
+    let sut = DeviceLocalZoneListView(viewModel: vm)
+    _ = sut.body
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/DeviceLocalZoneSignUpCTAViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/DeviceLocalZoneSignUpCTAViewTests.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+import Testing
+
+@testable import TownCrierPresentation
+
+@Suite("DeviceLocalZoneSignUpCTAView")
+@MainActor
+struct DeviceLocalZoneSignUpCTAViewTests {
+  @Test func init_createsView() {
+    let sut = DeviceLocalZoneSignUpCTAView(
+      onCreateAccount: {}, onSignIn: {}, onDismiss: {})
+    _ = sut.body
+  }
+
+  @Test func onCreateAccount_isCalled_whenCreateAccountTapped() {
+    var called = false
+    let sut = DeviceLocalZoneSignUpCTAView(
+      onCreateAccount: { called = true }, onSignIn: {}, onDismiss: {})
+    sut.simulateCreateAccountTap()
+    #expect(called)
+  }
+
+  @Test func onSignIn_isCalled_whenSignInTapped() {
+    var called = false
+    let sut = DeviceLocalZoneSignUpCTAView(
+      onCreateAccount: {}, onSignIn: { called = true }, onDismiss: {})
+    sut.simulateSignInTap()
+    #expect(called)
+  }
+
+  @Test func onDismiss_isCalled_whenNotNowTapped() {
+    var called = false
+    let sut = DeviceLocalZoneSignUpCTAView(
+      onCreateAccount: {}, onSignIn: {}, onDismiss: { called = true })
+    sut.simulateDismissTap()
+    #expect(called)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/DeviceLocalZoneTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/DeviceLocalZoneTests.swift
@@ -1,0 +1,83 @@
+import Testing
+
+@testable import TownCrierDomain
+
+@Suite("DeviceLocalZone value object")
+struct DeviceLocalZoneTests {
+  @Test func init_validValues_createsZone() throws {
+    let centre = try Coordinate(latitude: 52.2053, longitude: 0.1218)
+    let zone = try DeviceLocalZone(name: "Home", centre: centre, radiusMetres: 1000)
+
+    #expect(zone.name == "Home")
+    #expect(zone.centre == centre)
+    #expect(zone.radiusMetres == 1000)
+  }
+
+  @Test func init_emptyName_throws() throws {
+    let centre = try Coordinate(latitude: 52.2053, longitude: 0.1218)
+
+    #expect(throws: DomainError.invalidWatchZoneName) {
+      try DeviceLocalZone(name: "", centre: centre, radiusMetres: 1000)
+    }
+  }
+
+  @Test func init_whitespaceOnlyName_throws() throws {
+    let centre = try Coordinate(latitude: 52.2053, longitude: 0.1218)
+
+    #expect(throws: DomainError.invalidWatchZoneName) {
+      try DeviceLocalZone(name: "   ", centre: centre, radiusMetres: 1000)
+    }
+  }
+
+  @Test func init_trimsWhitespaceFromName() throws {
+    let centre = try Coordinate(latitude: 52.2053, longitude: 0.1218)
+
+    let zone = try DeviceLocalZone(name: "  Home  ", centre: centre, radiusMetres: 1000)
+
+    #expect(zone.name == "Home")
+  }
+
+  @Test func init_generatesUniqueId() throws {
+    let centre = try Coordinate(latitude: 52.2053, longitude: 0.1218)
+    let zone1 = try DeviceLocalZone(name: "Home", centre: centre, radiusMetres: 1000)
+    let zone2 = try DeviceLocalZone(name: "Home", centre: centre, radiusMetres: 1000)
+
+    #expect(zone1.id != zone2.id)
+  }
+
+  // MARK: - Radius clamp [100, 5000] (matches the public near-point clamp)
+
+  @Test func init_radiusAboveMax_clampsTo5000() throws {
+    let centre = try Coordinate(latitude: 52.2053, longitude: 0.1218)
+
+    let zone = try DeviceLocalZone(name: "Home", centre: centre, radiusMetres: 9000)
+
+    #expect(zone.radiusMetres == 5000)
+  }
+
+  @Test func init_radiusBelowMin_clampsTo100() throws {
+    let centre = try Coordinate(latitude: 52.2053, longitude: 0.1218)
+
+    let zone = try DeviceLocalZone(name: "Home", centre: centre, radiusMetres: 10)
+
+    #expect(zone.radiusMetres == 100)
+  }
+
+  @Test func init_radiusWithinRange_isUnchanged() throws {
+    let centre = try Coordinate(latitude: 52.2053, longitude: 0.1218)
+
+    let zone = try DeviceLocalZone(name: "Home", centre: centre, radiusMetres: 3000)
+
+    #expect(zone.radiusMetres == 3000)
+  }
+
+  @Test func clampRadius_matchesInitClamping() {
+    #expect(DeviceLocalZone.clampRadius(9000) == 5000)
+    #expect(DeviceLocalZone.clampRadius(10) == 100)
+    #expect(DeviceLocalZone.clampRadius(2500) == 2500)
+  }
+
+  @Test func maxZoneCount_isThree() {
+    #expect(DeviceLocalZone.maxZoneCount == 3)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/UserDefaultsDeviceLocalZoneRepositoryTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/UserDefaultsDeviceLocalZoneRepositoryTests.swift
@@ -1,0 +1,267 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierData
+
+/// GH#879 Phase 4 acceptance criteria: repository round-trip, cap-at-3
+/// enforcement, radius clamp [100, 5000], migration seeds zone 1 from the
+/// legacy `AnonymousBrowseState`.
+@Suite("UserDefaultsDeviceLocalZoneRepository")
+struct UserDefaultsDeviceLocalZoneRepositoryTests {
+  private func makeSUT(
+    legacyState: AnonymousBrowseState? = nil
+  ) -> (UserDefaultsDeviceLocalZoneRepository, SpyAnonymousBrowseStateRepository) {
+    // Isolated suite per test so parallel test runs never share state.
+    let defaults = UserDefaults(suiteName: UUID().uuidString)
+    let legacyRepository = SpyAnonymousBrowseStateRepository()
+    legacyRepository.loadResult = legacyState
+    let sut = UserDefaultsDeviceLocalZoneRepository(
+      // swiftlint:disable:next force_unwrapping
+      defaults: defaults!, legacyStateRepository: legacyRepository)
+    return (sut, legacyRepository)
+  }
+
+  private func makeZone(
+    name: String = "Home", radiusMetres: Double = 1000
+  ) throws -> DeviceLocalZone {
+    try DeviceLocalZone(name: name, centre: .cambridge, radiusMetres: radiusMetres)
+  }
+
+  // MARK: - Round-trip
+
+  @Test func loadAll_returnsEmpty_whenNothingSaved() {
+    let (sut, _) = makeSUT()
+
+    #expect(sut.loadAll().isEmpty)
+  }
+
+  @Test func saveThenLoadAll_roundTripsTheZone() throws {
+    let (sut, _) = makeSUT()
+    let zone = try makeZone()
+
+    try sut.save(zone)
+
+    #expect(sut.loadAll() == [zone])
+  }
+
+  @Test func save_existingId_replacesInPlace() throws {
+    let (sut, _) = makeSUT()
+    let zone = try makeZone(name: "Home")
+    try sut.save(zone)
+    let updated = try DeviceLocalZone(
+      id: zone.id, name: "Updated Home", centre: .cambridge, radiusMetres: 2000)
+
+    try sut.save(updated)
+
+    #expect(sut.loadAll() == [updated])
+  }
+
+  @Test func delete_removesTheZone() throws {
+    let (sut, _) = makeSUT()
+    let zone = try makeZone()
+    try sut.save(zone)
+
+    sut.delete(zone.id)
+
+    #expect(sut.loadAll().isEmpty)
+  }
+
+  @Test func delete_missingId_isNoOp() throws {
+    let (sut, _) = makeSUT()
+    let zone = try makeZone()
+    try sut.save(zone)
+
+    sut.delete(DeviceLocalZoneId())
+
+    #expect(sut.loadAll() == [zone])
+  }
+
+  // MARK: - Cap at 3
+
+  @Test func save_thirdZone_succeeds() throws {
+    let (sut, _) = makeSUT()
+    try sut.save(try makeZone(name: "One"))
+    try sut.save(try makeZone(name: "Two"))
+
+    try sut.save(try makeZone(name: "Three"))
+
+    #expect(sut.loadAll().count == 3)
+  }
+
+  @Test func save_fourthZone_throwsLimitReached() throws {
+    let (sut, _) = makeSUT()
+    try sut.save(try makeZone(name: "One"))
+    try sut.save(try makeZone(name: "Two"))
+    try sut.save(try makeZone(name: "Three"))
+
+    #expect(throws: DomainError.deviceLocalZoneLimitReached) {
+      try sut.save(try makeZone(name: "Four"))
+    }
+    #expect(sut.loadAll().count == 3)
+  }
+
+  @Test func save_editingExistingZone_atCap_doesNotThrow() throws {
+    let (sut, _) = makeSUT()
+    let first = try makeZone(name: "One")
+    try sut.save(first)
+    try sut.save(try makeZone(name: "Two"))
+    try sut.save(try makeZone(name: "Three"))
+
+    let renamed = try DeviceLocalZone(
+      id: first.id, name: "Renamed", centre: .cambridge, radiusMetres: 1000)
+    try sut.save(renamed)
+
+    #expect(sut.loadAll().contains(renamed))
+  }
+
+  // MARK: - Active zone
+
+  @Test func activeZoneId_isNil_whenNothingSaved() {
+    let (sut, _) = makeSUT()
+
+    #expect(sut.activeZoneId() == nil)
+  }
+
+  @Test func save_firstEverZone_becomesActive() throws {
+    let (sut, _) = makeSUT()
+    let zone = try makeZone()
+
+    try sut.save(zone)
+
+    #expect(sut.activeZoneId() == zone.id)
+  }
+
+  @Test func save_secondZone_doesNotChangeActiveZone() throws {
+    let (sut, _) = makeSUT()
+    let first = try makeZone(name: "One")
+    try sut.save(first)
+
+    try sut.save(try makeZone(name: "Two"))
+
+    #expect(sut.activeZoneId() == first.id)
+  }
+
+  @Test func setActiveZoneId_updatesTheActiveZone() throws {
+    let (sut, _) = makeSUT()
+    let first = try makeZone(name: "One")
+    let second = try makeZone(name: "Two")
+    try sut.save(first)
+    try sut.save(second)
+
+    sut.setActiveZoneId(second.id)
+
+    #expect(sut.activeZoneId() == second.id)
+  }
+
+  @Test func setActiveZoneId_nil_clearsTheActiveZone() throws {
+    let (sut, _) = makeSUT()
+    try sut.save(try makeZone())
+
+    sut.setActiveZoneId(nil)
+
+    #expect(sut.activeZoneId() == nil)
+  }
+
+  @Test func delete_activeZone_promotesFirstRemainingZone() throws {
+    let (sut, _) = makeSUT()
+    let first = try makeZone(name: "One")
+    let second = try makeZone(name: "Two")
+    try sut.save(first)
+    try sut.save(second)
+
+    sut.delete(first.id)
+
+    #expect(sut.activeZoneId() == second.id)
+  }
+
+  @Test func delete_lastZone_clearsActiveZone() throws {
+    let (sut, _) = makeSUT()
+    let zone = try makeZone()
+    try sut.save(zone)
+
+    sut.delete(zone.id)
+
+    #expect(sut.activeZoneId() == nil)
+  }
+
+  @Test func delete_nonActiveZone_doesNotChangeActiveZone() throws {
+    let (sut, _) = makeSUT()
+    let first = try makeZone(name: "One")
+    let second = try makeZone(name: "Two")
+    try sut.save(first)
+    try sut.save(second)
+
+    sut.delete(second.id)
+
+    #expect(sut.activeZoneId() == first.id)
+  }
+
+  // MARK: - Migration from legacy AnonymousBrowseState
+
+  @Test func loadAll_noStoredZonesNoLegacyState_seedsNothing() {
+    let (sut, _) = makeSUT(legacyState: nil)
+
+    #expect(sut.loadAll().isEmpty)
+    #expect(sut.activeZoneId() == nil)
+  }
+
+  @Test func loadAll_noStoredZones_seedsZoneFromLegacyState() throws {
+    let legacyState = AnonymousBrowseState(
+      postcode: try Postcode("CB1 2AD"),
+      coordinate: .cambridge,
+      radiusMetres: 1500,
+      createdAt: Date())
+    let (sut, _) = makeSUT(legacyState: legacyState)
+
+    let zones = sut.loadAll()
+
+    #expect(zones.count == 1)
+    #expect(zones.first?.name == "CB1 2AD")
+    #expect(zones.first?.centre == .cambridge)
+    #expect(zones.first?.radiusMetres == 1500)
+  }
+
+  @Test func loadAll_seedsFromLegacyState_setsItActive() throws {
+    let legacyState = AnonymousBrowseState(
+      postcode: try Postcode("CB1 2AD"), coordinate: .cambridge, createdAt: Date())
+    let (sut, _) = makeSUT(legacyState: legacyState)
+
+    let zones = sut.loadAll()
+
+    #expect(sut.activeZoneId() == zones.first?.id)
+  }
+
+  @Test func loadAll_whenZonesAlreadyExist_doesNotMigrateLegacyState() throws {
+    let legacyState = AnonymousBrowseState(
+      postcode: try Postcode("CB1 2AD"), coordinate: .cambridge, createdAt: Date())
+    let (sut, _) = makeSUT(legacyState: legacyState)
+    try sut.save(try makeZone(name: "Manually Added"))
+
+    let zones = sut.loadAll()
+
+    #expect(zones.count == 1)
+    #expect(zones.first?.name == "Manually Added")
+  }
+
+  @Test func loadAll_afterMigrationAndDeletion_doesNotReSeedFromLegacyState() throws {
+    let legacyState = AnonymousBrowseState(
+      postcode: try Postcode("CB1 2AD"), coordinate: .cambridge, createdAt: Date())
+    let (sut, _) = makeSUT(legacyState: legacyState)
+    let migrated = sut.loadAll()
+    #expect(migrated.count == 1)
+    sut.delete(migrated[0].id)
+
+    let zonesAfterDelete = sut.loadAll()
+
+    #expect(zonesAfterDelete.isEmpty)
+  }
+
+  @Test func loadAll_noLegacyStateRepositoryInjected_doesNotCrash() {
+    let defaults = UserDefaults(suiteName: UUID().uuidString)
+    // swiftlint:disable:next force_unwrapping
+    let sut = UserDefaultsDeviceLocalZoneRepository(defaults: defaults!)
+
+    #expect(sut.loadAll().isEmpty)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Spies/SpyDeviceLocalZoneRepository.swift
+++ b/mobile/ios/town-crier-tests/Sources/Spies/SpyDeviceLocalZoneRepository.swift
@@ -1,0 +1,40 @@
+import Foundation
+import TownCrierDomain
+
+final class SpyDeviceLocalZoneRepository: DeviceLocalZoneRepository, @unchecked Sendable {
+  var loadAllResult: [DeviceLocalZone] = []
+  private(set) var loadAllCallCount = 0
+
+  func loadAll() -> [DeviceLocalZone] {
+    loadAllCallCount += 1
+    return loadAllResult
+  }
+
+  private(set) var saveCalls: [DeviceLocalZone] = []
+  var saveError: Error?
+
+  func save(_ zone: DeviceLocalZone) throws {
+    saveCalls.append(zone)
+    if let saveError {
+      throw saveError
+    }
+  }
+
+  private(set) var deleteCalls: [DeviceLocalZoneId] = []
+
+  func delete(_ id: DeviceLocalZoneId) {
+    deleteCalls.append(id)
+  }
+
+  var activeZoneIdResult: DeviceLocalZoneId?
+  private(set) var setActiveZoneIdCalls: [DeviceLocalZoneId?] = []
+
+  func activeZoneId() -> DeviceLocalZoneId? {
+    activeZoneIdResult
+  }
+
+  func setActiveZoneId(_ id: DeviceLocalZoneId?) {
+    setActiveZoneIdCalls.append(id)
+    activeZoneIdResult = id
+  }
+}


### PR DESCRIPTION
## Changes
- New `DeviceLocalZone` domain type + `UserDefaultsDeviceLocalZoneRepository`: up to 3 on-device zones (name, centre, radius clamped 100–5000 m), active-zone tracking with promote-on-delete, and one-shot migration seeding zone 1 from the legacy anonymous browse state (GH #879 Phase 4, bead tc-hq9h7.4).
- Zones tab added to the anonymous shell (Applications/Map/Zones/Settings): create/edit/delete with client-side postcodes.io geocoding; alert affordances and the 4th-zone attempt render sign-up CTAs (copy never says "instant").
- Zone-driven browsing: the active zone drives the Applications list (zone picker chips mirroring the authed pattern) and re-centres the Map **in place** — the coordinator mutates the live map view model rather than replacing it (a replaced `@StateObject` is silently ignored by SwiftUI), with an identity-preserving regression test.
- Crash fix baked in: rapid zone-switching provoked a SIGABRT in MapKit's deferred clustering pass; fixed by debouncing active-zone map updates (mutual cancellation with the pan/zoom debounce) and coalescing annotation/overlay/camera mutations onto a single deferred main-actor hop.
- Map's always-visible radius picker compacted to a single row (screen-space feedback from Phase 3 verification).
- Sim-verified across three rounds, ending with a dedicated crash hunt: 5 deliberate switch/drag cycles + 60s+ of max-speed tab/chip churn, zero new crash logs, re-centre correct both directions. Follow-ups filed: tc-zagg4 (radius persistence design), tc-jxpjv (rare dropped re-centre under ultra-fast toggling, self-correcting).

Release-Note: Save up to three areas as watch zones and switch between them — before creating an account.

---
*Auto-shipped via ship skill*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ApYCEogBeZYu7UP4LEouyW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Zones area for anonymous users to create, edit, delete, and switch between saved local areas.
  * Applications can now be browsed using a selected area, with a zone picker shown when multiple areas exist.
  * Added a new area editor and sign-up prompt for users who reach the area limit.

* **Bug Fixes**
  * Improved map behavior when switching areas and reduced the chance of map update crashes.

* **Chores**
  * Existing anonymous area data is now carried forward automatically on first launch after update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->