### PR TITLE
feat: pause over-quota watch zones, Go phase (GH #889 P1)

### DIFF
--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -279,10 +279,14 @@ func newRouter(
 		// when the profile store is genuinely present — passing a typed-nil
 		// *profiles.PostgresStore would wrap into a non-nil interface and defeat the
 		// handler's nil-check (the same typed-nil gotcha guarded for the saved
-		// store above).
+		// store above). The list/patch handlers read the same store to compute
+		// each zone's derived "paused" field (GH#889): a downgrade that leaves a
+		// user over their new tier's watch-zone limit pauses the over-quota zones
+		// in API responses without deleting or mutating them.
 		zoneOpts := []watchzones.Option{watchzones.WithMetricsRecorder(registry)}
 		if store != nil {
 			zoneOpts = append(zoneOpts, watchzones.WithProfileCAS(store))
+			zoneOpts = append(zoneOpts, watchzones.WithProfileReader(store))
 		}
 		watchzones.Routes(mux, watchZoneStore, logger, zoneOpts...)
 		// application-authorities derives from the user's watch zones plus the

--- a/api-go/internal/notifydispatch/decision_test.go
+++ b/api-go/internal/notifydispatch/decision_test.go
@@ -14,11 +14,16 @@ import (
 // fakeZones serves the cross-partition zone-containment lookup. Matching is
 // purely geographic (tc-b179): the lookup no longer takes an authority, so the
 // fake returns its zones regardless of which authority the app is tagged with.
+// GetByUserID (GH#889) filters zones by owner, mirroring the real store's
+// per-user scoping, and records whether it was called so tests can assert the
+// unlimited-tier fast path skips it.
 type fakeZones struct {
-	zones    []watchzones.WatchZone
-	queryErr error
-	lastLat  float64
-	lastLng  float64
+	zones             []watchzones.WatchZone
+	queryErr          error
+	lastLat           float64
+	lastLng           float64
+	getByUserIDCalled bool
+	getByUserIDErr    error
 }
 
 func (f *fakeZones) FindZonesContaining(_ context.Context, lat, lng float64) ([]watchzones.WatchZone, error) {
@@ -28,6 +33,20 @@ func (f *fakeZones) FindZonesContaining(_ context.Context, lat, lng float64) ([]
 		return nil, f.queryErr
 	}
 	return f.zones, nil
+}
+
+func (f *fakeZones) GetByUserID(_ context.Context, userID string) ([]watchzones.WatchZone, error) {
+	f.getByUserIDCalled = true
+	if f.getByUserIDErr != nil {
+		return nil, f.getByUserIDErr
+	}
+	var owned []watchzones.WatchZone
+	for _, z := range f.zones {
+		if z.UserID == userID {
+			owned = append(owned, z)
+		}
+	}
+	return owned, nil
 }
 
 // fakeSaved serves the cross-partition saved-bookmark lookup.

--- a/api-go/internal/notifydispatch/enqueuer.go
+++ b/api-go/internal/notifydispatch/enqueuer.go
@@ -27,6 +27,8 @@ package notifydispatch
 import (
 	"context"
 	"log/slog"
+	"math"
+	"sort"
 	"time"
 
 	"github.com/AmyDe/town-crier/api-go/internal/applications"
@@ -47,6 +49,16 @@ type notificationWriter interface {
 // paid-only) and the push preference. *profiles.CosmosStore satisfies it.
 type profileReader interface {
 	Get(ctx context.Context, userID string) (*profiles.UserProfile, error)
+}
+
+// zoneRanker is the consumer-side slice of the watch-zone store the enqueuer
+// needs: zoneMatcher's point-in-zone lookup plus GetByUserID, which the pause
+// check (GH#889) uses to rank a user's zones oldest-first by (CreatedAt, ID)
+// against their effective-tier watch-zone limit. *watchzones.PostgresStore
+// (and the watchzones.Store interface cmd/worker wires) satisfy both.
+type zoneRanker interface {
+	zoneMatcher
+	GetByUserID(ctx context.Context, userID string) ([]watchzones.WatchZone, error)
 }
 
 // pushQueue is the consumer-side contract the dispatchers hand an already
@@ -73,7 +85,7 @@ type notificationMetricsRecorder interface {
 // EnqueueForApplication runs the per-app zone fan-out the poll handler calls.
 type Enqueuer struct {
 	notifications notificationWriter
-	zones         zoneMatcher
+	zones         zoneRanker
 	profiles      profileReader
 	push          pushQueue
 	newID         func() string
@@ -96,7 +108,7 @@ func (e *Enqueuer) WithMetrics(rec notificationMetricsRecorder) *Enqueuer {
 // can pin them.
 func NewEnqueuer(
 	notifs notificationWriter,
-	zones zoneMatcher,
+	zones zoneRanker,
 	profs profileReader,
 	push pushQueue,
 	newID func() string,
@@ -163,6 +175,26 @@ func (e *Enqueuer) Enqueue(ctx context.Context, app applications.PlanningApplica
 		return nil
 	}
 
+	// Pause check (GH#889): a subscription downgrade that leaves a user
+	// holding more zones than their new tier allows must stop generating NEW
+	// notification records for the over-quota zones — ranked oldest-first by
+	// (CreatedAt, ID) — without touching the zones themselves (they stay
+	// listed, editable and browsable; watchzones.handler surfaces the same
+	// derivation as the "paused" field). The unlimited (Pro) tier never needs
+	// the extra ranking query.
+	limit := profile.EffectiveTier(e.now()).WatchZoneLimit()
+	if limit < math.MaxInt32 {
+		userZones, zerr := e.zones.GetByUserID(ctx, zone.UserID)
+		if zerr != nil {
+			return zerr
+		}
+		if len(userZones) > limit && isPaused(userZones, zone.ID, limit) {
+			e.logger.DebugContext(ctx, "enqueue: zone paused (over quota), skipping",
+				"user", zone.UserID, "zone", zone.ID, "limit", limit)
+			return nil
+		}
+	}
+
 	zoneID := zone.ID
 	n := newRecord(recordInput{
 		id:          e.newID(),
@@ -191,4 +223,27 @@ func (e *Enqueuer) Enqueue(ctx context.Context, app applications.PlanningApplica
 		e.metrics.NotificationCreated(ctx, string(n.EventType), n.Sources)
 	}
 	return nil
+}
+
+// isPaused reports whether the zone identified by zoneID is paused (GH#889):
+// ranked oldest-first by (CreatedAt, ID) among zones (the owning user's full
+// zone set), its rank exceeds limit. The caller only invokes this once it has
+// already confirmed the tier is not unlimited. A zoneID absent from zones
+// (should not happen — the caller passes the user's own zone) fails open
+// (unpaused) rather than blocking a fan-out on a lookup mismatch.
+func isPaused(zones []watchzones.WatchZone, zoneID string, limit int) bool {
+	sorted := make([]watchzones.WatchZone, len(zones))
+	copy(sorted, zones)
+	sort.Slice(sorted, func(i, j int) bool {
+		if !sorted[i].CreatedAt.Equal(sorted[j].CreatedAt) {
+			return sorted[i].CreatedAt.Before(sorted[j].CreatedAt)
+		}
+		return sorted[i].ID < sorted[j].ID
+	})
+	for i, z := range sorted {
+		if z.ID == zoneID {
+			return i >= limit
+		}
+	}
+	return false
 }

--- a/api-go/internal/notifydispatch/enqueuer_test.go
+++ b/api-go/internal/notifydispatch/enqueuer_test.go
@@ -446,7 +446,6 @@ func TestEnqueuer_PersonalTierAtQuota_AllZonesActive(t *testing.T) {
 	allZones := []watchzones.WatchZone{z1, z2, z3}
 
 	for _, z := range allZones {
-		z := z
 		t.Run(z.ID, func(t *testing.T) {
 			t.Parallel()
 			zones := &fakeZones{zones: allZones}
@@ -467,14 +466,13 @@ func TestEnqueuer_ProTierOverTenZones_AllActiveAndSkipsRankingQuery(t *testing.T
 	t.Parallel()
 	// Pro tier is unlimited (math.MaxInt32): every one of the 10 zones must
 	// create a record, and the fast path must never call GetByUserID.
-	var allZones []watchzones.WatchZone
+	allZones := make([]watchzones.WatchZone, 0, 10)
 	for i := range 10 {
 		allZones = append(allZones, testZoneAt(t, strconv.Itoa(i), "auth0|alice",
 			time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC).AddDate(0, 0, i)))
 	}
 
 	for _, z := range allZones {
-		z := z
 		t.Run(z.ID, func(t *testing.T) {
 			t.Parallel()
 			zones := &fakeZones{zones: allZones}

--- a/api-go/internal/notifydispatch/enqueuer_test.go
+++ b/api-go/internal/notifydispatch/enqueuer_test.go
@@ -392,6 +392,137 @@ func TestEnqueuer_Dedup_SkipsWhenAlreadyNotified(t *testing.T) {
 	}
 }
 
+func TestEnqueuer_FreeTierOverQuota_PausesNewerZones(t *testing.T) {
+	t.Parallel()
+	// Free tier (limit 1) with 3 zones ranked oldest-first by (CreatedAt, ID):
+	// only rank 1 (zone-1, the oldest) is active; rank 2 (zone-2) is paused.
+	z1 := testZoneAt(t, "zone-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	z2 := testZoneAt(t, "zone-2", "auth0|alice", time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC))
+	z3 := testZoneAt(t, "zone-3", "auth0|alice", time.Date(2026, 6, 3, 0, 0, 0, 0, time.UTC))
+	allZones := []watchzones.WatchZone{z1, z2, z3}
+
+	t.Run("rank 2 creates no record", func(t *testing.T) {
+		t.Parallel()
+		zones := &fakeZones{zones: allZones}
+		enq, notifs, queue, _ := newEnqueuerHarnessWithZones(t, profiles.TierFree, zones)
+		app := testApplication(t, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
+
+		if err := enq.Enqueue(context.Background(), app, z2); err != nil {
+			t.Fatalf("Enqueue: %v", err)
+		}
+		if len(notifs.created) != 0 {
+			t.Errorf("paused (over-quota) zone must create NO record, got %d", len(notifs.created))
+		}
+		if len(queue.queued) != 0 {
+			t.Errorf("paused zone must not queue a push, got %d", len(queue.queued))
+		}
+		if !zones.getByUserIDCalled {
+			t.Error("bounded (non-unlimited) tier must call GetByUserID to rank the zone")
+		}
+	})
+
+	t.Run("rank 1 creates a record", func(t *testing.T) {
+		t.Parallel()
+		zones := &fakeZones{zones: allZones}
+		enq, notifs, _, _ := newEnqueuerHarnessWithZones(t, profiles.TierFree, zones)
+		app := testApplication(t, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
+
+		if err := enq.Enqueue(context.Background(), app, z1); err != nil {
+			t.Fatalf("Enqueue: %v", err)
+		}
+		if len(notifs.created) != 1 {
+			t.Errorf("the active (rank 1) zone must still create a record, got %d", len(notifs.created))
+		}
+	})
+}
+
+func TestEnqueuer_PersonalTierAtQuota_AllZonesActive(t *testing.T) {
+	t.Parallel()
+	// Personal tier (limit 3) with exactly 3 zones: nobody is over quota, so all
+	// three must still create records.
+	z1 := testZoneAt(t, "zone-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	z2 := testZoneAt(t, "zone-2", "auth0|alice", time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC))
+	z3 := testZoneAt(t, "zone-3", "auth0|alice", time.Date(2026, 6, 3, 0, 0, 0, 0, time.UTC))
+	allZones := []watchzones.WatchZone{z1, z2, z3}
+
+	for _, z := range allZones {
+		z := z
+		t.Run(z.ID, func(t *testing.T) {
+			t.Parallel()
+			zones := &fakeZones{zones: allZones}
+			enq, notifs, _, _ := newEnqueuerHarnessWithZones(t, profiles.TierPersonal, zones)
+			app := testApplication(t, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
+
+			if err := enq.Enqueue(context.Background(), app, z); err != nil {
+				t.Fatalf("Enqueue: %v", err)
+			}
+			if len(notifs.created) != 1 {
+				t.Errorf("zone %s: at-quota Personal tier must still create a record, got %d", z.ID, len(notifs.created))
+			}
+		})
+	}
+}
+
+func TestEnqueuer_ProTierOverTenZones_AllActiveAndSkipsRankingQuery(t *testing.T) {
+	t.Parallel()
+	// Pro tier is unlimited (math.MaxInt32): every one of the 10 zones must
+	// create a record, and the fast path must never call GetByUserID.
+	var allZones []watchzones.WatchZone
+	for i := range 10 {
+		allZones = append(allZones, testZoneAt(t, strconv.Itoa(i), "auth0|alice",
+			time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC).AddDate(0, 0, i)))
+	}
+
+	for _, z := range allZones {
+		z := z
+		t.Run(z.ID, func(t *testing.T) {
+			t.Parallel()
+			zones := &fakeZones{zones: allZones}
+			enq, notifs, _, _ := newEnqueuerHarnessWithZones(t, profiles.TierPro, zones)
+			app := testApplication(t, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
+
+			if err := enq.Enqueue(context.Background(), app, z); err != nil {
+				t.Fatalf("Enqueue: %v", err)
+			}
+			if len(notifs.created) != 1 {
+				t.Errorf("zone %s: Pro (unlimited) tier must still create a record, got %d", z.ID, len(notifs.created))
+			}
+			if zones.getByUserIDCalled {
+				t.Error("unlimited tier must skip the GetByUserID ranking query entirely")
+			}
+		})
+	}
+}
+
+func TestEnqueuer_LapsedPaidTier_RankedAgainstFreeLimit(t *testing.T) {
+	t.Parallel()
+	// Stored Personal (limit 3), but expired with no grace: EffectiveTier
+	// collapses to Free (limit 1), so rank 2 must be paused even though the
+	// stored tier would have allowed it.
+	notifs := newFakeNotifications()
+	profile := profileWithTier(t, "auth0|alice", profiles.TierPersonal)
+	past := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC) // before the harness clock
+	profile.SubscriptionExpiry = &past
+	profs := &fakeProfiles{byID: map[string]*profiles.UserProfile{"auth0|alice": profile}}
+	queue := &fakePushQueue{}
+
+	z1 := testZoneAt(t, "zone-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	z2 := testZoneAt(t, "zone-2", "auth0|alice", time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC))
+	zones := &fakeZones{zones: []watchzones.WatchZone{z1, z2}}
+	enq := NewEnqueuer(notifs, zones, profs, queue,
+		func() string { return "n-1" },
+		func() time.Time { return time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC) },
+		testLogger(t))
+	app := testApplication(t, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
+
+	if err := enq.Enqueue(context.Background(), app, z2); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if len(notifs.created) != 0 {
+		t.Errorf("a lapsed paid tier must be ranked against the Free limit, got %d records for rank-2 zone", len(notifs.created))
+	}
+}
+
 func TestEnqueuer_UnknownProfile_NoRecord(t *testing.T) {
 	t.Parallel()
 	enq, notifs, queue := newEnqueuerHarness(t, profiles.TierPro)

--- a/api-go/internal/watchzones/handler.go
+++ b/api-go/internal/watchzones/handler.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"math"
 	"net/http"
+	"sort"
 	"time"
 
 	"github.com/AmyDe/town-crier/api-go/internal/auth"
@@ -74,6 +76,17 @@ func WithProfileCAS(cas profileCAS) Option {
 	return func(h *handler) { h.profileCAS = cas }
 }
 
+// WithProfileReader wires the profile reader the list/patch handlers use to
+// compute each zone's derived "paused" field (GH#889): a zone whose
+// oldest-first rank among the caller's own zones — by (CreatedAt, ID) —
+// exceeds their current effective-tier watch-zone limit. Mirrors nearby.go's
+// create-path profile read. Not wiring this option leaves h.profiles nil, so
+// every zone reports unpaused (fail open, never block a read on a missing
+// dependency).
+func WithProfileReader(pr profileReader) Option {
+	return func(h *handler) { h.profiles = pr }
+}
+
 // handler serves the /v1/me/watch-zones surface. The auth middleware guarantees
 // a subject in context before these handlers run. The list/update/delete methods
 // use only store + logger; the create and applications methods (nearby.go) use
@@ -96,7 +109,7 @@ type handler struct {
 // (they need the profile, application, geocode, notification-state and
 // notification stores).
 func Routes(mux *http.ServeMux, store zoneStore, logger *slog.Logger, opts ...Option) {
-	h := &handler{store: store, logger: logger}
+	h := &handler{store: store, logger: logger, now: time.Now}
 	for _, opt := range opts {
 		opt(h)
 	}
@@ -106,7 +119,8 @@ func Routes(mux *http.ServeMux, store zoneStore, logger *slog.Logger, opts ...Op
 }
 
 // watchZoneSummary is the per-zone wire shape returned by list and update.
-// createdAt is deliberately absent from the summary.
+// createdAt is deliberately absent from the summary. Paused is additive
+// (GH#889): a derived, never-stored flag — see pausedIDs.
 type watchZoneSummary struct {
 	ID                  string  `json:"id"`
 	Name                string  `json:"name"`
@@ -116,9 +130,10 @@ type watchZoneSummary struct {
 	AuthorityID         int     `json:"authorityId"`
 	PushEnabled         bool    `json:"pushEnabled"`
 	EmailInstantEnabled bool    `json:"emailInstantEnabled"`
+	Paused              bool    `json:"paused"`
 }
 
-func summaryOf(z WatchZone) watchZoneSummary {
+func summaryOf(z WatchZone, paused bool) watchZoneSummary {
 	return watchZoneSummary{
 		ID:                  z.ID,
 		Name:                z.Name,
@@ -128,6 +143,7 @@ func summaryOf(z WatchZone) watchZoneSummary {
 		AuthorityID:         z.AuthorityID,
 		PushEnabled:         z.PushEnabled,
 		EmailInstantEnabled: z.EmailInstantEnabled,
+		Paused:              paused,
 	}
 }
 
@@ -150,11 +166,66 @@ func (h *handler) list(w http.ResponseWriter, r *http.Request) {
 		h.serverError(w, r, "list watch zones", err)
 		return
 	}
+	paused, err := h.pausedZoneIDs(r.Context(), userID, zones)
+	if err != nil {
+		h.serverError(w, r, "compute paused zones", err)
+		return
+	}
 	summaries := make([]watchZoneSummary, 0, len(zones))
 	for _, z := range zones {
-		summaries = append(summaries, summaryOf(z))
+		summaries = append(summaries, summaryOf(z, paused[z.ID]))
 	}
 	h.writeJSON(w, r, http.StatusOK, listResult{Zones: summaries})
+}
+
+// pausedZoneIDs resolves which of zones (the caller's full zone set) are
+// paused (GH#889): ranked oldest-first by (CreatedAt, ID), a zone is paused
+// once its rank exceeds the caller's current effective-tier watch-zone limit.
+// Returns a nil map — every zone unpaused — when no profile reader is wired,
+// the profile is missing, or the tier is unlimited (Pro): the same "fail
+// open" shape nearby.go's create-path quota check uses for a missing profile.
+func (h *handler) pausedZoneIDs(ctx context.Context, userID string, zones []WatchZone) (map[string]bool, error) {
+	if h.profiles == nil {
+		return nil, nil
+	}
+	profile, err := h.profiles.Get(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("load profile for pause check: %w", err)
+	}
+	if profile == nil {
+		return nil, nil
+	}
+	limit := profile.EffectiveTier(h.now()).WatchZoneLimit()
+	if limit >= math.MaxInt32 {
+		return nil, nil
+	}
+	return pausedIDs(zones, limit), nil
+}
+
+// pausedIDs partitions zones into the paused set (GH#889): ranked
+// oldest-first by (CreatedAt, ID), a zone whose rank exceeds limit is paused.
+// Purely derived — no schema change, no stored flag — so a re-upgrade or a
+// delete of an older zone revives the next zone in rank with zero extra work.
+// Never mutates zones.
+func pausedIDs(zones []WatchZone, limit int) map[string]bool {
+	if len(zones) <= limit {
+		return nil
+	}
+	sorted := make([]WatchZone, len(zones))
+	copy(sorted, zones)
+	sort.Slice(sorted, func(i, j int) bool {
+		if !sorted[i].CreatedAt.Equal(sorted[j].CreatedAt) {
+			return sorted[i].CreatedAt.Before(sorted[j].CreatedAt)
+		}
+		return sorted[i].ID < sorted[j].ID
+	})
+	paused := make(map[string]bool, len(sorted)-limit)
+	for i, z := range sorted {
+		if i >= limit {
+			paused[z.ID] = true
+		}
+	}
+	return paused
 }
 
 // patchRequest is the PATCH body: every field optional (nil = unchanged).
@@ -237,7 +308,25 @@ func (h *handler) patch(w http.ResponseWriter, r *http.Request) {
 	if h.metrics != nil {
 		h.metrics.WatchZoneUpdated(r.Context())
 	}
-	h.writeJSON(w, r, http.StatusOK, updateResult{Zone: summaryOf(updated)})
+
+	// The paused computation (GH#889) needs the caller's full zone set to rank
+	// the edited zone, unlike list (which already has it); skip the extra
+	// store round trip entirely when no profile reader is wired.
+	var paused bool
+	if h.profiles != nil {
+		allZones, zerr := h.store.GetByUserID(r.Context(), userID)
+		if zerr != nil {
+			h.serverError(w, r, "list watch zones for pause check", zerr)
+			return
+		}
+		pausedSet, perr := h.pausedZoneIDs(r.Context(), userID, allZones)
+		if perr != nil {
+			h.serverError(w, r, "compute paused zones", perr)
+			return
+		}
+		paused = pausedSet[updated.ID]
+	}
+	h.writeJSON(w, r, http.StatusOK, updateResult{Zone: summaryOf(updated, paused)})
 }
 
 // maxCASRetries is the maximum number of etag-conditional replace attempts for

--- a/api-go/internal/watchzones/handler_test.go
+++ b/api-go/internal/watchzones/handler_test.go
@@ -249,6 +249,147 @@ func TestPatch_RejectsOversizedRadius(t *testing.T) {
 	}
 }
 
+// threeZonesRankedByAge builds three zones for testUser with distinct,
+// ascending CreatedAt timestamps so oldest-first (CreatedAt, ID) ranking is
+// unambiguous: zone-1 is rank 1 (oldest), zone-2 rank 2, zone-3 rank 3.
+func threeZonesRankedByAge(t *testing.T) (zone1, zone2, zone3 WatchZone) {
+	t.Helper()
+	mk := func(id string, day int) WatchZone {
+		z, err := NewWatchZone(id, testUser, "Zone "+id, 51.5, -0.1, 1000, 99,
+			time.Date(2026, 6, day, 9, 0, 0, 0, time.UTC), true, true)
+		if err != nil {
+			t.Fatalf("NewWatchZone %s: %v", id, err)
+		}
+		return z
+	}
+	return mk("zone-1", 1), mk("zone-2", 2), mk("zone-3", 3)
+}
+
+func TestHandler_List_MarksPausedZonesOverEffectiveTierLimit(t *testing.T) {
+	t.Parallel()
+	z1, z2, z3 := threeZonesRankedByAge(t)
+	store := &fakeZoneStore{zones: []WatchZone{z1, z2, z3}}
+	mux := http.NewServeMux()
+	// Free tier: WatchZoneLimit() == 1, so only the oldest zone stays active.
+	Routes(mux, store, slog.New(slog.DiscardHandler), WithProfileReader(&fakeProfileReader{profile: freeProfile(t)}))
+
+	rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (body %s)", rec.Code, rec.Body)
+	}
+
+	// Golden-check first: every pre-existing field must round-trip unchanged,
+	// and "paused" must be the only addition (9 keys total per zone).
+	var raw struct {
+		Zones []map[string]any `json:"zones"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode raw: %v", err)
+	}
+	if len(raw.Zones) != 3 {
+		t.Fatalf("zones: got %d, want 3", len(raw.Zones))
+	}
+	wantKeys := []string{"id", "name", "latitude", "longitude", "radiusMetres", "authorityId", "pushEnabled", "emailInstantEnabled", "paused"}
+	for i, obj := range raw.Zones {
+		if len(obj) != len(wantKeys) {
+			t.Errorf("zone %d: got %d keys %v, want %d keys %v", i, len(obj), keysOf(obj), len(wantKeys), wantKeys)
+		}
+		for _, k := range wantKeys {
+			if _, ok := obj[k]; !ok {
+				t.Errorf("zone %d: missing pre-existing/expected key %q", i, k)
+			}
+		}
+	}
+
+	var got struct {
+		Zones []watchZoneSummary `json:"zones"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	wantPaused := map[string]bool{"zone-1": false, "zone-2": true, "zone-3": true}
+	for _, z := range got.Zones {
+		if z.Paused != wantPaused[z.ID] {
+			t.Errorf("zone %s: paused = %v, want %v", z.ID, z.Paused, wantPaused[z.ID])
+		}
+		// Pre-existing fields must still be byte-identical to summaryOf's
+		// direct mapping of the domain zone.
+		if z.Name != "Zone "+z.ID || z.Latitude != 51.5 || z.Longitude != -0.1 ||
+			z.RadiusMetres != 1000 || z.AuthorityID != 99 || !z.PushEnabled || !z.EmailInstantEnabled {
+			t.Errorf("zone %s: pre-existing fields changed: %+v", z.ID, z)
+		}
+	}
+}
+
+func keysOf(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+func TestHandler_Patch_ReturnsPausedForEditedZone(t *testing.T) {
+	t.Parallel()
+	z1, z2, _ := threeZonesRankedByAge(t)
+	tests := []struct {
+		name       string
+		zoneID     string
+		wantPaused bool
+	}{
+		{"editing the active (rank 1) zone reports unpaused", "zone-1", false},
+		{"editing an over-quota (rank 2) zone reports paused", "zone-2", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			store := &fakeZoneStore{zones: []WatchZone{z1, z2}}
+			mux := http.NewServeMux()
+			Routes(mux, store, slog.New(slog.DiscardHandler), WithProfileReader(&fakeProfileReader{profile: freeProfile(t)}))
+
+			rec := doReq(t, mux, http.MethodPatch, "/v1/me/watch-zones/"+tc.zoneID, `{"name":"Renamed"}`)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status: got %d, want 200 (body %s)", rec.Code, rec.Body)
+			}
+			var got struct {
+				Zone watchZoneSummary `json:"zone"`
+			}
+			if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if got.Zone.Name != "Renamed" {
+				t.Errorf("zone not updated: %+v", got.Zone)
+			}
+			if got.Zone.Paused != tc.wantPaused {
+				t.Errorf("paused: got %v, want %v", got.Zone.Paused, tc.wantPaused)
+			}
+		})
+	}
+}
+
+func TestHandler_List_NoProfileReaderWired_EveryZoneUnpaused(t *testing.T) {
+	t.Parallel()
+	// No WithProfileReader option: the pause computation must fail open rather
+	// than block the list response on a missing dependency.
+	z1, z2, z3 := threeZonesRankedByAge(t)
+	store := &fakeZoneStore{zones: []WatchZone{z1, z2, z3}}
+	rec := doReq(t, testMux(t, store), http.MethodGet, "/v1/me/watch-zones", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	var got struct {
+		Zones []watchZoneSummary `json:"zones"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	for _, z := range got.Zones {
+		if z.Paused {
+			t.Errorf("zone %s: paused = true with no profile reader wired, want false (fail open)", z.ID)
+		}
+	}
+}
+
 func TestHandler_Delete_NotFound(t *testing.T) {
 	t.Parallel()
 	rec := doReq(t, testMux(t, &fakeZoneStore{}), http.MethodDelete, "/v1/me/watch-zones/missing", "")


### PR DESCRIPTION
## Summary
- Phase 1 (Go) of GH#889: when a subscription downgrade leaves a user holding more watch zones than their effective tier allows, the over-quota zones stop generating new notification records and surface as `"paused": true` in the watch-zone API — never deleted, fully derived (ranked oldest-first by `(created_at, id)` against `EffectiveTier(now).WatchZoneLimit()`), no schema change, no stored flag.
- `notifydispatch.Enqueuer.Enqueue` skips record creation for a zone ranked past the caller's limit; the unlimited (Pro) tier short-circuits before the extra ranking query; a lapsed paid tier is ranked against its collapsed (Free) `EffectiveTier`.
- `GET /v1/me/watch-zones` and the PATCH response gain an additive `"paused": bool` per zone via a new `WithProfileReader` handler option, wired in `cmd/api/wiring.go`. All pre-existing summary fields are unchanged (golden-checked in tests).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./...` (clean)
- [x] `go test -race ./...` — 1641 passed, 48 packages
- [x] Enqueuer: Free-tier (limit 1) with 3 zones — rank 2 creates no record, rank 1 creates one
- [x] Enqueuer: Personal-tier (limit 3) with 3 zones — all create; Pro with 10 zones — all create, `GetByUserID` never called (unlimited fast path)
- [x] Enqueuer: lapsed-paid user ranked against Free limit, not stored Personal
- [x] Handler: `GET /v1/me/watch-zones` for a Free user with 3 zones — oldest `paused:false`, other two `paused:true`
- [x] Handler: PATCH response carries correct `paused` for the edited zone
- [x] Handler: no profile reader wired → every zone reports `paused:false` (fail open)

Closes tc-u77m1. Unblocks tc-m6ce1 (iOS), tc-6c3md (web), tc-h6evb (Android).

🤖 Generated with [Claude Code](https://claude.com/claude-code)