### PR TITLE
feat(ios): sign-up conversion of device-local zones (#879 Phase 5)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+DeviceLocalZoneConversion.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+DeviceLocalZoneConversion.swift
@@ -1,0 +1,69 @@
+import TownCrierDomain
+
+/// Post-signup conversion of leftover device-local zones (GH#879 Phase 5).
+/// The wizard's own zone (if any) is converted separately, via
+/// `AppCoordinator+Onboarding`'s prefill/`completeOnboarding()` seam — this
+/// extension handles everything left over after that: a one-time sheet
+/// offered immediately post-wizard, reachable again afterwards from the
+/// authed Zones tab's dismissible row for as long as any zones remain.
+extension AppCoordinator {
+  /// Presents the conversion sheet if any device-local zones remain after
+  /// the wizard's own conversion. Called from `completeOnboarding()`; a
+  /// no-op when no repository was injected or nothing is left to offer.
+  func presentDeviceLocalZoneConversionIfNeeded() {
+    guard let deviceLocalZoneRepository, !deviceLocalZoneRepository.loadAll().isEmpty else {
+      return
+    }
+    isDeviceLocalZoneConversionPresented = true
+  }
+
+  /// Builds the conversion sheet's view model from the current local-zone
+  /// state. Rebuilt fresh on every presentation (post-wizard, or reopened
+  /// from the Zones tab row) so it never shows already-converted or
+  /// already-deleted zones. Returns `nil` when no repository was injected —
+  /// the sheet's content closure degrades to showing nothing rather than
+  /// crashing.
+  public func makeDeviceLocalZoneConversionViewModel() -> DeviceLocalZoneConversionViewModel? {
+    guard let deviceLocalZoneRepository else { return nil }
+    let viewModel = DeviceLocalZoneConversionViewModel(
+      zones: deviceLocalZoneRepository.loadAll(),
+      watchZoneRepository: watchZoneRepository,
+      deviceLocalZoneRepository: deviceLocalZoneRepository
+    )
+    viewModel.onInsufficientEntitlement = { [weak self] in
+      // Quota breach mid-conversion (tc-gpjk precedent): close this sheet and
+      // present the subscription paywall instead of showing an inline error.
+      self?.isDeviceLocalZoneConversionPresented = false
+      self?.isSubscriptionPresented = true
+      self?.refreshAfterDeviceLocalZoneConversion()
+    }
+    viewModel.onFinished = { [weak self] in
+      self?.isDeviceLocalZoneConversionPresented = false
+      self?.refreshAfterDeviceLocalZoneConversion()
+    }
+    return viewModel
+  }
+
+  /// Reopens the conversion sheet from the authed Zones tab's dismissible
+  /// row (``WatchZoneListViewModel/onConvertLocalZones``). The sheet's
+  /// content is rebuilt fresh via `makeDeviceLocalZoneConversionViewModel()`
+  /// at presentation time, so this only needs to flip the flag.
+  public func reopenDeviceLocalZoneConversion() {
+    isDeviceLocalZoneConversionPresented = true
+  }
+
+  /// Refreshes the cached authed Zones list view model after a conversion
+  /// pass, so newly-created zones (and the now-shorter/empty unconverted-zone
+  /// row) show up without waiting for the next tab appearance.
+  private func refreshAfterDeviceLocalZoneConversion() {
+    pendingDeviceLocalZoneConversionRefresh = Task { [weak self] in
+      await self?.watchZoneListViewModel?.load()
+    }
+  }
+
+  /// Test-only synchronisation: await the most recently kicked-off post-
+  /// conversion refresh, mirroring `waitForPendingWatchZoneRefresh()`.
+  public func waitForPendingDeviceLocalZoneConversionRefresh() async {
+    await pendingDeviceLocalZoneConversionRefresh?.value
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+Onboarding.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+Onboarding.swift
@@ -52,14 +52,33 @@ extension AppCoordinator {
       await self?.resolveSubscriptionTier()
     }
 
-    // Anonymous browse post-signup handoff (GH#868 Phase 3.5): a user who
-    // located themselves before creating an account carries that postcode/
-    // coordinate straight into the wizard, landing on the radius step instead
-    // of being asked again. Only applies on fresh construction (never the
-    // cached-instance return above), so it fires at most once per session.
-    // Anonymous state is cleared immediately after so a future sign-out
-    // starts from the welcome screen, not a stale anonymous map.
-    if let anonymousBrowseStateRepository, let state = anonymousBrowseStateRepository.load() {
+    // Anonymous browse post-signup handoff (GH#868 Phase 3.5, extended
+    // GH#879 Phase 5): prefer the active device-local zone (name/centre/
+    // radius) over the legacy single AnonymousBrowseState blob — a user who
+    // created explicit local zones (Phase 4) gets their active area carried
+    // straight into the wizard. Only applies on fresh construction (never
+    // the cached-instance return above), so it fires at most once per
+    // session. Unlike the legacy blob (cleared immediately below), the
+    // device-local zone is NOT deleted here — only once completeOnboarding()
+    // confirms the wizard actually saved it server-side, so abandoning the
+    // wizard mid-flow never silently loses the zone.
+    let activeZone: DeviceLocalZone? = deviceLocalZoneRepository.flatMap { repository in
+      repository.activeZoneId().flatMap { activeId in
+        repository.loadAll().first { $0.id == activeId }
+      }
+    }
+    if let activeZone {
+      viewModel.prefill(
+        name: activeZone.name,
+        coordinate: activeZone.centre,
+        radiusMetres: activeZone.radiusMetres
+      )
+      pendingConvertedDeviceLocalZoneId = activeZone.id
+    } else if let anonymousBrowseStateRepository, let state = anonymousBrowseStateRepository.load() {
+      // No device-local zones exist — fall back to the legacy single
+      // postcode/coordinate blob for users who never went further than the
+      // anonymous map. Cleared immediately: a future sign-out starts from
+      // the welcome screen, not a stale anonymous map.
       viewModel.prefill(
         postcode: state.postcode, coordinate: state.coordinate, radiusMetres: state.radiusMetres)
       anonymousBrowseStateRepository.clear()
@@ -98,8 +117,19 @@ extension AppCoordinator {
 
   /// Invoked when the wizard saves the user's first zone. Flips the gate so the
   /// root view falls through to the main app and releases the wizard VM.
+  ///
+  /// GH#879 Phase 5: if the wizard was prefilled from a device-local zone,
+  /// this is the moment it is actually deleted from local storage — only now
+  /// that the server save is confirmed, never at prefill time. If any other
+  /// local zones remain, offers them for conversion
+  /// (``presentDeviceLocalZoneConversionIfNeeded()``).
   func completeOnboarding() {
     onboardingPresentation = .notRequired
     onboardingViewModel = nil
+    if let pendingConvertedDeviceLocalZoneId {
+      deviceLocalZoneRepository?.delete(pendingConvertedDeviceLocalZoneId)
+      self.pendingConvertedDeviceLocalZoneId = nil
+    }
+    presentDeviceLocalZoneConversionIfNeeded()
   }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+WatchZones.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+WatchZones.swift
@@ -18,7 +18,8 @@ extension AppCoordinator {
     }
     let viewModel = WatchZoneListViewModel(
       repository: watchZoneRepository,
-      featureGate: FeatureGate(tier: subscriptionTier)
+      featureGate: FeatureGate(tier: subscriptionTier),
+      deviceLocalZoneRepository: deviceLocalZoneRepository
     )
     viewModel.onAddZone = { [weak self] in
       self?.isAddingWatchZone = true
@@ -28,6 +29,11 @@ extension AppCoordinator {
     }
     viewModel.onViewPlans = { [weak self] in
       self?.isSubscriptionPresented = true
+    }
+    // Unconverted device-local zones row (GH#879 Phase 5): reopens the same
+    // conversion sheet completeOnboarding() presents post-wizard.
+    viewModel.onConvertLocalZones = { [weak self] in
+      self?.reopenDeviceLocalZoneConversion()
     }
     watchZoneListViewModel = viewModel
     return viewModel

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
@@ -34,6 +34,11 @@ public final class AppCoordinator: ObservableObject {
   @Published public var isAddingWatchZone = false
   @Published public var editingWatchZone: WatchZone?
   @Published public var isRedeemOfferCodePresented = false
+  /// Drives the post-signup "Add your other areas" conversion sheet (GH#879
+  /// Phase 5) — presented once immediately after ``completeOnboarding()``
+  /// when unconverted device-local zones remain, and reopened from the
+  /// authed Zones tab's dismissible row for as long as any remain.
+  @Published public var isDeviceLocalZoneConversionPresented = false
   /// Settings sheet — bound to the gear-icon toolbar action installed on each tab.
   @Published public var isSettingsPresented = false
   @Published public private(set) var subscriptionTier: SubscriptionTier = .free
@@ -67,6 +72,11 @@ public final class AppCoordinator: ObservableObject {
   // existing call sites/tests inject nothing. Internal so AppCoordinator+Detail
   // can read it.
   let anonymousApplicationDetailRepository: AnonymousApplicationDetailRepository?
+  // Device-local (pre-signup) zones (GH#879 Phase 4/5). Optional so existing
+  // call sites/tests that never exercise anonymous browsing inject nothing.
+  // Internal (not private) so AppCoordinator+Onboarding and
+  // AppCoordinator+DeviceLocalZoneConversion can read it.
+  let deviceLocalZoneRepository: DeviceLocalZoneRepository?
   /// Fired by the anonymous detail CTA (GH#879 Phase 2) — wired by the
   /// composition root to the same Auth0 entry point every sign-up surface uses.
   public var onRequestSignUp: (() -> Void)?
@@ -102,6 +112,13 @@ public final class AppCoordinator: ObservableObject {
   // and so SwiftUI's StateObject and the coordinator converge on one instance.
   // Internal (not private) so the AppCoordinator+Onboarding extension owns it.
   var onboardingViewModel: OnboardingViewModel?
+  // Set when the wizard is prefilled from an active device-local zone
+  // (GH#879 Phase 5); deleted from local storage only once completeOnboarding()
+  // confirms the save, never merely on wizard construction.
+  var pendingConvertedDeviceLocalZoneId: DeviceLocalZoneId?
+  // In-flight refresh of the authed Zones list after a device-local zone
+  // conversion pass (GH#879 Phase 5); tests await it, mirroring `pendingWatchZoneRefresh`.
+  var pendingDeviceLocalZoneConversionRefresh: Task<Void, Never>?
   // In-flight tasks tests can await deterministically (no `Task.sleep`).
   var pendingOfferCodeRefresh: Task<Void, Never>?
   // Internal (not private) so the AppCoordinator+WatchZones extension can drive it.
@@ -138,7 +155,8 @@ public final class AppCoordinator: ObservableObject {
     reviewPromptTracker: ReviewPromptTracker? = nil,
     anonymousBrowseStateRepository: AnonymousBrowseStateRepository? = nil,
     appearanceStore: AppearanceStore? = nil,
-    anonymousApplicationDetailRepository: AnonymousApplicationDetailRepository? = nil
+    anonymousApplicationDetailRepository: AnonymousApplicationDetailRepository? = nil,
+    deviceLocalZoneRepository: DeviceLocalZoneRepository? = nil
   ) {
     self.repository = repository
     self.authService = authService
@@ -169,6 +187,7 @@ public final class AppCoordinator: ObservableObject {
     self.anonymousBrowseStateRepository = anonymousBrowseStateRepository
     self.appearanceStore = appearanceStore
     self.anonymousApplicationDetailRepository = anonymousApplicationDetailRepository
+    self.deviceLocalZoneRepository = deviceLocalZoneRepository
 
     // Restore the last successfully resolved tier so that paying users
     // retain feature access immediately, even before the live resolution

--- a/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Modifiers/SelfSizingSheet.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Modifiers/SelfSizingSheet.swift
@@ -34,8 +34,10 @@ extension View {
   /// Presents this view in a sheet sized to its own content height.
   ///
   /// Use in place of `.presentationDetents([.medium])` for short, text-heavy
-  /// sheets where a fixed detent would clip and truncate the copy.
-  func selfSizingSheet() -> some View {
+  /// sheets where a fixed detent would clip and truncate the copy. Public so
+  /// the app-target composition root (a different module) can apply it too
+  /// — e.g. the device-local zone conversion sheet hoisted onto `MainTabView`.
+  public func selfSizingSheet() -> some View {
     modifier(SelfSizingSheetModifier())
   }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/OnboardingViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/OnboardingViewModel.swift
@@ -17,6 +17,12 @@ public final class OnboardingViewModel: ObservableObject, ErrorHandlingViewModel
   @Published public private(set) var isLoading = false
   @Published public internal(set) var error: DomainError?
   private var validatedPostcode: Postcode?
+  /// Set by ``prefill(name:coordinate:radiusMetres:)`` (GH#879 Phase 5): a
+  /// device-local zone's name is free text the user chose (or the postcode
+  /// it was seeded from), not necessarily a valid ``Postcode`` — so this
+  /// carries the name straight through to the zone ``confirmRadius()``
+  /// creates rather than round-tripping it through `Postcode` validation.
+  private var prefillZoneName: String?
   @Published public private(set) var geocodedCoordinate: Coordinate?
   @Published public var selectedRadiusMetres: Double = 1000
   private var createdWatchZone: WatchZone?
@@ -111,6 +117,20 @@ public final class OnboardingViewModel: ObservableObject, ErrorHandlingViewModel
     currentStep = .radiusPicker
   }
 
+  /// Seeds the wizard's zone name/coordinate/radius from an already-created
+  /// device-local zone (GH#879 Phase 5) and jumps straight to the radius
+  /// step, mirroring ``prefill(postcode:coordinate:radiusMetres:)`` but for a
+  /// zone whose name is arbitrary user text rather than a validated
+  /// postcode. `radiusMetres` is clamped the same way.
+  public func prefill(name: String, coordinate: Coordinate, radiusMetres: Double) {
+    prefillZoneName = name
+    postcodeInput = name
+    validatedPostcode = nil
+    geocodedCoordinate = coordinate
+    selectedRadiusMetres = min(max(radiusMetres, 100), maxRadiusMetres)
+    currentStep = .radiusPicker
+  }
+
   public func submitPostcode() async {
     isLoading = true
     error = nil
@@ -178,10 +198,18 @@ public final class OnboardingViewModel: ObservableObject, ErrorHandlingViewModel
   }
 
   public func confirmRadius() {
-    guard let coordinate = geocodedCoordinate, let postcode = validatedPostcode else { return }
+    guard let coordinate = geocodedCoordinate else { return }
     do {
-      let zone = try WatchZone(
-        postcode: postcode, centre: coordinate, radiusMetres: selectedRadiusMetres)
+      let zone: WatchZone
+      if let prefillZoneName {
+        zone = try WatchZone(
+          name: prefillZoneName, centre: coordinate, radiusMetres: selectedRadiusMetres)
+      } else if let postcode = validatedPostcode {
+        zone = try WatchZone(
+          postcode: postcode, centre: coordinate, radiusMetres: selectedRadiusMetres)
+      } else {
+        return
+      }
       createdWatchZone = zone
       currentStep = .notificationPermission
     } catch {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/DeviceLocalZoneConversionView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/DeviceLocalZoneConversionView.swift
@@ -1,0 +1,101 @@
+import SwiftUI
+import TownCrierDomain
+
+/// Post-signup "Add your other areas" conversion sheet (GH#879 Phase 5).
+///
+/// Lists the device-local zones (GH#879 Phase 4) the onboarding wizard did
+/// not already convert, offering to create them as real watch zones. A
+/// single "Add These Areas" action converts every listed zone sequentially,
+/// in order; hitting the tier's watch-zone quota mid-list routes to the
+/// subscription paywall (handled by the coordinator) and leaves the rest
+/// here, untouched. "Not Now" leaves everything in local storage — the
+/// authed Zones tab's dismissible row offers this sheet again later.
+public struct DeviceLocalZoneConversionView: View {
+  @StateObject private var viewModel: DeviceLocalZoneConversionViewModel
+
+  public init(viewModel: DeviceLocalZoneConversionViewModel) {
+    _viewModel = StateObject(wrappedValue: viewModel)
+  }
+
+  public var body: some View {
+    VStack(spacing: 0) {
+      header
+
+      List(viewModel.zones) { zone in
+        ConversionZoneRow(zone: zone)
+      }
+      .listStyle(.plain)
+      .scrollContentBackground(.hidden)
+      .background(Color.tcBackground)
+      .frame(minHeight: 120)
+
+      if let error = viewModel.error {
+        Text(error.userMessage)
+          .font(TCTypography.caption)
+          .foregroundStyle(Color.tcStatusRejected)
+          .padding(.horizontal, TCSpacing.medium)
+          .padding(.top, TCSpacing.small)
+      }
+
+      footer
+    }
+    .background(Color.tcSurfaceElevated)
+  }
+
+  private var header: some View {
+    VStack(alignment: .leading, spacing: TCSpacing.small) {
+      Text("Add your other areas")
+        .font(TCTypography.displaySmall)
+        .foregroundStyle(Color.tcTextPrimary)
+      Text("You saved these areas before signing up. Add them as watch zones to get alerts.")
+        .font(TCTypography.body)
+        .foregroundStyle(Color.tcTextSecondary)
+    }
+    .padding(TCSpacing.medium)
+  }
+
+  private var footer: some View {
+    VStack(spacing: TCSpacing.small) {
+      PrimaryButton(viewModel.isConverting ? "Adding…" : "Add These Areas") {
+        Task { await viewModel.convertAll() }
+      }
+      .disabled(viewModel.isConverting || viewModel.zones.isEmpty)
+
+      Button {
+        viewModel.dismiss()
+      } label: {
+        Text("Not Now")
+          .font(TCTypography.body)
+          .foregroundStyle(Color.tcTextSecondary)
+      }
+      .frame(minHeight: 44)
+      .disabled(viewModel.isConverting)
+    }
+    .padding(.horizontal, TCSpacing.medium)
+    .padding(.bottom, TCSpacing.medium)
+  }
+}
+
+private struct ConversionZoneRow: View {
+  let zone: DeviceLocalZone
+
+  var body: some View {
+    HStack(spacing: TCSpacing.medium) {
+      ZoneMapPreview(centre: zone.centre, radiusMetres: zone.radiusMetres)
+        .frame(width: 48, height: 48)
+        .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.small))
+
+      VStack(alignment: .leading, spacing: TCSpacing.extraSmall) {
+        Text(zone.name)
+          .font(.system(.headline).weight(.semibold))
+        Text(formatRadius(zone.radiusMetres))
+          .font(.system(.caption))
+          .foregroundStyle(Color.tcTextSecondary)
+      }
+
+      Spacer()
+    }
+    .padding(.vertical, TCSpacing.extraSmall)
+    .listRowBackground(Color.tcSurface)
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/DeviceLocalZoneConversionViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/DeviceLocalZoneConversionViewModel.swift
@@ -1,0 +1,81 @@
+import Foundation
+import TownCrierDomain
+
+/// Drives the post-signup "Add your other areas" conversion sheet (GH#879
+/// Phase 5): offers the device-local zones the onboarding wizard did NOT
+/// already convert (that conversion happens separately, via the wizard's own
+/// `WatchZoneRepository.save` call) for server-side creation.
+///
+/// Presented once immediately after `completeOnboarding()` when unconverted
+/// zones remain, and again from the authenticated Zones tab's dismissible
+/// row for as long as any remain
+/// (see `AppCoordinator+DeviceLocalZoneConversion`).
+@MainActor
+public final class DeviceLocalZoneConversionViewModel: ObservableObject {
+  @Published public private(set) var zones: [DeviceLocalZone]
+  @Published public private(set) var isConverting = false
+  @Published public internal(set) var error: DomainError?
+
+  private let watchZoneRepository: WatchZoneRepository
+  private let deviceLocalZoneRepository: DeviceLocalZoneRepository
+
+  /// Fired when a save hits the tier's watch-zone quota
+  /// (`DomainError.insufficientEntitlement`). Conversion stops here — the
+  /// triggering zone and everything after it in `zones` stay in local
+  /// storage, untouched.
+  var onInsufficientEntitlement: (() -> Void)?
+  /// Fired when a pass over `zones` finishes — either every zone converted,
+  /// or the user dismissed without converting the rest. Either way the sheet
+  /// should close.
+  var onFinished: (() -> Void)?
+
+  public init(
+    zones: [DeviceLocalZone],
+    watchZoneRepository: WatchZoneRepository,
+    deviceLocalZoneRepository: DeviceLocalZoneRepository
+  ) {
+    self.zones = zones
+    self.watchZoneRepository = watchZoneRepository
+    self.deviceLocalZoneRepository = deviceLocalZoneRepository
+  }
+
+  /// Converts every remaining zone sequentially, in list order — never in
+  /// parallel, so a mid-list quota breach leaves everything after it
+  /// untouched. Each success is deleted from local storage immediately.
+  /// Reuses exactly the wizard/authed-editor path for zone creation: no
+  /// `authorityId` is set, so the server resolves it from the coordinate.
+  public func convertAll() async {
+    isConverting = true
+    error = nil
+    for zone in zones {
+      do {
+        let watchZone = try WatchZone(
+          name: zone.name, centre: zone.centre, radiusMetres: zone.radiusMetres)
+        try await watchZoneRepository.save(watchZone)
+        deviceLocalZoneRepository.delete(zone.id)
+        zones.removeAll { $0.id == zone.id }
+      } catch DomainError.insufficientEntitlement {
+        isConverting = false
+        onInsufficientEntitlement?()
+        return
+      } catch let domainError as DomainError {
+        isConverting = false
+        error = domainError
+        return
+      } catch {
+        isConverting = false
+        self.error = .unexpected(error.localizedDescription)
+        return
+      }
+    }
+    isConverting = false
+    onFinished?()
+  }
+
+  /// The user declined to convert the remaining zones this time — they stay
+  /// in local storage and the dismissible Zones-tab row offers them again
+  /// (never silently discard user-created data).
+  public func dismiss() {
+    onFinished?()
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListView.swift
@@ -43,6 +43,26 @@ public struct WatchZoneListView: View {
               .listRowSeparator(.hidden)
           }
         }
+
+        if viewModel.showsLocalZoneRow {
+          Section {
+            UnconvertedLocalZoneRow(
+              count: viewModel.unconvertedLocalZones.count,
+              onTap: { viewModel.convertLocalZones() },
+              onDismiss: { viewModel.dismissLocalZoneRow() }
+            )
+            .listRowInsets(
+              EdgeInsets(
+                top: TCSpacing.medium,
+                leading: TCSpacing.medium,
+                bottom: TCSpacing.medium,
+                trailing: TCSpacing.medium
+              )
+            )
+            .listRowBackground(Color.clear)
+            .listRowSeparator(.hidden)
+          }
+        }
       }
     }
     .navigationTitle("Watch Zones")
@@ -136,4 +156,54 @@ private struct WatchZoneRow: View {
     .padding(.vertical, TCSpacing.extraSmall)
   }
 
+}
+
+/// Dismissible row surfaced while device-local zones (GH#879 Phase 4) remain
+/// unconverted after sign-up. Tapping the body reopens the "Add your other
+/// areas" conversion sheet; the trailing "x" dismisses the row for the
+/// session only — it reappears next launch while zones still remain, and
+/// clears entirely once none do (never silently discard user-created data).
+private struct UnconvertedLocalZoneRow: View {
+  let count: Int
+  let onTap: () -> Void
+  let onDismiss: () -> Void
+
+  private var bodyText: String {
+    "\(count) \(count == 1 ? "area" : "areas") from before you signed up"
+  }
+
+  var body: some View {
+    HStack(alignment: .top, spacing: TCSpacing.medium) {
+      Image(systemName: "mappin.and.ellipse")
+        .font(.system(.title3))
+        .foregroundStyle(Color.tcAmber)
+        .accessibilityHidden(true)
+
+      VStack(alignment: .leading, spacing: TCSpacing.extraSmall) {
+        Text(bodyText)
+          .font(TCTypography.body)
+          .foregroundStyle(Color.tcTextPrimary)
+          .fixedSize(horizontal: false, vertical: true)
+
+        Button(action: onTap) {
+          Text("Add them")
+            .font(TCTypography.bodyEmphasis)
+            .foregroundStyle(Color.tcAmber)
+        }
+      }
+
+      Spacer(minLength: 0)
+
+      Button(action: onDismiss) {
+        Image(systemName: "xmark")
+          .font(.system(.caption))
+          .foregroundStyle(Color.tcTextTertiary)
+      }
+      .buttonStyle(.plain)
+      .accessibilityLabel("Dismiss")
+    }
+    .padding(TCSpacing.medium)
+    .background(Color.tcAmberMuted)
+    .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.medium))
+  }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListView.swift
@@ -31,16 +31,7 @@ public struct WatchZoneListView: View {
         if viewModel.showsFreeTierUpsell {
           Section {
             WatchZoneInlineUpsellCard { viewModel.viewPlans() }
-              .listRowInsets(
-                EdgeInsets(
-                  top: TCSpacing.medium,
-                  leading: TCSpacing.medium,
-                  bottom: TCSpacing.medium,
-                  trailing: TCSpacing.medium
-                )
-              )
-              .listRowBackground(Color.clear)
-              .listRowSeparator(.hidden)
+              .cardRowInsets()
           }
         }
 
@@ -51,16 +42,7 @@ public struct WatchZoneListView: View {
               onTap: { viewModel.convertLocalZones() },
               onDismiss: { viewModel.dismissLocalZoneRow() }
             )
-            .listRowInsets(
-              EdgeInsets(
-                top: TCSpacing.medium,
-                leading: TCSpacing.medium,
-                bottom: TCSpacing.medium,
-                trailing: TCSpacing.medium
-              )
-            )
-            .listRowBackground(Color.clear)
-            .listRowSeparator(.hidden)
+            .cardRowInsets()
           }
         }
       }
@@ -127,6 +109,25 @@ public struct WatchZoneListView: View {
       }
       .padding(.vertical, TCSpacing.extraLarge)
     }
+  }
+}
+
+extension View {
+  /// Shared row insets for the card-style rows appended beneath the zone
+  /// list (the free-tier upsell card and the unconverted-local-zones row) —
+  /// clears the default list-row padding so each card fills the section
+  /// edge-to-edge with its own `TCSpacing.medium` margin.
+  func cardRowInsets() -> some View {
+    listRowInsets(
+      EdgeInsets(
+        top: TCSpacing.medium,
+        leading: TCSpacing.medium,
+        bottom: TCSpacing.medium,
+        trailing: TCSpacing.medium
+      )
+    )
+    .listRowBackground(Color.clear)
+    .listRowSeparator(.hidden)
   }
 }
 

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListViewModel.swift
@@ -13,6 +13,15 @@ public final class WatchZoneListViewModel: ObservableObject, ErrorHandlingViewMo
   @Published public private(set) var isLoading = false
   @Published public internal(set) var error: DomainError?
   @Published public var isUpgradePromptPresented = false
+  /// Device-local zones (GH#879 Phase 4) not yet converted to a real
+  /// `WatchZone` — populated by ``load()`` from the injected
+  /// `deviceLocalZoneRepository`. Always empty when no repository was
+  /// injected (existing call sites/tests are unaffected).
+  @Published public private(set) var unconvertedLocalZones: [DeviceLocalZone] = []
+  /// Session-only dismissal of the unconverted-zones row (GH#879 Phase 5).
+  /// Never persisted — a fresh `WatchZoneListViewModel` (next app launch)
+  /// always starts un-dismissed, so the row reappears while zones remain.
+  @Published public private(set) var isLocalZoneRowDismissed = false
 
   /// The proactive feature gate derived from the user's subscription tier.
   public let featureGate: FeatureGate
@@ -21,15 +30,41 @@ public final class WatchZoneListViewModel: ObservableObject, ErrorHandlingViewMo
   var onEditZone: ((WatchZone) -> Void)?
   var onUpgradeRequired: (() -> Void)?
   var onViewPlans: (() -> Void)?
+  /// Fired when the user taps the unconverted-zones row (GH#879 Phase 5) —
+  /// wired by the coordinator to reopen the conversion sheet.
+  var onConvertLocalZones: (() -> Void)?
 
   private let repository: WatchZoneRepository
+  private let deviceLocalZoneRepository: DeviceLocalZoneRepository?
 
   public init(
     repository: WatchZoneRepository,
-    featureGate: FeatureGate
+    featureGate: FeatureGate,
+    deviceLocalZoneRepository: DeviceLocalZoneRepository? = nil
   ) {
     self.repository = repository
     self.featureGate = featureGate
+    self.deviceLocalZoneRepository = deviceLocalZoneRepository
+  }
+
+  /// True while any unconverted device-local zone remains AND the user has
+  /// not dismissed the row this session — clears entirely once none remain,
+  /// independent of the dismiss flag (never keep an empty row dismissable).
+  public var showsLocalZoneRow: Bool {
+    !unconvertedLocalZones.isEmpty && !isLocalZoneRowDismissed
+  }
+
+  /// Hides the unconverted-zones row for the rest of this session. The row
+  /// reappears on next launch (a fresh view model) while zones still remain
+  /// — local zones are never silently discarded, only converted or
+  /// explicitly deleted.
+  public func dismissLocalZoneRow() {
+    isLocalZoneRowDismissed = true
+  }
+
+  /// Reopens the post-signup conversion sheet from the row's tap target.
+  public func convertLocalZones() {
+    onConvertLocalZones?()
   }
 
   /// Whether the user can add another watch zone given their tier and current count.
@@ -65,6 +100,7 @@ public final class WatchZoneListViewModel: ObservableObject, ErrorHandlingViewMo
     } catch {
       handleError(error)
     }
+    unconvertedLocalZones = deviceLocalZoneRepository?.loadAll() ?? []
 
     isLoading = false
   }

--- a/mobile/ios/town-crier-app/Sources/MainTabView.swift
+++ b/mobile/ios/town-crier-app/Sources/MainTabView.swift
@@ -102,6 +102,19 @@ struct MainTabView: View {
         }
       }
     )
+    // Post-signup "Add your other areas" conversion sheet (GH#879 Phase 5):
+    // presented once immediately after the wizard completes when unconverted
+    // device-local zones remain, and reopened from the authed Zones tab's
+    // dismissible row for as long as any remain. Content is rebuilt fresh on
+    // every presentation so it never shows already-converted/deleted zones.
+    // Hoisted to the TabView, mirroring the paywall sheet above, so it
+    // reaches the user regardless of active tab.
+    .sheet(isPresented: $coordinator.isDeviceLocalZoneConversionPresented) {
+      if let viewModel = coordinator.makeDeviceLocalZoneConversionViewModel() {
+        DeviceLocalZoneConversionView(viewModel: viewModel)
+          .selfSizingSheet()
+      }
+    }
   }
 
   /// Settings sheet — presented from the gear icon installed on every tab.

--- a/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
+++ b/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
@@ -123,7 +123,8 @@ struct TownCrierApp: App {
       reviewPromptTracker: reviewPromptTracker,
       anonymousBrowseStateRepository: anonymousBrowseStateRepository,
       appearanceStore: sharedAppearanceStore,
-      anonymousApplicationDetailRepository: anonymousApplicationDetailRepository
+      anonymousApplicationDetailRepository: anonymousApplicationDetailRepository,
+      deviceLocalZoneRepository: deviceLocalZoneRepository
     )
     reviewRequester.coordinator = appCoordinator  // weak; coordinator owns the tracker
     _coordinator = StateObject(wrappedValue: appCoordinator)

--- a/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorDeviceLocalZoneConversionTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorDeviceLocalZoneConversionTests.swift
@@ -1,0 +1,127 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+/// GH#879 Phase 5: post-wizard "Add your other areas" sheet presentation,
+/// quota-breach paywall routing, and reopening from the authed Zones tab.
+@Suite("AppCoordinator -- Device-Local Zone Conversion (GH#879 Phase 5)")
+@MainActor
+struct AppCoordinatorDeviceLocalZoneConversionTests {
+  private func makeSUT(
+    deviceLocalZoneRepository: SpyDeviceLocalZoneRepository? = nil,
+    watchZoneRepository: WatchZoneRepository = SpyWatchZoneRepository()
+  ) -> AppCoordinator {
+    AppCoordinator(
+      repository: SpyPlanningApplicationRepository(),
+      authService: SpyAuthenticationService(),
+      subscriptionService: SpySubscriptionService(),
+      userProfileRepository: SpyUserProfileRepository(),
+      watchZoneRepository: watchZoneRepository,
+      geocoder: SpyPostcodeGeocoder(),
+      onboardingRepository: SpyOnboardingRepository(),
+      notificationService: SpyNotificationService(),
+      appVersionProvider: SpyAppVersionProvider(),
+      versionConfigService: SpyVersionConfigService(),
+      deviceLocalZoneRepository: deviceLocalZoneRepository
+    )
+  }
+
+  private func makeZone(id: String, name: String) throws -> DeviceLocalZone {
+    try DeviceLocalZone(id: DeviceLocalZoneId(id), name: name, centre: .cambridge, radiusMetres: 1000)
+  }
+
+  // MARK: - Post-wizard sheet presentation
+
+  @Test func completeOnboarding_withUnconvertedZonesRemaining_presentsConversionSheet() throws {
+    let localRepo = SpyDeviceLocalZoneRepository()
+    let active = try makeZone(id: "a", name: "Home")
+    let other = try makeZone(id: "b", name: "Work")
+    localRepo.loadAllResult = [active, other]
+    localRepo.activeZoneIdResult = active.id
+    let sut = makeSUT(deviceLocalZoneRepository: localRepo)
+    _ = sut.makeOnboardingViewModel()
+
+    sut.completeOnboarding()
+
+    #expect(sut.isDeviceLocalZoneConversionPresented)
+  }
+
+  @Test func completeOnboarding_withNoZonesRemaining_doesNotPresentConversionSheet() throws {
+    let localRepo = SpyDeviceLocalZoneRepository()
+    let active = try makeZone(id: "a", name: "Home")
+    localRepo.loadAllResult = [active]
+    localRepo.activeZoneIdResult = active.id
+    let sut = makeSUT(deviceLocalZoneRepository: localRepo)
+    _ = sut.makeOnboardingViewModel()
+    // Simulate the wizard's own conversion actually removing the zone before
+    // the repository is next consulted.
+    localRepo.loadAllResult = []
+
+    sut.completeOnboarding()
+
+    #expect(!sut.isDeviceLocalZoneConversionPresented)
+  }
+
+  @Test func completeOnboarding_noDeviceLocalZoneRepository_doesNotPresentConversionSheet() {
+    let sut = makeSUT()
+
+    sut.completeOnboarding()
+
+    #expect(!sut.isDeviceLocalZoneConversionPresented)
+  }
+
+  @Test func isDeviceLocalZoneConversionPresented_isFalseByDefault() {
+    let sut = makeSUT()
+
+    #expect(!sut.isDeviceLocalZoneConversionPresented)
+  }
+
+  // MARK: - makeDeviceLocalZoneConversionViewModel
+
+  @Test func makeDeviceLocalZoneConversionViewModel_noRepository_returnsNil() {
+    let sut = makeSUT()
+
+    #expect(sut.makeDeviceLocalZoneConversionViewModel() == nil)
+  }
+
+  @Test func makeDeviceLocalZoneConversionViewModel_buildsFromCurrentLocalZones() throws {
+    let localRepo = SpyDeviceLocalZoneRepository()
+    let zone = try makeZone(id: "b", name: "Work")
+    localRepo.loadAllResult = [zone]
+    let sut = makeSUT(deviceLocalZoneRepository: localRepo)
+
+    let vm = sut.makeDeviceLocalZoneConversionViewModel()
+
+    #expect(vm?.zones == [zone])
+  }
+
+  // MARK: - Quota-breach routes to the paywall
+
+  @Test func conversionViewModel_onInsufficientEntitlement_dismissesSheetAndPresentsPaywall() async throws {
+    let localRepo = SpyDeviceLocalZoneRepository()
+    let zone = try makeZone(id: "b", name: "Work")
+    localRepo.loadAllResult = [zone]
+    let watchZoneRepo = SpyWatchZoneRepository()
+    watchZoneRepo.saveResult = .failure(DomainError.insufficientEntitlement(required: "personal"))
+    let sut = makeSUT(deviceLocalZoneRepository: localRepo, watchZoneRepository: watchZoneRepo)
+    sut.isDeviceLocalZoneConversionPresented = true
+    let vm = try #require(sut.makeDeviceLocalZoneConversionViewModel())
+
+    await vm.convertAll()
+
+    #expect(!sut.isDeviceLocalZoneConversionPresented)
+    #expect(sut.isSubscriptionPresented)
+  }
+
+  // MARK: - Reopening from the Zones tab row
+
+  @Test func reopenDeviceLocalZoneConversion_presentsSheet() {
+    let sut = makeSUT()
+
+    sut.reopenDeviceLocalZoneConversion()
+
+    #expect(sut.isDeviceLocalZoneConversionPresented)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorDeviceLocalZoneConversionTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorDeviceLocalZoneConversionTests.swift
@@ -124,4 +124,27 @@ struct AppCoordinatorDeviceLocalZoneConversionTests {
 
     #expect(sut.isDeviceLocalZoneConversionPresented)
   }
+
+  // MARK: - Zones-tab wiring
+
+  @Test func makeWatchZoneListViewModel_populatesUnconvertedLocalZones() async throws {
+    let localRepo = SpyDeviceLocalZoneRepository()
+    let zone = try makeZone(id: "b", name: "Work")
+    localRepo.loadAllResult = [zone]
+    let sut = makeSUT(deviceLocalZoneRepository: localRepo)
+
+    let vm = sut.makeWatchZoneListViewModel()
+    await vm.load()
+
+    #expect(vm.unconvertedLocalZones == [zone])
+  }
+
+  @Test func makeWatchZoneListViewModel_onConvertLocalZones_reopensConversionSheet() {
+    let sut = makeSUT()
+    let vm = sut.makeWatchZoneListViewModel()
+
+    vm.convertLocalZones()
+
+    #expect(sut.isDeviceLocalZoneConversionPresented)
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorDeviceLocalZonePrefillTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorDeviceLocalZonePrefillTests.swift
@@ -1,0 +1,144 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+/// GH#879 Phase 5: the onboarding wizard prefers an active device-local zone
+/// (GH#879 Phase 4) over the legacy single ``AnonymousBrowseState`` blob, and
+/// clears the converted zone only once `completeOnboarding()` has actually
+/// saved it server-side — never merely on wizard construction (abandoning
+/// the wizard mid-flow must not silently lose the user's data).
+@Suite("AppCoordinator -- Device-Local Zone Prefill (GH#879 Phase 5)")
+@MainActor
+struct AppCoordinatorDeviceLocalZonePrefillTests {
+  private func makeSUT(
+    deviceLocalZoneRepository: SpyDeviceLocalZoneRepository? = nil,
+    anonymousBrowseStateRepository: SpyAnonymousBrowseStateRepository? = nil
+  ) -> AppCoordinator {
+    AppCoordinator(
+      repository: SpyPlanningApplicationRepository(),
+      authService: SpyAuthenticationService(),
+      subscriptionService: SpySubscriptionService(),
+      userProfileRepository: SpyUserProfileRepository(),
+      watchZoneRepository: SpyWatchZoneRepository(),
+      geocoder: SpyPostcodeGeocoder(),
+      onboardingRepository: SpyOnboardingRepository(),
+      notificationService: SpyNotificationService(),
+      appVersionProvider: SpyAppVersionProvider(),
+      versionConfigService: SpyVersionConfigService(),
+      anonymousBrowseStateRepository: anonymousBrowseStateRepository,
+      deviceLocalZoneRepository: deviceLocalZoneRepository
+    )
+  }
+
+  private func makeZone(
+    id: String = "zone-a", name: String = "Home", radiusMetres: Double = 1500
+  ) throws -> DeviceLocalZone {
+    try DeviceLocalZone(
+      id: DeviceLocalZoneId(id), name: name, centre: .cambridge, radiusMetres: radiusMetres)
+  }
+
+  // MARK: - Prefers the active DeviceLocalZone over legacy state
+
+  @Test func makeOnboardingViewModel_withActiveDeviceLocalZone_prefillsFromIt() throws {
+    let localRepo = SpyDeviceLocalZoneRepository()
+    let zone = try makeZone(name: "Mum's House", radiusMetres: 1500)
+    localRepo.loadAllResult = [zone]
+    localRepo.activeZoneIdResult = zone.id
+    let sut = makeSUT(deviceLocalZoneRepository: localRepo)
+
+    let vm = sut.makeOnboardingViewModel()
+
+    #expect(vm.postcodeInput == "Mum's House")
+    #expect(vm.geocodedCoordinate == .cambridge)
+    #expect(vm.currentStep == .radiusPicker)
+    #expect(vm.selectedRadiusMetres == 1500)
+  }
+
+  @Test func makeOnboardingViewModel_withActiveDeviceLocalZone_ignoresLegacyState() throws {
+    let localRepo = SpyDeviceLocalZoneRepository()
+    let zone = try makeZone(name: "Mum's House")
+    localRepo.loadAllResult = [zone]
+    localRepo.activeZoneIdResult = zone.id
+    let legacyRepo = SpyAnonymousBrowseStateRepository()
+    legacyRepo.loadResult = AnonymousBrowseState(
+      postcode: try Postcode("CB1 2AD"), coordinate: .cambridge, createdAt: Date())
+    let sut = makeSUT(deviceLocalZoneRepository: localRepo, anonymousBrowseStateRepository: legacyRepo)
+
+    let vm = sut.makeOnboardingViewModel()
+
+    #expect(vm.postcodeInput == "Mum's House")
+    // The legacy blob is left completely untouched when a device-local zone
+    // takes priority — never read, never cleared.
+    #expect(legacyRepo.loadCallCount == 0)
+    #expect(legacyRepo.clearCallCount == 0)
+  }
+
+  @Test func makeOnboardingViewModel_withActiveDeviceLocalZone_doesNotDeleteAtConstructionTime() throws {
+    let localRepo = SpyDeviceLocalZoneRepository()
+    let zone = try makeZone()
+    localRepo.loadAllResult = [zone]
+    localRepo.activeZoneIdResult = zone.id
+    let sut = makeSUT(deviceLocalZoneRepository: localRepo)
+
+    _ = sut.makeOnboardingViewModel()
+
+    #expect(localRepo.deleteCalls.isEmpty)
+  }
+
+  // MARK: - Falls back to legacy state
+
+  @Test func makeOnboardingViewModel_noActiveDeviceLocalZone_fallsBackToLegacyState() throws {
+    let localRepo = SpyDeviceLocalZoneRepository()  // no zones, no active id
+    let legacyRepo = SpyAnonymousBrowseStateRepository()
+    let postcode = try Postcode("CB1 2AD")
+    legacyRepo.loadResult = AnonymousBrowseState(
+      postcode: postcode, coordinate: .cambridge, radiusMetres: 1200, createdAt: Date())
+    let sut = makeSUT(deviceLocalZoneRepository: localRepo, anonymousBrowseStateRepository: legacyRepo)
+
+    let vm = sut.makeOnboardingViewModel()
+
+    #expect(vm.postcodeInput == "CB1 2AD")
+    #expect(vm.selectedRadiusMetres == 1200)
+    #expect(legacyRepo.clearCallCount == 1)
+  }
+
+  @Test func makeOnboardingViewModel_noDeviceLocalZoneRepositoryInjected_fallsBackToLegacyState() throws {
+    let legacyRepo = SpyAnonymousBrowseStateRepository()
+    legacyRepo.loadResult = AnonymousBrowseState(
+      postcode: try Postcode("CB1 2AD"), coordinate: .cambridge, createdAt: Date())
+    let sut = makeSUT(anonymousBrowseStateRepository: legacyRepo)
+
+    let vm = sut.makeOnboardingViewModel()
+
+    #expect(vm.postcodeInput == "CB1 2AD")
+    #expect(legacyRepo.clearCallCount == 1)
+  }
+
+  // MARK: - Deferred clearing on completeOnboarding()
+
+  @Test func completeOnboarding_deletesOnlyTheConvertedActiveZone() throws {
+    let localRepo = SpyDeviceLocalZoneRepository()
+    let active = try makeZone(id: "zone-a", name: "Home")
+    let other = try makeZone(id: "zone-b", name: "Work")
+    localRepo.loadAllResult = [active, other]
+    localRepo.activeZoneIdResult = active.id
+    let sut = makeSUT(deviceLocalZoneRepository: localRepo)
+    _ = sut.makeOnboardingViewModel()
+
+    sut.completeOnboarding()
+
+    #expect(localRepo.deleteCalls == [active.id])
+  }
+
+  @Test func completeOnboarding_withNoPrefilledDeviceLocalZone_deletesNothing() {
+    let localRepo = SpyDeviceLocalZoneRepository()
+    let sut = makeSUT(deviceLocalZoneRepository: localRepo)
+    _ = sut.makeOnboardingViewModel()
+
+    sut.completeOnboarding()
+
+    #expect(localRepo.deleteCalls.isEmpty)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/DeviceLocalZoneConversionViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/DeviceLocalZoneConversionViewModelTests.swift
@@ -1,0 +1,180 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+/// GH#879 Phase 5: the post-signup "Add your other areas" conversion sheet.
+/// Offers device-local zones the wizard didn't already convert for
+/// server-side creation — sequential saves, in list order, stopping at the
+/// first tier-quota breach and leaving everything from that point on in
+/// local storage untouched.
+@Suite("DeviceLocalZoneConversionViewModel")
+@MainActor
+struct DeviceLocalZoneConversionViewModelTests {
+  private func makeZone(id: String, name: String, radiusMetres: Double = 1000) throws -> DeviceLocalZone {
+    try DeviceLocalZone(
+      id: DeviceLocalZoneId(id), name: name, centre: .cambridge, radiusMetres: radiusMetres)
+  }
+
+  private func makeSUT(zones: [DeviceLocalZone]) -> (
+    DeviceLocalZoneConversionViewModel, SpyWatchZoneRepository, SpyDeviceLocalZoneRepository
+  ) {
+    let watchZoneRepo = SpyWatchZoneRepository()
+    let localRepo = SpyDeviceLocalZoneRepository()
+    let sut = DeviceLocalZoneConversionViewModel(
+      zones: zones,
+      watchZoneRepository: watchZoneRepo,
+      deviceLocalZoneRepository: localRepo
+    )
+    return (sut, watchZoneRepo, localRepo)
+  }
+
+  // MARK: - Initial state
+
+  @Test func zones_seededFromInit() throws {
+    let zone = try makeZone(id: "a", name: "Home")
+    let (sut, _, _) = makeSUT(zones: [zone])
+
+    #expect(sut.zones == [zone])
+    #expect(!sut.isConverting)
+  }
+
+  // MARK: - Sequential conversion, all succeed
+
+  @Test func convertAll_savesEachZoneSequentiallyInListOrder() async throws {
+    let zoneA = try makeZone(id: "a", name: "Home")
+    let zoneB = try makeZone(id: "b", name: "Work")
+    let (sut, watchZoneRepo, _) = makeSUT(zones: [zoneA, zoneB])
+
+    await sut.convertAll()
+
+    #expect(watchZoneRepo.saveCalls.count == 2)
+    #expect(watchZoneRepo.saveCalls[0].name == "Home")
+    #expect(watchZoneRepo.saveCalls[1].name == "Work")
+  }
+
+  @Test func convertAll_deletesEachConvertedZoneFromLocalStorageImmediately() async throws {
+    let zoneA = try makeZone(id: "a", name: "Home")
+    let zoneB = try makeZone(id: "b", name: "Work")
+    let (sut, _, localRepo) = makeSUT(zones: [zoneA, zoneB])
+
+    await sut.convertAll()
+
+    #expect(localRepo.deleteCalls == [zoneA.id, zoneB.id])
+  }
+
+  @Test func convertAll_removesConvertedZonesFromPublishedList() async throws {
+    let zoneA = try makeZone(id: "a", name: "Home")
+    let zoneB = try makeZone(id: "b", name: "Work")
+    let (sut, _, _) = makeSUT(zones: [zoneA, zoneB])
+
+    await sut.convertAll()
+
+    #expect(sut.zones.isEmpty)
+  }
+
+  @Test func convertAll_whenAllSucceed_invokesOnFinished() async throws {
+    let zone = try makeZone(id: "a", name: "Home")
+    let (sut, _, _) = makeSUT(zones: [zone])
+    var finished = false
+    sut.onFinished = { finished = true }
+
+    await sut.convertAll()
+
+    #expect(finished)
+    #expect(!sut.isConverting)
+  }
+
+  @Test func convertAll_constructsWatchZoneFromDeviceLocalZoneNameCentreRadius() async throws {
+    let zone = try makeZone(id: "a", name: "Mum's House", radiusMetres: 1500)
+    let (sut, watchZoneRepo, _) = makeSUT(zones: [zone])
+
+    await sut.convertAll()
+
+    let saved = try #require(watchZoneRepo.saveCalls.first)
+    #expect(saved.name == "Mum's House")
+    #expect(saved.centre == zone.centre)
+    #expect(saved.radiusMetres == 1500)
+    // Reuses exactly the same "no authorityId, let the server resolve it
+    // from lat/lng" path the wizard and authed editor already use.
+    #expect(saved.authorityId == 0)
+  }
+
+  // MARK: - Quota breach stops conversion
+
+  @Test func convertAll_onInsufficientEntitlement_stopsAndInvokesCallback() async throws {
+    let zoneA = try makeZone(id: "a", name: "Home")
+    let zoneB = try makeZone(id: "b", name: "Work")
+    let zoneC = try makeZone(id: "c", name: "Allotment")
+    let (sut, watchZoneRepo, _) = makeSUT(zones: [zoneA, zoneB, zoneC])
+    watchZoneRepo.saveResults = [
+      .success(()),
+      .failure(DomainError.insufficientEntitlement(required: "personal")),
+    ]
+    var entitlementRouted = false
+    sut.onInsufficientEntitlement = { entitlementRouted = true }
+    var finished = false
+    sut.onFinished = { finished = true }
+
+    await sut.convertAll()
+
+    #expect(entitlementRouted)
+    #expect(!finished)
+    // Only the first zone was attempted+converted; the second attempt failed
+    // and the third was never reached.
+    #expect(watchZoneRepo.saveCalls.count == 2)
+    #expect(!sut.isConverting)
+  }
+
+  @Test func convertAll_onInsufficientEntitlement_leavesTriggeringAndLaterZonesLocal() async throws {
+    let zoneA = try makeZone(id: "a", name: "Home")
+    let zoneB = try makeZone(id: "b", name: "Work")
+    let zoneC = try makeZone(id: "c", name: "Allotment")
+    let (sut, watchZoneRepo, localRepo) = makeSUT(zones: [zoneA, zoneB, zoneC])
+    watchZoneRepo.saveResults = [
+      .success(()),
+      .failure(DomainError.insufficientEntitlement(required: "personal")),
+    ]
+
+    await sut.convertAll()
+
+    // Only the successfully-converted zone was deleted locally.
+    #expect(localRepo.deleteCalls == [zoneA.id])
+    // The zone that hit the quota, and the one after it, stay in the
+    // published list untouched — never silently discarded.
+    #expect(sut.zones == [zoneB, zoneC])
+  }
+
+  // MARK: - Generic failure also stops conversion (never silently discard data)
+
+  @Test func convertAll_onGenericFailure_stopsAndSetsError() async throws {
+    let zoneA = try makeZone(id: "a", name: "Home")
+    let zoneB = try makeZone(id: "b", name: "Work")
+    let (sut, watchZoneRepo, localRepo) = makeSUT(zones: [zoneA, zoneB])
+    watchZoneRepo.saveResults = [.failure(DomainError.networkUnavailable)]
+
+    await sut.convertAll()
+
+    #expect(sut.error == .networkUnavailable)
+    #expect(localRepo.deleteCalls.isEmpty)
+    #expect(sut.zones == [zoneA, zoneB])
+    #expect(!sut.isConverting)
+  }
+
+  // MARK: - Explicit dismiss
+
+  @Test func dismiss_invokesOnFinishedWithoutConvertingAnything() async throws {
+    let zone = try makeZone(id: "a", name: "Home")
+    let (sut, watchZoneRepo, localRepo) = makeSUT(zones: [zone])
+    var finished = false
+    sut.onFinished = { finished = true }
+
+    sut.dismiss()
+
+    #expect(finished)
+    #expect(watchZoneRepo.saveCalls.isEmpty)
+    #expect(localRepo.deleteCalls.isEmpty)
+    #expect(sut.zones == [zone])
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/DeviceLocalZoneConversionViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/DeviceLocalZoneConversionViewTests.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+@Suite("DeviceLocalZoneConversionView")
+@MainActor
+struct DeviceLocalZoneConversionViewTests {
+  private func makeZone(name: String = "Home") throws -> DeviceLocalZone {
+    try DeviceLocalZone(name: name, centre: .cambridge, radiusMetres: 1000)
+  }
+
+  private func makeViewModel(zones: [DeviceLocalZone]) -> DeviceLocalZoneConversionViewModel {
+    DeviceLocalZoneConversionViewModel(
+      zones: zones,
+      watchZoneRepository: SpyWatchZoneRepository(),
+      deviceLocalZoneRepository: SpyDeviceLocalZoneRepository()
+    )
+  }
+
+  @Test func body_renders_withZones() throws {
+    let vm = makeViewModel(zones: [try makeZone(name: "Home"), try makeZone(name: "Work")])
+    let sut = DeviceLocalZoneConversionView(viewModel: vm)
+    _ = sut.body
+  }
+
+  @Test func body_renders_whenEmpty() {
+    let vm = makeViewModel(zones: [])
+    let sut = DeviceLocalZoneConversionView(viewModel: vm)
+    _ = sut.body
+  }
+
+  @Test func body_renders_whileConverting() async throws {
+    let vm = makeViewModel(zones: [try makeZone()])
+    await vm.convertAll()
+    let sut = DeviceLocalZoneConversionView(viewModel: vm)
+    _ = sut.body
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/OnboardingViewModelDeviceLocalZonePrefillTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/OnboardingViewModelDeviceLocalZonePrefillTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+/// GH#879 Phase 5: seeding the wizard from an active ``DeviceLocalZone``
+/// (name/centre/radius) rather than the legacy single ``AnonymousBrowseState``
+/// blob. Split from `OnboardingViewModelTests` to stay under the project's
+/// file-length limit.
+@Suite("OnboardingViewModel -- Device-Local Zone Prefill")
+@MainActor
+struct OnboardingViewModelDeviceLocalZonePrefillTests {
+  private func makeSUT() -> (OnboardingViewModel, SpyWatchZoneRepository) {
+    let zoneRepo = SpyWatchZoneRepository()
+    let vm = OnboardingViewModel(
+      geocoder: SpyPostcodeGeocoder(),
+      watchZoneRepository: zoneRepo,
+      onboardingRepository: SpyOnboardingRepository(),
+      notificationService: SpyNotificationService()
+    )
+    return (vm, zoneRepo)
+  }
+
+  @Test func prefillByName_seedsNameAndCoordinate_andJumpsToRadiusPicker() throws {
+    let (sut, _) = makeSUT()
+    let coordinate = try Coordinate(latitude: 52.2053, longitude: 0.1218)
+
+    sut.prefill(name: "Mum's House", coordinate: coordinate, radiusMetres: 1500)
+
+    #expect(sut.postcodeInput == "Mum's House")
+    #expect(sut.geocodedCoordinate == coordinate)
+    #expect(sut.currentStep == .radiusPicker)
+    #expect(sut.selectedRadiusMetres == 1500)
+  }
+
+  @Test func prefillByName_thenConfirmRadius_createsZoneWithThatName() async throws {
+    let (sut, _) = makeSUT()
+    let coordinate = try Coordinate(latitude: 52.2053, longitude: 0.1218)
+    sut.prefill(name: "Mum's House", coordinate: coordinate, radiusMetres: 1500)
+
+    var completedZone: WatchZone?
+    sut.onComplete = { zone in completedZone = zone }
+    sut.confirmRadius()
+    await sut.skipNotifications()
+
+    #expect(completedZone != nil)
+    #expect(completedZone?.name == "Mum's House")
+    #expect(completedZone?.centre == coordinate)
+    #expect(completedZone?.radiusMetres == 1500)
+  }
+
+  @Test func prefillByName_withRadiusAboveTierMax_clampsToMaxRadiusMetres() throws {
+    let (sut, _) = makeSUT()
+    let coordinate = try Coordinate(latitude: 52.2053, longitude: 0.1218)
+
+    sut.prefill(name: "Mum's House", coordinate: coordinate, radiusMetres: 5000)
+
+    #expect(sut.selectedRadiusMetres == 2000)
+  }
+
+  @Test func prefillByName_withRadiusBelowMinimum_clampsTo100() throws {
+    let (sut, _) = makeSUT()
+    let coordinate = try Coordinate(latitude: 52.2053, longitude: 0.1218)
+
+    sut.prefill(name: "Mum's House", coordinate: coordinate, radiusMetres: 10)
+
+    #expect(sut.selectedRadiusMetres == 100)
+  }
+
+  @Test func confirmRadius_withoutAnyPrefillOrPostcode_doesNothing() {
+    // Guards against a stray confirmRadius() call before either prefill path
+    // or submitPostcode() ever ran — should never crash or fabricate a zone.
+    let (sut, _) = makeSUT()
+
+    sut.confirmRadius()
+
+    #expect(sut.currentStep == .welcome)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/WatchZoneListViewModelDeviceLocalZoneRowTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WatchZoneListViewModelDeviceLocalZoneRowTests.swift
@@ -1,0 +1,126 @@
+import Foundation
+import Testing
+
+@testable import TownCrierDomain
+@testable import TownCrierPresentation
+
+/// GH#879 Phase 5: the authed Zones tab's dismissible "N areas from before
+/// you signed up" row — visible while any device-local zones remain
+/// unconverted, dismissible for the session, and re-shown next launch (a
+/// fresh view-model instance) while zones still remain.
+@MainActor
+@Suite("WatchZoneListViewModel -- Device-Local Zone Row")
+struct WatchZoneListViewModelDeviceLocalZoneRowTests {
+  private func makeLocalZone(name: String = "Home") throws -> DeviceLocalZone {
+    try DeviceLocalZone(name: name, centre: .cambridge, radiusMetres: 1000)
+  }
+
+  @Test func load_withNoDeviceLocalZoneRepository_neverShowsRow() async {
+    let sut = WatchZoneListViewModel(
+      repository: SpyWatchZoneRepository(),
+      featureGate: FeatureGate(tier: .free)
+    )
+
+    await sut.load()
+
+    #expect(!sut.showsLocalZoneRow)
+    #expect(sut.unconvertedLocalZones.isEmpty)
+  }
+
+  @Test func load_withUnconvertedLocalZones_populatesThemAndShowsRow() async throws {
+    let localRepo = SpyDeviceLocalZoneRepository()
+    let zone = try makeLocalZone(name: "Work")
+    localRepo.loadAllResult = [zone]
+    let sut = WatchZoneListViewModel(
+      repository: SpyWatchZoneRepository(),
+      featureGate: FeatureGate(tier: .free),
+      deviceLocalZoneRepository: localRepo
+    )
+
+    await sut.load()
+
+    #expect(sut.unconvertedLocalZones == [zone])
+    #expect(sut.showsLocalZoneRow)
+  }
+
+  @Test func load_withNoUnconvertedLocalZones_doesNotShowRow() async {
+    let localRepo = SpyDeviceLocalZoneRepository()
+    localRepo.loadAllResult = []
+    let sut = WatchZoneListViewModel(
+      repository: SpyWatchZoneRepository(),
+      featureGate: FeatureGate(tier: .free),
+      deviceLocalZoneRepository: localRepo
+    )
+
+    await sut.load()
+
+    #expect(!sut.showsLocalZoneRow)
+  }
+
+  @Test func dismissLocalZoneRow_hidesRowForTheSession() async throws {
+    let localRepo = SpyDeviceLocalZoneRepository()
+    localRepo.loadAllResult = [try makeLocalZone()]
+    let sut = WatchZoneListViewModel(
+      repository: SpyWatchZoneRepository(),
+      featureGate: FeatureGate(tier: .free),
+      deviceLocalZoneRepository: localRepo
+    )
+    await sut.load()
+    #expect(sut.showsLocalZoneRow)
+
+    sut.dismissLocalZoneRow()
+
+    #expect(!sut.showsLocalZoneRow)
+  }
+
+  @Test func dismissLocalZoneRow_thenReload_staysDismissed() async throws {
+    let localRepo = SpyDeviceLocalZoneRepository()
+    localRepo.loadAllResult = [try makeLocalZone()]
+    let sut = WatchZoneListViewModel(
+      repository: SpyWatchZoneRepository(),
+      featureGate: FeatureGate(tier: .free),
+      deviceLocalZoneRepository: localRepo
+    )
+    await sut.load()
+    sut.dismissLocalZoneRow()
+
+    // A pull-to-refresh (another load()) must not un-dismiss the row within
+    // the same session — only a fresh VM instance (next launch) resets it.
+    await sut.load()
+
+    #expect(!sut.showsLocalZoneRow)
+  }
+
+  @Test func load_withZonesRemainingAfterConversion_clearsRow() async throws {
+    let localRepo = SpyDeviceLocalZoneRepository()
+    localRepo.loadAllResult = [try makeLocalZone()]
+    let sut = WatchZoneListViewModel(
+      repository: SpyWatchZoneRepository(),
+      featureGate: FeatureGate(tier: .free),
+      deviceLocalZoneRepository: localRepo
+    )
+    await sut.load()
+    #expect(sut.showsLocalZoneRow)
+
+    // All remaining zones converted or deleted elsewhere; a later load()
+    // (e.g. the coordinator's post-conversion refresh) must clear the row.
+    localRepo.loadAllResult = []
+    await sut.load()
+
+    #expect(!sut.showsLocalZoneRow)
+    #expect(sut.unconvertedLocalZones.isEmpty)
+  }
+
+  @Test func convertLocalZones_invokesOnConvertLocalZones() {
+    let sut = WatchZoneListViewModel(
+      repository: SpyWatchZoneRepository(),
+      featureGate: FeatureGate(tier: .free)
+    )
+    var invoked = false
+    sut.onConvertLocalZones = { invoked = true }
+
+    sut.convertLocalZones()
+
+    #expect(invoked)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/WatchZoneListViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WatchZoneListViewTests.swift
@@ -70,4 +70,25 @@ struct WatchZoneListViewTests {
     let sut = WatchZoneListView(viewModel: vm)
     _ = sut.body
   }
+
+  // MARK: - Unconverted device-local zones row (GH#879 Phase 5)
+
+  @Test func body_renders_whenLocalZoneRowShown() async throws {
+    let spy = SpyWatchZoneRepository()
+    let localRepo = SpyDeviceLocalZoneRepository()
+    localRepo.loadAllResult = [
+      try DeviceLocalZone(name: "Home", centre: .cambridge, radiusMetres: 1000)
+    ]
+    let vm = WatchZoneListViewModel(
+      repository: spy,
+      featureGate: FeatureGate(tier: .free),
+      deviceLocalZoneRepository: localRepo
+    )
+    await vm.load()
+
+    #expect(vm.showsLocalZoneRow)
+
+    let sut = WatchZoneListView(viewModel: vm)
+    _ = sut.body
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Spies/SpyWatchZoneRepository.swift
+++ b/mobile/ios/town-crier-tests/Sources/Spies/SpyWatchZoneRepository.swift
@@ -4,10 +4,19 @@ import TownCrierDomain
 final class SpyWatchZoneRepository: WatchZoneRepository, @unchecked Sendable {
   private(set) var saveCalls: [WatchZone] = []
   var saveResult: Result<Void, Error> = .success(())
+  /// Per-call results consumed in order, one per `save(_:)` invocation —
+  /// lets a test script a sequence (e.g. "first zone succeeds, second hits
+  /// the quota"). Falls back to `saveResult` once exhausted (or if never
+  /// set), so existing single-result tests are unaffected.
+  var saveResults: [Result<Void, Error>] = []
 
   func save(_ zone: WatchZone) async throws {
     saveCalls.append(zone)
-    try saveResult.get()
+    if saveCalls.count <= saveResults.count {
+      try saveResults[saveCalls.count - 1].get()
+    } else {
+      try saveResult.get()
+    }
   }
 
   private(set) var updateCalls: [WatchZone] = []


### PR DESCRIPTION
## Changes
- The onboarding wizard now prefills from the ACTIVE device-local zone (name, centre, radius) in preference to the legacy anonymous browse state, and removes the local zone only after its server watch zone is actually created — never at wizard construction (GH #879 Phase 5, bead tc-hq9h7.5).
- After the wizard, a one-time "Add your other areas" sheet converts remaining local zones sequentially via the authed watch-zone repository; a quota `insufficientEntitlement` routes to the View Plans paywall and stops the run, leaving unconverted zones safely on-device.
- The authenticated Zones tab shows a dismissible row ("N areas from before you signed up") while unconverted local zones remain, reopening the conversion sheet; session-only dismissal, clears when none remain. User-created data is never silently discarded.
- `SelfSizingSheet` widened to `public` (cross-module use from the app shell — caught by the xcodebuild gate, invisible to `swift build`).

## Verification
- 1779 Swift Testing tests green (all Phase 5 acceptance criteria covered: prefill preference + convert-then-clear, sequential conversion + paywall stop, row lifecycle); CI-pinned SwiftLint 0.63.2 clean; xcodebuild sim build green.
- Live sim verification: anonymous-shell regression PASS, local-zone storage compatibility PASS (seeded zones read + rendered + editable), zero new crash logs. The fresh-signup and authed-conversion legs are not reachable by the simulator driver (Auth0 hosted webview) — tracked for a real-device pass in tc-785hn alongside the equivalent #868 residual.

Closes the last phase of #879.

Release-Note: The areas you saved before signing up now carry over — we'll offer to turn them into real watch zones after you create your account.

---
*Auto-shipped via ship skill*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ApYCEogBeZYu7UP4LEouyW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a post-signup “Add your other areas” flow to convert saved device-local areas into watch zones.
  * The Zones tab can now show remaining local areas and reopen the conversion sheet.
  * Onboarding now pre-fills from an existing saved area name, location, and radius when available.

* **Bug Fixes**
  * Improved handling of subscription limits during conversion by directing users to the paywall.
  * Better preserves and refreshes area data after conversion, with clearer dismiss and retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->