### PR TITLE
feat(ios): anon single editable device-local zone (tc-kpufx)

### DIFF
--- a/mobile/ios/packages/town-crier-data/Sources/AnonymousBrowse/UserDefaultsDeviceLocalZoneRepository.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/AnonymousBrowse/UserDefaultsDeviceLocalZoneRepository.swift
@@ -13,6 +13,15 @@ import TownCrierDomain
 /// postcode string, centre/radius from the state) and makes it active.
 /// `AnonymousBrowseState` itself is left untouched —
 /// `AppCoordinator+Onboarding`'s post-signup prefill still reads it.
+///
+/// Trim (GH#888): every ``loadAll()`` call also idempotently enforces the
+/// cap dropping from 3 to 1 — if more than one zone is stored (a device that
+/// installed a Phase 4/5 TestFlight build before this change), it keeps the
+/// ACTIVE zone (falling back to the first if none is active), persists the
+/// reduced set, and clears the discarded zones. No new one-shot flag is
+/// needed for this: it is safe to re-run on every call because it is a
+/// no-op once at most one zone remains. User-approved 2026-07-08 — existing
+/// multi-zone TestFlight installs are not a migration concern beyond this.
 public final class UserDefaultsDeviceLocalZoneRepository: DeviceLocalZoneRepository,
   @unchecked Sendable {
   private let defaults: UserDefaults
@@ -33,7 +42,7 @@ public final class UserDefaultsDeviceLocalZoneRepository: DeviceLocalZoneReposit
 
   public func loadAll() -> [DeviceLocalZone] {
     migrateIfNeeded()
-    return storedZones()
+    return trimToActiveZoneIfNeeded()
   }
 
   public func save(_ zone: DeviceLocalZone) throws {
@@ -72,6 +81,22 @@ public final class UserDefaultsDeviceLocalZoneRepository: DeviceLocalZoneReposit
       return
     }
     defaults.set(id.value, forKey: activeZoneIdKey)
+  }
+
+  // MARK: - Trim (GH#888)
+
+  /// Enforces the cap on read: keeps only the active zone (or the first
+  /// zone, if none is marked active) when more than one is stored, and
+  /// persists the reduction so subsequent calls are a no-op. Returns the
+  /// (possibly already-compliant) stored zones.
+  private func trimToActiveZoneIfNeeded() -> [DeviceLocalZone] {
+    let zones = storedZones()
+    guard zones.count > 1 else { return zones }
+    let activeId = activeZoneId()
+    let keeper = zones.first { $0.id == activeId } ?? zones[0]
+    persist([keeper])
+    setActiveZoneId(keeper.id)
+    return [keeper]
   }
 
   // MARK: - Migration

