### PR TITLE
feat(design): flip tokens.json to Public Notice v2 values (#852)

### DIFF
--- a/.claude/skills/design-language/references/tokens.md
+++ b/.claude/skills/design-language/references/tokens.md
@@ -15,26 +15,26 @@ Status colours follow the PlanIt vocabulary (Permitted / Conditions / Rejected).
 
 | Token | Web | iOS | Android | Light | Dark | OLED | Platforms |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `amber` | `--tc-amber` | `Color.tcAmber` | `TcPalette.amber` | `#D4910A` | `#E9A620` | `#E9A620` | Web, iOS, Android |
-| `amber-muted` | `--tc-amber-muted` | `Color.tcAmberMuted` | `TcPalette.amberMuted` | `#D4910A @ 15%` | `#E9A620 @ 15%` | `#E9A620 @ 15%` | Web, iOS, Android |
-| `amber-hover` | `--tc-amber-hover` | — | `TcPalette.amberHover` | `#B87A08` | `#F0B83A` | `#F0B83A` | Web, Android |
+| `amber` | `--tc-amber` | `Color.tcAmber` | `TcPalette.amber` | `#9E6709` | `#E9A620` | `#E9A620` | Web, iOS, Android |
+| `amber-muted` | `--tc-amber-muted` | `Color.tcAmberMuted` | `TcPalette.amberMuted` | `#9E6709 @ 12%` | `#E9A620 @ 15%` | `#E9A620 @ 15%` | Web, iOS, Android |
+| `amber-hover` | `--tc-amber-hover` | — | `TcPalette.amberHover` | `#8A5F06` | `#F0B83A` | `#F0B83A` | Web, Android |
 
 ### Surface
 
 | Token | Web | iOS | Android | Light | Dark | OLED | Platforms |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `background` | `--tc-background` | `Color.tcBackground` | `TcPalette.background` | `#FAF8F5` | `#1A1A1E` | `#000000` | Web, iOS, Android |
-| `surface` | `--tc-surface` | `Color.tcSurface` | `TcPalette.surface` | `#FFFFFF` | `#242428` | `#0A0A0A` | Web, iOS, Android |
-| `surface-elevated` | `--tc-surface-elevated` | `Color.tcSurfaceElevated` | `TcPalette.surfaceElevated` | `#FFFFFF` | `#2E2E33` | `#161616` | Web, iOS, Android |
+| `background` | `--tc-background` | `Color.tcBackground` | `TcPalette.background` | `#F5F0E6` | `#191713` | `#000000` | Web, iOS, Android |
+| `surface` | `--tc-surface` | `Color.tcSurface` | `TcPalette.surface` | `#FFFDF6` | `#23201A` | `#0A0908` | Web, iOS, Android |
+| `surface-elevated` | `--tc-surface-elevated` | `Color.tcSurfaceElevated` | `TcPalette.surfaceElevated` | `#FFFDF6` | `#2B2822` | `#151310` | Web, iOS, Android |
 
 ### Text
 
 | Token | Web | iOS | Android | Light | Dark | OLED | Platforms |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `text-primary` | `--tc-text-primary` | `Color.tcTextPrimary` | `TcPalette.textPrimary` | `#1C1917` | `#F1EFE9` | `#F1EFE9` | Web, iOS, Android |
-| `text-secondary` | `--tc-text-secondary` | `Color.tcTextSecondary` | `TcPalette.textSecondary` | `#6B6560` | `#9B9590` | `#9B9590` | Web, iOS, Android |
-| `text-tertiary` | `--tc-text-tertiary` | `Color.tcTextTertiary` | `TcPalette.textTertiary` | `#A39E98` | `#5C5852` | `#5C5852` | Web, iOS, Android |
-| `text-on-accent` | `--tc-text-on-accent` | `Color.tcTextOnAccent` | `TcPalette.textOnAccent` | `#FFFFFF` | `#1C1917` | `#1C1917` | Web, iOS, Android |
+| `text-primary` | `--tc-text-primary` | `Color.tcTextPrimary` | `TcPalette.textPrimary` | `#24201A` | `#EFE9DC` | `#EFE9DC` | Web, iOS, Android |
+| `text-secondary` | `--tc-text-secondary` | `Color.tcTextSecondary` | `TcPalette.textSecondary` | `#6D665C` | `#A69E8F` | `#A69E8F` | Web, iOS, Android |
+| `text-tertiary` | `--tc-text-tertiary` | `Color.tcTextTertiary` | `TcPalette.textTertiary` | `#A79E90` | `#6E675B` | `#6E675B` | Web, iOS, Android |
+| `text-on-accent` | `--tc-text-on-accent` | `Color.tcTextOnAccent` | `TcPalette.textOnAccent` | `#FFFDF8` | `#1C1917` | `#1C1917` | Web, iOS, Android |
 
 ### Status
 
@@ -51,8 +51,8 @@ Status colours follow the PlanIt vocabulary (Permitted / Conditions / Rejected).
 
 | Token | Web | iOS | Android | Light | Dark | OLED | Platforms |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `border` | `--tc-border` | `Color.tcBorder` | `TcPalette.border` | `#E8E4DF` | `#3A3A3F` | `#1E1E22` | Web, iOS, Android |
-| `border-focused` | `--tc-border-focused` | `Color.tcBorderFocused` | `TcPalette.borderFocused` | `#D4910A` | `#E9A620` | `#E9A620` | Web, iOS, Android |
+| `border` | `--tc-border` | `Color.tcBorder` | `TcPalette.border` | `#DAD2C2` | `#3A352B` | `#26221A` | Web, iOS, Android |
+| `border-focused` | `--tc-border-focused` | `Color.tcBorderFocused` | `TcPalette.borderFocused` | `#9E6709` | `#E9A620` | `#E9A620` | Web, iOS, Android |
 | `overlay` | `--tc-overlay` | `Color.tcOverlay` | `TcPalette.overlay` | `#000000 @ 40%` | `#000000 @ 50%` | `#000000 @ 50%` | Web, iOS, Android |
 
 ### Spacing
@@ -70,9 +70,9 @@ Status colours follow the PlanIt vocabulary (Permitted / Conditions / Rejected).
 
 | Token | Web | iOS | Android | Value | Platforms |
 | --- | --- | --- | --- | --- | --- |
-| `sm` | `--tc-radius-sm` | `TCCornerRadius.small` | `TownCrierRadius.sm` | 8pt | Web, iOS, Android |
-| `md` | `--tc-radius-md` | `TCCornerRadius.medium` | `TownCrierRadius.md` | 12pt | Web, iOS, Android |
-| `lg` | `--tc-radius-lg` | `TCCornerRadius.large` | `TownCrierRadius.lg` | 16pt | Web, iOS, Android |
+| `sm` | `--tc-radius-sm` | `TCCornerRadius.small` | `TownCrierRadius.sm` | 3pt | Web, iOS, Android |
+| `md` | `--tc-radius-md` | `TCCornerRadius.medium` | `TownCrierRadius.md` | 6pt | Web, iOS, Android |
+| `lg` | `--tc-radius-lg` | `TCCornerRadius.large` | `TownCrierRadius.lg` | 12pt | Web, iOS, Android |
 | `full` | `--tc-radius-full` | — | `TownCrierRadius.full` | capsule | Web, Android |
 
 ### Shadows
@@ -81,7 +81,7 @@ Web only. Dark and OLED communicate elevation through surface stepping, not shad
 
 | Token | Web | Light | Dark / OLED | Platforms |
 | --- | --- | --- | --- | --- |
-| `card` | `--tc-shadow-card` | `0 2px 8px rgba(0, 0, 0, 0.05)` | `none` | Web |
+| `card` | `--tc-shadow-card` | `0 1px 3px rgba(0, 0, 0, 0.06)` | `none` | Web |
 | `elevated` | `--tc-shadow-elevated` | `0 4px 16px rgba(0, 0, 0, 0.08)` | `none` | Web |
 
 ### Motion durations

--- a/api-go/internal/designtokens/tokens_gen.go
+++ b/api-go/internal/designtokens/tokens_gen.go
@@ -15,23 +15,23 @@ import "image/color"
 
 // Hex strings per theme (leading '#'), for HTML/CSS template consumers.
 const (
-	AmberLightHex            = "#D4910A"
+	AmberLightHex            = "#9E6709"
 	AmberDarkHex             = "#E9A620"
-	AmberHoverLightHex       = "#B87A08"
+	AmberHoverLightHex       = "#8A5F06"
 	AmberHoverDarkHex        = "#F0B83A"
-	BackgroundLightHex       = "#FAF8F5"
-	BackgroundDarkHex        = "#1A1A1E"
-	SurfaceLightHex          = "#FFFFFF"
-	SurfaceDarkHex           = "#242428"
-	SurfaceElevatedLightHex  = "#FFFFFF"
-	SurfaceElevatedDarkHex   = "#2E2E33"
-	TextPrimaryLightHex      = "#1C1917"
-	TextPrimaryDarkHex       = "#F1EFE9"
-	TextSecondaryLightHex    = "#6B6560"
-	TextSecondaryDarkHex     = "#9B9590"
-	TextTertiaryLightHex     = "#A39E98"
-	TextTertiaryDarkHex      = "#5C5852"
-	TextOnAccentLightHex     = "#FFFFFF"
+	BackgroundLightHex       = "#F5F0E6"
+	BackgroundDarkHex        = "#191713"
+	SurfaceLightHex          = "#FFFDF6"
+	SurfaceDarkHex           = "#23201A"
+	SurfaceElevatedLightHex  = "#FFFDF6"
+	SurfaceElevatedDarkHex   = "#2B2822"
+	TextPrimaryLightHex      = "#24201A"
+	TextPrimaryDarkHex       = "#EFE9DC"
+	TextSecondaryLightHex    = "#6D665C"
+	TextSecondaryDarkHex     = "#A69E8F"
+	TextTertiaryLightHex     = "#A79E90"
+	TextTertiaryDarkHex      = "#6E675B"
+	TextOnAccentLightHex     = "#FFFDF8"
 	TextOnAccentDarkHex      = "#1C1917"
 	StatusPermittedLightHex  = "#1A7D37"
 	StatusPermittedDarkHex   = "#34C759"
@@ -45,32 +45,32 @@ const (
 	StatusWithdrawnDarkHex   = "#8E8A85"
 	StatusAppealedLightHex   = "#7C3AED"
 	StatusAppealedDarkHex    = "#A78BFA"
-	BorderLightHex           = "#E8E4DF"
-	BorderDarkHex            = "#3A3A3F"
-	BorderFocusedLightHex    = "#D4910A"
+	BorderLightHex           = "#DAD2C2"
+	BorderDarkHex            = "#3A352B"
+	BorderFocusedLightHex    = "#9E6709"
 	BorderFocusedDarkHex     = "#E9A620"
 )
 
 // RGBA values for image renderers. color.RGBA is alpha-premultiplied; every
 // brand colour here is fully opaque (A: 0xFF), so R/G/B are the raw channels.
 var (
-	AmberLight            = color.RGBA{R: 0xD4, G: 0x91, B: 0x0A, A: 0xFF}
+	AmberLight            = color.RGBA{R: 0x9E, G: 0x67, B: 0x09, A: 0xFF}
 	AmberDark             = color.RGBA{R: 0xE9, G: 0xA6, B: 0x20, A: 0xFF}
-	AmberHoverLight       = color.RGBA{R: 0xB8, G: 0x7A, B: 0x08, A: 0xFF}
+	AmberHoverLight       = color.RGBA{R: 0x8A, G: 0x5F, B: 0x06, A: 0xFF}
 	AmberHoverDark        = color.RGBA{R: 0xF0, G: 0xB8, B: 0x3A, A: 0xFF}
-	BackgroundLight       = color.RGBA{R: 0xFA, G: 0xF8, B: 0xF5, A: 0xFF}
-	BackgroundDark        = color.RGBA{R: 0x1A, G: 0x1A, B: 0x1E, A: 0xFF}
-	SurfaceLight          = color.RGBA{R: 0xFF, G: 0xFF, B: 0xFF, A: 0xFF}
-	SurfaceDark           = color.RGBA{R: 0x24, G: 0x24, B: 0x28, A: 0xFF}
-	SurfaceElevatedLight  = color.RGBA{R: 0xFF, G: 0xFF, B: 0xFF, A: 0xFF}
-	SurfaceElevatedDark   = color.RGBA{R: 0x2E, G: 0x2E, B: 0x33, A: 0xFF}
-	TextPrimaryLight      = color.RGBA{R: 0x1C, G: 0x19, B: 0x17, A: 0xFF}
-	TextPrimaryDark       = color.RGBA{R: 0xF1, G: 0xEF, B: 0xE9, A: 0xFF}
-	TextSecondaryLight    = color.RGBA{R: 0x6B, G: 0x65, B: 0x60, A: 0xFF}
-	TextSecondaryDark     = color.RGBA{R: 0x9B, G: 0x95, B: 0x90, A: 0xFF}
-	TextTertiaryLight     = color.RGBA{R: 0xA3, G: 0x9E, B: 0x98, A: 0xFF}
-	TextTertiaryDark      = color.RGBA{R: 0x5C, G: 0x58, B: 0x52, A: 0xFF}
-	TextOnAccentLight     = color.RGBA{R: 0xFF, G: 0xFF, B: 0xFF, A: 0xFF}
+	BackgroundLight       = color.RGBA{R: 0xF5, G: 0xF0, B: 0xE6, A: 0xFF}
+	BackgroundDark        = color.RGBA{R: 0x19, G: 0x17, B: 0x13, A: 0xFF}
+	SurfaceLight          = color.RGBA{R: 0xFF, G: 0xFD, B: 0xF6, A: 0xFF}
+	SurfaceDark           = color.RGBA{R: 0x23, G: 0x20, B: 0x1A, A: 0xFF}
+	SurfaceElevatedLight  = color.RGBA{R: 0xFF, G: 0xFD, B: 0xF6, A: 0xFF}
+	SurfaceElevatedDark   = color.RGBA{R: 0x2B, G: 0x28, B: 0x22, A: 0xFF}
+	TextPrimaryLight      = color.RGBA{R: 0x24, G: 0x20, B: 0x1A, A: 0xFF}
+	TextPrimaryDark       = color.RGBA{R: 0xEF, G: 0xE9, B: 0xDC, A: 0xFF}
+	TextSecondaryLight    = color.RGBA{R: 0x6D, G: 0x66, B: 0x5C, A: 0xFF}
+	TextSecondaryDark     = color.RGBA{R: 0xA6, G: 0x9E, B: 0x8F, A: 0xFF}
+	TextTertiaryLight     = color.RGBA{R: 0xA7, G: 0x9E, B: 0x90, A: 0xFF}
+	TextTertiaryDark      = color.RGBA{R: 0x6E, G: 0x67, B: 0x5B, A: 0xFF}
+	TextOnAccentLight     = color.RGBA{R: 0xFF, G: 0xFD, B: 0xF8, A: 0xFF}
 	TextOnAccentDark      = color.RGBA{R: 0x1C, G: 0x19, B: 0x17, A: 0xFF}
 	StatusPermittedLight  = color.RGBA{R: 0x1A, G: 0x7D, B: 0x37, A: 0xFF}
 	StatusPermittedDark   = color.RGBA{R: 0x34, G: 0xC7, B: 0x59, A: 0xFF}
@@ -84,9 +84,9 @@ var (
 	StatusWithdrawnDark   = color.RGBA{R: 0x8E, G: 0x8A, B: 0x85, A: 0xFF}
 	StatusAppealedLight   = color.RGBA{R: 0x7C, G: 0x3A, B: 0xED, A: 0xFF}
 	StatusAppealedDark    = color.RGBA{R: 0xA7, G: 0x8B, B: 0xFA, A: 0xFF}
-	BorderLight           = color.RGBA{R: 0xE8, G: 0xE4, B: 0xDF, A: 0xFF}
-	BorderDark            = color.RGBA{R: 0x3A, G: 0x3A, B: 0x3F, A: 0xFF}
-	BorderFocusedLight    = color.RGBA{R: 0xD4, G: 0x91, B: 0x0A, A: 0xFF}
+	BorderLight           = color.RGBA{R: 0xDA, G: 0xD2, B: 0xC2, A: 0xFF}
+	BorderDark            = color.RGBA{R: 0x3A, G: 0x35, B: 0x2B, A: 0xFF}
+	BorderFocusedLight    = color.RGBA{R: 0x9E, G: 0x67, B: 0x09, A: 0xFF}
 	BorderFocusedDark     = color.RGBA{R: 0xE9, G: 0xA6, B: 0x20, A: 0xFF}
 )
 

--- a/api-go/internal/sharepage/templates/tokens.gohtml
+++ b/api-go/internal/sharepage/templates/tokens.gohtml
@@ -1,11 +1,12 @@
 {{/* GENERATED FILE — edit design/tokens.json and run scripts/design-tokens/generate.mjs. See ADR 0040. */}}
 {{define "tokenVars"}}
 :root{
-  --bg:#FAF8F5;--surface:#FFFFFF;--text-primary:#1C1917;--text-secondary:#6B6560;
-  --text-tertiary:#A39E98;--border:#E8E4DF;--amber:#D4910A;--amber-hover:#B87A08;
-  --text-on-accent:#FFFFFF;--amber-muted:rgba(212,145,10,0.15);
-  --radius-sm:8px;--radius-md:12px;
+  --bg:#F5F0E6;--surface:#FFFDF6;--text-primary:#24201A;--text-secondary:#6D665C;
+  --text-tertiary:#A79E90;--border:#DAD2C2;--amber:#9E6709;--amber-hover:#8A5F06;
+  --text-on-accent:#FFFDF8;--amber-muted:rgba(158,103,9,0.12);
+  --radius-sm:3px;--radius-md:6px;
   --space-xs:4px;--space-sm:8px;--space-md:16px;--space-lg:24px;--space-xl:32px;
+  --font-display:'Fraunces', 'Iowan Old Style', Georgia, serif;--font-mono:ui-monospace, 'SF Mono', Menlo, 'Roboto Mono', monospace;
   /* Shared status vocabulary (tc-r4n9 decision 4): three colour buckets, not a
      five-way traffic light — granted (green), refused (red), neutral for
      "Undecided" and every long-tail state. Mirrors web/scripts/lib/render-shared.mjs. */
@@ -15,8 +16,8 @@
 }
 @media (prefers-color-scheme:dark){
   :root{
-    --bg:#1A1A1E;--surface:#242428;--text-primary:#F1EFE9;--text-secondary:#9B9590;
-    --text-tertiary:#5C5852;--border:#3A3A3F;--amber:#E9A620;--amber-hover:#F0B83A;
+    --bg:#191713;--surface:#23201A;--text-primary:#EFE9DC;--text-secondary:#A69E8F;
+    --text-tertiary:#6E675B;--border:#3A352B;--amber:#E9A620;--amber-hover:#F0B83A;
     --text-on-accent:#1C1917;--amber-muted:rgba(233,166,32,0.15);
     --status-granted:#34C759;--status-granted-bg:rgba(52,199,89,0.15);
     --status-refused:#FF453A;--status-refused-bg:rgba(255,69,58,0.15);

--- a/design/tokens.json
+++ b/design/tokens.json
@@ -3,44 +3,44 @@
   "color": {
     "amber": {
       "doc": "Primary accent. Warm gold evoking town crier bells.",
-      "light": "#D4910A", "dark": "#E9A620", "oled": "#E9A620"
+      "light": "#9E6709", "dark": "#E9A620", "oled": "#E9A620"
     },
     "amber-hover": {
       "doc": "Pressed/hover state for amber interactive elements.",
       "platforms": ["web", "android"],
-      "light": "#B87A08", "dark": "#F0B83A", "oled": "#F0B83A"
+      "light": "#8A5F06", "dark": "#F0B83A", "oled": "#F0B83A"
     },
     "amber-muted": {
       "doc": "Lower-emphasis accent for secondary buttons and tags.",
-      "base": "amber", "alpha": 0.15
+      "base": "amber", "alpha": { "light": 0.12, "dark": 0.15, "oled": 0.15 }
     },
     "background": {
       "doc": "Page-level background.",
-      "light": "#FAF8F5", "dark": "#1A1A1E", "oled": "#000000"
+      "light": "#F5F0E6", "dark": "#191713", "oled": "#000000"
     },
     "surface": {
       "doc": "Card and component background.",
-      "light": "#FFFFFF", "dark": "#242428", "oled": "#0A0A0A"
+      "light": "#FFFDF6", "dark": "#23201A", "oled": "#0A0908"
     },
     "surface-elevated": {
       "doc": "Modals, bottom sheets, popovers.",
-      "light": "#FFFFFF", "dark": "#2E2E33", "oled": "#161616"
+      "light": "#FFFDF6", "dark": "#2B2822", "oled": "#151310"
     },
     "text-primary": {
       "doc": "Body text and headings.",
-      "light": "#1C1917", "dark": "#F1EFE9", "oled": "#F1EFE9"
+      "light": "#24201A", "dark": "#EFE9DC", "oled": "#EFE9DC"
     },
     "text-secondary": {
       "doc": "Captions, metadata, timestamps.",
-      "light": "#6B6560", "dark": "#9B9590", "oled": "#9B9590"
+      "light": "#6D665C", "dark": "#A69E8F", "oled": "#A69E8F"
     },
     "text-tertiary": {
       "doc": "Placeholder text, disabled labels.",
-      "light": "#A39E98", "dark": "#5C5852", "oled": "#5C5852"
+      "light": "#A79E90", "dark": "#6E675B", "oled": "#6E675B"
     },
     "text-on-accent": {
       "doc": "Text rendered on tcAmber backgrounds.",
-      "light": "#FFFFFF", "dark": "#1C1917", "oled": "#1C1917"
+      "light": "#FFFDF8", "dark": "#1C1917", "oled": "#1C1917"
     },
     "status-permitted": {
       "doc": "Application granted (PlanIt `Permitted`).",
@@ -68,7 +68,7 @@
     },
     "border": {
       "doc": "Subtle dividers and card outlines.",
-      "light": "#E8E4DF", "dark": "#3A3A3F", "oled": "#1E1E22"
+      "light": "#DAD2C2", "dark": "#3A352B", "oled": "#26221A"
     },
     "border-focused": {
       "doc": "Focus rings and active input borders.",
@@ -81,13 +81,15 @@
   },
   "statusBuckets": { "granted": "status-permitted", "refused": "status-rejected", "neutral": "status-withdrawn" },
   "shadow": {
-    "card":     { "light": "0 2px 8px rgba(0, 0, 0, 0.05)",  "dark": "none", "oled": "none" },
+    "card":     { "light": "0 1px 3px rgba(0, 0, 0, 0.06)",  "dark": "none", "oled": "none" },
     "elevated": { "light": "0 4px 16px rgba(0, 0, 0, 0.08)", "dark": "none", "oled": "none" }
   },
   "spacing": { "xs": 4, "sm": 8, "md": 16, "lg": 24, "xl": 32, "xxl": 48 },
-  "radius":  { "sm": 8, "md": 12, "lg": 16, "full": 9999 },
+  "radius":  { "sm": 3, "md": 6, "lg": 12, "full": 9999 },
   "typography": {
     "font-family": "'Inter', system-ui, -apple-system, sans-serif",
+    "font-display": "'Fraunces', 'Iowan Old Style', Georgia, serif",
+    "font-mono": "ui-monospace, 'SF Mono', Menlo, 'Roboto Mono', monospace",
     "sizes": { "hero": "3.5rem", "display-large": "2rem", "display-small": "1.5rem", "h3": "1.25rem", "headline": "1.125rem", "body": "1rem", "caption": "0.875rem" },
     "weights": { "regular": 400, "medium": 500, "semibold": 600, "bold": 700 },
     "leadings": { "tight": 1.2, "snug": 1.25, "normal": 1.3, "relaxed": 1.4 }

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/designsystem/Color.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/designsystem/Color.kt
@@ -38,42 +38,40 @@ internal data class TcPalette(
     val overlay: Color,
 )
 
-private fun muted(amber: Color) = amber.copy(alpha = 0.15f)
-
 internal val LightPalette =
     TcPalette(
-        amber = Color(0xFFD4910A),
-        amberMuted = muted(Color(0xFFD4910A)),
-        amberHover = Color(0xFFB87A08),
-        background = Color(0xFFFAF8F5),
-        surface = Color(0xFFFFFFFF),
-        surfaceElevated = Color(0xFFFFFFFF),
-        textPrimary = Color(0xFF1C1917),
-        textSecondary = Color(0xFF6B6560),
-        textTertiary = Color(0xFFA39E98),
-        textOnAccent = Color(0xFFFFFFFF),
+        amber = Color(0xFF9E6709),
+        amberMuted = Color(0xFF9E6709).copy(alpha = 0.12f),
+        amberHover = Color(0xFF8A5F06),
+        background = Color(0xFFF5F0E6),
+        surface = Color(0xFFFFFDF6),
+        surfaceElevated = Color(0xFFFFFDF6),
+        textPrimary = Color(0xFF24201A),
+        textSecondary = Color(0xFF6D665C),
+        textTertiary = Color(0xFFA79E90),
+        textOnAccent = Color(0xFFFFFDF8),
         statusPermitted = Color(0xFF1A7D37),
         statusConditions = Color(0xFFB85C00),
         statusRejected = Color(0xFFC42B2B),
         statusPending = Color(0xFFC27A0A),
         statusWithdrawn = Color(0xFF7A7570),
         statusAppealed = Color(0xFF7C3AED),
-        border = Color(0xFFE8E4DF),
-        borderFocused = Color(0xFFD4910A),
+        border = Color(0xFFDAD2C2),
+        borderFocused = Color(0xFF9E6709),
         overlay = Color.Black.copy(alpha = 0.40f),
     )
 
 internal val DarkPalette =
     TcPalette(
         amber = Color(0xFFE9A620),
-        amberMuted = muted(Color(0xFFE9A620)),
+        amberMuted = Color(0xFFE9A620).copy(alpha = 0.15f),
         amberHover = Color(0xFFF0B83A),
-        background = Color(0xFF1A1A1E),
-        surface = Color(0xFF242428),
-        surfaceElevated = Color(0xFF2E2E33),
-        textPrimary = Color(0xFFF1EFE9),
-        textSecondary = Color(0xFF9B9590),
-        textTertiary = Color(0xFF5C5852),
+        background = Color(0xFF191713),
+        surface = Color(0xFF23201A),
+        surfaceElevated = Color(0xFF2B2822),
+        textPrimary = Color(0xFFEFE9DC),
+        textSecondary = Color(0xFFA69E8F),
+        textTertiary = Color(0xFF6E675B),
         textOnAccent = Color(0xFF1C1917),
         statusPermitted = Color(0xFF34C759),
         statusConditions = Color(0xFFFF9F0A),
@@ -81,7 +79,7 @@ internal val DarkPalette =
         statusPending = Color(0xFFFFB340),
         statusWithdrawn = Color(0xFF8E8A85),
         statusAppealed = Color(0xFFA78BFA),
-        border = Color(0xFF3A3A3F),
+        border = Color(0xFF3A352B),
         borderFocused = Color(0xFFE9A620),
         overlay = Color.Black.copy(alpha = 0.50f),
     )
@@ -92,7 +90,7 @@ internal val DarkPalette =
 internal val OledPalette =
     DarkPalette.copy(
         background = Color(0xFF000000),
-        surface = Color(0xFF0A0A0A),
-        surfaceElevated = Color(0xFF161616),
-        border = Color(0xFF1E1E22),
+        surface = Color(0xFF0A0908),
+        surfaceElevated = Color(0xFF151310),
+        border = Color(0xFF26221A),
     )

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/designsystem/ThemeMappingTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/designsystem/ThemeMappingTest.kt
@@ -19,19 +19,19 @@ class ThemeMappingTest {
 
         @Test
         fun `light Material role mapping matches the epic token table`() {
-            assertEquals(Color(0xFFD4910A), scheme.primary) // tcAmber
-            assertEquals(Color(0xFFFFFFFF), scheme.onPrimary) // tcTextOnAccent
-            assertEquals(Color(0xFF1C1917), scheme.onPrimaryContainer) // tcTextPrimary
-            assertEquals(Color(0xFFFAF8F5), scheme.background) // tcBackground
-            assertEquals(Color(0xFF1C1917), scheme.onBackground) // tcTextPrimary
-            assertEquals(Color(0xFFFFFFFF), scheme.surface) // tcSurface
-            assertEquals(Color(0xFF1C1917), scheme.onSurface) // tcTextPrimary
-            assertEquals(Color(0xFFFFFFFF), scheme.surfaceContainerHigh) // tcSurfaceElevated
-            assertEquals(Color(0xFF6B6560), scheme.onSurfaceVariant) // tcTextSecondary
-            assertEquals(Color(0xFFE8E4DF), scheme.outline) // tcBorder
-            assertEquals(Color(0xFFE8E4DF), scheme.outlineVariant) // tcBorder
+            assertEquals(Color(0xFF9E6709), scheme.primary) // tcAmber
+            assertEquals(Color(0xFFFFFDF8), scheme.onPrimary) // tcTextOnAccent
+            assertEquals(Color(0xFF24201A), scheme.onPrimaryContainer) // tcTextPrimary
+            assertEquals(Color(0xFFF5F0E6), scheme.background) // tcBackground
+            assertEquals(Color(0xFF24201A), scheme.onBackground) // tcTextPrimary
+            assertEquals(Color(0xFFFFFDF6), scheme.surface) // tcSurface
+            assertEquals(Color(0xFF24201A), scheme.onSurface) // tcTextPrimary
+            assertEquals(Color(0xFFFFFDF6), scheme.surfaceContainerHigh) // tcSurfaceElevated
+            assertEquals(Color(0xFF6D665C), scheme.onSurfaceVariant) // tcTextSecondary
+            assertEquals(Color(0xFFDAD2C2), scheme.outline) // tcBorder
+            assertEquals(Color(0xFFDAD2C2), scheme.outlineVariant) // tcBorder
             assertEquals(Color(0xFFC42B2B), scheme.error) // tcStatusRejected
-            assertEquals(Color(0xFFFFFFFF), scheme.onError) // tcTextOnAccent
+            assertEquals(Color(0xFFFFFDF8), scheme.onError) // tcTextOnAccent
             assertEquals(Color.Black.copy(alpha = 0.40f), scheme.scrim) // tcOverlay @40%
         }
 
@@ -43,7 +43,7 @@ class ThemeMappingTest {
             assertEquals(Color(0xFFC27A0A), extended.statusPending)
             assertEquals(Color(0xFF7A7570), extended.statusWithdrawn)
             assertEquals(Color(0xFF7C3AED), extended.statusAppealed)
-            assertEquals(Color(0xFFD4910A).copy(alpha = 0.15f), extended.amberMuted)
+            assertEquals(Color(0xFF9E6709).copy(alpha = 0.12f), extended.amberMuted)
             assertEquals(Color.Black.copy(alpha = 0.40f), extended.overlay)
         }
     }
@@ -57,15 +57,15 @@ class ThemeMappingTest {
         fun `dark Material role mapping matches the epic token table`() {
             assertEquals(Color(0xFFE9A620), scheme.primary) // tcAmber
             assertEquals(Color(0xFF1C1917), scheme.onPrimary) // tcTextOnAccent
-            assertEquals(Color(0xFFF1EFE9), scheme.onPrimaryContainer) // tcTextPrimary
-            assertEquals(Color(0xFF1A1A1E), scheme.background) // tcBackground
-            assertEquals(Color(0xFFF1EFE9), scheme.onBackground) // tcTextPrimary
-            assertEquals(Color(0xFF242428), scheme.surface) // tcSurface
-            assertEquals(Color(0xFFF1EFE9), scheme.onSurface) // tcTextPrimary
-            assertEquals(Color(0xFF2E2E33), scheme.surfaceContainerHigh) // tcSurfaceElevated
-            assertEquals(Color(0xFF9B9590), scheme.onSurfaceVariant) // tcTextSecondary
-            assertEquals(Color(0xFF3A3A3F), scheme.outline) // tcBorder
-            assertEquals(Color(0xFF3A3A3F), scheme.outlineVariant) // tcBorder
+            assertEquals(Color(0xFFEFE9DC), scheme.onPrimaryContainer) // tcTextPrimary
+            assertEquals(Color(0xFF191713), scheme.background) // tcBackground
+            assertEquals(Color(0xFFEFE9DC), scheme.onBackground) // tcTextPrimary
+            assertEquals(Color(0xFF23201A), scheme.surface) // tcSurface
+            assertEquals(Color(0xFFEFE9DC), scheme.onSurface) // tcTextPrimary
+            assertEquals(Color(0xFF2B2822), scheme.surfaceContainerHigh) // tcSurfaceElevated
+            assertEquals(Color(0xFFA69E8F), scheme.onSurfaceVariant) // tcTextSecondary
+            assertEquals(Color(0xFF3A352B), scheme.outline) // tcBorder
+            assertEquals(Color(0xFF3A352B), scheme.outlineVariant) // tcBorder
             assertEquals(Color(0xFFFF453A), scheme.error) // tcStatusRejected
             assertEquals(Color(0xFF1C1917), scheme.onError) // tcTextOnAccent
             assertEquals(Color.Black.copy(alpha = 0.50f), scheme.scrim) // tcOverlay @50%
@@ -94,13 +94,13 @@ class ThemeMappingTest {
             assertEquals(Color(0xFFE9A620), scheme.primary) // tcAmber (same as dark)
             assertEquals(Color(0xFF1C1917), scheme.onPrimary) // tcTextOnAccent
             assertEquals(Color(0xFF000000), scheme.background) // tcBackground — true black
-            assertEquals(Color(0xFFF1EFE9), scheme.onBackground) // tcTextPrimary
-            assertEquals(Color(0xFF0A0A0A), scheme.surface) // tcSurface
-            assertEquals(Color(0xFFF1EFE9), scheme.onSurface) // tcTextPrimary
-            assertEquals(Color(0xFF161616), scheme.surfaceContainerHigh) // tcSurfaceElevated
-            assertEquals(Color(0xFF9B9590), scheme.onSurfaceVariant) // tcTextSecondary
-            assertEquals(Color(0xFF1E1E22), scheme.outline) // tcBorder
-            assertEquals(Color(0xFF1E1E22), scheme.outlineVariant) // tcBorder
+            assertEquals(Color(0xFFEFE9DC), scheme.onBackground) // tcTextPrimary
+            assertEquals(Color(0xFF0A0908), scheme.surface) // tcSurface
+            assertEquals(Color(0xFFEFE9DC), scheme.onSurface) // tcTextPrimary
+            assertEquals(Color(0xFF151310), scheme.surfaceContainerHigh) // tcSurfaceElevated
+            assertEquals(Color(0xFFA69E8F), scheme.onSurfaceVariant) // tcTextSecondary
+            assertEquals(Color(0xFF26221A), scheme.outline) // tcBorder
+            assertEquals(Color(0xFF26221A), scheme.outlineVariant) // tcBorder
             assertEquals(Color(0xFFFF453A), scheme.error) // tcStatusRejected (same as dark)
             assertEquals(Color.Black.copy(alpha = 0.50f), scheme.scrim) // tcOverlay @50% (same as dark)
         }

--- a/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Colors/Color+TownCrier.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Colors/Color+TownCrier.swift
@@ -6,40 +6,40 @@ import SwiftUI
 
 extension Color {
   /// Primary accent. Warm gold evoking town crier bells.
-  public static let tcAmber = Color.themed(light: 0xD4910A, dark: 0xE9A620, oled: 0xE9A620)
+  public static let tcAmber = Color.themed(light: 0x9E6709, dark: 0xE9A620, oled: 0xE9A620)
 
   /// Lower-emphasis accent for secondary buttons and tags.
-  public static let tcAmberMuted = tcAmber.opacity(0.15)
+  public static let tcAmberMuted = tcAmber.opacity(0.12)
 }
 
 // MARK: - Surfaces
 
 extension Color {
   /// Page-level background.
-  public static let tcBackground = Color.themed(light: 0xFAF8F5, dark: 0x1A1A1E, oled: 0x000000)
+  public static let tcBackground = Color.themed(light: 0xF5F0E6, dark: 0x191713, oled: 0x000000)
 
   /// Card and component background.
-  public static let tcSurface = Color.themed(light: 0xFFFFFF, dark: 0x242428, oled: 0x0A0A0A)
+  public static let tcSurface = Color.themed(light: 0xFFFDF6, dark: 0x23201A, oled: 0x0A0908)
 
   /// Modals, bottom sheets, popovers.
   public static let tcSurfaceElevated = Color.themed(
-    light: 0xFFFFFF, dark: 0x2E2E33, oled: 0x161616)
+    light: 0xFFFDF6, dark: 0x2B2822, oled: 0x151310)
 }
 
 // MARK: - Text
 
 extension Color {
   /// Body text and headings.
-  public static let tcTextPrimary = Color.themed(light: 0x1C1917, dark: 0xF1EFE9, oled: 0xF1EFE9)
+  public static let tcTextPrimary = Color.themed(light: 0x24201A, dark: 0xEFE9DC, oled: 0xEFE9DC)
 
   /// Captions, metadata, timestamps.
-  public static let tcTextSecondary = Color.themed(light: 0x6B6560, dark: 0x9B9590, oled: 0x9B9590)
+  public static let tcTextSecondary = Color.themed(light: 0x6D665C, dark: 0xA69E8F, oled: 0xA69E8F)
 
   /// Placeholder text, disabled labels.
-  public static let tcTextTertiary = Color.themed(light: 0xA39E98, dark: 0x5C5852, oled: 0x5C5852)
+  public static let tcTextTertiary = Color.themed(light: 0xA79E90, dark: 0x6E675B, oled: 0x6E675B)
 
   /// Text rendered on tcAmber backgrounds.
-  public static let tcTextOnAccent = Color.themed(light: 0xFFFFFF, dark: 0x1C1917, oled: 0x1C1917)
+  public static let tcTextOnAccent = Color.themed(light: 0xFFFDF8, dark: 0x1C1917, oled: 0x1C1917)
 }
 
 // MARK: - Status
@@ -73,7 +73,7 @@ extension Color {
 
 extension Color {
   /// Subtle dividers and card outlines.
-  public static let tcBorder = Color.themed(light: 0xE8E4DF, dark: 0x3A3A3F, oled: 0x1E1E22)
+  public static let tcBorder = Color.themed(light: 0xDAD2C2, dark: 0x3A352B, oled: 0x26221A)
 
   /// Focus rings and active input borders.
   public static let tcBorderFocused = tcAmber

--- a/scripts/design-tokens/generate.mjs
+++ b/scripts/design-tokens/generate.mjs
@@ -261,6 +261,8 @@ function spaInvariantVars(tokens) {
     ``,
     `  /* Typography — Inter via Google Fonts */`,
     `  --tc-font-family: ${t['font-family']};`,
+    `  --tc-font-display: ${t['font-display']};`,
+    `  --tc-font-mono: ${t['font-mono']};`,
     ``,
     `  --tc-text-hero: ${t.sizes.hero};`,
     `  --tc-text-display-large: ${t.sizes['display-large']};`,
@@ -404,10 +406,10 @@ function seoThemedVars(tokens, theme, indent, withComments) {
          previous five-way ad-hoc per-appState palette. The *-bg tokens are the
          foreground colour at 15% opacity, for the filled badge style. */`;
   const bgIntro = `      /* Background scale converged with the share-page family (see
-         api-go/internal/sharepage/templates/styles.gohtml): a warm cream field
-         (--tc-background: #FAF8F5) behind a white card (--tc-surface:
-         #FFFFFF) in light mode, so SEO pages and share pages read as one
-         product rather than two differently-themed properties. */`;
+         api-go/internal/sharepage/templates/styles.gohtml): a warm paper field
+         (--tc-background) behind a warmer off-white card (--tc-surface) in light
+         mode, so SEO pages and share pages read as one product rather than two
+         differently-themed properties. */`;
 
   const lines = [];
   if (withComments) lines.push(bgIntro);
@@ -442,6 +444,8 @@ function seoThemedVars(tokens, theme, indent, withComments) {
       `      --tc-space-xl: ${px(tokens.spacing.xl)};`,
       `      --tc-space-xxl: ${px(tokens.spacing.xxl)};`,
       `      --tc-font-family: ${tokens.typography['font-family']};`,
+      `      --tc-font-display: ${tokens.typography['font-display']};`,
+      `      --tc-font-mono: ${tokens.typography['font-mono']};`,
       // SEO reading width — narrower than the SPA's --tc-content-max-width
       // (1120px); a page-local literal, not a shared token.
       `      --tc-content-max-width: 760px;`,
@@ -593,6 +597,7 @@ function sharepageThemeBlock(tokens, theme, indent, withInvariants) {
     lines.push(
       `${pad}--radius-sm:${px(tokens.radius.sm)};--radius-md:${px(tokens.radius.md)};`,
       `${pad}--space-xs:${px(tokens.spacing.xs)};--space-sm:${px(tokens.spacing.sm)};--space-md:${px(tokens.spacing.md)};--space-lg:${px(tokens.spacing.lg)};--space-xl:${px(tokens.spacing.xl)};`,
+      `${pad}--font-display:${tokens.typography['font-display']};--font-mono:${tokens.typography['font-mono']};`,
       `${pad}/* Shared status vocabulary (tc-r4n9 decision 4): three colour buckets, not a`,
       `${pad}   five-way traffic light — granted (green), refused (red), neutral for`,
       `${pad}   "Undecided" and every long-tail state. Mirrors web/scripts/lib/render-shared.mjs. */`,
@@ -725,7 +730,11 @@ function iosColorExpr(colors, name) {
     // Token-reference base (amber-muted, border-focused) -> the iOS member.
     const baseName = iosTokenName(entry.base);
     if ('alpha' in entry) {
-      return { expr: `${baseName}.opacity(${entry.alpha})`, wrappable: false };
+      // iOS applies a single flat .opacity() to a theme-aware base — there is no
+      // per-theme-opacity helper — so a per-theme alpha collapses to the light
+      // value, the same rule the overlay scrim already uses above.
+      const alpha = typeof entry.alpha === 'object' ? entry.alpha.light : entry.alpha;
+      return { expr: `${baseName}.opacity(${alpha})`, wrappable: false };
     }
     return { expr: baseName, wrappable: false };
   }
@@ -844,14 +853,14 @@ function androidColorExpr(colors, name, theme) {
       const alpha = typeof entry.alpha === 'object' ? entry.alpha[theme] : entry.alpha;
       return `${baseExpr}.copy(alpha = ${kotlinAlpha(alpha)})`;
     }
-    // Token-reference base. amber-muted uses the muted() helper, which bakes in
-    // alpha 0.15; any other alpha would need a helper that doesn't exist.
+    // Token-reference base. A per-theme (or scalar) alpha applies .copy(alpha=)
+    // per theme, matching the overlay scrim style; Android emits one field per
+    // theme, so it carries the per-theme alpha natively (unlike iOS's single
+    // flat value).
     const baseHex = bareHex(resolveColor(colors, entry.base, theme));
     if ('alpha' in entry) {
-      if (entry.alpha !== 0.15) {
-        throw new Error(`Android muted() encodes alpha 0.15 only, not ${entry.alpha} (token "${name}")`);
-      }
-      return `muted(Color(0xFF${baseHex}))`;
+      const alpha = typeof entry.alpha === 'object' ? entry.alpha[theme] : entry.alpha;
+      return `Color(0xFF${baseHex}).copy(alpha = ${kotlinAlpha(alpha)})`;
     }
     return `Color(0xFF${baseHex})`;
   }
@@ -919,8 +928,6 @@ import androidx.compose.ui.graphics.Color
 internal data class TcPalette(
 ${fields}
 )
-
-private fun muted(amber: Color) = amber.copy(alpha = 0.15f)
 
 internal val LightPalette =
     TcPalette(

--- a/scripts/design-tokens/generate.test.mjs
+++ b/scripts/design-tokens/generate.test.mjs
@@ -45,7 +45,7 @@ const SKILL_BEGIN = '<!-- tokens:generated:begin -->';
 const SKILL_END = '<!-- tokens:generated:end -->';
 
 test('resolveColor returns the direct per-theme value', () => {
-  assert.equal(resolveColor(tokens.color, 'amber', 'light'), '#D4910A');
+  assert.equal(resolveColor(tokens.color, 'amber', 'light'), '#9E6709');
   assert.equal(resolveColor(tokens.color, 'amber', 'dark'), '#E9A620');
   assert.equal(resolveColor(tokens.color, 'amber', 'oled'), '#E9A620');
   assert.equal(resolveColor(tokens.color, 'background', 'oled'), '#000000');
@@ -60,9 +60,10 @@ test('resolveColor follows a base reference with no alpha (per theme)', () => {
   assert.equal(resolveColor(tokens.color, 'border-focused', 'dark'), '#E9A620');
 });
 
-test('resolveColor emits rgba() for a scalar alpha over a token base', () => {
-  // amber-muted: { base: "amber", alpha: 0.15 } -> rgba of amber, 15%.
-  assert.equal(resolveColor(tokens.color, 'amber-muted', 'light'), 'rgba(212, 145, 10, 0.15)');
+test('resolveColor emits rgba() for a per-theme alpha over a token base', () => {
+  // amber-muted: { base: "amber", alpha: { light: 0.12, dark: 0.15, oled: 0.15 } }
+  // -> rgba of amber at the per-theme alpha.
+  assert.equal(resolveColor(tokens.color, 'amber-muted', 'light'), 'rgba(158, 103, 9, 0.12)');
   assert.equal(resolveColor(tokens.color, 'amber-muted', 'dark'), 'rgba(233, 166, 32, 0.15)');
   assert.equal(resolveColor(tokens.color, 'amber-muted', 'oled'), 'rgba(233, 166, 32, 0.15)');
 });
@@ -121,10 +122,10 @@ test('emitGoTokens emits the generated-code marker, package clause, and import',
 
 test('emitGoTokens emits hex-string consts per theme, light+dark only (no OLED)', () => {
   const go = emitGoTokens(tokens);
-  assert.match(go, /AmberLightHex\s+= "#D4910A"/);
+  assert.match(go, /AmberLightHex\s+= "#9E6709"/);
   assert.match(go, /AmberDarkHex\s+= "#E9A620"/);
   // A base-ref token (border-focused -> amber) still resolves to a concrete hex.
-  assert.match(go, /BorderFocusedLightHex\s+= "#D4910A"/);
+  assert.match(go, /BorderFocusedLightHex\s+= "#9E6709"/);
   // Symbols are PascalCase (…OledHex); the doc's all-caps "OLED" must not match,
   // so this stays case-sensitive.
   assert.ok(!/Oled/.test(go), 'no Go-rendered surface implements OLED — no Oled symbol should be emitted');
@@ -132,8 +133,8 @@ test('emitGoTokens emits hex-string consts per theme, light+dark only (no OLED)'
 
 test('emitGoTokens converts hex to color.RGBA correctly (incl. zero-padded low byte)', () => {
   const go = emitGoTokens(tokens);
-  // #D4910A -> R:0xD4 G:0x91 B:0x0A — the 0x0A verifies two-digit padding.
-  assert.match(go, /AmberLight\s+= color\.RGBA\{R: 0xD4, G: 0x91, B: 0x0A, A: 0xFF\}/);
+  // #9E6709 -> R:0x9E G:0x67 B:0x09 — the 0x09 verifies two-digit padding.
+  assert.match(go, /AmberLight\s+= color\.RGBA\{R: 0x9E, G: 0x67, B: 0x09, A: 0xFF\}/);
   assert.match(go, /AmberDark\s+= color\.RGBA\{R: 0xE9, G: 0xA6, B: 0x20, A: 0xFF\}/);
   // White is an emitted image-renderer primitive, not a token.
   assert.match(go, /var White = color\.RGBA\{R: 0xFF, G: 0xFF, B: 0xFF, A: 0xFF\}/);
@@ -185,7 +186,7 @@ test('emitSharepageTokensGohtml uses the true neutral bucket (withdrawn), unlike
 test('emitSharepageTokensGohtml emits compact rgba() fills at 15% (share-page style)', () => {
   const html = emitSharepageTokensGohtml(tokens);
   assert.match(html, /--status-granted-bg:rgba\(26,125,55,0\.15\);/); // #1A7D37 @ 15%
-  assert.match(html, /--amber-muted:rgba\(212,145,10,0\.15\);/); // amber light @ 15%
+  assert.match(html, /--amber-muted:rgba\(158,103,9,0\.12\);/); // amber light @ 12%
   assert.ok(!/rgba\(26, 125, 55/.test(html), 'share-page rgba() has no spaces after commas');
 });
 
@@ -260,7 +261,7 @@ test('emitIosColors skips amber-hover (per-platform skip list)', () => {
 
 test('emitIosColors renders derived tokens in their iOS forms', () => {
   const out = emitIosColors(tokens);
-  assert.ok(out.includes('public static let tcAmberMuted = tcAmber.opacity(0.15)'));
+  assert.ok(out.includes('public static let tcAmberMuted = tcAmber.opacity(0.12)'));
   assert.ok(out.includes('public static let tcBorderFocused = tcAmber\n'));
   // overlay is a flat scrim using the light-theme alpha, not a themed colour.
   assert.ok(out.includes('public static let tcOverlay = Color.black.opacity(0.4)'));
@@ -278,10 +279,13 @@ test('emitAndroidColors reproduces the committed Color.kt byte-for-byte', () => 
 
 test('emitAndroidColors keeps amber-hover and formats overlay alpha per theme', () => {
   const out = emitAndroidColors(tokens);
-  assert.ok(out.includes('amberHover = Color(0xFFB87A08)'));
+  assert.ok(out.includes('amberHover = Color(0xFF8A5F06)'));
   assert.ok(out.includes('overlay = Color.Black.copy(alpha = 0.40f)'), 'light overlay alpha');
   assert.ok(out.includes('overlay = Color.Black.copy(alpha = 0.50f)'), 'dark overlay alpha');
-  assert.ok(out.includes('amberMuted = muted(Color(0xFFD4910A))'), 'amber-muted uses the muted() helper');
+  assert.ok(
+    out.includes('amberMuted = Color(0xFF9E6709).copy(alpha = 0.12f)'),
+    'amber-muted is amber at the per-theme light alpha (0.12)',
+  );
 });
 
 test('emitAndroidColors OledPalette overrides exactly the four differing fields', () => {

--- a/web/scripts/lib/__tests__/render-shared.test.mjs
+++ b/web/scripts/lib/__tests__/render-shared.test.mjs
@@ -444,7 +444,7 @@ describe('pageStyles status chip vocabulary (decision 4: shared palette, filled 
     const root = rootDeclarations(pageStyles());
     expect(root).toMatch(/--tc-status-granted: #1A7D37;/);
     expect(root).toMatch(/--tc-status-refused: #C42B2B;/);
-    expect(root).toMatch(/--tc-status-neutral: #6B6560;/);
+    expect(root).toMatch(/--tc-status-neutral: #6D665C;/);
     expect(root).toMatch(/--tc-status-granted-bg:/);
     expect(root).toMatch(/--tc-status-refused-bg:/);
     expect(root).toMatch(/--tc-status-neutral-bg:/);
@@ -454,7 +454,7 @@ describe('pageStyles status chip vocabulary (decision 4: shared palette, filled 
     const dark = darkMediaDeclarations(pageStyles());
     expect(dark).toMatch(/--tc-status-granted: #34C759;/);
     expect(dark).toMatch(/--tc-status-refused: #FF453A;/);
-    expect(dark).toMatch(/--tc-status-neutral: #9B9590;/);
+    expect(dark).toMatch(/--tc-status-neutral: #A69E8F;/);
   });
 
   it('no longer defines the old ad-hoc per-state status tokens', () => {
@@ -511,26 +511,26 @@ describe('pageStyles light-first token flip (tc-r4n9.1)', () => {
 
   it('defaults :root to the light-mode values directly (no query needed)', () => {
     const root = rootDeclarations(pageStyles());
-    expect(root).toMatch(/--tc-amber: #D4910A;/);
-    expect(root).toMatch(/--tc-amber-hover: #B87A08;/);
-    expect(root).toMatch(/--tc-background: #FAF8F5;/);
-    expect(root).toMatch(/--tc-surface: #FFFFFF;/);
-    expect(root).toMatch(/--tc-text-primary: #1C1917;/);
-    expect(root).toMatch(/--tc-text-secondary: #6B6560;/);
-    expect(root).toMatch(/--tc-text-on-accent: #FFFFFF;/);
-    expect(root).toMatch(/--tc-border: #E8E4DF;/);
+    expect(root).toMatch(/--tc-amber: #9E6709;/);
+    expect(root).toMatch(/--tc-amber-hover: #8A5F06;/);
+    expect(root).toMatch(/--tc-background: #F5F0E6;/);
+    expect(root).toMatch(/--tc-surface: #FFFDF6;/);
+    expect(root).toMatch(/--tc-text-primary: #24201A;/);
+    expect(root).toMatch(/--tc-text-secondary: #6D665C;/);
+    expect(root).toMatch(/--tc-text-on-accent: #FFFDF8;/);
+    expect(root).toMatch(/--tc-border: #DAD2C2;/);
   });
 
   it('moves the former dark defaults, byte-for-byte, into @media (prefers-color-scheme: dark)', () => {
     const dark = darkMediaDeclarations(pageStyles());
     expect(dark).toMatch(/--tc-amber: #E9A620;/);
     expect(dark).toMatch(/--tc-amber-hover: #F0B83A;/);
-    expect(dark).toMatch(/--tc-background: #1A1A1E;/);
-    expect(dark).toMatch(/--tc-surface: #242428;/);
-    expect(dark).toMatch(/--tc-text-primary: #F1EFE9;/);
-    expect(dark).toMatch(/--tc-text-secondary: #9B9590;/);
+    expect(dark).toMatch(/--tc-background: #191713;/);
+    expect(dark).toMatch(/--tc-surface: #23201A;/);
+    expect(dark).toMatch(/--tc-text-primary: #EFE9DC;/);
+    expect(dark).toMatch(/--tc-text-secondary: #A69E8F;/);
     expect(dark).toMatch(/--tc-text-on-accent: #1C1917;/);
-    expect(dark).toMatch(/--tc-border: #3A3A3F;/);
+    expect(dark).toMatch(/--tc-border: #3A352B;/);
   });
 
   it('no longer gates light values behind a prefers-color-scheme: light query', () => {
@@ -550,7 +550,10 @@ describe('pageStyles light-first token flip (tc-r4n9.1)', () => {
     // :root token block itself (not just JSDoc above the function), so it is
     // visible to anyone reading the generated page source.
     expect(root).toMatch(/\/\*[^]*share page[^]*\*\//i);
-    expect(root.toLowerCase()).toContain('faf8f5');
+    // Value-agnostic on purpose: the comment references the token names, not the
+    // hexes, so a palette flip (e.g. Public Notice v2) can't leave it stale.
+    expect(root.toLowerCase()).toContain('background scale');
+    expect(root).toContain('--tc-background');
   });
 });
 

--- a/web/scripts/lib/tokens.generated.mjs
+++ b/web/scripts/lib/tokens.generated.mjs
@@ -4,17 +4,17 @@
 export const SEO_TOKEN_CSS = `    /* GENERATED — design tokens from design/tokens.json; run scripts/design-tokens/generate.mjs */
     :root {
       /* Background scale converged with the share-page family (see
-         api-go/internal/sharepage/templates/styles.gohtml): a warm cream field
-         (--tc-background: #FAF8F5) behind a white card (--tc-surface:
-         #FFFFFF) in light mode, so SEO pages and share pages read as one
-         product rather than two differently-themed properties. */
-      --tc-amber: #D4910A;
-      --tc-amber-hover: #B87A08;
-      --tc-background: #FAF8F5;
-      --tc-surface: #FFFFFF;
-      --tc-text-primary: #1C1917;
-      --tc-text-secondary: #6B6560;
-      --tc-text-on-accent: #FFFFFF;
+         api-go/internal/sharepage/templates/styles.gohtml): a warm paper field
+         (--tc-background) behind a warmer off-white card (--tc-surface) in light
+         mode, so SEO pages and share pages read as one product rather than two
+         differently-themed properties. */
+      --tc-amber: #9E6709;
+      --tc-amber-hover: #8A5F06;
+      --tc-background: #F5F0E6;
+      --tc-surface: #FFFDF6;
+      --tc-text-primary: #24201A;
+      --tc-text-secondary: #6D665C;
+      --tc-text-on-accent: #FFFDF8;
       /* Shared status chip vocabulary (decision 4, punch-list #794): three
          canonical buckets — granted (green), refused (red), neutral (the
          undecided/long-tail catch-all) — converged with the design-language
@@ -25,10 +25,10 @@ export const SEO_TOKEN_CSS = `    /* GENERATED — design tokens from design/tok
       --tc-status-granted-bg: #1A7D3726;
       --tc-status-refused: #C42B2B;
       --tc-status-refused-bg: #C42B2B26;
-      --tc-status-neutral: #6B6560;
-      --tc-status-neutral-bg: #6B656026;
-      --tc-border: #E8E4DF;
-      --tc-radius-md: 12px;
+      --tc-status-neutral: #6D665C;
+      --tc-status-neutral-bg: #6D665C26;
+      --tc-border: #DAD2C2;
+      --tc-radius-md: 6px;
       --tc-radius-full: 9999px;
       --tc-space-sm: 8px;
       --tc-space-md: 16px;
@@ -36,23 +36,25 @@ export const SEO_TOKEN_CSS = `    /* GENERATED — design tokens from design/tok
       --tc-space-xl: 32px;
       --tc-space-xxl: 48px;
       --tc-font-family: 'Inter', system-ui, -apple-system, sans-serif;
+      --tc-font-display: 'Fraunces', 'Iowan Old Style', Georgia, serif;
+      --tc-font-mono: ui-monospace, 'SF Mono', Menlo, 'Roboto Mono', monospace;
       --tc-content-max-width: 760px;
     }
     @media (prefers-color-scheme: dark) {
       :root {
         --tc-amber: #E9A620;
         --tc-amber-hover: #F0B83A;
-        --tc-background: #1A1A1E;
-        --tc-surface: #242428;
-        --tc-text-primary: #F1EFE9;
-        --tc-text-secondary: #9B9590;
+        --tc-background: #191713;
+        --tc-surface: #23201A;
+        --tc-text-primary: #EFE9DC;
+        --tc-text-secondary: #A69E8F;
         --tc-text-on-accent: #1C1917;
         --tc-status-granted: #34C759;
         --tc-status-granted-bg: #34C75926;
         --tc-status-refused: #FF453A;
         --tc-status-refused-bg: #FF453A26;
-        --tc-status-neutral: #9B9590;
-        --tc-status-neutral-bg: #9B959026;
-        --tc-border: #3A3A3F;
+        --tc-status-neutral: #A69E8F;
+        --tc-status-neutral-bg: #A69E8F26;
+        --tc-border: #3A352B;
       }
     }`;

--- a/web/src/__tests__/design-tokens.test.tsx
+++ b/web/src/__tests__/design-tokens.test.tsx
@@ -13,30 +13,30 @@ describe('Design tokens (tokens.css)', () => {
   const css = readCss(tokensPath);
 
   it('defines dark theme colour tokens on :root (default)', () => {
-    expect(css).toContain('--tc-background: #1A1A1E');
-    expect(css).toContain('--tc-surface: #242428');
-    expect(css).toContain('--tc-surface-elevated: #2E2E33');
+    expect(css).toContain('--tc-background: #191713');
+    expect(css).toContain('--tc-surface: #23201A');
+    expect(css).toContain('--tc-surface-elevated: #2B2822');
     expect(css).toContain('--tc-amber: #E9A620');
-    expect(css).toContain('--tc-text-primary: #F1EFE9');
-    expect(css).toContain('--tc-text-secondary: #9B9590');
-    expect(css).toContain('--tc-text-tertiary: #5C5852');
+    expect(css).toContain('--tc-text-primary: #EFE9DC');
+    expect(css).toContain('--tc-text-secondary: #A69E8F');
+    expect(css).toContain('--tc-text-tertiary: #6E675B');
     expect(css).toContain('--tc-text-on-accent: #1C1917');
   });
 
   it('defines light theme tokens under [data-theme="light"]', () => {
     expect(css).toContain('[data-theme="light"]');
-    expect(css).toContain('--tc-background: #FAF8F5');
-    expect(css).toContain('--tc-surface: #FFFFFF');
-    expect(css).toContain('--tc-amber: #D4910A');
-    expect(css).toContain('--tc-text-primary: #1C1917');
-    expect(css).toContain('--tc-text-secondary: #6B6560');
+    expect(css).toContain('--tc-background: #F5F0E6');
+    expect(css).toContain('--tc-surface: #FFFDF6');
+    expect(css).toContain('--tc-amber: #9E6709');
+    expect(css).toContain('--tc-text-primary: #24201A');
+    expect(css).toContain('--tc-text-secondary: #6D665C');
   });
 
   it('defines OLED dark tokens under [data-theme="oled-dark"]', () => {
     expect(css).toContain('[data-theme="oled-dark"]');
     expect(css).toContain('--tc-background: #000000');
-    expect(css).toContain('--tc-surface: #0A0A0A');
-    expect(css).toContain('--tc-surface-elevated: #161616');
+    expect(css).toContain('--tc-surface: #0A0908');
+    expect(css).toContain('--tc-surface-elevated: #151310');
   });
 
   it('defines status tokens for all PlanIt application states', () => {
@@ -64,14 +64,16 @@ describe('Design tokens (tokens.css)', () => {
   });
 
   it('defines corner radius tokens', () => {
-    expect(css).toContain('--tc-radius-sm: 8px');
-    expect(css).toContain('--tc-radius-md: 12px');
-    expect(css).toContain('--tc-radius-lg: 16px');
+    expect(css).toContain('--tc-radius-sm: 3px');
+    expect(css).toContain('--tc-radius-md: 6px');
+    expect(css).toContain('--tc-radius-lg: 12px');
     expect(css).toContain('--tc-radius-full: 9999px');
   });
 
   it('defines typography tokens', () => {
     expect(css).toContain('--tc-font-family');
+    expect(css).toContain("--tc-font-display: 'Fraunces', 'Iowan Old Style', Georgia, serif");
+    expect(css).toContain("--tc-font-mono: ui-monospace, 'SF Mono', Menlo, 'Roboto Mono', monospace");
     expect(css).toContain('--tc-text-display-large');
     expect(css).toContain('--tc-text-display-small');
     expect(css).toContain('--tc-text-headline');

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -14,14 +14,14 @@
   --tc-amber-hover: #F0B83A;
 
   /* Surfaces */
-  --tc-background: #1A1A1E;
-  --tc-surface: #242428;
-  --tc-surface-elevated: #2E2E33;
+  --tc-background: #191713;
+  --tc-surface: #23201A;
+  --tc-surface-elevated: #2B2822;
 
   /* Text */
-  --tc-text-primary: #F1EFE9;
-  --tc-text-secondary: #9B9590;
-  --tc-text-tertiary: #5C5852;
+  --tc-text-primary: #EFE9DC;
+  --tc-text-secondary: #A69E8F;
+  --tc-text-tertiary: #6E675B;
   --tc-text-on-accent: #1C1917;
 
   /* Status (PlanIt vocabulary: Permitted / Conditions / Rejected) */
@@ -33,7 +33,7 @@
   --tc-status-appealed: #A78BFA;
 
   /* Utility */
-  --tc-border: #3A3A3F;
+  --tc-border: #3A352B;
   --tc-border-focused: #E9A620;
   --tc-overlay: rgba(0, 0, 0, 0.5);
 
@@ -50,13 +50,15 @@
   --tc-space-xxl: 48px;
 
   /* Corner radius */
-  --tc-radius-sm: 8px;
-  --tc-radius-md: 12px;
-  --tc-radius-lg: 16px;
+  --tc-radius-sm: 3px;
+  --tc-radius-md: 6px;
+  --tc-radius-lg: 12px;
   --tc-radius-full: 9999px;
 
   /* Typography — Inter via Google Fonts */
   --tc-font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  --tc-font-display: 'Fraunces', 'Iowan Old Style', Georgia, serif;
+  --tc-font-mono: ui-monospace, 'SF Mono', Menlo, 'Roboto Mono', monospace;
 
   --tc-text-hero: 3.5rem;
   --tc-text-display-large: 2rem;
@@ -88,20 +90,20 @@
 /* ---------- Light theme ---------- */
 [data-theme="light"] {
   /* Brand */
-  --tc-amber: #D4910A;
-  --tc-amber-muted: rgba(212, 145, 10, 0.15);
-  --tc-amber-hover: #B87A08;
+  --tc-amber: #9E6709;
+  --tc-amber-muted: rgba(158, 103, 9, 0.12);
+  --tc-amber-hover: #8A5F06;
 
   /* Surfaces */
-  --tc-background: #FAF8F5;
-  --tc-surface: #FFFFFF;
-  --tc-surface-elevated: #FFFFFF;
+  --tc-background: #F5F0E6;
+  --tc-surface: #FFFDF6;
+  --tc-surface-elevated: #FFFDF6;
 
   /* Text */
-  --tc-text-primary: #1C1917;
-  --tc-text-secondary: #6B6560;
-  --tc-text-tertiary: #A39E98;
-  --tc-text-on-accent: #FFFFFF;
+  --tc-text-primary: #24201A;
+  --tc-text-secondary: #6D665C;
+  --tc-text-tertiary: #A79E90;
+  --tc-text-on-accent: #FFFDF8;
 
   /* Status (PlanIt vocabulary: Permitted / Conditions / Rejected) */
   --tc-status-permitted: #1A7D37;
@@ -112,12 +114,12 @@
   --tc-status-appealed: #7C3AED;
 
   /* Utility */
-  --tc-border: #E8E4DF;
-  --tc-border-focused: #D4910A;
+  --tc-border: #DAD2C2;
+  --tc-border-focused: #9E6709;
   --tc-overlay: rgba(0, 0, 0, 0.4);
 
   /* Shadows (light mode only) */
-  --tc-shadow-card: 0 2px 8px rgba(0, 0, 0, 0.05);
+  --tc-shadow-card: 0 1px 3px rgba(0, 0, 0, 0.06);
   --tc-shadow-elevated: 0 4px 16px rgba(0, 0, 0, 0.08);
 }
 
@@ -130,13 +132,13 @@
 
   /* Surfaces */
   --tc-background: #000000;
-  --tc-surface: #0A0A0A;
-  --tc-surface-elevated: #161616;
+  --tc-surface: #0A0908;
+  --tc-surface-elevated: #151310;
 
   /* Text — same as dark */
-  --tc-text-primary: #F1EFE9;
-  --tc-text-secondary: #9B9590;
-  --tc-text-tertiary: #5C5852;
+  --tc-text-primary: #EFE9DC;
+  --tc-text-secondary: #A69E8F;
+  --tc-text-tertiary: #6E675B;
   --tc-text-on-accent: #1C1917;
 
   /* Status — same as dark (PlanIt vocabulary) */
@@ -148,7 +150,7 @@
   --tc-status-appealed: #A78BFA;
 
   /* Utility */
-  --tc-border: #1E1E22;
+  --tc-border: #26221A;
   --tc-border-focused: #E9A620;
   --tc-overlay: rgba(0, 0, 0, 0.5);
 
@@ -161,20 +163,20 @@
 @media (prefers-color-scheme: light) {
   :root:not([data-theme]) {
     /* Brand */
-    --tc-amber: #D4910A;
-    --tc-amber-muted: rgba(212, 145, 10, 0.15);
-    --tc-amber-hover: #B87A08;
+    --tc-amber: #9E6709;
+    --tc-amber-muted: rgba(158, 103, 9, 0.12);
+    --tc-amber-hover: #8A5F06;
 
     /* Surfaces */
-    --tc-background: #FAF8F5;
-    --tc-surface: #FFFFFF;
-    --tc-surface-elevated: #FFFFFF;
+    --tc-background: #F5F0E6;
+    --tc-surface: #FFFDF6;
+    --tc-surface-elevated: #FFFDF6;
 
     /* Text */
-    --tc-text-primary: #1C1917;
-    --tc-text-secondary: #6B6560;
-    --tc-text-tertiary: #A39E98;
-    --tc-text-on-accent: #FFFFFF;
+    --tc-text-primary: #24201A;
+    --tc-text-secondary: #6D665C;
+    --tc-text-tertiary: #A79E90;
+    --tc-text-on-accent: #FFFDF8;
 
     /* Status (PlanIt vocabulary) */
     --tc-status-permitted: #1A7D37;
@@ -185,12 +187,12 @@
     --tc-status-appealed: #7C3AED;
 
     /* Utility */
-    --tc-border: #E8E4DF;
-    --tc-border-focused: #D4910A;
+    --tc-border: #DAD2C2;
+    --tc-border-focused: #9E6709;
     --tc-overlay: rgba(0, 0, 0, 0.4);
 
     /* Shadows (light mode only) */
-    --tc-shadow-card: 0 2px 8px rgba(0, 0, 0, 0.05);
+    --tc-shadow-card: 0 1px 3px rgba(0, 0, 0, 0.06);
     --tc-shadow-elevated: 0 4px 16px rgba(0, 0, 0, 0.08);
   }
 }


### PR DESCRIPTION
Implements #852 (epic #848, slice R0). Flips `design/tokens.json` from v1 to the Public Notice **v2** values and regenerates every surface, so the SPA, SEO pages, share page, OG card, iOS colours and Android colours all move to the new warm/paper palette and web+Go surfaces to the new radii in one atomic change. **Values only** — no component shape changes (those land in R1–R5). Statuses are semantically locked and unchanged in all three themes.

## What changed
- `design/tokens.json` — full v2 value flip + two new typography tokens (`font-display`, `font-mono`); `amber-muted` alpha becomes per-theme (`{light 0.12, dark 0.15, oled 0.15}`).
- `scripts/design-tokens/generate.mjs` — emits `--tc-font-display`/`--tc-font-mono` to the SPA CSS and SEO block, and bare `--font-display`/`--font-mono` to the share-page tokenVars; handles per-theme alpha over a token-ref base for iOS (flat, light value) and Android (per-theme). Also made one stale hardcoded-hex comment in the SEO block value-agnostic so it can't rot on future flips.
- All 7 generated files regenerated; drift check green; **zero hand-edits** to generated files.
- Value-pinning tests updated to v2: `web/src/__tests__/design-tokens.test.tsx`, `web/scripts/lib/__tests__/render-shared.test.mjs`, `scripts/design-tokens/generate.test.mjs`, `mobile/android/.../ThemeMappingTest.kt`.

## Contrast gate (computed, not eyeballed)
Script: WCAG 2.x relative-luminance ratios. **All pass.**

| Check | Light | Dark | OLED | Min |
|---|---|---|---|---|
| text-on-accent on amber | **4.70** | — | — | 4.5 |
| amber on background | **4.20** | — | — | 3.0 |
| text-primary on background | 14.26 | 14.80 | 17.36 | 4.5 |
| text-primary on surface | 15.91 | 13.43 | 16.45 | 4.5 |
| text-secondary on background | 4.99 | 6.74 | 7.91 | 4.5 |
| text-secondary on surface | 5.57 | 6.12 | 7.49 | 4.5 |
| border vs background | 1.32 | 1.47 | 1.33 | 1.3 |
| status-permitted on surface | 5.12 | 7.32 | 8.96 | 3.0 |
| status-conditions on surface | 4.52 | 7.90 | 9.68 | 3.0 |
| status-rejected on surface | 5.54 | 4.77 | 5.84 | 3.0 |
| status-pending on surface | 3.39 | 9.11 | 11.16 | 3.0 |
| status-withdrawn on surface | 4.48 | 4.74 | 5.80 | 3.0 |
| status-appealed on surface | 5.60 | 5.97 | 7.31 | 3.0 |

## Deviations from the issue's literal table (with reasons)
1. **Light `amber` = `#9E6709`, not the issue's `#B27B0B`.** `#B27B0B` fails the text-on-accent gate (3.60:1 < 4.5). Followed the issue's prescribed darkening recipe (R,G −10 / B −1 per step): `#B27B0B → #A8710A` (4.11, still fails) `→ #9E6709` — the **first** value that passes both gates (on-accent **4.70**, on-background **4.20**, well above 3.0). `border-focused` (follows amber) and the Go `AmberLight` (OG card fallback fill + pin) inherit `#9E6709`.
2. **OLED `border` = `#26221A`, not the issue's `#201D18`.** `#201D18` gives only 1.25:1 vs true-black background — under the 1.3 visibility gate (v1's `#1E1E22` was also under, at 1.264, so OLED never met this newly-asserted gate). Nudged the warm near-black up to `#26221A` (1.33:1), matching the light/dark border margins; stays warm and near-black, on-direction.
3. **Light `amber-hover` kept at the issue's `#8A5F06`.** It's still darker than the darkened base `#9E6709`, so it remains a valid pressed/hover state — no change needed.

## `amber-muted` now per-theme alpha
v2 wants light 0.12 / dark 0.15 / oled 0.15 (was a uniform 0.15). Web and Android carry per-theme alpha natively (each emits one value per theme). iOS applies a single flat `.opacity()` to a theme-aware base and has no per-theme-opacity helper, so it collapses to the **light** value (`tcAmber.opacity(0.12)`) — the exact rule the overlay scrim already uses. Net iOS effect: dark/OLED muted tags render at 0.12 rather than 0.15 alpha (≈3% more transparent, imperceptible); the underlying amber colour still updates. Inventing per-theme-opacity infra on iOS is out of scope for a values-only flip.

## OG "golden fixtures"
There are **no golden PNG fixtures** under `api-go/internal/sharepage/` to rebake. The OG card colours are computed from the generated `designtokens` Go constants (`fallbackBg = AmberLight`, `pinFill = AmberDark`), so the card automatically renders the new palette, and the card tests assert against those same computed constants (e.g. `sameRGB(img, fallbackBg)`) — they stay green. The card's fallback background + pin do change colour (intentional, `#9E6709`/`#E9A620`), verified by `go test` (1643 pass).

## Intended intermediate-state note
The design-language skill doc's radius table regenerates to the **canonical** v2 radii (3/6/12pt). iOS/Android radius constants are hand-maintained and still hold the old radii until R4/R5 (per the issue — mobile gets new **colours** only from this PR), so the doc leads the mobile code there deliberately and briefly.

## Gates (all green)
- `node scripts/design-tokens/generate.mjs --check` — in sync (7 files)
- generator unit tests — 29 pass
- `web`: `npx vitest run` — 1140 pass; `npx tsc --noEmit` — no errors
- `api-go`: `go build ./...` clean; `go test ./...` — 1643 pass
- `mobile/ios`: `swift test` — 1794 pass (one clean full run; a pre-existing, unrelated concurrency flake in `MapViewModelStackTests` tripped once then passed 3/3 in isolation and on a clean full re-run — nothing this change touches)
- `mobile/android`: `./gradlew test` — BUILD SUCCESSFUL

Not merging — leaving visual before/after verification (separate subagent, per epic protocol) and merge to the team lead.
