### PR TITLE
fix: TestFlight changelog no longer truncates squash-wrapped Release-Note trailers

### DIFF
--- a/scripts/ios-release-notes.sh
+++ b/scripts/ios-release-notes.sh
@@ -45,11 +45,36 @@ fi
 STOCK="Bug fixes and performance improvements."
 
 # --- Source 1: authored Release-Note: trailers (verbatim, any commit) --------
-# `|| true` guards against grep exiting 1 (no match) tripping pipefail.
+# GitHub hard-wraps squash-commit bodies at ~72 chars, so a trailer authored as
+# one line can arrive wrapped across several. Join continuation lines until the
+# paragraph ends: a blank line, another `Key:` trailer, or a markdown-ish line
+# (`---` rule, list bullet, heading, HTML comment). A directly following
+# Release-Note: line starts a new note rather than being swallowed.
 trailer_notes="$(
   git log --format='%B' "$RANGE" 2>/dev/null \
-    | grep -iE '^Release-Note:' \
-    | sed -E 's/^[Rr]elease-[Nn]ote:[[:space:]]*//' || true
+    | awk '
+        function flush() { if (collecting) { print note; collecting = 0 } }
+        {
+          if (collecting) {
+            if ($0 ~ /^[[:space:]]*$/ \
+                || $0 ~ /^[[:alnum:]][[:alnum:]-]*:([[:space:]]|$)/ \
+                || $0 ~ /^(---|\*|-[[:space:]]|#|<|`)/) {
+              flush()
+            } else {
+              sub(/[[:space:]]+$/, "")
+              note = note " " $0
+              next
+            }
+          }
+          if ($0 ~ /^[Rr]elease-[Nn]ote:[[:space:]]*/) {
+            note = $0
+            sub(/^[Rr]elease-[Nn]ote:[[:space:]]*/, "", note)
+            sub(/[[:space:]]+$/, "", note)
+            collecting = 1
+          }
+        }
+        END { flush() }
+      ' || true
 )"
 
 # --- Source 2: cleaned mobile/ios subjects for commits WITHOUT a trailer -----


### PR DESCRIPTION
## Changes
- GitHub hard-wraps squash-commit bodies at ~72 chars, so `Release-Note:` trailers longer than one line arrive wrapped — and `scripts/ios-release-notes.sh` grepped single lines, truncating every such changelog entry mid-sentence (bead tc-oyhxw).
- Source 1 now joins continuation lines via an awk state machine (paragraph ends at a blank line, another `Key:` trailer, or a markdown-ish line; consecutive `Release-Note:` lines each start a new note).
- Verified against real history: all six trailers from today's PRs (#881–#886) now emit complete sentences, and the v0.16.3..v0.16.5 range recovers PR #876's previously truncated entry ("…group together as you zoom out").

---
*Auto-shipped via ship skill*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ApYCEogBeZYu7UP4LEouyW