--- a/mobile/ios/packages/town-crier-domain/Sources/Entities/DomainError.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/Entities/DomainError.swift
@@ -19,11 +19,13 @@ public enum DomainError: Error, Equatable, Sendable {
   case restoreFailed(String)
   case unexpected(String)
   case insufficientEntitlement(required: String)
-  /// Attempted to save a NEW device-local zone (GH#879 Phase 4) while already
-  /// at ``DeviceLocalZone/maxZoneCount``. Distinct from
-  /// `.insufficientEntitlement`: this is an on-device cap with no
-  /// subscription tier behind it, so the UI routes to a sign-up CTA rather
-  /// than the paywall.
+  /// Attempted to save a NEW device-local zone while already at
+  /// ``DeviceLocalZone/maxZoneCount`` (GH#888: now 1, matching the Free
+  /// tier). The Zones tab UI no longer offers a create path — only edit — so
+  /// this now guards only defensively (e.g. a stale client); the repository
+  /// cap stays in place regardless. Distinct from `.insufficientEntitlement`:
+  /// this is an on-device cap with no subscription tier behind it, so the UI
+  /// routes to a sign-up CTA rather than the paywall.
   case deviceLocalZoneLimitReached
 
   /// User-facing title for display in error states.
@@ -80,7 +82,7 @@ public enum DomainError: Error, Equatable, Sendable {
     case .insufficientEntitlement:
       return "This feature is on a higher plan. Upgrade to use it."
     case .deviceLocalZoneLimitReached:
-      return "You can save up to 3 areas on this device. Delete one, or create a free account."
+      return "You can save one area on this device. Create a free account to add more."
     case .invalidPostcode(let raw):
       return "The postcode '\(raw)' doesn't look right. Please enter a valid UK postcode."
     case .geocodingFailed:

--- a/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/DeviceLocalZone.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/DeviceLocalZone.swift
@@ -18,10 +18,15 @@ public struct DeviceLocalZone: Equatable, Hashable, Identifiable, Sendable {
   public static let minRadiusMetres: Double = 100
   public static let maxRadiusMetres: Double = 5000
 
-  /// The on-device cap. Matches the Personal tier's watch-zone quota so a
-  /// post-signup conversion is never an absurd "delete some of your areas
-  /// first" moment (GH#879 pre-resolved decision).
-  public static let maxZoneCount = 3
+  /// The on-device cap. Deliberately 1, matching the Free tier's single
+  /// server zone (GH#888 — reverses GH#879 Phase 4's "match Personal tier"
+  /// pre-resolved decision). That earlier 3-zone cap made sign-up a net LOSS:
+  /// converting to a Free account could only keep one of three device-local
+  /// areas, and the very first extra-zone save hit
+  /// `DomainError.insufficientEntitlement`, bouncing a brand-new account
+  /// straight into the paywall. A cap of 1 means anonymous browsing never
+  /// promises more than a free account actually gets.
+  public static let maxZoneCount = 1
 
   public init(
     id: DeviceLocalZoneId = DeviceLocalZoneId(),

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousApplicationListView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousApplicationListView.swift
@@ -6,11 +6,15 @@ import TownCrierDomain
 /// ``ApplicationListRow`` the authenticated Applications tab uses. No
 /// sort/filter chips (pre-resolved: v1 is nearest-first only).
 ///
-/// GH#879 Phase 4: when more than one device-local zone exists, a zone
-/// picker chip row appears above the list — mirroring the authed
-/// `ApplicationListView`'s zone chips (`ApplicationListView.swift:120-140`)
-/// but over ``DeviceLocalZone``. Switching the active zone re-fetches this
-/// list and re-centres the Map tab.
+/// GH#879 Phase 4: when a device-local zone exists, a zone picker chip row
+/// appears above the list — mirroring the authed `ApplicationListView`'s
+/// zone chips (`ApplicationListView.swift:120-140`) but over
+/// ``DeviceLocalZone``. Switching the active zone re-fetches this list and
+/// re-centres the Map tab.
+///
+/// GH#888: the on-device cap is now one zone, so the chip row (with its
+/// trailing "Add area" chip) always renders once a zone exists — it is no
+/// longer gated on a second zone existing to make it a meaningful choice.
 public struct AnonymousApplicationListView: View {
   @StateObject private var viewModel: AnonymousApplicationListViewModel
 
@@ -36,6 +40,14 @@ public struct AnonymousApplicationListView: View {
     .refreshable {
       await viewModel.loadApplications()
     }
+    .sheet(isPresented: $viewModel.isSignUpCTAPresented) {
+      DeviceLocalZoneSignUpCTAView(
+        onCreateAccount: { viewModel.confirmSignUp() },
+        onSignIn: { viewModel.confirmSignUp() },
+        onDismiss: { viewModel.dismissSignUpCTA() }
+      )
+      .selfSizingSheet()
+    }
   }
 
   // MARK: - Zone picker (GH#879 Phase 4)
@@ -54,6 +66,15 @@ public struct AnonymousApplicationListView: View {
                 await viewModel.selectZone(zone)
               }
             }
+          }
+
+          // GH#888: the on-device cap is one zone — adding another always
+          // routes to the sign-up CTA rather than a device-local editor.
+          CapsuleChipView(
+            label: "+ Add area",
+            isSelected: false
+          ) {
+            viewModel.requestAddArea()
           }
         }
         .padding(.horizontal, TCSpacing.medium)

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousApplicationListViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousApplicationListViewModel.swift
@@ -15,6 +15,14 @@ import TownCrierDomain
 /// `fallbackCoordinate`/`fallbackRadiusMetres` back the query only in the
 /// practically-unreachable case no device-local zone exists at all (e.g.
 /// before the legacy-state migration has ever run).
+///
+/// GH#888: the on-device cap dropped to one zone, so the picker row is now
+/// always shown once any zone exists (``showZonePicker``), rather than only
+/// once a second zone made a picker a meaningful choice. A trailing
+/// "Add area" chip renders alongside it, routing to the same sign-up CTA
+/// sheet every other anonymous zone-limit affordance uses
+/// (``isSignUpCTAPresented``) — adding a second area now requires an
+/// account.
 @MainActor
 public final class AnonymousApplicationListViewModel: ObservableObject, ErrorHandlingViewModel {
   @Published public private(set) var applications: [PlanningApplication] = []
@@ -22,6 +30,7 @@ public final class AnonymousApplicationListViewModel: ObservableObject, ErrorHan
   @Published public internal(set) var error: DomainError?
   @Published public private(set) var zones: [DeviceLocalZone] = []
   @Published public private(set) var selectedZone: DeviceLocalZone?
+  @Published public var isSignUpCTAPresented = false
 
   /// Mirrors ``AnonymousMapViewModel/defaultLimit`` — `near-point` returns at
   /// most this many results in nearest-first order; the anonymous list is a
@@ -44,15 +53,21 @@ public final class AnonymousApplicationListViewModel: ObservableObject, ErrorHan
   /// the coordinator can re-centre the Map tab to match.
   public var onActiveZoneChanged: ((DeviceLocalZone) -> Void)?
 
+  /// Fired when the user confirms the "Add area" chip's sign-up CTA
+  /// (GH#888). Wired by the coordinator to the same single sign-up/sign-in
+  /// entry point every anonymous CTA uses.
+  public var onRequestSignUp: (() -> Void)?
+
   public var isEmpty: Bool {
     applications.isEmpty && error == nil && !isLoading
   }
 
-  /// True when the picker should render — mirrors the authed
-  /// `ApplicationListViewModel.showZonePicker`: a single zone is no
-  /// meaningful choice.
+  /// True when the zone chip row should render (GH#888): unlike the authed
+  /// `ApplicationListViewModel.showZonePicker`, a single zone IS shown —
+  /// it's paired with a trailing "Add area" chip, so even one zone is a
+  /// meaningful row (the chip and the CTA, not a choice between zones).
   public var showZonePicker: Bool {
-    zones.count > 1
+    !zones.isEmpty
   }
 
   public init(
@@ -117,6 +132,22 @@ public final class AnonymousApplicationListViewModel: ObservableObject, ErrorHan
 
   public func selectApplication(_ application: PlanningApplication) {
     onShowApplicationDetail?(application)
+  }
+
+  /// The trailing "Add area" chip (GH#888) — the on-device cap is one zone,
+  /// so adding another always routes to the sign-up CTA rather than opening
+  /// a device-local editor.
+  public func requestAddArea() {
+    isSignUpCTAPresented = true
+  }
+
+  public func dismissSignUpCTA() {
+    isSignUpCTAPresented = false
+  }
+
+  public func confirmSignUp() {
+    isSignUpCTAPresented = false
+    onRequestSignUp?()
   }
 
   private func refreshZones() {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousBrowseCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousBrowseCoordinator.swift
@@ -53,6 +53,23 @@ public final class AnonymousBrowseCoordinator: ObservableObject {
   /// alongside the newly chosen radius (GH#868 Phase 3 refinement). Also the
   /// source for the Applications tab's list view model (GH#879 Phase 3).
   private var currentState: AnonymousBrowseState?
+  /// The live Applications list view model, cached the first time
+  /// ``makeApplicationListViewModel()`` builds one, and returned unchanged on
+  /// every later call (GH#888). Necessary for the SAME reason
+  /// ``mapViewModel`` is a stored property mutated in place rather than
+  /// rebuilt: `AnonymousMainTabView`'s tab content is re-evaluated on every
+  /// `selectedTab`/coordinator change (`TabView` builds every tab's content
+  /// closure up front, not just the selected one), so a naive "build fresh
+  /// every call" factory would hand back a throwaway instance the mounted
+  /// `AnonymousApplicationListView`'s `@StateObject` immediately discards —
+  /// leaving nothing for a later Zones-tab edit to refetch. Caching the
+  /// first instance gives ``makeDeviceLocalZoneListViewModel()``'s
+  /// `onZonesChanged` wiring a stable handle to call `loadApplications()` on.
+  private var applicationListViewModel: AnonymousApplicationListViewModel?
+  /// Test-only synchronisation handle for the Applications-list refetch
+  /// ``makeDeviceLocalZoneListViewModel()`` kicks off after a Zones-tab edit
+  /// — mirrors `AnonymousMapViewModel.waitForPendingRegionChangeRefetch()`.
+  private var pendingZoneEditRefetchTask: Task<Void, Never>?
   /// Single live source of truth for the appearance preference (GH#878),
   /// shared with `SettingsViewModel` — injected by the composition root so
   /// the welcome screen's appearance control and the root
@@ -147,6 +164,7 @@ public final class AnonymousBrowseCoordinator: ObservableObject {
     stateRepository.clear()
     currentState = nil
     mapViewModel = nil
+    applicationListViewModel = nil
     screen = .welcome
   }
 
@@ -161,6 +179,11 @@ public final class AnonymousBrowseCoordinator: ObservableObject {
   /// transitions to `.tabs` once `currentState` (and `mapViewModel`) are both
   /// set.
   public func makeApplicationListViewModel() -> AnonymousApplicationListViewModel? {
+    // Cached (GH#888) — see `applicationListViewModel`'s own docs for why a
+    // fresh instance on every call would be silently discarded by the
+    // mounted view's `@StateObject`, leaving nothing for a Zones-tab edit to
+    // refetch later.
+    if let applicationListViewModel { return applicationListViewModel }
     guard let state = currentState else { return nil }
     let viewModel = AnonymousApplicationListViewModel(
       repository: applicationsRepository,
@@ -183,17 +206,42 @@ public final class AnonymousBrowseCoordinator: ObservableObject {
     viewModel.onActiveZoneChanged = { [weak self] zone in
       self?.mapViewModel?.updateActiveZone(zone)
     }
+    // The "Add area" chip's sign-up CTA (GH#888) — the on-device cap is one
+    // zone, so adding another always routes here.
+    viewModel.onRequestSignUp = { [weak self] in self?.onRequestSignIn?() }
+    applicationListViewModel = viewModel
     return viewModel
   }
 
-  /// Builds the Zones tab's view model (GH#879 Phase 4), sharing the same
-  /// anonymous `PostcodeGeocoder` instance postcode entry uses (never
-  /// `/v1/geocode`).
+  /// Builds the Zones tab's view model, sharing the same anonymous
+  /// `PostcodeGeocoder` instance postcode entry uses (never `/v1/geocode`).
+  ///
+  /// GH#888: a successful edit fires ``DeviceLocalZoneListViewModel/onZonesChanged``
+  /// with the saved zone. That mutates the EXISTING `mapViewModel` in place
+  /// via `updateActiveZone(_:)` — the same identity-preserving requirement
+  /// `onActiveZoneChanged` above satisfies, and for the same reason (see
+  /// that wiring's docs) — and kicks off a refetch of the cached
+  /// ``applicationListViewModel`` so the Applications tab picks up the edit
+  /// without a relaunch.
   public func makeDeviceLocalZoneListViewModel() -> DeviceLocalZoneListViewModel {
     let viewModel = DeviceLocalZoneListViewModel(
       repository: deviceLocalZoneRepository, geocoder: geocoder)
     viewModel.onRequestSignUp = { [weak self] in self?.onRequestSignIn?() }
+    viewModel.onZonesChanged = { [weak self] zone in
+      guard let self else { return }
+      mapViewModel?.updateActiveZone(zone)
+      pendingZoneEditRefetchTask = Task { [weak self] in
+        await self?.applicationListViewModel?.loadApplications()
+      }
+    }
     return viewModel
+  }
+
+  /// Test-only synchronisation: await the most recently scheduled
+  /// Applications-list refetch triggered by a Zones-tab edit (GH#888),
+  /// mirroring `AnonymousMapViewModel.waitForPendingRegionChangeRefetch()`.
+  public func waitForPendingZoneEditRefetch() async {
+    await pendingZoneEditRefetchTask?.value
   }
 
   /// Builds the Settings tab's view model, sharing the same live

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/DeviceLocalZoneEditorView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/DeviceLocalZoneEditorView.swift
@@ -1,8 +1,13 @@
 import SwiftUI
 import TownCrierDomain
 
-/// Create or edit a device-local zone: name → postcode entry → radius picker
-/// → map preview → save (GH#879 Phase 4).
+/// Edits the anonymous user's single device-local zone: name → postcode →
+/// radius picker → map preview → save (GH#888: no create mode any more — see
+/// ``DeviceLocalZoneEditorViewModel``'s docs).
+///
+/// The postcode field is always shown, even though the zone already has a
+/// coordinate: it's the only way left to correct a mistyped onboarding
+/// postcode now there's no add/delete path to fall back on.
 ///
 /// Visual conventions mirror the authed `WatchZoneEditorView`, but this is a
 /// separate, simpler anonymous editor — no entitlement gate, no per-zone
@@ -20,18 +25,14 @@ public struct DeviceLocalZoneEditorView: View {
     NavigationStack {
       Form {
         nameSection
-        if viewModel.isPostcodeFieldVisible {
-          postcodeSection
-        }
-        if viewModel.geocodedCoordinate != nil {
-          radiusSection
-          mapPreviewSection
-        }
+        postcodeSection
+        radiusSection
+        mapPreviewSection
         if let error = viewModel.error {
           errorSection(error)
         }
       }
-      .navigationTitle(viewModel.isEditing ? "Edit Area" : "New Area")
+      .navigationTitle("Edit Area")
       #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
       #endif
@@ -52,7 +53,7 @@ public struct DeviceLocalZoneEditorView: View {
             }
           }
           .disabled(
-            viewModel.geocodedCoordinate == nil || viewModel.isLoading
+            viewModel.isLoading
               || viewModel.nameInput.trimmingCharacters(in: .whitespaces).isEmpty
           )
         }
@@ -128,25 +129,22 @@ public struct DeviceLocalZoneEditorView: View {
     }
   }
 
-  @ViewBuilder
   private var mapPreviewSection: some View {
-    if let coordinate = viewModel.geocodedCoordinate {
-      Section("Preview") {
-        ZoneMapPreview(
-          centre: coordinate,
-          radiusMetres: viewModel.selectedRadiusMetres,
-          strokeWidth: 2
-        )
-        .frame(height: 220)
-        .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.medium))
-        .listRowInsets(
-          EdgeInsets(
-            top: TCSpacing.small,
-            leading: TCSpacing.medium,
-            bottom: TCSpacing.small,
-            trailing: TCSpacing.medium
-          ))
-      }
+    Section("Preview") {
+      ZoneMapPreview(
+        centre: viewModel.geocodedCoordinate,
+        radiusMetres: viewModel.selectedRadiusMetres,
+        strokeWidth: 2
+      )
+      .frame(height: 220)
+      .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.medium))
+      .listRowInsets(
+        EdgeInsets(
+          top: TCSpacing.small,
+          leading: TCSpacing.medium,
+          bottom: TCSpacing.small,
+          trailing: TCSpacing.medium
+        ))
     }
   }
 

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/DeviceLocalZoneEditorViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/DeviceLocalZoneEditorViewModel.swift
@@ -1,10 +1,18 @@
 import Foundation
 import TownCrierDomain
 
-/// Creates or edits a single device-local zone (GH#879 Phase 4): name,
-/// postcode entry geocoded client-side via `PostcodeGeocoder` — never
-/// `/v1/geocode` — and a radius clamped to
-/// `[DeviceLocalZone.minRadiusMetres, DeviceLocalZone.maxRadiusMetres]`.
+/// Edits the anonymous user's single device-local zone (GH#888: the
+/// on-device cap dropped to 1, so this editor no longer has a "create new
+/// zone" mode — the Zones tab's only entry point is `editZone(_:)` on the
+/// existing zone, so `editing` is a required, already-geocoded zone rather
+/// than an optional "nil means new"). Postcode entry is geocoded
+/// client-side via `PostcodeGeocoder` — never `/v1/geocode` — and radius is
+/// clamped to `[DeviceLocalZone.minRadiusMetres, DeviceLocalZone.maxRadiusMetres]`.
+///
+/// The postcode field is always reachable, even though the zone already has
+/// a coordinate: it's the only way to correct a mistyped onboarding postcode
+/// (GH#888 acceptance criteria) without deleting and re-seeding the zone,
+/// which isn't possible any more now there's no add path.
 ///
 /// Visual/interaction conventions mirror the authed `WatchZoneEditorViewModel`,
 /// but this is a distinct, simpler type — no tier, no entitlement gating, no
@@ -12,10 +20,14 @@ import TownCrierDomain
 /// is a sign-up CTA handled by the list, not the editor.
 @MainActor
 public final class DeviceLocalZoneEditorViewModel: ObservableObject, ErrorHandlingViewModel {
-  @Published public var nameInput: String = ""
+  @Published public var nameInput: String
   @Published public var postcodeInput: String = ""
-  @Published public var selectedRadiusMetres: Double = 1000
-  @Published public private(set) var geocodedCoordinate: Coordinate?
+  @Published public var selectedRadiusMetres: Double
+  /// The zone's coordinate — seeded from the zone being edited, and updated
+  /// by a successful ``submitPostcode()``. Never nil: unlike GH#879 Phase 4's
+  /// "new zone" mode, this editor always starts from an existing zone that
+  /// already has a coordinate.
+  @Published public private(set) var geocodedCoordinate: Coordinate
   @Published public private(set) var isLoading = false
   @Published public internal(set) var error: DomainError?
 
@@ -23,36 +35,29 @@ public final class DeviceLocalZoneEditorViewModel: ObservableObject, ErrorHandli
 
   /// Invoked when saving would exceed the on-device cap
   /// (`DomainError.deviceLocalZoneLimitReached`) — the list dismisses the
-  /// editor and shows the sign-up CTA instead of an inline error.
+  /// editor and shows the sign-up CTA instead of an inline error. Defensive
+  /// only (GH#888): this editor only ever edits the zone already occupying
+  /// the cap, never creates a new one.
   public var onRequestSignUp: (() -> Void)?
 
-  public let isEditing: Bool
   public let minRadiusMetres = DeviceLocalZone.minRadiusMetres
   public let maxRadiusMetres = DeviceLocalZone.maxRadiusMetres
 
   private let geocoder: PostcodeGeocoder
   private let repository: DeviceLocalZoneRepository
-  private let existingId: DeviceLocalZoneId?
+  private let existingId: DeviceLocalZoneId
 
   public init(
     geocoder: PostcodeGeocoder,
     repository: DeviceLocalZoneRepository,
-    editing zone: DeviceLocalZone? = nil
+    editing zone: DeviceLocalZone
   ) {
     self.geocoder = geocoder
     self.repository = repository
-    self.isEditing = zone != nil
-    self.existingId = zone?.id
-
-    if let zone {
-      self.nameInput = zone.name
-      self.selectedRadiusMetres = zone.radiusMetres
-      self.geocodedCoordinate = zone.centre
-    }
-  }
-
-  public var isPostcodeFieldVisible: Bool {
-    !isEditing
+    self.existingId = zone.id
+    self.nameInput = zone.name
+    self.selectedRadiusMetres = zone.radiusMetres
+    self.geocodedCoordinate = zone.centre
   }
 
   public func submitPostcode() async {
@@ -89,14 +94,13 @@ public final class DeviceLocalZoneEditorViewModel: ObservableObject, ErrorHandli
   /// editor stays open.
   @discardableResult
   public func save() async -> Bool {
-    guard let coordinate = geocodedCoordinate else { return false }
     error = nil
 
     do {
       let zone = try DeviceLocalZone(
-        id: existingId ?? DeviceLocalZoneId(),
+        id: existingId,
         name: nameInput,
-        centre: coordinate,
+        centre: geocodedCoordinate,
         radiusMetres: selectedRadiusMetres
       )
       try repository.save(zone)

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/DeviceLocalZoneListView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/DeviceLocalZoneListView.swift
@@ -1,12 +1,15 @@
 import SwiftUI
 import TownCrierDomain
 
-/// The anonymous (pre-signup) Zones tab (GH#879 Phase 4): up to
-/// ``DeviceLocalZone/maxZoneCount`` device-local areas with create/edit/
-/// delete. Mirrors `WatchZoneListView`'s visual conventions, but every
-/// notification affordance and any attempt to add a 4th zone route to a
-/// sign-up CTA rather than a real quota/entitlement flow — device-local
-/// zones never deliver alerts.
+/// The anonymous (pre-signup) Zones tab (GH#888): exactly one editable
+/// device-local area. No toolbar "+", no swipe-to-delete — the on-device cap
+/// is ``DeviceLocalZone/maxZoneCount`` == 1, and the only surviving mutation
+/// is editing the single zone via a row tap. A persistent sign-up pitch sits
+/// below the zone: with the add path gone, it is the only remaining route to
+/// another area, so it is load-bearing rather than decorative — copy pitches
+/// more areas AND alerts, and (like every anonymous CTA) never says
+/// "instant", since instant alerts are a paid, server-enforced entitlement
+/// (#868/#879 precedent).
 public struct DeviceLocalZoneListView: View {
   @StateObject private var viewModel: DeviceLocalZoneListViewModel
 
@@ -16,38 +19,23 @@ public struct DeviceLocalZoneListView: View {
 
   public var body: some View {
     List {
-      if viewModel.zones.isEmpty {
-        emptyState
+      if let zone = viewModel.zones.first {
+        DeviceLocalZoneRow(zone: zone) { viewModel.requestAlertsSignUp() }
+          .contentShape(Rectangle())
+          .onTapGesture { viewModel.editZone(zone) }
+        signUpPitchSection
       } else {
-        ForEach(viewModel.zones) { zone in
-          DeviceLocalZoneRow(zone: zone) { viewModel.requestAlertsSignUp() }
-            .contentShape(Rectangle())
-            .onTapGesture { viewModel.editZone(zone) }
-        }
-        .onDelete { indexSet in
-          guard let index = indexSet.first else { return }
-          viewModel.deleteZone(viewModel.zones[index])
-        }
+        emptyState
       }
     }
     .scrollContentBackground(.hidden)
     .background(Color.tcBackground)
     .navigationTitle("Zones")
-    .toolbar {
-      ToolbarItem(placement: .primaryAction) {
-        Button {
-          viewModel.addZoneTapped()
-        } label: {
-          Image(systemName: "plus")
-        }
-        .accessibilityLabel("Add Area")
-      }
-    }
     .task {
       viewModel.load()
     }
-    .sheet(item: $viewModel.editorTarget) { target in
-      DeviceLocalZoneEditorView(viewModel: viewModel.makeEditorViewModel(for: target))
+    .sheet(item: $viewModel.editorTarget) { zone in
+      DeviceLocalZoneEditorView(viewModel: viewModel.makeEditorViewModel(for: zone))
     }
     .sheet(isPresented: $viewModel.isSignUpCTAPresented) {
       DeviceLocalZoneSignUpCTAView(
@@ -59,27 +47,45 @@ public struct DeviceLocalZoneListView: View {
     }
   }
 
+  /// Load-bearing sign-up pitch (GH#888): this is the only remaining route to
+  /// another area now the cap is one.
+  private var signUpPitchSection: some View {
+    Section {
+      VStack(alignment: .leading, spacing: TCSpacing.small) {
+        Text("Want more areas or alerts?")
+          .font(TCTypography.headline)
+          .foregroundStyle(Color.tcTextPrimary)
+        Text(
+          "Create a free account to save more areas and get notified when things change."
+        )
+        .font(TCTypography.body)
+        .foregroundStyle(Color.tcTextSecondary)
+
+        HStack(spacing: TCSpacing.medium) {
+          PrimaryButton("Create free account") { viewModel.requestSignUpFromPitch() }
+
+          Button("Sign in") { viewModel.requestSignUpFromPitch() }
+            .font(TCTypography.bodyEmphasis)
+            .foregroundStyle(Color.tcTextSecondary)
+        }
+      }
+      .padding(.vertical, TCSpacing.small)
+    }
+    .listRowBackground(Color.tcSurface)
+  }
+
   private var emptyState: some View {
     Section {
       VStack(spacing: TCSpacing.medium) {
         Image(systemName: "mappin.and.ellipse")
           .font(.system(.largeTitle))
           .foregroundStyle(Color.tcTextTertiary)
-        Text("No Areas Yet")
+        Text("No Area Set Up")
           .font(.system(.headline).weight(.semibold))
-        Text("Add an area to see nearby planning applications.")
+        Text("Complete onboarding to set up your area.")
           .font(.system(.body))
           .foregroundStyle(Color.tcTextSecondary)
           .multilineTextAlignment(.center)
-        Button {
-          viewModel.addZoneTapped()
-        } label: {
-          Text("Add Area")
-            .font(.system(.body).weight(.semibold))
-            .frame(maxWidth: .infinity)
-        }
-        .buttonStyle(.borderedProminent)
-        .tint(Color.tcAmber)
       }
       .padding(.vertical, TCSpacing.extraLarge)
     }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/DeviceLocalZoneListViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/DeviceLocalZoneListViewModel.swift
@@ -1,75 +1,60 @@
 import Foundation
 import TownCrierDomain
 
-/// Drives the anonymous (pre-signup) Zones tab (GH#879 Phase 4): up to
-/// ``DeviceLocalZone/maxZoneCount`` device-local areas with create/edit/
-/// delete. Deliberately has no notion of a real quota/entitlement flow —
-/// attempting to add a 4th zone, and tapping any per-row alert affordance,
-/// both route straight to a sign-up CTA (``isSignUpCTAPresented``).
+/// Drives the anonymous (pre-signup) Zones tab (GH#888): exactly one
+/// editable device-local area (``DeviceLocalZone/maxZoneCount`` == 1),
+/// seeded from the onboarding postcode. No add, no delete — GH#888 reverses
+/// GH#879 Phase 4's 3-zone cap, which made signing up a net loss of areas.
+/// Tapping the zone still opens the editor; any per-row alert affordance
+/// still routes straight to a sign-up CTA (``isSignUpCTAPresented``).
 @MainActor
 public final class DeviceLocalZoneListViewModel: ObservableObject {
-  /// What the create/edit sheet should show. `Identifiable` so it binds
-  /// directly to `.sheet(item:)`.
-  public enum EditorTarget: Identifiable, Equatable {
-    case new
-    case edit(DeviceLocalZone)
-
-    public var id: String {
-      switch self {
-      case .new: return "new"
-      case .edit(let zone): return zone.id.value
-      }
-    }
-  }
-
   @Published public private(set) var zones: [DeviceLocalZone] = []
-  @Published public var editorTarget: EditorTarget?
+  /// The zone currently open in the editor sheet. `DeviceLocalZone` is
+  /// already `Identifiable`, so this binds directly to `.sheet(item:)`
+  /// without a separate wrapper enum — unlike GH#879 Phase 4, there is no
+  /// "new" case any more since the add path is gone.
+  @Published public var editorTarget: DeviceLocalZone?
   @Published public var isSignUpCTAPresented = false
 
   private let repository: DeviceLocalZoneRepository
   private let geocoder: PostcodeGeocoder
 
-  /// Fired when the user confirms the sign-up CTA (cap reached, or a
-  /// per-row alert affordance tapped). Wired by the coordinator to the same
-  /// single sign-up/sign-in entry point every anonymous CTA uses.
+  /// Fired when the user confirms the sign-up CTA (a per-row alert
+  /// affordance, or the persistent sign-up pitch below the zone). Wired by
+  /// the coordinator to the same single sign-up/sign-in entry point every
+  /// anonymous CTA uses.
   public var onRequestSignUp: (() -> Void)?
+
+  /// Fired with the saved zone after a successful editor save (GH#888), so
+  /// the coordinator can propagate the edit live to the Map tab
+  /// (`AnonymousMapViewModel.updateActiveZone(_:)`) and the Applications
+  /// list — mirrors ``AnonymousApplicationListViewModel/onActiveZoneChanged``.
+  public var onZonesChanged: ((DeviceLocalZone) -> Void)?
 
   public init(repository: DeviceLocalZoneRepository, geocoder: PostcodeGeocoder) {
     self.repository = repository
     self.geocoder = geocoder
   }
 
-  public var canAddZone: Bool {
-    zones.count < DeviceLocalZone.maxZoneCount
-  }
-
   public func load() {
     zones = repository.loadAll()
   }
 
-  /// The "+" toolbar action and the empty state's "Add Area" button. Opens
-  /// the editor when there's still headroom; otherwise routes straight to
-  /// the sign-up CTA — never opens the editor just to reject the save.
-  public func addZoneTapped() {
-    if canAddZone {
-      editorTarget = .new
-    } else {
-      isSignUpCTAPresented = true
-    }
-  }
-
   public func editZone(_ zone: DeviceLocalZone) {
-    editorTarget = .edit(zone)
+    editorTarget = zone
   }
 
-  public func deleteZone(_ zone: DeviceLocalZone) {
-    repository.delete(zone.id)
-    zones.removeAll { $0.id == zone.id }
-  }
-
-  /// Any alert/notification affordance on a zone row is a sign-up CTA —
-  /// device-local zones never deliver alerts (GH#879 Phase 4).
+  /// Any alert/notification affordance on the zone row is a sign-up CTA —
+  /// device-local zones never deliver alerts.
   public func requestAlertsSignUp() {
+    isSignUpCTAPresented = true
+  }
+
+  /// The persistent "want more areas or alerts?" pitch below the zone
+  /// (GH#888) — with the cap at one, this is the only remaining route to
+  /// another area.
+  public func requestSignUpFromPitch() {
     isSignUpCTAPresented = true
   }
 
@@ -86,20 +71,18 @@ public final class DeviceLocalZoneListViewModel: ObservableObject {
     editorTarget = nil
   }
 
-  /// Builds the editor view model for `target`, wiring its callbacks back
-  /// into this list: a successful save dismisses the editor and reloads the
-  /// zone list from the repository; a cap breach dismisses the editor and
-  /// shows the sign-up CTA instead of an inline error.
-  public func makeEditorViewModel(for target: EditorTarget) -> DeviceLocalZoneEditorViewModel {
-    let editingZone: DeviceLocalZone? = {
-      if case .edit(let zone) = target { return zone }
-      return nil
-    }()
+  /// Builds the editor view model for `zone`. A successful save dismisses
+  /// the editor, reloads the zone list from the repository, and notifies
+  /// ``onZonesChanged`` with the saved zone; a cap breach (defensive only —
+  /// the UI no longer offers a create path) dismisses the editor and shows
+  /// the sign-up CTA instead of an inline error.
+  public func makeEditorViewModel(for zone: DeviceLocalZone) -> DeviceLocalZoneEditorViewModel {
     let viewModel = DeviceLocalZoneEditorViewModel(
-      geocoder: geocoder, repository: repository, editing: editingZone)
-    viewModel.onSave = { [weak self] _ in
+      geocoder: geocoder, repository: repository, editing: zone)
+    viewModel.onSave = { [weak self] saved in
       self?.editorTarget = nil
       self?.load()
+      self?.onZonesChanged?(saved)
     }
     viewModel.onRequestSignUp = { [weak self] in
       self?.editorTarget = nil

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousApplicationListViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousApplicationListViewModelTests.swift
@@ -12,6 +12,11 @@ import TownCrierDomain
 /// zone picker mirroring the authed `ApplicationListViewModel`'s pattern.
 /// `fallbackCoordinate`/`fallbackRadiusMetres` back the query only in the
 /// practically-unreachable case no device-local zone exists at all.
+///
+/// GH#888: the on-device cap dropped to one zone, so `showZonePicker` now
+/// renders once any zone exists (not only when a second exists), paired
+/// with a trailing "Add area" chip that routes to the sign-up CTA
+/// (`isSignUpCTAPresented`/`requestAddArea()`/`confirmSignUp()`).
 @Suite("AnonymousApplicationListViewModel")
 @MainActor
 struct AnonymousApplicationListViewModelTests {
@@ -20,7 +25,10 @@ struct AnonymousApplicationListViewModelTests {
     fallbackRadiusMetres: Double = 2000,
     zones: [DeviceLocalZone] = [],
     activeZoneId: DeviceLocalZoneId? = nil
-  ) -> (AnonymousApplicationListViewModel, SpyAnonymousApplicationsRepository, SpyDeviceLocalZoneRepository) {
+  ) -> (
+    AnonymousApplicationListViewModel, SpyAnonymousApplicationsRepository,
+    SpyDeviceLocalZoneRepository
+  ) {
     let repository = SpyAnonymousApplicationsRepository()
     let zoneRepository = SpyDeviceLocalZoneRepository()
     zoneRepository.loadAllResult = zones
@@ -159,17 +167,26 @@ struct AnonymousApplicationListViewModelTests {
     #expect(sut.selectedZone == zone)
   }
 
-  @Test func showZonePicker_false_whenZeroOrOneZone() async throws {
-    let (sutZero, repoZero, _) = makeSUT(zones: [])
-    repoZero.fetchNearbyResult = .success([])
-    await sutZero.loadApplications()
-    #expect(!sutZero.showZonePicker)
+  /// GH#888: the on-device cap dropped to one zone, so the picker row (with
+  /// its trailing "Add area" chip) now renders once ANY zone exists — it is
+  /// only hidden in the practically-unreachable zero-zone case.
+  @Test func showZonePicker_false_whenZeroZones() async throws {
+    let (sut, repository, _) = makeSUT(zones: [])
+    repository.fetchNearbyResult = .success([])
 
+    await sut.loadApplications()
+
+    #expect(!sut.showZonePicker)
+  }
+
+  @Test func showZonePicker_true_whenOneZone() async throws {
     let zone = try makeZone()
-    let (sutOne, repoOne, _) = makeSUT(zones: [zone])
-    repoOne.fetchNearbyResult = .success([])
-    await sutOne.loadApplications()
-    #expect(!sutOne.showZonePicker)
+    let (sut, repository, _) = makeSUT(zones: [zone])
+    repository.fetchNearbyResult = .success([])
+
+    await sut.loadApplications()
+
+    #expect(sut.showZonePicker)
   }
 
   @Test func showZonePicker_true_whenMultipleZones() async throws {
@@ -180,6 +197,37 @@ struct AnonymousApplicationListViewModelTests {
     await sut.loadApplications()
 
     #expect(sut.showZonePicker)
+  }
+
+  // MARK: - "Add area" chip -> sign-up CTA (GH#888)
+
+  @Test func requestAddArea_presentsSignUpCTA() {
+    let (sut, _, _) = makeSUT()
+
+    sut.requestAddArea()
+
+    #expect(sut.isSignUpCTAPresented)
+  }
+
+  @Test func dismissSignUpCTA_clearsTheFlag() {
+    let (sut, _, _) = makeSUT()
+    sut.requestAddArea()
+
+    sut.dismissSignUpCTA()
+
+    #expect(!sut.isSignUpCTAPresented)
+  }
+
+  @Test func confirmSignUp_clearsTheFlagAndInvokesOnRequestSignUp() {
+    let (sut, _, _) = makeSUT()
+    sut.requestAddArea()
+    var requested = false
+    sut.onRequestSignUp = { requested = true }
+
+    sut.confirmSignUp()
+
+    #expect(!sut.isSignUpCTAPresented)
+    #expect(requested)
   }
 
   @Test func selectZone_persistsActiveZoneAndRefetches() async throws {

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousBrowseCoordinatorTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousBrowseCoordinatorTests.swift
@@ -339,4 +339,62 @@ struct AnonymousBrowseCoordinatorTests {
     #expect(sut.mapViewModel?.anchorCoordinate == zoneB.centre)
     #expect(sut.mapViewModel?.radiusMetres == zoneB.radiusMetres)
   }
+
+  // MARK: - Zones-tab edit propagation (GH#888)
+
+  /// Mirrors the Phase 4 regression test above: an edit saved on the Zones
+  /// tab must mutate the SAME `AnonymousMapViewModel` instance in place
+  /// (`AnonymousMapView`'s `@StateObject` would otherwise keep rendering the old one).
+  @Test
+  func deviceLocalZoneListViewModel_onZonesChanged_reCentresTheSameMapViewModelInstance() throws {
+    let (sut, _, _, _, _) = makeSUT(persistedState: testState)
+    let zonesVM = sut.makeDeviceLocalZoneListViewModel()
+    let originalMapViewModel = sut.mapViewModel
+    let editedZone = try DeviceLocalZone(
+      name: "Edited",
+      centre: try Coordinate(latitude: 51.5074, longitude: -0.1278),
+      radiusMetres: 2500)
+
+    zonesVM.onZonesChanged?(editedZone)
+
+    #expect(sut.mapViewModel === originalMapViewModel)
+    #expect(sut.mapViewModel?.centreLat == editedZone.centre.latitude)
+    #expect(sut.mapViewModel?.anchorCoordinate == editedZone.centre)
+    #expect(sut.mapViewModel?.radiusMetres == editedZone.radiusMetres)
+  }
+
+  /// The Applications tab must pick up a Zones-tab edit without a relaunch —
+  /// asserted here against the SAME cached `AnonymousApplicationListViewModel`
+  /// instance `makeApplicationListViewModel()` hands back on every call
+  /// (GH#888), mirroring how the map identity is preserved above.
+  @Test
+  func deviceLocalZoneListViewModel_onZonesChanged_refetchesTheApplicationsList() async throws {
+    let (sut, _, _, applicationsRepository, _) = makeSUT(persistedState: testState)
+    applicationsRepository.fetchNearbyResult = .success([.pendingReview])
+    let listViewModel = sut.makeApplicationListViewModel()
+    await listViewModel?.loadApplications()
+    let zonesVM = sut.makeDeviceLocalZoneListViewModel()
+    let editedZone = try DeviceLocalZone(name: "Edited", centre: .cambridge, radiusMetres: 2500)
+    applicationsRepository.fetchNearbyResult = .success([.permitted])
+
+    zonesVM.onZonesChanged?(editedZone)
+    await sut.waitForPendingZoneEditRefetch()
+
+    #expect(sut.makeApplicationListViewModel() === listViewModel)
+    #expect(listViewModel?.applications == [.permitted])
+  }
+
+  /// `makeApplicationListViewModel()` returns the SAME cached instance on
+  /// every call (GH#888) — necessary so a later Zones-tab edit's refetch
+  /// lands on the instance the mounted view is actually showing, rather than
+  /// a throwaway `AnonymousApplicationListView`'s `@StateObject` silently
+  /// discards.
+  @Test func makeApplicationListViewModel_calledTwice_returnsTheSameInstance() {
+    let (sut, _, _, _, _) = makeSUT(persistedState: testState)
+
+    let first = sut.makeApplicationListViewModel()
+    let second = sut.makeApplicationListViewModel()
+
+    #expect(first === second)
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/DeviceLocalZoneEditorViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/DeviceLocalZoneEditorViewModelTests.swift
@@ -4,14 +4,20 @@ import TownCrierDomain
 
 @testable import TownCrierPresentation
 
-/// GH#879 Phase 4: create/edit a single device-local zone — name, postcode
-/// entry geocoded client-side, radius clamped to
-/// `[DeviceLocalZone.minRadiusMetres, DeviceLocalZone.maxRadiusMetres]`.
+/// GH#888: edits the anonymous user's single device-local zone. There is no
+/// longer a "create new zone" mode (the on-device cap dropped to 1, and the
+/// Zones tab's only entry point is `editZone(_:)` on the existing zone), so
+/// `editing` is a required zone and `geocodedCoordinate` is always seeded —
+/// never nil. The postcode field/`submitPostcode()` stay fully reachable
+/// while editing (a live-verified regression: they were previously hidden
+/// behind an `isEditing` gate that made sense only when a distinct "new
+/// zone" mode existed), so a mistyped onboarding postcode can still be
+/// corrected.
 @Suite("DeviceLocalZoneEditorViewModel")
 @MainActor
 struct DeviceLocalZoneEditorViewModelTests {
   private func makeSUT(
-    editing zone: DeviceLocalZone? = nil
+    editing zone: DeviceLocalZone
   ) -> (DeviceLocalZoneEditorViewModel, SpyPostcodeGeocoder, SpyDeviceLocalZoneRepository) {
     let geocoder = SpyPostcodeGeocoder()
     let repository = SpyDeviceLocalZoneRepository()
@@ -20,59 +26,54 @@ struct DeviceLocalZoneEditorViewModelTests {
     return (sut, geocoder, repository)
   }
 
-  // MARK: - New zone
-
-  @Test func init_new_isNotEditing() {
-    let (sut, _, _) = makeSUT()
-
-    #expect(!sut.isEditing)
-    #expect(sut.isPostcodeFieldVisible)
-    #expect(sut.geocodedCoordinate == nil)
+  private func makeZone(
+    name: String = "Home", radiusMetres: Double = 1000
+  ) throws -> DeviceLocalZone {
+    try DeviceLocalZone(name: name, centre: .cambridge, radiusMetres: radiusMetres)
   }
 
-  @Test func init_new_defaultRadiusIsWithinRange() {
-    let (sut, _, _) = makeSUT()
+  // MARK: - Init seeds from the zone being edited
 
-    #expect(sut.selectedRadiusMetres >= DeviceLocalZone.minRadiusMetres)
-    #expect(sut.selectedRadiusMetres <= DeviceLocalZone.maxRadiusMetres)
-  }
-
-  @Test func radiusBounds_matchDeviceLocalZoneClamp() {
-    let (sut, _, _) = makeSUT()
-
-    #expect(sut.minRadiusMetres == DeviceLocalZone.minRadiusMetres)
-    #expect(sut.maxRadiusMetres == DeviceLocalZone.maxRadiusMetres)
-  }
-
-  // MARK: - Editing an existing zone
-
-  @Test func init_editing_seedsFieldsFromZone() throws {
+  @Test func init_seedsFieldsFromTheZoneBeingEdited() throws {
     let zone = try DeviceLocalZone(name: "Home", centre: .cambridge, radiusMetres: 1500)
 
     let (sut, _, _) = makeSUT(editing: zone)
 
-    #expect(sut.isEditing)
-    #expect(!sut.isPostcodeFieldVisible)
     #expect(sut.nameInput == "Home")
     #expect(sut.selectedRadiusMetres == 1500)
     #expect(sut.geocodedCoordinate == .cambridge)
   }
 
-  // MARK: - Postcode submission
+  @Test func radiusBounds_matchDeviceLocalZoneClamp() throws {
+    let (sut, _, _) = makeSUT(editing: try makeZone())
 
-  @Test func submitPostcode_validPostcode_setsGeocodedCoordinate() async throws {
-    let (sut, geocoder, _) = makeSUT()
-    geocoder.geocodeResult = .success(.cambridge)
-    sut.postcodeInput = "CB1 2AD"
+    #expect(sut.minRadiusMetres == DeviceLocalZone.minRadiusMetres)
+    #expect(sut.maxRadiusMetres == DeviceLocalZone.maxRadiusMetres)
+  }
+
+  // MARK: - Postcode submission (GH#888: reachable while editing)
+
+  /// The regression this bead fixes: correcting the postcode of the
+  /// anonymous user's single (already-geocoded) zone must actually update
+  /// `geocodedCoordinate` — proving nothing gates `submitPostcode()` or its
+  /// effect away just because the zone already has a coordinate.
+  @Test func submitPostcode_whileEditingAnExistingZone_updatesGeocodedCoordinateToTheNewPostcode() async throws {
+    let existingZone = try makeZone()
+    let (sut, geocoder, _) = makeSUT(editing: existingZone)
+    let newCoordinate = try Coordinate(latitude: 51.5074, longitude: -0.1278)
+    geocoder.geocodeResult = .success(newCoordinate)
+    sut.postcodeInput = "SW1A 1AA"
 
     await sut.submitPostcode()
 
-    #expect(sut.geocodedCoordinate == .cambridge)
+    #expect(sut.geocodedCoordinate == newCoordinate)
+    #expect(sut.geocodedCoordinate != existingZone.centre)
     #expect(sut.error == nil)
   }
 
   @Test func submitPostcode_emptyNameInput_defaultsNameToPostcode() async throws {
-    let (sut, geocoder, _) = makeSUT()
+    let (sut, geocoder, _) = makeSUT(editing: try makeZone())
+    sut.nameInput = ""
     geocoder.geocodeResult = .success(.cambridge)
     sut.postcodeInput = "CB1 2AD"
 
@@ -82,9 +83,8 @@ struct DeviceLocalZoneEditorViewModelTests {
   }
 
   @Test func submitPostcode_existingNameInput_doesNotOverwriteName() async throws {
-    let (sut, geocoder, _) = makeSUT()
+    let (sut, geocoder, _) = makeSUT(editing: try makeZone(name: "My Custom Name"))
     geocoder.geocodeResult = .success(.cambridge)
-    sut.nameInput = "My Custom Name"
     sut.postcodeInput = "CB1 2AD"
 
     await sut.submitPostcode()
@@ -92,44 +92,29 @@ struct DeviceLocalZoneEditorViewModelTests {
     #expect(sut.nameInput == "My Custom Name")
   }
 
-  @Test func submitPostcode_invalidPostcode_setsError() async {
-    let (sut, _, _) = makeSUT()
+  @Test func submitPostcode_invalidPostcode_setsError() async throws {
+    let (sut, _, _) = makeSUT(editing: try makeZone())
     sut.postcodeInput = "not a postcode"
 
     await sut.submitPostcode()
 
-    #expect(sut.geocodedCoordinate == nil)
     #expect(sut.error != nil)
   }
 
-  @Test func submitPostcode_geocoderFailure_setsError() async {
-    let (sut, geocoder, _) = makeSUT()
+  @Test func submitPostcode_geocoderFailure_setsError() async throws {
+    let (sut, geocoder, _) = makeSUT(editing: try makeZone())
     geocoder.geocodeResult = .failure(DomainError.geocodingFailed("CB1 2AD"))
     sut.postcodeInput = "CB1 2AD"
 
     await sut.submitPostcode()
 
-    #expect(sut.geocodedCoordinate == nil)
     #expect(sut.error == .geocodingFailed("CB1 2AD"))
   }
 
   // MARK: - Save
 
-  @Test func save_noGeocodedCoordinate_returnsFalse() async {
-    let (sut, _, repository) = makeSUT()
-
-    let result = await sut.save()
-
-    #expect(!result)
-    #expect(repository.saveCalls.isEmpty)
-  }
-
-  @Test func save_validZone_persistsAndReturnsTrue() async throws {
-    let (sut, geocoder, repository) = makeSUT()
-    geocoder.geocodeResult = .success(.cambridge)
-    sut.postcodeInput = "CB1 2AD"
-    await sut.submitPostcode()
-    sut.nameInput = "Home"
+  @Test func save_persistsAndReturnsTrue() async throws {
+    let (sut, _, repository) = makeSUT(editing: try makeZone(name: "Home"))
     sut.selectedRadiusMetres = 2000
 
     let result = await sut.save()
@@ -140,12 +125,8 @@ struct DeviceLocalZoneEditorViewModelTests {
     #expect(repository.saveCalls.first?.radiusMetres == 2000)
   }
 
-  @Test func save_invokesOnSaveWithTheSavedZone() async {
-    let (sut, geocoder, _) = makeSUT()
-    geocoder.geocodeResult = .success(.cambridge)
-    sut.postcodeInput = "CB1 2AD"
-    await sut.submitPostcode()
-    sut.nameInput = "Home"
+  @Test func save_invokesOnSaveWithTheSavedZone() async throws {
+    let (sut, _, _) = makeSUT(editing: try makeZone(name: "Home"))
     var saved: DeviceLocalZone?
     sut.onSave = { saved = $0 }
 
@@ -154,8 +135,20 @@ struct DeviceLocalZoneEditorViewModelTests {
     #expect(saved?.name == "Home")
   }
 
-  @Test func save_editingExistingZone_reusesTheSameId() async throws {
-    let zone = try DeviceLocalZone(name: "Home", centre: .cambridge, radiusMetres: 1000)
+  @Test func save_afterCorrectingThePostcode_persistsTheNewCoordinate() async throws {
+    let (sut, geocoder, repository) = makeSUT(editing: try makeZone())
+    let newCoordinate = try Coordinate(latitude: 51.5074, longitude: -0.1278)
+    geocoder.geocodeResult = .success(newCoordinate)
+    sut.postcodeInput = "SW1A 1AA"
+    await sut.submitPostcode()
+
+    await sut.save()
+
+    #expect(repository.saveCalls.first?.centre == newCoordinate)
+  }
+
+  @Test func save_reusesTheZonesExistingId() async throws {
+    let zone = try makeZone(name: "Home")
     let (sut, _, repository) = makeSUT(editing: zone)
     sut.nameInput = "Renamed"
 
@@ -165,12 +158,8 @@ struct DeviceLocalZoneEditorViewModelTests {
     #expect(repository.saveCalls.first?.name == "Renamed")
   }
 
-  @Test func save_repositoryThrowsLimitReached_invokesOnRequestSignUpAndReturnsFalse() async {
-    let (sut, geocoder, repository) = makeSUT()
-    geocoder.geocodeResult = .success(.cambridge)
-    sut.postcodeInput = "CB1 2AD"
-    await sut.submitPostcode()
-    sut.nameInput = "Home"
+  @Test func save_repositoryThrowsLimitReached_invokesOnRequestSignUpAndReturnsFalse() async throws {
+    let (sut, _, repository) = makeSUT(editing: try makeZone())
     repository.saveError = DomainError.deviceLocalZoneLimitReached
     var requested = false
     sut.onRequestSignUp = { requested = true }
@@ -182,12 +171,8 @@ struct DeviceLocalZoneEditorViewModelTests {
     #expect(sut.error == nil)
   }
 
-  @Test func save_repositoryThrowsOtherError_setsInlineErrorAndReturnsFalse() async {
-    let (sut, geocoder, repository) = makeSUT()
-    geocoder.geocodeResult = .success(.cambridge)
-    sut.postcodeInput = "CB1 2AD"
-    await sut.submitPostcode()
-    sut.nameInput = "Home"
+  @Test func save_repositoryThrowsOtherError_setsInlineErrorAndReturnsFalse() async throws {
+    let (sut, _, repository) = makeSUT(editing: try makeZone())
     repository.saveError = DomainError.networkUnavailable
     var requested = false
     sut.onRequestSignUp = { requested = true }

--- a/mobile/ios/town-crier-tests/Sources/Features/DeviceLocalZoneEditorViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/DeviceLocalZoneEditorViewTests.swift
@@ -4,12 +4,17 @@ import TownCrierDomain
 
 @testable import TownCrierPresentation
 
+/// GH#888: no more "create" mode — the editor always opens on the anonymous
+/// user's existing single zone, and the postcode field renders
+/// unconditionally (see `DeviceLocalZoneEditorViewModel`'s docs).
 @MainActor
 @Suite("DeviceLocalZoneEditorView")
 struct DeviceLocalZoneEditorViewTests {
-  private func makeViewModel(
-    editing zone: DeviceLocalZone? = nil
-  ) -> DeviceLocalZoneEditorViewModel {
+  private func makeZone(name: String = "Home") throws -> DeviceLocalZone {
+    try DeviceLocalZone(name: name, centre: .cambridge, radiusMetres: 1500)
+  }
+
+  private func makeViewModel(editing zone: DeviceLocalZone) -> DeviceLocalZoneEditorViewModel {
     DeviceLocalZoneEditorViewModel(
       geocoder: SpyPostcodeGeocoder(),
       repository: SpyDeviceLocalZoneRepository(),
@@ -17,29 +22,22 @@ struct DeviceLocalZoneEditorViewTests {
     )
   }
 
-  @Test func body_renders_inCreateMode_withoutCoordinate() {
-    let vm = makeViewModel()
+  @Test func body_renders() throws {
+    let vm = makeViewModel(editing: try makeZone())
     let sut = DeviceLocalZoneEditorView(viewModel: vm)
     _ = sut.body
   }
 
-  @Test func body_renders_inEditMode() throws {
-    let zone = try DeviceLocalZone(name: "Home", centre: .cambridge, radiusMetres: 1500)
-    let vm = makeViewModel(editing: zone)
-    let sut = DeviceLocalZoneEditorView(viewModel: vm)
-    _ = sut.body
-  }
-
-  @Test func body_renders_afterPostcodeGeocoded() async {
-    let vm = makeViewModel()
+  @Test func body_renders_afterPostcodeGeocoded() async throws {
+    let vm = makeViewModel(editing: try makeZone())
     vm.postcodeInput = "CB1 2AD"
     await vm.submitPostcode()
     let sut = DeviceLocalZoneEditorView(viewModel: vm)
     _ = sut.body
   }
 
-  @Test func body_renders_withErrorState() async {
-    let vm = makeViewModel()
+  @Test func body_renders_withErrorState() async throws {
+    let vm = makeViewModel(editing: try makeZone())
     vm.postcodeInput = "not a postcode"
     await vm.submitPostcode()
     let sut = DeviceLocalZoneEditorView(viewModel: vm)

--- a/mobile/ios/town-crier-tests/Sources/Features/DeviceLocalZoneListViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/DeviceLocalZoneListViewModelTests.swift
@@ -13,10 +13,13 @@ import TownCrierDomain
 @Suite("DeviceLocalZoneListViewModel")
 @MainActor
 struct DeviceLocalZoneListViewModelTests {
-  private func makeSUT() -> (DeviceLocalZoneListViewModel, SpyDeviceLocalZoneRepository) {
+  private func makeSUT() -> (
+    DeviceLocalZoneListViewModel, SpyDeviceLocalZoneRepository, SpyPostcodeGeocoder
+  ) {
     let repository = SpyDeviceLocalZoneRepository()
-    let sut = DeviceLocalZoneListViewModel(repository: repository, geocoder: SpyPostcodeGeocoder())
-    return (sut, repository)
+    let geocoder = SpyPostcodeGeocoder()
+    let sut = DeviceLocalZoneListViewModel(repository: repository, geocoder: geocoder)
+    return (sut, repository, geocoder)
   }
 
   private func makeZone(name: String = "Home") throws -> DeviceLocalZone {
@@ -26,7 +29,7 @@ struct DeviceLocalZoneListViewModelTests {
   // MARK: - Load
 
   @Test func load_populatesZonesFromRepository() throws {
-    let (sut, repository) = makeSUT()
+    let (sut, repository, _) = makeSUT()
     let zone = try makeZone(name: "Home")
     repository.loadAllResult = [zone]
 
@@ -38,7 +41,7 @@ struct DeviceLocalZoneListViewModelTests {
   // MARK: - editZone
 
   @Test func editZone_opensEditorForThatZone() throws {
-    let (sut, _) = makeSUT()
+    let (sut, _, _) = makeSUT()
     let zone = try makeZone()
 
     sut.editZone(zone)
@@ -49,7 +52,7 @@ struct DeviceLocalZoneListViewModelTests {
   // MARK: - Alert affordance -> sign-up CTA
 
   @Test func requestAlertsSignUp_presentsSignUpCTA() {
-    let (sut, _) = makeSUT()
+    let (sut, _, _) = makeSUT()
 
     sut.requestAlertsSignUp()
 
@@ -60,7 +63,7 @@ struct DeviceLocalZoneListViewModelTests {
   /// (GH#888) is the only remaining route to another area now the cap is
   /// one — it routes to the same sign-up CTA as the per-row bell.
   @Test func requestSignUpFromPitch_presentsSignUpCTA() {
-    let (sut, _) = makeSUT()
+    let (sut, _, _) = makeSUT()
 
     sut.requestSignUpFromPitch()
 
@@ -68,7 +71,7 @@ struct DeviceLocalZoneListViewModelTests {
   }
 
   @Test func dismissSignUpCTA_clearsTheFlag() {
-    let (sut, _) = makeSUT()
+    let (sut, _, _) = makeSUT()
     sut.requestAlertsSignUp()
 
     sut.dismissSignUpCTA()
@@ -77,7 +80,7 @@ struct DeviceLocalZoneListViewModelTests {
   }
 
   @Test func confirmSignUp_clearsTheFlagAndInvokesOnRequestSignUp() {
-    let (sut, _) = makeSUT()
+    let (sut, _, _) = makeSUT()
     sut.requestAlertsSignUp()
     var requested = false
     sut.onRequestSignUp = { requested = true }
@@ -91,7 +94,7 @@ struct DeviceLocalZoneListViewModelTests {
   // MARK: - Editor dismissal / reload
 
   @Test func dismissEditor_clearsEditorTarget() throws {
-    let (sut, _) = makeSUT()
+    let (sut, _, _) = makeSUT()
     sut.editZone(try makeZone())
 
     sut.dismissEditor()
@@ -100,17 +103,16 @@ struct DeviceLocalZoneListViewModelTests {
   }
 
   @Test func makeEditorViewModel_seedsFromTheZoneBeingEdited() throws {
-    let (sut, _) = makeSUT()
+    let (sut, _, _) = makeSUT()
     let zone = try makeZone(name: "Existing")
 
     let editorVM = sut.makeEditorViewModel(for: zone)
 
-    #expect(editorVM.isEditing)
     #expect(editorVM.nameInput == "Existing")
   }
 
   @Test func makeEditorViewModel_onSave_dismissesEditorAndReloadsZones() throws {
-    let (sut, repository) = makeSUT()
+    let (sut, repository, _) = makeSUT()
     let zone = try makeZone(name: "Home")
     sut.editZone(zone)
     let editorVM = sut.makeEditorViewModel(for: zone)
@@ -128,7 +130,7 @@ struct DeviceLocalZoneListViewModelTests {
   /// `onZonesChanged` with the saved zone, so the coordinator can propagate
   /// it to the Map and Applications tabs.
   @Test func makeEditorViewModel_onSave_invokesOnZonesChangedWithTheSavedZone() throws {
-    let (sut, repository) = makeSUT()
+    let (sut, repository, _) = makeSUT()
     let zone = try makeZone(name: "Home")
     sut.editZone(zone)
     let editorVM = sut.makeEditorViewModel(for: zone)
@@ -143,8 +145,31 @@ struct DeviceLocalZoneListViewModelTests {
     #expect(changed == [saved])
   }
 
+  /// The regression this bead fixes (live-verified): the postcode field was
+  /// previously hidden whenever the editor opened in "editing" mode, which
+  /// GH#888 made the ONLY reachable mode — permanently stranding a mistyped
+  /// onboarding postcode. Proves the field is reachable end-to-end: editing
+  /// the postcode and saving still fires `onZonesChanged` with the
+  /// corrected coordinate.
+  @Test func makeEditorViewModel_afterCorrectingPostcode_onSave_invokesOnZonesChangedWithNewCoordinate() async throws {
+    let (sut, _, geocoder) = makeSUT()
+    let zone = try makeZone(name: "Home")
+    sut.editZone(zone)
+    let editorVM = sut.makeEditorViewModel(for: zone)
+    let newCoordinate = try Coordinate(latitude: 51.5074, longitude: -0.1278)
+    geocoder.geocodeResult = .success(newCoordinate)
+    editorVM.postcodeInput = "SW1A 1AA"
+    await editorVM.submitPostcode()
+    var changed: [DeviceLocalZone] = []
+    sut.onZonesChanged = { changed.append($0) }
+
+    await editorVM.save()
+
+    #expect(changed.first?.centre == newCoordinate)
+  }
+
   @Test func makeEditorViewModel_onRequestSignUp_dismissesEditorAndPresentsCTA() throws {
-    let (sut, _) = makeSUT()
+    let (sut, _, _) = makeSUT()
     let zone = try makeZone()
     sut.editZone(zone)
     let editorVM = sut.makeEditorViewModel(for: zone)

--- a/mobile/ios/town-crier-tests/Sources/Features/DeviceLocalZoneListViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/DeviceLocalZoneListViewModelTests.swift
@@ -4,10 +4,12 @@ import TownCrierDomain
 
 @testable import TownCrierPresentation
 
-/// GH#879 Phase 4: the anonymous Zones tab — up to `DeviceLocalZone.maxZoneCount`
-/// device-local areas with create/edit/delete. Any alert affordance and any
-/// attempt to add a 4th zone route to the sign-up CTA rather than a real
-/// quota/entitlement flow.
+/// GH#888: the anonymous Zones tab now holds exactly one editable
+/// device-local zone (`DeviceLocalZone.maxZoneCount == 1`) — no add, no
+/// delete. Any alert affordance (row bell or the persistent sign-up pitch)
+/// routes to the sign-up CTA, and a successful edit notifies
+/// `onZonesChanged` so the coordinator can propagate it live to the Map and
+/// Applications tabs.
 @Suite("DeviceLocalZoneListViewModel")
 @MainActor
 struct DeviceLocalZoneListViewModelTests {
@@ -25,52 +27,12 @@ struct DeviceLocalZoneListViewModelTests {
 
   @Test func load_populatesZonesFromRepository() throws {
     let (sut, repository) = makeSUT()
-    repository.loadAllResult = [try makeZone(name: "One"), try makeZone(name: "Two")]
+    let zone = try makeZone(name: "Home")
+    repository.loadAllResult = [zone]
 
     sut.load()
 
-    #expect(sut.zones.count == 2)
-  }
-
-  // MARK: - canAddZone
-
-  @Test func canAddZone_true_belowCap() throws {
-    let (sut, repository) = makeSUT()
-    repository.loadAllResult = [try makeZone(), try makeZone()]
-    sut.load()
-
-    #expect(sut.canAddZone)
-  }
-
-  @Test func canAddZone_false_atCap() throws {
-    let (sut, repository) = makeSUT()
-    repository.loadAllResult = [try makeZone(name: "1"), try makeZone(name: "2"), try makeZone(name: "3")]
-    sut.load()
-
-    #expect(!sut.canAddZone)
-  }
-
-  // MARK: - addZoneTapped
-
-  @Test func addZoneTapped_belowCap_opensNewEditor() {
-    let (sut, _) = makeSUT()
-    sut.load()
-
-    sut.addZoneTapped()
-
-    #expect(sut.editorTarget == .new)
-    #expect(!sut.isSignUpCTAPresented)
-  }
-
-  @Test func addZoneTapped_atCap_presentsSignUpCTA() throws {
-    let (sut, repository) = makeSUT()
-    repository.loadAllResult = [try makeZone(name: "1"), try makeZone(name: "2"), try makeZone(name: "3")]
-    sut.load()
-
-    sut.addZoneTapped()
-
-    #expect(sut.editorTarget == nil)
-    #expect(sut.isSignUpCTAPresented)
+    #expect(sut.zones == [zone])
   }
 
   // MARK: - editZone
@@ -81,21 +43,7 @@ struct DeviceLocalZoneListViewModelTests {
 
     sut.editZone(zone)
 
-    #expect(sut.editorTarget == .edit(zone))
-  }
-
-  // MARK: - deleteZone
-
-  @Test func deleteZone_removesFromRepositoryAndLocalList() throws {
-    let (sut, repository) = makeSUT()
-    let zone = try makeZone()
-    repository.loadAllResult = [zone]
-    sut.load()
-
-    sut.deleteZone(zone)
-
-    #expect(repository.deleteCalls == [zone.id])
-    #expect(sut.zones.isEmpty)
+    #expect(sut.editorTarget == zone)
   }
 
   // MARK: - Alert affordance -> sign-up CTA
@@ -104,6 +52,17 @@ struct DeviceLocalZoneListViewModelTests {
     let (sut, _) = makeSUT()
 
     sut.requestAlertsSignUp()
+
+    #expect(sut.isSignUpCTAPresented)
+  }
+
+  /// The persistent "want more areas or alerts?" pitch below the zone
+  /// (GH#888) is the only remaining route to another area now the cap is
+  /// one — it routes to the same sign-up CTA as the per-row bell.
+  @Test func requestSignUpFromPitch_presentsSignUpCTA() {
+    let (sut, _) = makeSUT()
+
+    sut.requestSignUpFromPitch()
 
     #expect(sut.isSignUpCTAPresented)
   }
@@ -131,28 +90,20 @@ struct DeviceLocalZoneListViewModelTests {
 
   // MARK: - Editor dismissal / reload
 
-  @Test func dismissEditor_clearsEditorTarget() {
+  @Test func dismissEditor_clearsEditorTarget() throws {
     let (sut, _) = makeSUT()
-    sut.addZoneTapped()
+    sut.editZone(try makeZone())
 
     sut.dismissEditor()
 
     #expect(sut.editorTarget == nil)
   }
 
-  @Test func makeEditorViewModel_forNew_isNotEditing() {
-    let (sut, _) = makeSUT()
-
-    let editorVM = sut.makeEditorViewModel(for: .new)
-
-    #expect(!editorVM.isEditing)
-  }
-
-  @Test func makeEditorViewModel_forEdit_seedsFromZone() throws {
+  @Test func makeEditorViewModel_seedsFromTheZoneBeingEdited() throws {
     let (sut, _) = makeSUT()
     let zone = try makeZone(name: "Existing")
 
-    let editorVM = sut.makeEditorViewModel(for: .edit(zone))
+    let editorVM = sut.makeEditorViewModel(for: zone)
 
     #expect(editorVM.isEditing)
     #expect(editorVM.nameInput == "Existing")
@@ -160,9 +111,11 @@ struct DeviceLocalZoneListViewModelTests {
 
   @Test func makeEditorViewModel_onSave_dismissesEditorAndReloadsZones() throws {
     let (sut, repository) = makeSUT()
-    sut.addZoneTapped()
-    let editorVM = sut.makeEditorViewModel(for: .new)
-    let saved = try makeZone(name: "Saved")
+    let zone = try makeZone(name: "Home")
+    sut.editZone(zone)
+    let editorVM = sut.makeEditorViewModel(for: zone)
+    let saved = try DeviceLocalZone(
+      id: zone.id, name: "Renamed", centre: .cambridge, radiusMetres: 2000)
     repository.loadAllResult = [saved]
 
     editorVM.onSave?(saved)
@@ -171,10 +124,30 @@ struct DeviceLocalZoneListViewModelTests {
     #expect(sut.zones == [saved])
   }
 
-  @Test func makeEditorViewModel_onRequestSignUp_dismissesEditorAndPresentsCTA() {
+  /// GH#888 acceptance criterion: a successful editor save fires
+  /// `onZonesChanged` with the saved zone, so the coordinator can propagate
+  /// it to the Map and Applications tabs.
+  @Test func makeEditorViewModel_onSave_invokesOnZonesChangedWithTheSavedZone() throws {
+    let (sut, repository) = makeSUT()
+    let zone = try makeZone(name: "Home")
+    sut.editZone(zone)
+    let editorVM = sut.makeEditorViewModel(for: zone)
+    let saved = try DeviceLocalZone(
+      id: zone.id, name: "Renamed", centre: .cambridge, radiusMetres: 2000)
+    repository.loadAllResult = [saved]
+    var changed: [DeviceLocalZone] = []
+    sut.onZonesChanged = { changed.append($0) }
+
+    editorVM.onSave?(saved)
+
+    #expect(changed == [saved])
+  }
+
+  @Test func makeEditorViewModel_onRequestSignUp_dismissesEditorAndPresentsCTA() throws {
     let (sut, _) = makeSUT()
-    sut.addZoneTapped()
-    let editorVM = sut.makeEditorViewModel(for: .new)
+    let zone = try makeZone()
+    sut.editZone(zone)
+    let editorVM = sut.makeEditorViewModel(for: zone)
 
     editorVM.onRequestSignUp?()
 

--- a/mobile/ios/town-crier-tests/Sources/Features/DeviceLocalZoneListViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/DeviceLocalZoneListViewTests.swift
@@ -23,30 +23,26 @@ struct DeviceLocalZoneListViewTests {
     _ = sut.body
   }
 
-  @Test func body_renders_withZones() throws {
+  @Test func body_renders_withZone() throws {
     let (vm, repository) = makeViewModel()
-    repository.loadAllResult = [try makeZone(name: "One"), try makeZone(name: "Two")]
+    repository.loadAllResult = [try makeZone(name: "Home")]
     vm.load()
 
     let sut = DeviceLocalZoneListView(viewModel: vm)
     _ = sut.body
   }
 
-  @Test func body_renders_whenEditorPresented() {
+  @Test func body_renders_whenEditorPresented() throws {
     let (vm, _) = makeViewModel()
-    vm.addZoneTapped()
+    vm.editZone(try makeZone())
 
     let sut = DeviceLocalZoneListView(viewModel: vm)
     _ = sut.body
   }
 
-  @Test func body_renders_whenSignUpCTAPresented() throws {
-    let (vm, repository) = makeViewModel()
-    repository.loadAllResult = [
-      try makeZone(name: "1"), try makeZone(name: "2"), try makeZone(name: "3"),
-    ]
-    vm.load()
-    vm.addZoneTapped()
+  @Test func body_renders_whenSignUpCTAPresented() {
+    let (vm, _) = makeViewModel()
+    vm.requestAlertsSignUp()
 
     #expect(vm.isSignUpCTAPresented)
 

--- a/mobile/ios/town-crier-tests/Sources/Features/DeviceLocalZoneTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/DeviceLocalZoneTests.swift
@@ -77,7 +77,7 @@ struct DeviceLocalZoneTests {
     #expect(DeviceLocalZone.clampRadius(2500) == 2500)
   }
 
-  @Test func maxZoneCount_isThree() {
-    #expect(DeviceLocalZone.maxZoneCount == 3)
+  @Test func maxZoneCount_isOne() {
+    #expect(DeviceLocalZone.maxZoneCount == 1)
   }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/UserDefaultsDeviceLocalZoneRepositoryTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/UserDefaultsDeviceLocalZoneRepositoryTests.swift
@@ -4,9 +4,11 @@ import TownCrierDomain
 
 @testable import TownCrierData
 
-/// GH#879 Phase 4 acceptance criteria: repository round-trip, cap-at-3
-/// enforcement, radius clamp [100, 5000], migration seeds zone 1 from the
-/// legacy `AnonymousBrowseState`.
+/// GH#879 Phase 4 / GH#888 acceptance criteria: repository round-trip,
+/// cap-at-1 enforcement (GH#888 reversed the original cap-at-3), radius
+/// clamp [100, 5000], migration seeds zone 1 from the legacy
+/// `AnonymousBrowseState`, and an idempotent trim-to-active-zone on every
+/// `loadAll()` call self-heals any pre-GH#888 multi-zone install.
 @Suite("UserDefaultsDeviceLocalZoneRepository")
 struct UserDefaultsDeviceLocalZoneRepositoryTests {
   private func makeSUT(
@@ -26,6 +28,48 @@ struct UserDefaultsDeviceLocalZoneRepositoryTests {
     name: String = "Home", radiusMetres: Double = 1000
   ) throws -> DeviceLocalZone {
     try DeviceLocalZone(name: name, centre: .cambridge, radiusMetres: radiusMetres)
+  }
+
+  /// A repository/defaults pair with no legacy-state repository injected —
+  /// used by the trim tests (GH#888), which need direct access to the
+  /// `UserDefaults` suite to seed pre-existing (pre-GH#888) multi-zone
+  /// storage.
+  private func makeSUTAndDefaults() -> (UserDefaultsDeviceLocalZoneRepository, UserDefaults) {
+    let defaults = UserDefaults(suiteName: UUID().uuidString)
+    // swiftlint:disable:next force_unwrapping
+    let sut = UserDefaultsDeviceLocalZoneRepository(defaults: defaults!)
+    // swiftlint:disable:next force_unwrapping
+    return (sut, defaults!)
+  }
+
+  /// Wire-format fixture mirroring the production repository's private
+  /// `StoredZone` shape — lets the trim tests (GH#888) seed the UserDefaults
+  /// suite directly, as if it were a pre-GH#888 multi-zone TestFlight
+  /// install, bypassing the (now much lower) `save()` cap entirely.
+  private struct RawStoredZone: Codable {
+    let id: String
+    let name: String
+    let latitude: Double
+    let longitude: Double
+    let radiusMetres: Double
+
+    init(_ zone: DeviceLocalZone) {
+      id = zone.id.value
+      name = zone.name
+      latitude = zone.centre.latitude
+      longitude = zone.centre.longitude
+      radiusMetres = zone.radiusMetres
+    }
+  }
+
+  private func seedRawZones(
+    _ zones: [DeviceLocalZone], activeId: DeviceLocalZoneId?, in defaults: UserDefaults
+  ) throws {
+    let data = try JSONEncoder().encode(zones.map(RawStoredZone.init))
+    defaults.set(data, forKey: "deviceLocalZones")
+    if let activeId {
+      defaults.set(activeId.value, forKey: "deviceLocalZoneActiveId")
+    }
   }
 
   // MARK: - Round-trip
@@ -77,42 +121,28 @@ struct UserDefaultsDeviceLocalZoneRepositoryTests {
     #expect(sut.loadAll() == [zone])
   }
 
-  // MARK: - Cap at 3
+  // MARK: - Cap at 1 (GH#888 — reversed the original cap-at-3)
 
-  @Test func save_thirdZone_succeeds() throws {
+  @Test func save_secondZone_throwsLimitReached() throws {
     let (sut, _) = makeSUT()
     try sut.save(try makeZone(name: "One"))
-    try sut.save(try makeZone(name: "Two"))
-
-    try sut.save(try makeZone(name: "Three"))
-
-    #expect(sut.loadAll().count == 3)
-  }
-
-  @Test func save_fourthZone_throwsLimitReached() throws {
-    let (sut, _) = makeSUT()
-    try sut.save(try makeZone(name: "One"))
-    try sut.save(try makeZone(name: "Two"))
-    try sut.save(try makeZone(name: "Three"))
 
     #expect(throws: DomainError.deviceLocalZoneLimitReached) {
-      try sut.save(try makeZone(name: "Four"))
+      try sut.save(try makeZone(name: "Two"))
     }
-    #expect(sut.loadAll().count == 3)
+    #expect(sut.loadAll().count == 1)
   }
 
   @Test func save_editingExistingZone_atCap_doesNotThrow() throws {
     let (sut, _) = makeSUT()
     let first = try makeZone(name: "One")
     try sut.save(first)
-    try sut.save(try makeZone(name: "Two"))
-    try sut.save(try makeZone(name: "Three"))
 
     let renamed = try DeviceLocalZone(
       id: first.id, name: "Renamed", centre: .cambridge, radiusMetres: 1000)
     try sut.save(renamed)
 
-    #expect(sut.loadAll().contains(renamed))
+    #expect(sut.loadAll() == [renamed])
   }
 
   // MARK: - Active zone
@@ -132,22 +162,11 @@ struct UserDefaultsDeviceLocalZoneRepositoryTests {
     #expect(sut.activeZoneId() == zone.id)
   }
 
-  @Test func save_secondZone_doesNotChangeActiveZone() throws {
-    let (sut, _) = makeSUT()
-    let first = try makeZone(name: "One")
-    try sut.save(first)
-
-    try sut.save(try makeZone(name: "Two"))
-
-    #expect(sut.activeZoneId() == first.id)
-  }
-
   @Test func setActiveZoneId_updatesTheActiveZone() throws {
-    let (sut, _) = makeSUT()
+    let (sut, defaults) = makeSUTAndDefaults()
     let first = try makeZone(name: "One")
     let second = try makeZone(name: "Two")
-    try sut.save(first)
-    try sut.save(second)
+    try seedRawZones([first, second], activeId: first.id, in: defaults)
 
     sut.setActiveZoneId(second.id)
 
@@ -164,11 +183,10 @@ struct UserDefaultsDeviceLocalZoneRepositoryTests {
   }
 
   @Test func delete_activeZone_promotesFirstRemainingZone() throws {
-    let (sut, _) = makeSUT()
+    let (sut, defaults) = makeSUTAndDefaults()
     let first = try makeZone(name: "One")
     let second = try makeZone(name: "Two")
-    try sut.save(first)
-    try sut.save(second)
+    try seedRawZones([first, second], activeId: first.id, in: defaults)
 
     sut.delete(first.id)
 
@@ -186,15 +204,69 @@ struct UserDefaultsDeviceLocalZoneRepositoryTests {
   }
 
   @Test func delete_nonActiveZone_doesNotChangeActiveZone() throws {
-    let (sut, _) = makeSUT()
+    let (sut, defaults) = makeSUTAndDefaults()
     let first = try makeZone(name: "One")
     let second = try makeZone(name: "Two")
-    try sut.save(first)
-    try sut.save(second)
+    try seedRawZones([first, second], activeId: first.id, in: defaults)
 
     sut.delete(second.id)
 
     #expect(sut.activeZoneId() == first.id)
+  }
+
+  // MARK: - Trim to active zone (GH#888)
+
+  /// The exact acceptance-criteria scenario: storage seeded with 3 zones
+  /// (active = the 2nd) — `loadAll()` returns only the active zone.
+  @Test func loadAll_moreThanOneZoneStored_activeSet_returnsOnlyTheActiveZone() throws {
+    let (sut, defaults) = makeSUTAndDefaults()
+    let one = try makeZone(name: "One")
+    let two = try makeZone(name: "Two")
+    let three = try makeZone(name: "Three")
+    try seedRawZones([one, two, three], activeId: two.id, in: defaults)
+
+    let zones = sut.loadAll()
+
+    #expect(zones == [two])
+  }
+
+  /// The trim is PERSISTED, not just returned transiently — a fresh
+  /// repository instance over the same `UserDefaults` suite (mirroring an
+  /// app relaunch) sees the same single zone.
+  @Test func loadAll_moreThanOneZoneStored_persistsTheTrim() throws {
+    let (sut, defaults) = makeSUTAndDefaults()
+    let one = try makeZone(name: "One")
+    let two = try makeZone(name: "Two")
+    let three = try makeZone(name: "Three")
+    try seedRawZones([one, two, three], activeId: two.id, in: defaults)
+
+    _ = sut.loadAll()
+
+    let reloaded = UserDefaultsDeviceLocalZoneRepository(defaults: defaults)
+    #expect(reloaded.loadAll() == [two])
+    #expect(reloaded.activeZoneId() == two.id)
+  }
+
+  @Test func loadAll_moreThanOneZoneStored_noActiveSet_keepsTheFirstZone() throws {
+    let (sut, defaults) = makeSUTAndDefaults()
+    let one = try makeZone(name: "One")
+    let two = try makeZone(name: "Two")
+    try seedRawZones([one, two], activeId: nil, in: defaults)
+
+    let zones = sut.loadAll()
+
+    #expect(zones == [one])
+    #expect(sut.activeZoneId() == one.id)
+  }
+
+  /// Idempotent: once at most one zone remains, repeated calls are a no-op.
+  @Test func loadAll_alreadyAtMostOneZone_isANoOp() throws {
+    let (sut, _) = makeSUT()
+    let zone = try makeZone()
+    try sut.save(zone)
+
+    #expect(sut.loadAll() == [zone])
+    #expect(sut.loadAll() == [zone])
   }
 
   // MARK: - Migration from legacy AnonymousBrowseState


### PR DESCRIPTION
## Summary
- Anonymous device-local zones reduced from 3 to exactly 1 (matches Free tier — reverses #879's "match Personal" decision, which made sign-up feel like a net loss of areas).
- Zones-tab edits (postcode, name, radius) now propagate live to the Map and Applications tabs with no relaunch required.
- Applications tab always shows the zone chip (+ "Add area" sign-up CTA) instead of only once a second zone existed.
- Pre-existing multi-zone TestFlight installs self-heal via an idempotent trim-to-active on load.
- Fix included: the zone editor's postcode field was found unreachable during simulator verification (a dead "create new zone" code path left `isEditing` permanently true) — removed the dead branch so postcode/radius are both always editable, matching #888's explicit rationale of never stranding a mistyped onboarding postcode.

## Test plan
- [x] `swift build`, `swift test` (1782/1782), `swiftlint lint --strict` (0 new violations vs main baseline)
- [x] Simulator-verified by a dispatched subagent (mobile-mcp): postcode edit → Map re-centres + Applications list updates live, no relaunch; single zone chip + Add-area chip; sign-up copy never says "instant"; zero add/delete affordances on Zones tab
- [x] Release-Note trailers on both user-facing commits

Closes #888 (tc-kpufx)

🤖 Generated with [Claude Code](https://claude.com/claude-code)