### PR TITLE
ci: re-pin actions/setup-java to current v5 SHA in pr-gate.yml (tc-5859i)

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -290,7 +290,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
-      - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
+      - uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
         with:
           distribution: temurin
           java-version: '21'
@@ -314,7 +314,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
-      - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
+      - uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
         with:
           distribution: temurin
           java-version: '21'


### PR DESCRIPTION
## Summary

Pre-existing CI drift fix discovered while landing the Public Notice rebrand epic (#848/#849) — unrelated to that epic's content, but blocking every PR's required **PR Gate** check, including all epic sub-issue PRs.

`.github/workflows/pr-gate.yml`'s "GitHub Actions: Lint (actionlint + zizmor)" job was failing on `main` with:

```
##[warning]pr-gate.yml:293: action's hash pin has mismatched or missing version comment: points to commit 0f481fcb6134
##[warning]pr-gate.yml:317: action's hash pin has mismatched or missing version comment: points to commit 0f481fcb6134
##[error]Process completed with exit code 13.
```

`actions/setup-java` was SHA-pinned to `1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5` in #843 (2026-07-05). The floating `v5` tag upstream has since moved — `gh api repos/actions/setup-java/git/refs/tags/v5` now resolves to `0f481fcb613427c0f801b606911222b5b6f3083a` (2026-07-07) — so zizmor's `ref-version-mismatch` audit (only surfaced in "online" mode, i.e. with `GH_TOKEN` set, which the CI job does) flags the pin as stale at both call sites (`android-lint`, `android-build-test`).

Re-pinned both occurrences to the current `v5` commit; the `# v5` comment is unchanged since it's still accurate.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr-gate.yml'))"` — parses clean
- [x] `actionlint -color .github/workflows/*.yml` — exit 0
- [x] `GH_TOKEN=$(gh auth token) uvx "zizmor@1.26.1" --format=github .` — reproduced both warnings pre-fix (exit 13), zero warnings post-fix (exit 0)
- [x] Scope check: diff touches only `.github/workflows/pr-gate.yml`