### PR TITLE
feat: paused-zone badge, web (GH #889 P3) (tc-6c3md)

### DIFF
--- a/web/src/domain/types.ts
+++ b/web/src/domain/types.ts
@@ -137,6 +137,13 @@ export interface WatchZoneSummary {
   readonly authorityId: AuthorityId;
   readonly pushEnabled: boolean;
   readonly emailInstantEnabled: boolean;
+  /**
+   * True when this zone exceeds the caller's current tier zone limit and has
+   * stopped generating new notifications (GH#889). Derived server-side from
+   * `(createdAt, id)` rank against `EffectiveTier(now).WatchZoneLimit()` —
+   * never computed client-side. Additive, always present on the wire.
+   */
+  readonly paused: boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/web/src/features/WatchZones/WatchZoneListPage.module.css
+++ b/web/src/features/WatchZones/WatchZoneListPage.module.css
@@ -58,11 +58,38 @@
   min-width: 0;
 }
 
+.zoneNameRow {
+  display: flex;
+  align-items: center;
+  gap: var(--tc-space-sm);
+  margin-bottom: var(--tc-space-xs);
+}
+
 .zoneName {
   font-size: var(--tc-text-body);
   font-weight: var(--tc-font-semibold);
   color: var(--tc-text-primary);
-  margin: 0 0 var(--tc-space-xs) 0;
+  margin: 0;
+}
+
+/*
+ * Paused status pill — mirrors the ApplicationCard statusBadge pattern
+ * (design-language "Status Badges": capsule shape, status color at 15%
+ * background / full opacity text, caption-emphasis weight). Uses the
+ * withdrawn token since a paused zone is inactive, not an error or warning.
+ */
+.pausedBadge {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--tc-space-xs) var(--tc-space-sm);
+  border-radius: var(--tc-radius-full);
+  background: color-mix(in srgb, var(--tc-status-withdrawn) 15%, transparent);
+  color: var(--tc-status-withdrawn);
+  font-size: var(--tc-text-caption);
+  font-weight: var(--tc-weight-medium);
+  line-height: var(--tc-leading-normal);
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .zoneRadius {

--- a/web/src/features/WatchZones/WatchZoneListPage.tsx
+++ b/web/src/features/WatchZones/WatchZoneListPage.tsx
@@ -60,7 +60,18 @@ export function WatchZoneListPage({ repository }: Props) {
           {zones.map((zone) => (
             <li key={zone.id} className={styles.card}>
               <div className={styles.cardContent}>
-                <h2 className={styles.zoneName}>{zone.name}</h2>
+                <div className={styles.zoneNameRow}>
+                  <h2 className={styles.zoneName}>{zone.name}</h2>
+                  {zone.paused && (
+                    <span
+                      className={styles.pausedBadge}
+                      data-testid="zone-paused-badge"
+                      title="This area is paused because it's over your plan's zone limit. Upgrade for more zones."
+                    >
+                      Paused
+                    </span>
+                  )}
+                </div>
                 <p className={styles.zoneRadius}>{formatRadius(zone.radiusMetres)}</p>
               </div>
               <div className={styles.cardActions}>

--- a/web/src/features/WatchZones/__tests__/WatchZoneListPage.test.tsx
+++ b/web/src/features/WatchZones/__tests__/WatchZoneListPage.test.tsx
@@ -99,4 +99,22 @@ describe('WatchZoneListPage', () => {
     const editLink = screen.getByRole('link', { name: /edit/i });
     expect(editLink).toHaveAttribute('href', '/watch-zones/zone-1');
   });
+
+  it('renders a Paused badge when a zone is paused', async () => {
+    spy.listResult = [aWatchZone({ paused: true })];
+
+    renderWithRouter(<WatchZoneListPage repository={spy} />);
+
+    expect(await screen.findByText('Paused')).toBeInTheDocument();
+  });
+
+  it('does not render a Paused badge when a zone is not paused', async () => {
+    spy.listResult = [aWatchZone({ paused: false })];
+
+    renderWithRouter(<WatchZoneListPage repository={spy} />);
+
+    await screen.findByText('Home');
+
+    expect(screen.queryByText('Paused')).not.toBeInTheDocument();
+  });
 });

--- a/web/src/features/WatchZones/__tests__/fixtures/watch-zone.fixtures.ts
+++ b/web/src/features/WatchZones/__tests__/fixtures/watch-zone.fixtures.ts
@@ -14,6 +14,7 @@ export function aWatchZone(overrides?: Partial<WatchZoneSummary>): WatchZoneSumm
     authorityId: asAuthorityId(1),
     pushEnabled: true,
     emailInstantEnabled: true,
+    paused: false,
     ...overrides,
   };
 }
@@ -28,6 +29,7 @@ export function aSecondWatchZone(overrides?: Partial<WatchZoneSummary>): WatchZo
     authorityId: asAuthorityId(2),
     pushEnabled: true,
     emailInstantEnabled: true,
+    paused: false,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary
- Web WatchZones list now renders a "Paused" status pill on any zone where the API's `paused` field is `true` (backend derivation shipped in #892).
- Styled on the existing `--tc-status-withdrawn` token (grey/inactive), with a tooltip explaining the zone is over the plan's quota and inviting upgrade.
- Purely additive/display-only — no client-side pause computation.

## Test plan
- [x] `npx tsc --noEmit`, `npx vitest run` (1140 tests), `npx eslint .`, `npm run build` all clean
- [x] New tests: badge renders when `paused: true`, absent when `false`
- [x] UI-verified by a dispatched subagent (agent-browser): badge shows only on paused zones, layout intact, tooltip text correct, no console errors

## Follow-up filed
- tc-hzqej (discovered-from): pre-existing undefined CSS custom properties (`--tc-font-bold` etc.) in WatchZones styles — unrelated to this change, not fixed here.

Closes #889 Phase 3 (tc-6c3md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)