### PR TITLE
feat(ios): paused-zone badge + paywall route (tc-m6ce1)

### DIFF
--- a/mobile/ios/packages/town-crier-data/Sources/Repositories/APIWatchZoneRepository.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Repositories/APIWatchZoneRepository.swift
@@ -143,6 +143,12 @@ struct WatchZoneSummaryDTO: Decodable, Sendable {
   let authorityId: Int
   let pushEnabled: Bool
   let emailInstantEnabled: Bool
+  /// Server-derived: true when this zone currently exceeds the user's
+  /// effective tier quota and has stopped generating notifications (GH#889
+  /// P1/P2). Absent on responses predating this field, so it hydrates to
+  /// `false` (an unpaused zone) — same forward/back-compat treatment as
+  /// `pushEnabled`/`emailInstantEnabled` above.
+  let paused: Bool
 
   init(
     id: String,
@@ -152,7 +158,8 @@ struct WatchZoneSummaryDTO: Decodable, Sendable {
     radiusMetres: Double,
     authorityId: Int,
     pushEnabled: Bool = true,
-    emailInstantEnabled: Bool = true
+    emailInstantEnabled: Bool = true,
+    paused: Bool = false
   ) {
     self.id = id
     self.name = name
@@ -162,6 +169,7 @@ struct WatchZoneSummaryDTO: Decodable, Sendable {
     self.authorityId = authorityId
     self.pushEnabled = pushEnabled
     self.emailInstantEnabled = emailInstantEnabled
+    self.paused = paused
   }
 
   init(from decoder: Decoder) throws {
@@ -176,11 +184,13 @@ struct WatchZoneSummaryDTO: Decodable, Sendable {
     self.pushEnabled = try container.decodeIfPresent(Bool.self, forKey: .pushEnabled) ?? true
     self.emailInstantEnabled =
       try container.decodeIfPresent(Bool.self, forKey: .emailInstantEnabled) ?? true
+    // GH#889 P2: absent (older API/back-compat) hydrates to false (not paused).
+    self.paused = try container.decodeIfPresent(Bool.self, forKey: .paused) ?? false
   }
 
   private enum CodingKeys: String, CodingKey {
     case id, name, latitude, longitude, radiusMetres, authorityId
-    case pushEnabled, emailInstantEnabled
+    case pushEnabled, emailInstantEnabled, paused
   }
 
   func toDomain() throws -> WatchZone {
@@ -192,7 +202,8 @@ struct WatchZoneSummaryDTO: Decodable, Sendable {
       radiusMetres: radiusMetres,
       authorityId: authorityId,
       pushEnabled: pushEnabled,
-      emailInstantEnabled: emailInstantEnabled
+      emailInstantEnabled: emailInstantEnabled,
+      paused: paused
     )
   }
 }

--- a/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/WatchZone.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/WatchZone.swift
@@ -9,6 +9,13 @@ public struct WatchZone: Equatable, Hashable, Identifiable, Sendable {
   public let authorityId: Int
   public let pushEnabled: Bool
   public let emailInstantEnabled: Bool
+  /// Whether this zone currently exceeds the user's effective tier quota and
+  /// has stopped generating new notifications (GH#889 P1/P2). Purely a
+  /// server-derived display flag — never computed or mutated by the client.
+  /// A paused zone remains fully listed, editable, and deletable; it is
+  /// automatically revived (server-side, with no client action) once the
+  /// user upgrades or deletes older zones.
+  public let paused: Bool
 
   public init(
     id: WatchZoneId = WatchZoneId(),
@@ -17,7 +24,8 @@ public struct WatchZone: Equatable, Hashable, Identifiable, Sendable {
     radiusMetres: Double,
     authorityId: Int = 0,
     pushEnabled: Bool = true,
-    emailInstantEnabled: Bool = true
+    emailInstantEnabled: Bool = true,
+    paused: Bool = false
   ) throws {
     let trimmed = name.trimmingCharacters(in: .whitespaces)
     guard !trimmed.isEmpty else {
@@ -33,6 +41,7 @@ public struct WatchZone: Equatable, Hashable, Identifiable, Sendable {
     self.authorityId = authorityId
     self.pushEnabled = pushEnabled
     self.emailInstantEnabled = emailInstantEnabled
+    self.paused = paused
   }
 
   /// Convenience initializer that derives the zone name from a validated postcode.
@@ -43,7 +52,8 @@ public struct WatchZone: Equatable, Hashable, Identifiable, Sendable {
     radiusMetres: Double,
     authorityId: Int = 0,
     pushEnabled: Bool = true,
-    emailInstantEnabled: Bool = true
+    emailInstantEnabled: Bool = true,
+    paused: Bool = false
   ) throws {
     try self.init(
       id: id,
@@ -52,7 +62,8 @@ public struct WatchZone: Equatable, Hashable, Identifiable, Sendable {
       radiusMetres: radiusMetres,
       authorityId: authorityId,
       pushEnabled: pushEnabled,
-      emailInstantEnabled: emailInstantEnabled
+      emailInstantEnabled: emailInstantEnabled,
+      paused: paused
     )
   }
 

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/PausedZoneBadge.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/PausedZoneBadge.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+/// A compact "Paused" indicator shown on a watch zone row that currently
+/// exceeds the user's tier quota and has stopped generating notifications
+/// (GH#889 P1/P2 — a subscription downgrade left the user over quota; oldest
+/// zones stay active, newest are paused).
+///
+/// The badge doubles as its own upgrade affordance: tapping it opens the
+/// subscription paywall via the host's `onUpgrade` closure, which
+/// ``WatchZoneListView`` wires to ``WatchZoneListViewModel/viewPlans()`` —
+/// the same routing method used by the toolbar upgrade badge and the
+/// free-tier inline upsell card, so every "upgrade" entry point on the Watch
+/// Zones screen converges on one paywall presentation path.
+///
+/// Follows the design language's status-badge shape (capsule, paired icon,
+/// 15% opacity background) using `tcStatusWithdrawn` — the same "no longer
+/// active" grey used for withdrawn applications — since a paused zone is, in
+/// the same sense, currently dormant. The zone itself is never deleted,
+/// edited, or hidden while paused; only new notifications stop.
+struct PausedZoneBadge: View {
+  /// User-facing copy, kept in one place so it can be unit-tested directly.
+  enum Copy {
+    static let label = "Paused"
+    static let accessibilityLabel =
+      "Paused. This zone exceeds your plan's limit and won't generate new notifications."
+    static let accessibilityHint = "Opens subscription plans"
+  }
+
+  private let onUpgrade: () -> Void
+
+  init(onUpgrade: @escaping () -> Void) {
+    self.onUpgrade = onUpgrade
+  }
+
+  var body: some View {
+    Button(action: onUpgrade) {
+      HStack(spacing: TCSpacing.extraSmall) {
+        Image(systemName: "pause.circle.fill")
+        Text(Copy.label)
+        Image(systemName: "arrow.up.circle.fill")
+          .foregroundStyle(Color.tcAmber)
+      }
+      .font(TCTypography.captionEmphasis)
+      .foregroundStyle(Color.tcStatusWithdrawn)
+      .padding(.horizontal, TCSpacing.small)
+      .padding(.vertical, TCSpacing.extraSmall)
+      .background(Color.tcStatusWithdrawn.opacity(0.15))
+      .clipShape(Capsule())
+    }
+    .buttonStyle(.plain)
+    .accessibilityLabel(Copy.accessibilityLabel)
+    .accessibilityHint(Copy.accessibilityHint)
+  }
+
+  // MARK: - Test Helpers
+
+  /// Simulates tapping the badge for unit testing.
+  func simulateUpgradeTap() {
+    onUpgrade()
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListView.swift
@@ -5,6 +5,10 @@ import TownCrierDomain
 ///
 /// When the user has reached their tier's zone limit, the add button is replaced
 /// with an ``UpgradeBadgeView`` and tapping it triggers the upgrade flow.
+///
+/// A zone paused by a subscription downgrade (GH#889 P1/P2) shows a
+/// ``PausedZoneBadge`` on its row; tapping the badge routes to the same
+/// subscription paywall via ``WatchZoneListViewModel/viewPlans()``.
 public struct WatchZoneListView: View {
   @StateObject private var viewModel: WatchZoneListViewModel
 
@@ -18,7 +22,7 @@ public struct WatchZoneListView: View {
         emptyState
       } else {
         ForEach(viewModel.zones) { zone in
-          WatchZoneRow(zone: zone)
+          WatchZoneRow(zone: zone) { viewModel.viewPlans() }
             .contentShape(Rectangle())
             .onTapGesture { viewModel.editZone(zone) }
         }
@@ -133,6 +137,7 @@ extension View {
 
 private struct WatchZoneRow: View {
   let zone: WatchZone
+  let onUpgrade: () -> Void
 
   var body: some View {
     HStack(spacing: TCSpacing.medium) {
@@ -146,6 +151,9 @@ private struct WatchZoneRow: View {
         Text(formatRadius(zone.radiusMetres))
           .font(.system(.caption))
           .foregroundStyle(Color.tcTextSecondary)
+        if zone.paused {
+          PausedZoneBadge(onUpgrade: onUpgrade)
+        }
       }
 
       Spacer()

--- a/mobile/ios/town-crier-tests/Sources/Features/APIWatchZoneRepositoryPausedTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APIWatchZoneRepositoryPausedTests.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierData
+
+/// Paused-zone wire-format tests for `APIWatchZoneRepository` (GH#889 P2).
+///
+/// A zone is marked `paused` server-side when a subscription downgrade left
+/// the user over their tier's quota — purely a display flag, never computed
+/// or mutated by the client.
+@Suite("APIWatchZoneRepository — paused zones")
+struct APIWatchZoneRepositoryPausedTests {
+
+  // swiftlint:disable:next force_unwrapping
+  private let baseURL = URL(string: "https://api-dev.towncrierapp.uk")!
+
+  private func makeSUT(
+    responses: [(Data, URLResponse)]
+  ) -> (APIWatchZoneRepository, StubHTTPTransport) {
+    let authService = SpyAuthenticationService()
+    authService.currentSessionResult = .valid
+    let transport = StubHTTPTransport()
+    transport.responses = responses
+    let apiClient = URLSessionAPIClient(
+      baseURL: baseURL,
+      authService: authService,
+      transport: transport
+    )
+    let sut = APIWatchZoneRepository(apiClient: apiClient)
+    return (sut, transport)
+  }
+
+  // swiftlint:disable force_unwrapping
+  private func httpResponse(statusCode: Int) -> HTTPURLResponse {
+    HTTPURLResponse(
+      url: baseURL,
+      statusCode: statusCode,
+      httpVersion: nil,
+      headerFields: nil
+    )!
+  }
+  // swiftlint:enable force_unwrapping
+
+  @Test("loadAll decodes paused: true from the API response")
+  func loadAll_pausedTrue_decodesPausedField() async throws {
+    let json = """
+      {
+          "zones": [
+              {
+                  "id": "zone-001",
+                  "name": "CB1 2AD",
+                  "latitude": 52.2053,
+                  "longitude": 0.1218,
+                  "radiusMetres": 2000,
+                  "authorityId": 123,
+                  "paused": true
+              }
+          ]
+      }
+      """
+    let (sut, _) = makeSUT(responses: [
+      (Data(json.utf8), httpResponse(statusCode: 200))
+    ])
+
+    let zones = try await sut.loadAll()
+
+    #expect(zones.count == 1)
+    #expect(zones[0].paused)
+  }
+
+  @Test("loadAll defaults paused to false when the field is absent (back-compat)")
+  func loadAll_missingPaused_defaultsToFalse() async throws {
+    let json = """
+      {
+          "zones": [
+              {
+                  "id": "zone-001",
+                  "name": "CB1 2AD",
+                  "latitude": 52.2053,
+                  "longitude": 0.1218,
+                  "radiusMetres": 2000,
+                  "authorityId": 123
+              }
+          ]
+      }
+      """
+    let (sut, _) = makeSUT(responses: [
+      (Data(json.utf8), httpResponse(statusCode: 200))
+    ])
+
+    let zones = try await sut.loadAll()
+
+    #expect(zones.count == 1)
+    #expect(!zones[0].paused)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/PausedZoneBadgeTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/PausedZoneBadgeTests.swift
@@ -1,0 +1,61 @@
+import Testing
+
+@testable import TownCrierDomain
+@testable import TownCrierPresentation
+
+/// Tests for the "Paused" badge shown on a watch zone row that currently
+/// exceeds the user's tier quota (GH#889 P2). The badge is itself the
+/// upgrade affordance — tapping it opens the subscription paywall via the
+/// host's `onUpgrade` closure, which ``WatchZoneListView`` wires to
+/// ``WatchZoneListViewModel/viewPlans()`` — the same routing method used by
+/// the toolbar upgrade badge and the free-tier inline upsell card, so every
+/// "upgrade" entry point in the Watch Zones screen converges on one paywall
+/// presentation path.
+@MainActor
+@Suite("PausedZoneBadge")
+struct PausedZoneBadgeTests {
+
+  // MARK: - Copy
+
+  @Test func label_readsPaused() {
+    #expect(PausedZoneBadge.Copy.label == "Paused")
+  }
+
+  @Test func accessibilityHint_opensPlans() {
+    #expect(PausedZoneBadge.Copy.accessibilityHint == "Opens subscription plans")
+  }
+
+  // MARK: - View
+
+  @Test func body_renders() {
+    let sut = PausedZoneBadge {}
+    _ = sut.body
+  }
+
+  // MARK: - Callback
+
+  @Test func onUpgrade_isCalled_whenTapped() {
+    var called = false
+    let sut = PausedZoneBadge { called = true }
+
+    sut.simulateUpgradeTap()
+
+    #expect(called)
+  }
+
+  @Test func upgradeTap_triggersViewModelViewPlans() async {
+    let spy = SpyWatchZoneRepository()
+    let viewModel = WatchZoneListViewModel(
+      repository: spy,
+      featureGate: FeatureGate(tier: .free)
+    )
+    var viewPlansCalled = false
+    viewModel.onViewPlans = { viewPlansCalled = true }
+    let sut = PausedZoneBadge { viewModel.viewPlans() }
+
+    sut.simulateUpgradeTap()
+
+    #expect(viewPlansCalled)
+    #expect(!viewModel.isUpgradePromptPresented)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/WatchZoneListViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WatchZoneListViewModelTests.swift
@@ -328,6 +328,17 @@ struct WatchZoneListViewModelTests {
     #expect(!sut.isUpgradePromptPresented)
   }
 
+  // MARK: - Paused zones (GH#889 P2)
+
+  @Test func load_exposesPausedFlagPerZone() async {
+    spyRepository.loadAllResult = .success([.cambridge, .cambridgePaused])
+
+    await sut.load()
+
+    #expect(sut.zones[0].paused == false)
+    #expect(sut.zones[1].paused == true)
+  }
+
   @Test func upgradeValueProposition_returnsNonEmptyString() async {
     let sut = WatchZoneListViewModel(
       repository: spyRepository,

--- a/mobile/ios/town-crier-tests/Sources/Features/WatchZoneListViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WatchZoneListViewTests.swift
@@ -71,6 +71,19 @@ struct WatchZoneListViewTests {
     _ = sut.body
   }
 
+  // MARK: - Paused zones (GH#889 P2)
+
+  @Test func body_renders_whenZonePaused() async {
+    let (vm, spy) = makeViewModel()
+    spy.loadAllResult = .success([.cambridgePaused])
+    await vm.load()
+
+    #expect(vm.zones[0].paused)
+
+    let sut = WatchZoneListView(viewModel: vm)
+    _ = sut.body
+  }
+
   // MARK: - Unconverted device-local zones row (GH#879 Phase 5)
 
   @Test func body_renders_whenLocalZoneRowShown() async throws {

--- a/mobile/ios/town-crier-tests/Sources/Features/WatchZoneSummaryDTOTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WatchZoneSummaryDTOTests.swift
@@ -147,4 +147,55 @@ struct WatchZoneSummaryDTOTests {
     #expect(!dto.pushEnabled)
     #expect(!dto.emailInstantEnabled)
   }
+
+  // MARK: - Paused zones (GH#889 P2)
+
+  @Test("toDomain carries paused to domain model")
+  func toDomain_carriesPausedFlag() throws {
+    let dto = WatchZoneSummaryDTO(
+      id: "zone-ok",
+      name: "CB1 2AD",
+      latitude: 52.2053,
+      longitude: 0.1218,
+      radiusMetres: 2000,
+      authorityId: 123,
+      paused: true
+    )
+
+    let zone = try dto.toDomain()
+    #expect(zone.paused)
+  }
+
+  @Test("decoding DTO without paused defaults to false (back-compat)")
+  func decoding_missingPaused_defaultsToFalse() throws {
+    let json = """
+      {
+          "id": "zone-001",
+          "name": "CB1 2AD",
+          "latitude": 52.2053,
+          "longitude": 0.1218,
+          "radiusMetres": 2000,
+          "authorityId": 123
+      }
+      """
+    let dto = try JSONDecoder().decode(WatchZoneSummaryDTO.self, from: Data(json.utf8))
+    #expect(!dto.paused)
+  }
+
+  @Test("decoding DTO with explicit paused: true preserves it")
+  func decoding_explicitPausedTrue_isPreserved() throws {
+    let json = """
+      {
+          "id": "zone-001",
+          "name": "CB1 2AD",
+          "latitude": 52.2053,
+          "longitude": 0.1218,
+          "radiusMetres": 2000,
+          "authorityId": 123,
+          "paused": true
+      }
+      """
+    let dto = try JSONDecoder().decode(WatchZoneSummaryDTO.self, from: Data(json.utf8))
+    #expect(dto.paused)
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Fixtures/PlanningApplication+Fixtures.swift
+++ b/mobile/ios/town-crier-tests/Sources/Fixtures/PlanningApplication+Fixtures.swift
@@ -119,6 +119,17 @@ extension WatchZone {
     radiusMetres: 1500,
     authorityId: 456
   )
+
+  /// A zone paused because a subscription downgrade left the user over their
+  /// tier's quota (GH#889 P1/P2) — never deleted, purely a display flag.
+  static let cambridgePaused = try! WatchZone(
+    id: WatchZoneId("zone-003"),
+    postcode: .cambridge,
+    centre: .cambridge,
+    radiusMetres: 2000,
+    authorityId: 123,
+    paused: true
+  )
 }
 
 extension MapCluster {


### PR DESCRIPTION
## Summary
- Authed WatchZones list (WatchZoneListView) now decodes the server's `paused` field (backend derivation shipped in #892, default `false` for back-compat) and shows a "Paused" badge on any over-quota zone.
- Tapping the badge routes to the existing View Plans paywall (same `viewModel.viewPlans()` path as the other upgrade affordances on this screen).

## Test plan
- [x] `swift build`, `swift test` (1794/1794), `swiftlint lint --strict` (0 violations, CI-pinned 0.63.2)
- [x] DTO/decoder tests: `paused` decodes true/false/absent(→false)
- [x] ViewModel test: exposes `paused` per zone
- [x] Badge tests: renders conditionally, tap invokes `onUpgrade` → `viewModel.viewPlans()`
- [x] Live sim check: build/install/launch clean, no crashes. The authed paused-zone screen itself could not be reached live in this pass (no test-account credentials available in this session) — verified via the unit/component tests above instead; noting the fidelity gap here rather than claiming a false live pass.

## Follow-ups filed (pre-existing, unrelated to this change)
- tc-uan5d: local Homebrew swiftlint (0.65.0) vs CI-pinned (0.63.2) version drift causes false-positive opt-in-rule violations locally.
- tc-5snf5: `swift-format format --in-place --recursive .` reformats ~38 unrelated files repo-wide (formatter/config drift).

Closes #889 Phase 2 (tc-m6ce1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for showing paused watch zones in the app.
  * Paused zones now display a visible “Paused” badge with upgrade messaging.
  * Users can tap the badge to view subscription options.

* **Bug Fixes**
  * Kept paused-zone data compatible with older server responses by defaulting the new status to false when missing.
  * Ensured paused status is carried through to the app’s zone display and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->