### PR TITLE
feat(seo): Public Notice broadsheet treatment for /planning/* pages (tc-ekk4e)

### DIFF
--- a/web/scripts/lib/__tests__/render-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-page.test.mjs
@@ -154,18 +154,18 @@ describe('renderPlanningPage', () => {
   it('renders each application address as the headline and status label', () => {
     const html = renderPlanningPage(pageData());
     expect(html).toContain(
-      '<h3 class="appCard__address">12 Mill Road, Basingstoke, RG21 1AA</h3>',
+      '<h3 class="ledgerRow__address">12 Mill Road, Basingstoke, RG21 1AA</h3>',
     );
     expect(html).toContain('Erection of two-storey rear extension');
     expect(html).toContain('Granted'); // Permitted -> Granted
     expect(html).toContain('Refused'); // Rejected -> Refused
   });
 
-  it('demotes the reference to small card metadata and removes per-card external links (decisions 5 & 6)', () => {
+  it('demotes the reference to small ledger-row metadata and removes per-row external links (decisions 5 & 6)', () => {
     const html = renderPlanningPage(pageData());
-    expect(html).toContain('<p class="appCard__ref">26/0001/FUL</p>');
-    expect(html).not.toContain('<h3 class="appCard__ref">');
-    // The per-card PlanIt/council links are gone (decision 6) — official-record
+    expect(html).toContain('<p class="ledgerRow__ref">26/0001/FUL</p>');
+    expect(html).not.toContain('<h3 class="ledgerRow__ref">');
+    // The per-row PlanIt/council links are gone (decision 6) — official-record
     // links now live on the share page only.
     expect(html).not.toContain(
       'https://www.basingstoke.gov.uk/planning/26-0001-FUL',
@@ -174,13 +174,13 @@ describe('renderPlanningPage', () => {
     expect(html).not.toContain('class="appLink"');
   });
 
-  it('makes the whole card a real anchor to its share page, with a visible "View details" affordance', () => {
+  it('makes the whole row a real anchor to its share page, with a visible "View details" affordance', () => {
     const html = renderPlanningPage(pageData());
     // app.name (26/0001/FUL) is the ref, slashes kept as separators.
     expect(html).toContain(
-      '<a class="appCard__link" href="https://share.towncrierapp.uk/a/basingstoke-and-deane/26/0001/FUL">',
+      '<a class="ledgerRow__link" href="https://share.towncrierapp.uk/a/basingstoke-and-deane/26/0001/FUL">',
     );
-    expect(html).toContain('<span class="appCard__cta">View details →</span>');
+    expect(html).toContain('<span class="ledgerRow__cta">View details →</span>');
     // The share page is the item URL in the ItemList structured data too.
     expect(html).toContain(
       '"url":"https://share.towncrierapp.uk/a/basingstoke-and-deane/26/0001/FUL"',
@@ -209,17 +209,17 @@ describe('renderPlanningPage', () => {
       expect(html).not.toContain('Last updated');
     });
 
-    // tc-s0yf (GH #819) deliberately reintroduces a per-card date line — under a
-    // NEW class (`appCard__dates`) and format (Started/Decided, sourced from the
-    // application's own real-world dates, not a re-index marker) — distinct from
-    // the old "Last updated" line this describe block's title refers to.
-    it('renders the Started/Decided date line once per card (tc-s0yf)', () => {
+    // tc-s0yf (GH #819) deliberately reintroduces a per-row date line — under a
+    // NEW class (`ledgerRow__date`) and format (Started/Decided, sourced from
+    // the application's own real-world dates, not a re-index marker) — distinct
+    // from the old "Last updated" line this describe block's title refers to.
+    it('renders the Started/Decided date line once per row (tc-s0yf)', () => {
       const html = renderPlanningPage(pageData());
       expect(html).toContain(
-        '<p class="appCard__dates">Started 15 Jan 2026 · Awaiting decision</p>',
+        '<p class="ledgerRow__date">Started 15 Jan 2026 · Awaiting decision</p>',
       );
       expect(html).toContain(
-        '<p class="appCard__dates">Started 3 Feb 2026 · Awaiting decision</p>',
+        '<p class="ledgerRow__date">Started 3 Feb 2026 · Awaiting decision</p>',
       );
     });
   });
@@ -299,7 +299,7 @@ describe('renderPlanningPage', () => {
 
     // The bare class name also appears in the inline stylesheet, so assertions
     // target the rendered card markup.
-    const MID_CARD = 'class="appCard appCard--cta"';
+    const MID_CARD = 'class="ledgerCta"';
 
     it('slots a CTA card into a long list, after the eighth application', () => {
       const html = renderPlanningPage(pageData({ applications: manyApplications(12) }));
@@ -308,7 +308,7 @@ describe('renderPlanningPage', () => {
       expect(html).toContain('Get told when the next one lands');
       // After the 8th card, before the 9th. Scoped to the rendered list —
       // the JSON-LD in <head> repeats the addresses much earlier in the page.
-      const list = html.slice(html.indexOf('<ul class="appList">'));
+      const list = html.slice(html.indexOf('<ul class="ledger">'));
       expect(list.indexOf('8 Mill Road')).toBeLessThan(list.indexOf(MID_CARD));
       expect(list.indexOf(MID_CARD)).toBeLessThan(list.indexOf('9 Mill Road'));
     });
@@ -351,13 +351,13 @@ describe('renderPlanningPage', () => {
       // Directly after the lead paragraph...
       expect(html.indexOf('class="lead"')).toBeLessThan(html.indexOf('class="ctaInline"'));
       // ...and above the applications list.
-      expect(html.indexOf('class="ctaInline"')).toBeLessThan(html.indexOf('class="appList"'));
+      expect(html.indexOf('class="ctaInline"')).toBeLessThan(html.indexOf('class="ledger"'));
     });
 
     it('keeps the existing bottom banner CTA in addition to the inline one (not a replacement)', () => {
       const html = renderPlanningPage(pageData());
       expect(html).toContain('<section class="cta">');
-      expect(html.indexOf('class="appList"')).toBeLessThan(html.indexOf('<section class="cta">'));
+      expect(html.indexOf('class="ledger"')).toBeLessThan(html.indexOf('<section class="cta">'));
     });
   });
 
@@ -374,6 +374,27 @@ describe('renderPlanningPage', () => {
     expect(headerHtml).toContain('target="_blank"');
     // The brand link stays on the left.
     expect(headerHtml).toContain('>Town Crier</a>');
+  });
+
+  describe('masthead (double rule, small-caps wordmark)', () => {
+    it('renders the double rule beneath the masthead, inside the site header', () => {
+      const html = renderPlanningPage(pageData());
+      const header = html.match(/<header class="siteHeader">[\s\S]*?<\/header>/);
+      expect(header).not.toBeNull();
+      const [headerHtml] = header;
+      expect(headerHtml).toContain('class="siteHeader__ruleHeavy"');
+      expect(headerHtml).toContain('class="siteHeader__ruleHairline"');
+    });
+
+    it('gives the wordmark its own small-caps class', () => {
+      const html = renderPlanningPage(pageData());
+      expect(html).toContain('<a href="/" class="siteHeader__wordmark">Town Crier</a>');
+    });
+  });
+
+  it('opens the applications ledger with a small-caps brass section label', () => {
+    const html = renderPlanningPage(pageData());
+    expect(html).toContain('<h2 class="ledger__heading">Latest notices</h2>');
   });
 
   it('keeps the rich bottom CTA block when the header CTA is present', () => {
@@ -463,7 +484,7 @@ describe('renderPlanningPage', () => {
         pageData({ towns: [{ name: 'Basingstoke', slug: 'basingstoke' }] }),
       );
       // After the recent-applications <ul>, before the how-to-comment explainer.
-      expect(html.indexOf('class="appList"')).toBeLessThan(
+      expect(html.indexOf('class="ledger"')).toBeLessThan(
         html.indexOf('class="townLinks"'),
       );
       expect(html.indexOf('class="townLinks"')).toBeLessThan(

--- a/web/scripts/lib/__tests__/render-planning-index.test.mjs
+++ b/web/scripts/lib/__tests__/render-planning-index.test.mjs
@@ -224,4 +224,21 @@ describe('renderPlanningIndexPage', () => {
     expect(html).toContain('Ordnance Survey');
     expect(html).toContain('OpenStreetMap');
   });
+
+  describe('masthead (double rule, small-caps wordmark) — Public Notice broadsheet, consistent with the authority/town pages', () => {
+    it('renders the double rule beneath the masthead, inside the site header', () => {
+      const html = renderPlanningIndexPage(indexData());
+      const header = html.match(/<header class="siteHeader">[\s\S]*?<\/header>/);
+      expect(header).not.toBeNull();
+      const [headerHtml] = header;
+      expect(headerHtml).toContain('class="siteHeader__ruleHeavy"');
+      expect(headerHtml).toContain('class="siteHeader__ruleHairline"');
+    });
+
+    it('gives the wordmark its own small-caps class and keeps the brass header CTA', () => {
+      const html = renderPlanningIndexPage(indexData());
+      expect(html).toContain('<a href="/" class="siteHeader__wordmark">Town Crier</a>');
+      expect(html).toContain('siteHeader__cta');
+    });
+  });
 });

--- a/web/scripts/lib/__tests__/render-shared.test.mjs
+++ b/web/scripts/lib/__tests__/render-shared.test.mjs
@@ -39,24 +39,24 @@ function application(overrides = {}) {
   };
 }
 
-describe('renderApplicationsList card structure (decision 5: address is the human hook)', () => {
+describe('renderApplicationsList ledger row structure (decision 5: address is the human hook)', () => {
   it('renders the address as the <h3> headline', () => {
     const html = renderApplicationsList([application()], SLUG);
     expect(html).toContain(
-      '<h3 class="appCard__address">12 Mill Road, Basingstoke, RG21 1AA</h3>',
+      '<h3 class="ledgerRow__address">12 Mill Road, Basingstoke, RG21 1AA</h3>',
     );
   });
 
   it('demotes the council reference to small metadata text, not a heading', () => {
     const html = renderApplicationsList([application()], SLUG);
-    expect(html).toContain('<p class="appCard__ref">26/0001/FUL</p>');
-    expect(html).not.toContain('<h3 class="appCard__ref">');
-    expect(html).not.toContain('appCard__refLink');
+    expect(html).toContain('<p class="ledgerRow__ref">26/0001/FUL</p>');
+    expect(html).not.toContain('<h3 class="ledgerRow__ref">');
+    expect(html).not.toContain('ledgerRow__refLink');
   });
 
   it('omits the reference metadata line entirely when the app carries no ref', () => {
     const html = renderApplicationsList([application({ name: '' })], SLUG);
-    expect(html).not.toContain('appCard__ref');
+    expect(html).not.toContain('ledgerRow__ref');
   });
 
   it('HTML-escapes the address', () => {
@@ -77,7 +77,7 @@ describe('renderApplicationsList description truncation (word boundary)', () => 
       [application({ description: longDescription })],
       SLUG,
     );
-    const match = html.match(/<p class="appCard__desc">([^<]*)<\/p>/);
+    const match = html.match(/<p class="ledgerRow__desc">([^<]*)<\/p>/);
     expect(match).not.toBeNull();
     const rendered = match[1];
     expect(rendered.endsWith('…')).toBe(true);
@@ -93,20 +93,20 @@ describe('renderApplicationsList description truncation (word boundary)', () => 
   it('leaves a short description unchanged with no ellipsis', () => {
     const html = renderApplicationsList([application()], SLUG);
     expect(html).toContain(
-      '<p class="appCard__desc">Erection of two-storey rear extension</p>',
+      '<p class="ledgerRow__desc">Erection of two-storey rear extension</p>',
     );
   });
 });
 
 describe('renderApplicationsList share-page affordance (decision 6)', () => {
-  it('wraps the whole card in a real anchor pointing at the share page', () => {
+  it('wraps the whole row in a real anchor pointing at the share page', () => {
     const html = renderApplicationsList([application()], SLUG);
-    expect(html).toContain(`<a class="appCard__link" href="${SHARE_HREF}">`);
+    expect(html).toContain(`<a class="ledgerRow__link" href="${SHARE_HREF}">`);
   });
 
-  it('includes a visible "View details" affordance inside the card link', () => {
+  it('includes a visible "View details" affordance inside the row link', () => {
     const html = renderApplicationsList([application()], SLUG);
-    expect(html).toContain('<span class="appCard__cta">View details →</span>');
+    expect(html).toContain('<span class="ledgerRow__cta">View details →</span>');
   });
 
   it('never relies on a JS-only click handler for the share-page target', () => {
@@ -125,23 +125,23 @@ describe('renderApplicationsList share-page affordance (decision 6)', () => {
     );
   });
 
-  it('falls back to a non-linked card when no share URL can be built (no slug supplied)', () => {
+  it('falls back to a non-linked row when no share URL can be built (no slug supplied)', () => {
     const html = renderApplicationsList([application()]);
-    expect(html).not.toContain('appCard__link');
+    expect(html).not.toContain('ledgerRow__link');
     expect(html).not.toContain('View details');
     expect(html).not.toContain('share.towncrierapp.uk');
   });
 
-  it('falls back to a non-linked card when the app carries no ref', () => {
+  it('falls back to a non-linked row when the app carries no ref', () => {
     const html = renderApplicationsList([application({ name: '' })], SLUG);
-    expect(html).not.toContain('appCard__link');
+    expect(html).not.toContain('ledgerRow__link');
     expect(html).not.toContain('View details');
     expect(html).not.toContain('share.towncrierapp.uk');
   });
 });
 
 describe('renderApplicationsList external link removal (decision 6)', () => {
-  it('renders no per-card links to PlanIt or the council website', () => {
+  it('renders no per-row links to PlanIt or the council website', () => {
     const html = renderApplicationsList([application()], SLUG);
     expect(html).not.toContain(PLANIT_CAPTION);
     expect(html).not.toContain(COUNCIL_CAPTION);
@@ -159,23 +159,25 @@ describe('renderApplicationsList external link removal (decision 6)', () => {
   });
 });
 
-describe('renderApplicationsList status chip vocabulary (decision 4: shared vocabulary)', () => {
-  it('colours a Granted (Permitted) application with the granted chip', () => {
+describe('renderApplicationsList status stamp vocabulary (decision 4: shared vocabulary; Public Notice stamp language)', () => {
+  it('colours a Granted (Permitted) application with the granted stamp and pairs an icon with the label (accessibility invariant)', () => {
     const html = renderApplicationsList(
       [application({ appState: 'Permitted' })],
       SLUG,
     );
-    expect(html).toContain('class="status status--granted"');
-    expect(html).toContain('>Granted<');
+    expect(html).toContain('class="stamp stamp--granted"');
+    expect(html).toContain('<span class="stamp__label">Granted</span>');
+    expect(html).toContain('class="stamp__icon"');
+    expect(html).toMatch(/class="stamp__icon"[^>]*aria-hidden="true"/);
   });
 
-  it('colours a Refused (Rejected) application with the refused chip', () => {
+  it('colours a Refused (Rejected) application with the refused stamp', () => {
     const html = renderApplicationsList(
       [application({ appState: 'Rejected' })],
       SLUG,
     );
-    expect(html).toContain('class="status status--refused"');
-    expect(html).toContain('>Refused<');
+    expect(html).toContain('class="stamp stamp--refused"');
+    expect(html).toContain('<span class="stamp__label">Refused</span>');
   });
 
   it.each([
@@ -185,18 +187,18 @@ describe('renderApplicationsList status chip vocabulary (decision 4: shared voca
     ['Undecided', 'Undecided'],
     [null, 'Unknown'],
   ])(
-    'buckets the long-tail / undecided state %s under the shared neutral chip',
+    'buckets the long-tail / undecided state %s under the shared neutral stamp',
     (appState, label) => {
       const html = renderApplicationsList(
         [application({ appState })],
         SLUG,
       );
-      expect(html).toContain('class="status status--neutral"');
-      expect(html).toContain(`>${label}<`);
+      expect(html).toContain('class="stamp stamp--neutral"');
+      expect(html).toContain(`<span class="stamp__label">${label}</span>`);
     },
   );
 
-  it('only ever emits the three canonical chip modifiers, never the old per-state ones', () => {
+  it('only ever emits the three canonical stamp modifiers, never the old per-state ones', () => {
     const states = [
       'Permitted',
       'Rejected',
@@ -210,10 +212,16 @@ describe('renderApplicationsList status chip vocabulary (decision 4: shared voca
       states.map((appState) => application({ appState })),
       SLUG,
     );
-    const modifiers = [...html.matchAll(/class="status status--(\w+)"/g)].map(
+    const modifiers = [...html.matchAll(/class="stamp stamp--(\w+)"/g)].map(
       (m) => m[1],
     );
     expect(new Set(modifiers)).toEqual(new Set(['granted', 'refused', 'neutral']));
+  });
+
+  it('never emits the old filled-chip class names', () => {
+    const html = renderApplicationsList([application()], SLUG);
+    expect(html).not.toContain('class="status status--');
+    expect(html).not.toContain('appCard');
   });
 });
 
@@ -223,7 +231,7 @@ describe('renderApplicationsList Started/Decided date line (tc-s0yf, GH #819)', 
       [application({ startDate: '2021-05-28', decidedDate: '2021-07-09' })],
       SLUG,
     );
-    expect(html).toContain('<p class="appCard__dates">Decided 9 Jul 2021</p>');
+    expect(html).toContain('<p class="ledgerRow__date">Decided 9 Jul 2021</p>');
     expect(html).not.toContain('Started 28 May 2021');
   });
 
@@ -233,7 +241,7 @@ describe('renderApplicationsList Started/Decided date line (tc-s0yf, GH #819)', 
       SLUG,
     );
     expect(html).toContain(
-      '<p class="appCard__dates">Started 4 Jul 2026 · Awaiting decision</p>',
+      '<p class="ledgerRow__date">Started 4 Jul 2026 · Awaiting decision</p>',
     );
   });
 
@@ -242,7 +250,7 @@ describe('renderApplicationsList Started/Decided date line (tc-s0yf, GH #819)', 
       [application({ startDate: null, decidedDate: '2021-07-09' })],
       SLUG,
     );
-    expect(html).toContain('<p class="appCard__dates">Decided 9 Jul 2021</p>');
+    expect(html).toContain('<p class="ledgerRow__date">Decided 9 Jul 2021</p>');
   });
 
   it('renders no date line at all when neither date is present, without crashing or emitting "undefined"/"Invalid Date"', () => {
@@ -250,7 +258,7 @@ describe('renderApplicationsList Started/Decided date line (tc-s0yf, GH #819)', 
       [application({ startDate: null, decidedDate: null })],
       SLUG,
     );
-    expect(html).not.toContain('appCard__dates');
+    expect(html).not.toContain('ledgerRow__date');
     expect(html).not.toContain('undefined');
     expect(html).not.toContain('Invalid Date');
   });
@@ -260,13 +268,13 @@ describe('renderApplicationsList Started/Decided date line (tc-s0yf, GH #819)', 
     delete app.decidedDate;
     const html = renderApplicationsList([app], SLUG);
     expect(html).toContain(
-      '<p class="appCard__dates">Started 15 Jan 2026 · Awaiting decision</p>',
+      '<p class="ledgerRow__date">Started 15 Jan 2026 · Awaiting decision</p>',
     );
     expect(html).not.toContain('undefined');
   });
 });
 
-describe('renderStatusSummary (tc-r4n9.3: compact Granted/Refused/Undecided strip)', () => {
+describe('renderStatusSummary (tc-r4n9.3: compact Granted/Refused/Undecided strip, Public Notice stamp language)', () => {
   const BREAKDOWN = [
     { appState: 'Permitted', count: 20 },
     { appState: 'Rejected', count: 12 },
@@ -283,11 +291,12 @@ describe('renderStatusSummary (tc-r4n9.3: compact Granted/Refused/Undecided stri
     expect(html).toMatch(/42[\s\S]{0,20}total/);
   });
 
-  it('reuses the shared per-card status chip vocabulary/colours for the strip items', () => {
+  it('reuses the shared stamp vocabulary/colours for the strip items, with icon + label', () => {
     const html = renderStatusSummary(BREAKDOWN);
-    expect(html).toContain('status--granted');
-    expect(html).toContain('status--refused');
-    expect(html).toContain('status--neutral');
+    expect(html).toContain('stamp--granted');
+    expect(html).toContain('stamp--refused');
+    expect(html).toContain('stamp--neutral');
+    expect((html.match(/class="stamp__icon"/g) ?? []).length).toBeGreaterThanOrEqual(3);
   });
 
   it('does not enumerate every top-level status as its own row (compact, not a wall of lines)', () => {
@@ -307,8 +316,8 @@ describe('renderStatusSummary (tc-r4n9.3: compact Granted/Refused/Undecided stri
     expect(html).toContain('<summary>Other (8)</summary>');
     expect(html).toContain('Granted with conditions');
     expect(html).toContain('Withdrawn');
-    // The long-tail states are inside the disclosure, not top-level chips.
-    expect(html).not.toMatch(/status--\w+">\s*5 Granted with conditions/);
+    // The long-tail states are inside the disclosure, not top-level stamps.
+    expect(html).not.toMatch(/stamp--\w+">\s*5 Granted with conditions/);
   });
 
   it('omits the Other disclosure entirely when there is no long tail', () => {
@@ -384,26 +393,128 @@ describe('renderAttributionList', () => {
   });
 });
 
-describe('pageStyles appCard__link (whole-card share-page affordance)', () => {
-  it('styles the whole-card link to inherit colour with no underline', () => {
+describe('pageStyles masthead (double rule, small-caps wordmark, brass text CTA)', () => {
+  it('gives the wordmark a small-caps, letterspaced treatment', () => {
     const css = pageStyles();
-    expect(css).toContain('.appCard__link');
-    expect(css).toMatch(/\.appCard__link \{[^}]*color: inherit/);
-    expect(css).toMatch(/\.appCard__link \{[^}]*text-decoration: none/);
+    expect(css).toContain('.siteHeader__wordmark');
+    expect(css).toMatch(/\.siteHeader__wordmark \{[^}]*font-variant: small-caps/);
+  });
+
+  it('restyles the header CTA as a plain brass text link, not a filled button', () => {
+    const css = pageStyles();
+    expect(css).toMatch(/a\.siteHeader__cta \{[^}]*color: var\(--tc-amber\)/);
+    // No filled-pill chrome left on the header CTA.
+    expect(css).not.toMatch(/a\.siteHeader__cta \{[^}]*background: var\(--tc-amber\)/);
+  });
+
+  it('renders a double rule beneath the masthead — a 2.5px heavy rule over a 1px hairline', () => {
+    const css = pageStyles();
+    expect(css).toMatch(/\.siteHeader__ruleHeavy \{[^}]*height: 2\.5px/);
+    expect(css).toMatch(/\.siteHeader__ruleHeavy \{[^}]*var\(--tc-text-primary\)/);
+    expect(css).toMatch(/\.siteHeader__ruleHairline \{[^}]*height: 1px/);
+    expect(css).toMatch(/\.siteHeader__ruleHairline \{[^}]*var\(--tc-border\)/);
+  });
+});
+
+describe('pageStyles breadcrumb (mono small-caps dateline)', () => {
+  it('sets the breadcrumb in the mono font role, small-caps, letterspaced', () => {
+    const css = pageStyles();
+    expect(css).toMatch(/\.breadcrumb \{[^}]*font-family: var\(--tc-font-mono\)/);
+    expect(css).toMatch(/\.breadcrumb \{[^}]*font-variant: small-caps/);
+  });
+
+  it('separates dateline segments with a right-pointing angle quote, not a slash', () => {
+    const css = pageStyles();
+    expect(css).toMatch(/\.breadcrumb li::after \{[^}]*content: '›'/);
+  });
+});
+
+describe('pageStyles H1 (Fraunces display face)', () => {
+  it('sets h1 to the display font token, whose fallback stack keeps it readable if Fraunces 404s', () => {
+    const css = pageStyles();
+    expect(css).toMatch(/^\s*h1 \{[^}]*font-family: var\(--tc-font-display\)/m);
+  });
+});
+
+describe('pageStyles Fraunces self-hosting (zero external font requests)', () => {
+  it('declares 400 and 600 weight @font-face blocks pointing at same-origin woff2 files', () => {
+    const css = pageStyles();
+    expect(css).toMatch(
+      /@font-face \{[^}]*font-family: 'Fraunces';[^}]*font-weight: 400;[^}]*src: url\('\/fonts\/fraunces-latin-400-normal\.woff2'\) format\('woff2'\);/,
+    );
+    expect(css).toMatch(
+      /@font-face \{[^}]*font-family: 'Fraunces';[^}]*font-weight: 600;[^}]*src: url\('\/fonts\/fraunces-latin-600-normal\.woff2'\) format\('woff2'\);/,
+    );
+  });
+
+  it('uses font-display: swap on every @font-face block', () => {
+    const css = pageStyles();
+    const blocks = css.match(/@font-face \{[^}]*\}/g) ?? [];
+    expect(blocks.length).toBeGreaterThan(0);
+    for (const block of blocks) {
+      expect(block).toContain('font-display: swap');
+    }
+  });
+
+  it('never references a third-party font host', () => {
+    const css = pageStyles();
+    expect(css).not.toContain('https://fonts');
+    expect(css).not.toContain('fonts.googleapis.com');
+    expect(css).not.toContain('fonts.gstatic.com');
+  });
+});
+
+describe('pageStyles ledger (section heading, rows, stamps)', () => {
+  it('opens the ledger with a small-caps brass label over a heavy 2px rule', () => {
+    const css = pageStyles();
+    expect(css).toMatch(/\.ledger__heading \{[^}]*font-variant: small-caps/);
+    expect(css).toMatch(/\.ledger__heading \{[^}]*color: var\(--tc-amber\)/);
+    expect(css).toMatch(/\.ledger__heading \{[^}]*border-top: 2px solid var\(--tc-text-primary\)/);
+  });
+
+  it('separates ledger rows with a hairline rule, not a boxed card border', () => {
+    const css = pageStyles();
+    expect(css).toMatch(/\.ledgerRow \{[^}]*border-bottom: 1px solid var\(--tc-border\)/);
+    expect(css).not.toMatch(/\.ledgerRow \{[^}]*border: 1px solid var\(--tc-border\);\s*border-radius/);
+  });
+
+  it('sets the ledger row address in the Fraunces 600 display face', () => {
+    const css = pageStyles();
+    expect(css).toMatch(/\.ledgerRow__address \{[^}]*font-family: var\(--tc-font-display\)/);
+    expect(css).toMatch(/\.ledgerRow__address \{[^}]*font-weight: 600/);
+  });
+
+  it('sets the ledger row meta column (ref + date) in the mono font role', () => {
+    const css = pageStyles();
+    expect(css).toMatch(/\.ledgerRow__meta \{[^}]*font-family: var\(--tc-font-mono\)/);
+  });
+
+  it('styles the whole-row link to inherit colour with no underline', () => {
+    const css = pageStyles();
+    expect(css).toContain('.ledgerRow__link');
+    expect(css).toMatch(/\.ledgerRow__link \{[^}]*color: inherit/);
+    expect(css).toMatch(/\.ledgerRow__link \{[^}]*text-decoration: none/);
   });
 
   it('styles the "View details" affordance in the amber accent colour', () => {
     const css = pageStyles();
-    expect(css).toContain('.appCard__cta');
-    expect(css).toMatch(/\.appCard__cta \{[^}]*var\(--tc-amber\)/);
+    expect(css).toContain('.ledgerRow__cta');
+    expect(css).toMatch(/\.ledgerRow__cta \{[^}]*var\(--tc-amber\)/);
   });
-});
 
-describe('pageStyles appCard__dates (Started/Decided date line, tc-s0yf)', () => {
-  it('styles the date line as secondary metadata text using design tokens', () => {
+  it('styles the stamp outlined (currentColor border, no fill) with an uppercase letterspaced label', () => {
     const css = pageStyles();
-    expect(css).toContain('.appCard__dates');
-    expect(css).toMatch(/\.appCard__dates \{[^}]*var\(--tc-text-secondary\)/);
+    expect(css).toMatch(/\.stamp \{[^}]*border: 1\.5px solid currentColor/);
+    expect(css).toMatch(/\.stamp \{[^}]*background: transparent/);
+    expect(css).toMatch(/\.stamp__label \{[^}]*text-transform: uppercase/);
+    expect(css).toMatch(/\.stamp__label \{[^}]*letter-spacing: 0\.12em/);
+  });
+
+  it('keeps the three canonical stamp colour modifiers', () => {
+    const css = pageStyles();
+    expect(css).toMatch(/\.stamp--granted \{[^}]*color: var\(--tc-status-granted\)/);
+    expect(css).toMatch(/\.stamp--refused \{[^}]*color: var\(--tc-status-refused\)/);
+    expect(css).toMatch(/\.stamp--neutral \{[^}]*color: var\(--tc-status-neutral\)/);
   });
 });
 
@@ -417,7 +528,7 @@ describe('pageStyles townLinks', () => {
   });
 });
 
-describe('pageStyles status chip vocabulary (decision 4: shared palette, filled style)', () => {
+describe('pageStyles status colour tokens (decision 4: shared palette, light-first)', () => {
   /**
    * @param {string} css
    * @returns {string} the declarations inside the top-level `:root { ... }`
@@ -440,14 +551,11 @@ describe('pageStyles status chip vocabulary (decision 4: shared palette, filled 
     return match ? match[1] : '';
   }
 
-  it('defines the three canonical status colour tokens, light-first, plus their fill backgrounds', () => {
+  it('defines the three canonical status colour tokens, light-first', () => {
     const root = rootDeclarations(pageStyles());
     expect(root).toMatch(/--tc-status-granted: #1A7D37;/);
     expect(root).toMatch(/--tc-status-refused: #C42B2B;/);
     expect(root).toMatch(/--tc-status-neutral: #6D665C;/);
-    expect(root).toMatch(/--tc-status-granted-bg:/);
-    expect(root).toMatch(/--tc-status-refused-bg:/);
-    expect(root).toMatch(/--tc-status-neutral-bg:/);
   });
 
   it('moves the dark variants of the status tokens into the dark media query', () => {
@@ -465,24 +573,6 @@ describe('pageStyles status chip vocabulary (decision 4: shared palette, filled 
     expect(css).not.toContain('--tc-status-withdrawn');
     expect(css).not.toContain('--tc-status-appealed');
     expect(css).not.toContain('--tc-status-default');
-  });
-
-  it('styles each chip as a filled badge (background fill + full-opacity text) per design-language, not outlined', () => {
-    const css = pageStyles();
-    expect(css).toMatch(
-      /\.status--granted \{[^}]*background: var\(--tc-status-granted-bg\)/,
-    );
-    expect(css).toMatch(
-      /\.status--granted \{[^}]*color: var\(--tc-status-granted\)/,
-    );
-    expect(css).toMatch(
-      /\.status--refused \{[^}]*background: var\(--tc-status-refused-bg\)/,
-    );
-    expect(css).toMatch(
-      /\.status--neutral \{[^}]*background: var\(--tc-status-neutral-bg\)/,
-    );
-    // The base .status rule no longer draws the old outlined-chip border.
-    expect(css).not.toMatch(/\.status \{[^}]*border: 1px solid currentColor/);
   });
 });
 
@@ -557,9 +647,9 @@ describe('pageStyles light-first token flip (tc-r4n9.1)', () => {
   });
 });
 
-describe('renderMidListCta and mid-list injection (tc-fgoyj)', () => {
+describe('renderMidListCta and mid-list injection (tc-fgoyj, filed-notice CTA band)', () => {
   const STORE_HREF = 'https://apps.apple.com/x?pt=1&ct=seo-lpa-mid&mt=8';
-  const MID_CARD = 'class="appCard appCard--cta"';
+  const MID_CARD = 'class="ledgerCta"';
 
   /** @param {number} count */
   function manyApplications(count) {
@@ -572,7 +662,7 @@ describe('renderMidListCta and mid-list injection (tc-fgoyj)', () => {
     );
   }
 
-  it('renders a card-shaped CTA naming the area, never disguised as an application', () => {
+  it('renders a filed-notice card CTA naming the area, never disguised as an application', () => {
     const html = renderMidListCta('Basingstoke and Deane', STORE_HREF);
     expect(html).toContain(MID_CARD);
     expect(html).toContain('Get told when the next one lands');
@@ -582,8 +672,8 @@ describe('renderMidListCta and mid-list injection (tc-fgoyj)', () => {
     expect(html).toContain(`href="${STORE_HREF}"`);
     expect(html).toContain('rel="noopener"');
     expect(html).toContain('target="_blank"');
-    // A pitch card must not carry application-card furniture.
-    expect(html).not.toContain('appCard__address');
+    // A pitch card must not carry ledger-row furniture.
+    expect(html).not.toContain('ledgerRow__address');
     expect(html).not.toContain('View details');
   });
 
@@ -611,6 +701,20 @@ describe('renderMidListCta and mid-list injection (tc-fgoyj)', () => {
     expect(withCta).not.toContain(MID_CARD);
     const withoutArg = renderApplicationsList(manyApplications(12), SLUG);
     expect(withoutArg).not.toContain(MID_CARD);
+  });
+});
+
+describe('pageStyles CTA bands (filed-notice card shape, 2px brass top rule, Fraunces headline)', () => {
+  it('gives the mid-list CTA card a 2px brass top rule and a Fraunces headline', () => {
+    const css = pageStyles();
+    expect(css).toMatch(/\.ledgerCta \{[^}]*border-top: 2px solid var\(--tc-amber\)/);
+    expect(css).toMatch(/\.ledgerCta__heading \{[^}]*font-family: var\(--tc-font-display\)/);
+  });
+
+  it('gives the bottom CTA banner the same 2px brass top rule and Fraunces headline treatment', () => {
+    const css = pageStyles();
+    expect(css).toMatch(/\.cta \{[^}]*border-top: 2px solid var\(--tc-amber\)/);
+    expect(css).toMatch(/\.cta__heading \{[^}]*font-family: var\(--tc-font-display\)/);
   });
 });
 

--- a/web/scripts/lib/__tests__/render-town-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-town-page.test.mjs
@@ -100,30 +100,30 @@ describe('renderTownPage', () => {
   it('renders each application address as the headline and status label', () => {
     const html = renderTownPage(townData());
     expect(html).toContain(
-      '<h3 class="appCard__address">Lemon Quay, Truro, TR1 2LW</h3>',
+      '<h3 class="ledgerRow__address">Lemon Quay, Truro, TR1 2LW</h3>',
     );
     expect(html).toContain('Change of use of ground floor from retail to café');
     expect(html).toContain('Granted'); // Permitted -> Granted
     expect(html).toContain('Refused'); // Rejected -> Refused
   });
 
-  it('demotes the reference to small card metadata and removes per-card external links (decisions 5 & 6)', () => {
+  it('demotes the reference to small ledger-row metadata and removes per-row external links (decisions 5 & 6)', () => {
     const html = renderTownPage(townData());
-    expect(html).toContain('<p class="appCard__ref">26/0001</p>');
-    expect(html).not.toContain('<h3 class="appCard__ref">');
+    expect(html).toContain('<p class="ledgerRow__ref">26/0001</p>');
+    expect(html).not.toContain('<h3 class="ledgerRow__ref">');
     expect(html).not.toContain('https://planning.cornwall.gov.uk/26-0001');
     expect(html).not.toContain('https://planit.org.uk/planapplic/CW-26-0001');
     expect(html).not.toContain('class="appLink"');
   });
 
-  it('makes the whole card a real anchor to its share page, with a visible "View details" affordance', () => {
+  it('makes the whole row a real anchor to its share page, with a visible "View details" affordance', () => {
     const html = renderTownPage(townData());
     // Town-page apps are scoped to the town's own authority, so authoritySlug is
-    // correct for every card.
+    // correct for every row.
     expect(html).toContain(
-      '<a class="appCard__link" href="https://share.towncrierapp.uk/a/cornwall/26/0001">',
+      '<a class="ledgerRow__link" href="https://share.towncrierapp.uk/a/cornwall/26/0001">',
     );
-    expect(html).toContain('<span class="appCard__cta">View details →</span>');
+    expect(html).toContain('<span class="ledgerRow__cta">View details →</span>');
     expect(html).toContain(
       '"url":"https://share.towncrierapp.uk/a/cornwall/26/0001"',
     );
@@ -151,17 +151,17 @@ describe('renderTownPage', () => {
       expect(html).not.toContain('Last updated');
     });
 
-    // tc-s0yf (GH #819) deliberately reintroduces a per-card date line — under a
-    // NEW class (`appCard__dates`) and format (Started/Decided, sourced from the
-    // application's own real-world dates, not a re-index marker) — distinct from
-    // the old "Last updated" line this describe block's title refers to.
-    it('renders the Started/Decided date line once per card (tc-s0yf)', () => {
+    // tc-s0yf (GH #819) deliberately reintroduces a per-row date line — under a
+    // NEW class (`ledgerRow__date`) and format (Started/Decided, sourced from
+    // the application's own real-world dates, not a re-index marker) — distinct
+    // from the old "Last updated" line this describe block's title refers to.
+    it('renders the Started/Decided date line once per row (tc-s0yf)', () => {
       const html = renderTownPage(townData());
       expect(html).toContain(
-        '<p class="appCard__dates">Started 12 Jan 2026 · Awaiting decision</p>',
+        '<p class="ledgerRow__date">Started 12 Jan 2026 · Awaiting decision</p>',
       );
       expect(html).toContain(
-        '<p class="appCard__dates">Started 1 Feb 2026 · Awaiting decision</p>',
+        '<p class="ledgerRow__date">Started 1 Feb 2026 · Awaiting decision</p>',
       );
     });
   });
@@ -242,7 +242,7 @@ describe('renderTownPage', () => {
 
     // The bare class name also appears in the inline stylesheet, so assertions
     // target the rendered card markup.
-    const MID_CARD = 'class="appCard appCard--cta"';
+    const MID_CARD = 'class="ledgerCta"';
 
     it('slots a CTA card naming the town into a long list, after the eighth application', () => {
       const html = renderTownPage(townData({ applications: manyApplications(12) }));
@@ -251,7 +251,7 @@ describe('renderTownPage', () => {
       expect(html).toContain('Town Crier watches Truro');
       // After the 8th card, before the 9th. Scoped to the rendered list —
       // the JSON-LD in <head> repeats the addresses much earlier in the page.
-      const list = html.slice(html.indexOf('<ul class="appList">'));
+      const list = html.slice(html.indexOf('<ul class="ledger">'));
       expect(list.indexOf('8 Lemon Quay')).toBeLessThan(list.indexOf(MID_CARD));
       expect(list.indexOf(MID_CARD)).toBeLessThan(list.indexOf('9 Lemon Quay'));
     });
@@ -286,13 +286,13 @@ describe('renderTownPage', () => {
       const html = renderTownPage(townData());
       expect(html).toContain('class="ctaInline"');
       expect(html.indexOf('class="lead"')).toBeLessThan(html.indexOf('class="ctaInline"'));
-      expect(html.indexOf('class="ctaInline"')).toBeLessThan(html.indexOf('class="appList"'));
+      expect(html.indexOf('class="ctaInline"')).toBeLessThan(html.indexOf('class="ledger"'));
     });
 
     it('keeps the existing bottom banner CTA in addition to the inline one (not a replacement)', () => {
       const html = renderTownPage(townData());
       expect(html).toContain('<section class="cta">');
-      expect(html.indexOf('class="appList"')).toBeLessThan(html.indexOf('<section class="cta">'));
+      expect(html.indexOf('class="ledger"')).toBeLessThan(html.indexOf('<section class="cta">'));
     });
   });
 
@@ -315,6 +315,27 @@ describe('renderTownPage', () => {
     expect(headerHtml).toContain('target="_blank"');
     // The brand link stays on the left.
     expect(headerHtml).toContain('>Town Crier</a>');
+  });
+
+  describe('masthead (double rule, small-caps wordmark)', () => {
+    it('renders the double rule beneath the masthead, inside the site header', () => {
+      const html = renderTownPage(townData());
+      const header = html.match(/<header class="siteHeader">[\s\S]*?<\/header>/);
+      expect(header).not.toBeNull();
+      const [headerHtml] = header;
+      expect(headerHtml).toContain('class="siteHeader__ruleHeavy"');
+      expect(headerHtml).toContain('class="siteHeader__ruleHairline"');
+    });
+
+    it('gives the wordmark its own small-caps class', () => {
+      const html = renderTownPage(townData());
+      expect(html).toContain('<a href="/" class="siteHeader__wordmark">Town Crier</a>');
+    });
+  });
+
+  it('opens the applications ledger with a small-caps brass section label', () => {
+    const html = renderTownPage(townData());
+    expect(html).toContain('<h2 class="ledger__heading">Latest notices</h2>');
   });
 
   it('keeps the rich bottom CTA block when the header CTA is present', () => {

--- a/web/scripts/lib/__tests__/render-towns-index.test.mjs
+++ b/web/scripts/lib/__tests__/render-towns-index.test.mjs
@@ -217,4 +217,21 @@ describe('renderTownsIndexPage', () => {
     const html = renderTownsIndexPage([entry(), entry({ townName: 'Adur', townSlug: 'adur' })]);
     expect(html).toContain('2 towns');
   });
+
+  describe('masthead (double rule, small-caps wordmark) — Public Notice broadsheet, consistent with the authority/town pages', () => {
+    it('renders the double rule beneath the masthead, inside the site header', () => {
+      const html = renderTownsIndexPage([entry()]);
+      const header = html.match(/<header class="siteHeader">[\s\S]*?<\/header>/);
+      expect(header).not.toBeNull();
+      const [headerHtml] = header;
+      expect(headerHtml).toContain('class="siteHeader__ruleHeavy"');
+      expect(headerHtml).toContain('class="siteHeader__ruleHairline"');
+    });
+
+    it('gives the wordmark its own small-caps class and keeps the brass header CTA', () => {
+      const html = renderTownsIndexPage([entry()]);
+      expect(html).toContain('<a href="/" class="siteHeader__wordmark">Town Crier</a>');
+      expect(html).toContain('siteHeader__cta');
+    });
+  });
 });

--- a/web/scripts/lib/render-page.mjs
+++ b/web/scripts/lib/render-page.mjs
@@ -165,11 +165,12 @@ ${pageStyles()}
   <body>
     <div class="wrap">
       <header class="siteHeader">
-        <a href="/">Town Crier</a>
-        <nav class="siteHeader__nav">
-          <a href="/">Home</a>
+        <div class="siteHeader__inner">
+          <a href="/" class="siteHeader__wordmark">Town Crier</a>
           <a class="siteHeader__cta" href="${appStoreUrl('seo-lpa-hdr')}" rel="noopener" target="_blank">Get the app</a>
-        </nav>
+        </div>
+        <div class="siteHeader__ruleHeavy"></div>
+        <div class="siteHeader__ruleHairline"></div>
       </header>
       <nav class="breadcrumb" aria-label="Breadcrumb">
         <ol>
@@ -185,8 +186,8 @@ ${renderInlineCta(data.areaName, appStoreUrl('seo-lpa-inline'))}
 
 ${renderStatusSummary(data.statusBreakdown)}
 
-        <h2>Recent applications</h2>
-        <ul class="appList">
+        <h2 class="ledger__heading">Latest notices</h2>
+        <ul class="ledger">
 ${applicationsList}
         </ul>
 ${townLinks}
@@ -208,7 +209,7 @@ ${townLinks}
         </section>
 
         <section class="cta">
-          <h2>Get push alerts for ${area}</h2>
+          <h2 class="cta__heading">Get push alerts for ${area}</h2>
           <p>
             Draw a circle on the map and Town Crier will notify you the moment a new
             planning application is submitted or decided inside it. Most councils

--- a/web/scripts/lib/render-planning-index.mjs
+++ b/web/scripts/lib/render-planning-index.mjs
@@ -217,11 +217,12 @@ ${pageStyles()}
   <body>
     <div class="wrap">
       <header class="siteHeader">
-        <a href="/">Town Crier</a>
-        <nav class="siteHeader__nav">
-          <a href="/">Home</a>
+        <div class="siteHeader__inner">
+          <a href="/" class="siteHeader__wordmark">Town Crier</a>
           <a class="siteHeader__cta" href="${storeHref}" rel="noopener" target="_blank">Get the app</a>
-        </nav>
+        </div>
+        <div class="siteHeader__ruleHeavy"></div>
+        <div class="siteHeader__ruleHairline"></div>
       </header>
       <nav class="breadcrumb" aria-label="Breadcrumb">
         <ol>
@@ -237,7 +238,7 @@ ${letterNav}
 ${letterSections}
 
         <section class="cta">
-          <h2>Get push alerts for your area</h2>
+          <h2 class="cta__heading">Get push alerts for your area</h2>
           <p>
             Draw a circle on the map and Town Crier will notify you the moment a new
             planning application is submitted or decided inside it.

--- a/web/scripts/lib/render-shared.mjs
+++ b/web/scripts/lib/render-shared.mjs
@@ -94,13 +94,48 @@ function applicationDateLine(app) {
 }
 
 /**
+ * Inline SVG glyph for one status-stamp bucket, paired with every stamp's
+ * text label (icon + label is an accessibility invariant across the Public
+ * Notice component language — status must never be conveyed by colour alone;
+ * ~8% of men have some form of colour vision deficiency). Decorative only
+ * (`aria-hidden`); the accessible label is the adjacent `.stamp__label` text.
+ * Mirrors the stroke-based glyph style of the SPA's `StatusIcon` component
+ * (`web/src/components/StatusIcon/StatusIcon.tsx`), collapsed to the three
+ * canonical SEO/share-page buckets (decision 4).
+ *
+ * @type {Record<'granted' | 'refused' | 'neutral', string>}
+ */
+const STATUS_STAMP_ICON = {
+  granted:
+    '<svg class="stamp__icon" width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3.5 8.5 6.5 11.5 12.5 4.5" /></svg>',
+  refused:
+    '<svg class="stamp__icon" width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 4 12 12" /><path d="M12 4 4 12" /></svg>',
+  neutral:
+    '<svg class="stamp__icon" width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 8H12" /></svg>',
+};
+
+/**
+ * Render one outlined status "stamp" (Public Notice component language):
+ * uppercase, letterspaced label plus its paired icon, in the given bucket's
+ * colour, no fill. `label` is expected to already be HTML-escaped by the
+ * caller (matches every other data-derived string in this module).
+ *
+ * @param {'granted' | 'refused' | 'neutral'} modifier
+ * @param {string} label already-escaped resident-facing label text
+ * @returns {string}
+ */
+function renderStamp(modifier, label) {
+  return `<span class="stamp stamp--${modifier}">${STATUS_STAMP_ICON[modifier]}<span class="stamp__label">${label}</span></span>`;
+}
+
+/**
  * @param {PlanningApplicationItem} app
  * @param {string} [authoritySlug] the page's authority slug; when present (and
- *   the app carries a ref), the whole card becomes a do-follow link to our own
+ *   the app carries a ref), the whole row becomes a do-follow link to our own
  *   public share page for the application (decision 6). Every application on a
  *   page belongs to this one authority (authority pages read one partition;
  *   town pages scope the near query to a single authority), so the slug is
- *   correct for every card.
+ *   correct for every row.
  * @returns {string}
  */
 function renderApplication(app, authoritySlug) {
@@ -108,7 +143,7 @@ function renderApplication(app, authoritySlug) {
   const modifier = statusColorModifier(app.appState);
   const description = escapeHtml(truncate(app.description, MAX_DESCRIPTION_LENGTH));
 
-  // Address is the human hook (decision 5): it is the card's heading. The
+  // Address is the human hook (decision 5): it is the row's heading. The
   // council reference is demoted to small metadata underneath, and omitted
   // entirely when the app carries none.
   const address = escapeHtml(app.address);
@@ -119,33 +154,39 @@ function renderApplication(app, authoritySlug) {
   // every other data-derived string in this function.
   const dateLine = escapeHtml(applicationDateLine(app));
 
-  // Per-card external links to PlanIt/the council are retired (decision 6):
-  // the card's one click target is our own share page, surfaced as a real,
-  // crawlable <a href> around the whole card plus a visible "View details"
+  // Per-row external links to PlanIt/the council are retired (decision 6):
+  // the row's one click target is our own share page, surfaced as a real,
+  // crawlable <a href> around the whole row plus a visible "View details"
   // affordance — never a JS-only click handler. Falls back to a plain,
-  // non-linked card when no share URL can be built (no slug, or no ref).
+  // non-linked row when no share URL can be built (no slug, or no ref).
   const share = shareUrl(authoritySlug, app.name);
+  const stamp = renderStamp(modifier, label);
 
-  const body = `        <div class="appCard__head">
-          <h3 class="appCard__address">${address}</h3>
-          <span class="status status--${modifier}">${label}</span>
-        </div>
-        ${ref ? `<p class="appCard__ref">${ref}</p>` : ''}
-        ${dateLine ? `<p class="appCard__dates">${dateLine}</p>` : ''}
-        <p class="appCard__desc">${description}</p>
-        <div class="appCard__meta">
-          ${share ? `<span class="appCard__cta">View details →</span>` : ''}
+  // Fixed-width mono ref+date column (Public Notice ledger row).
+  const meta = `        <div class="ledgerRow__meta">
+          ${ref ? `<p class="ledgerRow__ref">${ref}</p>` : ''}
+          ${dateLine ? `<p class="ledgerRow__date">${dateLine}</p>` : ''}
+        </div>`;
+  const body = `        <div class="ledgerRow__body">
+          <div class="ledgerRow__head">
+            <h3 class="ledgerRow__address">${address}</h3>
+            ${stamp}
+          </div>
+          <p class="ledgerRow__desc">${description}</p>
+          ${share ? `<span class="ledgerRow__cta">View details →</span>` : ''}
         </div>`;
 
   if (share) {
-    return `      <li class="appCard">
-        <a class="appCard__link" href="${escapeHtml(share)}">
+    return `      <li class="ledgerRow">
+        <a class="ledgerRow__link" href="${escapeHtml(share)}">
+${meta}
 ${body}
         </a>
       </li>`;
   }
 
-  return `      <li class="appCard">
+  return `      <li class="ledgerRow">
+${meta}
 ${body}
       </li>`;
 }
@@ -160,11 +201,13 @@ const MID_LIST_CTA_AFTER = 8;
 const MID_LIST_CTA_MIN_APPLICATIONS = 12;
 
 /**
- * Render the mid-list CTA card (tc-fgoyj): a card-shaped `<li>` slotted into
- * the applications list itself, because on a full 30-card page the inline pill
- * above the list and the banner below it are separated by a very long scroll
- * with no ask in between. Styled as a card so it reads as part of the list,
- * but visibly a Town Crier pitch — never disguised as an application.
+ * Render the mid-list CTA card (tc-fgoyj): a filed-notice-shaped `<li>`
+ * slotted into the ledger itself, because on a full 30-row page the inline
+ * pill above the list and the banner below it are separated by a very long
+ * scroll with no ask in between. Styled as a card (2px brass top rule,
+ * Fraunces headline — see the `.ledgerCta*` rules in {@link pageStyles}) so it
+ * visibly breaks the ledger's row rhythm as a Town Crier pitch, never
+ * disguised as an application.
  *
  * @param {string} area   the resident-facing area name (authority or town)
  * @param {string} storeHref   the campaign-tagged App Store link for this
@@ -174,10 +217,10 @@ const MID_LIST_CTA_MIN_APPLICATIONS = 12;
  * @returns {string}
  */
 export function renderMidListCta(area, storeHref) {
-  return `      <li class="appCard appCard--cta">
-        <h3 class="appCard__ctaHeading">Get told when the next one lands</h3>
-        <p class="appCard__ctaBody">Town Crier watches ${escapeHtml(area)} and alerts you when a new application is submitted or decided. Free to download.</p>
-        <a class="ctaInline__button" href="${storeHref}" rel="noopener" target="_blank">Get the app</a>
+  return `      <li class="ledgerCta">
+        <h3 class="ledgerCta__heading">Get told when the next one lands</h3>
+        <p class="ledgerCta__body">Town Crier watches ${escapeHtml(area)} and alerts you when a new application is submitted or decided. Free to download.</p>
+        <a class="ledgerCta__button" href="${storeHref}" rel="noopener" target="_blank">Get the app</a>
       </li>`;
 }
 
@@ -205,10 +248,10 @@ export function renderApplicationsList(applications, authoritySlug, midCta) {
 /**
  * Render the compact "Status breakdown" strip (tc-r4n9.3, punch-list #794
  * Phase 3): one line of three headline buckets (Granted / Refused /
- * Undecided) plus the total, using the SAME `.status--granted` /
- * `.status--refused` / `.status--neutral` chip vocabulary and colours as the
- * per-card chips (decision 4) for visual consistency between the aggregate
- * summary and the individual cards. Replaces the old one-row-per-appState
+ * Undecided) plus the total, using the SAME `.stamp--granted` /
+ * `.stamp--refused` / `.stamp--neutral` stamp vocabulary and colours as the
+ * per-row stamps (decision 4) for visual consistency between the aggregate
+ * summary and the individual rows. Replaces the old one-row-per-appState
  * `renderStats` list, which advertised every long-tail state as its own
  * top-level row.
  *
@@ -242,9 +285,9 @@ ${other
   return `    <section class="statusSummary" aria-label="Application status summary">
       <h2 class="statusSummary__heading">Status breakdown</h2>
       <div class="statusSummary__strip">
-        <span class="statusSummary__item status status--granted">${granted} Granted</span>
-        <span class="statusSummary__item status status--refused">${refused} Refused</span>
-        <span class="statusSummary__item status status--neutral">${undecided} Undecided</span>
+        <span class="statusSummary__item stamp stamp--granted">${STATUS_STAMP_ICON.granted}<span class="stamp__label">${granted} Granted</span></span>
+        <span class="statusSummary__item stamp stamp--refused">${STATUS_STAMP_ICON.refused}<span class="stamp__label">${refused} Refused</span></span>
+        <span class="statusSummary__item stamp stamp--neutral">${STATUS_STAMP_ICON.neutral}<span class="stamp__label">${undecided} Undecided</span></span>
         <span class="statusSummary__total">${total} total</span>
       </div>${otherDisclosure}
     </section>`;
@@ -343,6 +386,29 @@ export function renderAttributionList(lines = ATTRIBUTION_LINES) {
  */
 export function pageStyles() {
   return `${SEO_TOKEN_CSS}
+    /* ---------- Self-hosted Fraunces (Public Notice display face) ----------
+       Same self-hosting rationale as the SPA (web/src/styles/global.css):
+       served from /public/fonts (committed by #853), so the page makes zero
+       third-party font requests. Display roles only (H1, ledger addresses,
+       CTA headlines) — body text stays on --tc-font-family (Inter).
+       font-display: swap means a slow font fetch never blocks text from
+       painting, and --tc-font-display's serif fallback stack ('Iowan Old
+       Style', Georgia, serif) keeps every heading fully readable even if the
+       woff2 request 404s. */
+    @font-face {
+      font-family: 'Fraunces';
+      font-style: normal;
+      font-weight: 400;
+      font-display: swap;
+      src: url('/fonts/fraunces-latin-400-normal.woff2') format('woff2');
+    }
+    @font-face {
+      font-family: 'Fraunces';
+      font-style: normal;
+      font-weight: 600;
+      font-display: swap;
+      src: url('/fonts/fraunces-latin-600-normal.woff2') format('woff2');
+    }
     @font-face {
       font-family: 'Inter';
       font-style: normal;
@@ -364,86 +430,133 @@ export function pageStyles() {
       margin: 0 auto;
       padding: var(--tc-space-md);
     }
-    .siteHeader {
+    /* ---------- Masthead: small-caps wordmark, brass text CTA, double rule
+       (Public Notice component language, mirrors the SPA Navbar). ---------- */
+    .siteHeader { padding-top: var(--tc-space-md); }
+    .siteHeader__inner {
       display: flex;
       align-items: center;
       justify-content: space-between;
       flex-wrap: wrap;
       gap: var(--tc-space-sm);
-      padding: var(--tc-space-md) 0;
-      border-bottom: 1px solid var(--tc-border);
+      padding-bottom: var(--tc-space-md);
     }
-    .siteHeader a { color: var(--tc-text-primary); text-decoration: none; font-weight: 700; }
-    .siteHeader__nav { display: flex; align-items: center; gap: var(--tc-space-md); }
-    .siteHeader a.siteHeader__cta {
-      padding: var(--tc-space-sm) var(--tc-space-md);
-      background: var(--tc-amber);
-      color: var(--tc-text-on-accent);
-      border-radius: var(--tc-radius-md);
+    .siteHeader a { text-decoration: none; }
+    .siteHeader__wordmark {
+      color: var(--tc-text-primary);
+      font-weight: 700;
+      font-variant: small-caps;
+      letter-spacing: 0.08em;
     }
-    .siteHeader a.siteHeader__cta:hover { background: var(--tc-amber-hover); }
-    .breadcrumb { margin: var(--tc-space-md) 0 0; font-size: 0.875rem; color: var(--tc-text-secondary); }
+    /* "Get the app" is a plain brass text link, not a filled pill — the
+       header keeps the click-through, only the shape changes. */
+    a.siteHeader__cta { color: var(--tc-amber); font-weight: 700; }
+    a.siteHeader__cta:hover { color: var(--tc-amber-hover); text-decoration: underline; }
+    /* Double rule beneath the masthead: a 2.5px heavy rule over a 1px
+       hairline, 3px gap. */
+    .siteHeader__ruleHeavy { height: 2.5px; background: var(--tc-text-primary); }
+    .siteHeader__ruleHairline { height: 1px; background: var(--tc-border); margin-top: 3px; }
+    /* ---------- Breadcrumb -> mono small-caps dateline ---------- */
+    .breadcrumb {
+      margin: var(--tc-space-md) 0 0;
+      font-family: var(--tc-font-mono);
+      font-size: 0.75rem;
+      color: var(--tc-text-secondary);
+      font-variant: small-caps;
+      letter-spacing: 0.04em;
+    }
     .breadcrumb ol { list-style: none; margin: 0; padding: 0; display: flex; flex-wrap: wrap; gap: var(--tc-space-sm); }
-    .breadcrumb li::after { content: '/'; margin-left: var(--tc-space-sm); color: var(--tc-text-secondary); }
+    .breadcrumb li::after { content: '›'; margin-left: var(--tc-space-sm); color: var(--tc-text-secondary); }
     .breadcrumb li:last-child::after { content: ''; margin: 0; }
     .breadcrumb a { color: var(--tc-text-secondary); text-decoration: none; }
     .breadcrumb a:hover { color: var(--tc-amber); text-decoration: underline; }
-    h1 { font-size: 2rem; line-height: 1.2; margin: var(--tc-space-xl) 0 var(--tc-space-sm); }
+    /* H1 moves to the Fraunces display face; the token's own fallback stack
+       keeps it fully readable if the woff2 request above 404s. */
+    h1 { font-family: var(--tc-font-display); font-weight: 600; font-size: 2rem; line-height: 1.2; margin: var(--tc-space-xl) 0 var(--tc-space-sm); }
     h2 { font-size: 1.5rem; margin: var(--tc-space-xl) 0 var(--tc-space-md); }
     h3 { font-size: 1.125rem; margin: 0; }
     /* Single freshness line (tc-r4n9.3), placed near the H1. */
     .dataUpdated { margin: 0 0 var(--tc-space-sm); font-size: 0.875rem; color: var(--tc-text-secondary); }
     .lead { font-size: 1.125rem; color: var(--tc-text-secondary); margin: 0 0 var(--tc-space-lg); }
-    .appList { list-style: none; margin: 0; padding: 0; display: grid; gap: var(--tc-space-md); }
-    .appCard {
-      background: var(--tc-surface);
-      border: 1px solid var(--tc-border);
-      border-radius: var(--tc-radius-md);
-      padding: var(--tc-space-md);
+    /* ---------- Ledger: a flat, full-width list of hairline-ruled rows
+       instead of boxed cards — reads better over a long crawlable page. Opens
+       with a small-caps brass label over a heavy 2px rule. ---------- */
+    .ledger__heading {
+      font-variant: small-caps;
+      letter-spacing: 0.08em;
+      font-weight: 700;
+      font-size: 0.9375rem;
+      color: var(--tc-amber);
+      margin: var(--tc-space-xl) 0 0;
+      padding-top: var(--tc-space-md);
+      border-top: 2px solid var(--tc-text-primary);
     }
-    /* The whole card is the share-page click target (decision 6): a real,
-       crawlable <a href> wraps every card that has a share URL, styled to
-       read as plain card content rather than a traditional blue link. */
-    .appCard__link { display: block; color: inherit; text-decoration: none; }
-    .appCard__link:focus-visible {
+    .ledger { list-style: none; margin: var(--tc-space-sm) 0 0; padding: 0; }
+    .ledgerRow { border-bottom: 1px solid var(--tc-border); }
+    .ledgerRow__link {
+      display: flex;
+      flex-direction: column;
+      gap: var(--tc-space-xs, 4px);
+      padding: var(--tc-space-md) 0;
+      color: inherit;
+      text-decoration: none;
+    }
+    .ledgerRow__link:focus-visible {
       outline: 2px solid var(--tc-amber);
       outline-offset: 2px;
-      border-radius: var(--tc-radius-md);
     }
-    .appCard__link:hover .appCard__address { color: var(--tc-amber); }
-    .appCard__link:hover .appCard__cta { color: var(--tc-amber-hover); text-decoration: underline; }
-    .appCard__head { display: flex; align-items: flex-start; justify-content: space-between; gap: var(--tc-space-sm); }
-    /* Address is the human hook (decision 5): the card headline. */
-    .appCard__address { margin: 0; font-weight: 600; overflow-wrap: anywhere; }
-    /* The council reference is demoted to small metadata under the headline. */
-    .appCard__ref { margin: var(--tc-space-sm) 0; font-size: 0.8125rem; color: var(--tc-text-secondary); overflow-wrap: anywhere; }
-    /* Started/Decided real-world date line (tc-s0yf, GH #819) — same secondary
-       metadata treatment as the reference line above it. */
-    .appCard__dates { margin: 0 0 var(--tc-space-sm); font-size: 0.8125rem; color: var(--tc-text-secondary); }
-    .appCard__desc { margin: 0 0 var(--tc-space-sm); color: var(--tc-text-secondary); }
-    .appCard__meta { display: flex; flex-wrap: wrap; gap: var(--tc-space-md); align-items: center; font-size: 0.875rem; }
+    .ledgerRow__link:hover .ledgerRow__address { color: var(--tc-amber); }
+    .ledgerRow__link:hover .ledgerRow__cta { color: var(--tc-amber-hover); text-decoration: underline; }
+    /* Fixed-width mono ref+date column, set alongside the body from tablet up. */
+    .ledgerRow__meta {
+      font-family: var(--tc-font-mono);
+      font-size: 0.75rem;
+      color: var(--tc-text-secondary);
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+    .ledgerRow__ref, .ledgerRow__date { margin: 0; }
+    .ledgerRow__body { min-width: 0; }
+    .ledgerRow__head { display: flex; align-items: flex-start; justify-content: space-between; gap: var(--tc-space-sm); }
+    /* Address is the human hook (decision 5): Fraunces 600, the row's one
+       display-face element. */
+    .ledgerRow__address { font-family: var(--tc-font-display); font-weight: 600; margin: 0; overflow-wrap: anywhere; }
+    .ledgerRow__desc { margin: var(--tc-space-xs, 4px) 0 0; color: var(--tc-text-secondary); }
     /* Visible share-page affordance (decision 6) — a real anchor, not a
-       JS-only click handler; this is the text cue, the href is the whole card. */
-    .appCard__cta { color: var(--tc-amber); font-weight: 600; }
-    .status {
+       JS-only click handler; this is the text cue, the href is the whole row. */
+    .ledgerRow__cta { display: inline-block; margin-top: var(--tc-space-xs, 4px); color: var(--tc-amber); font-weight: 600; }
+    @media (min-width: 640px) {
+      .ledgerRow__link { flex-direction: row; align-items: flex-start; gap: var(--tc-space-md); }
+      .ledgerRow__meta { flex: 0 0 108px; }
+      .ledgerRow__body { flex: 1 1 auto; }
+    }
+    /* ---------- Status stamp: outlined, uppercase, letterspaced, icon +
+       label always (accessibility invariant — colour is never the sole
+       indicator). Same three-bucket vocabulary/colours as before (decision
+       4), no longer filled. ---------- */
+    .stamp {
       display: inline-flex;
       align-items: center;
-      border-radius: var(--tc-radius-full);
+      gap: 4px;
       padding: 2px var(--tc-space-sm);
-      font-size: 0.8125rem;
-      font-weight: 600;
+      border: 1.5px solid currentColor;
+      border-radius: 3px;
+      background: transparent;
+      font-size: 0.6875rem;
+      font-weight: 700;
       white-space: nowrap;
+      flex-shrink: 0;
     }
-    /* Shared filled-chip vocabulary (decision 4): three canonical buckets,
-       background = foreground colour at 15% opacity, converged with the
-       design-language Status Badge pattern. */
-    .status--granted { color: var(--tc-status-granted); background: var(--tc-status-granted-bg); }
-    .status--refused { color: var(--tc-status-refused); background: var(--tc-status-refused-bg); }
-    .status--neutral { color: var(--tc-status-neutral); background: var(--tc-status-neutral-bg); }
-    /* Compact "Status breakdown" strip (tc-r4n9.3): one row of chip-style
-       headline buckets (reusing the .status--granted/refused/neutral chip
-       vocabulary above) plus the total, with any long tail folded behind the
-       .statusSummary__other <details> instead of a one-row-per-state list. */
+    .stamp__label { text-transform: uppercase; letter-spacing: 0.12em; }
+    .stamp__icon { flex-shrink: 0; }
+    .stamp--granted { color: var(--tc-status-granted); }
+    .stamp--refused { color: var(--tc-status-refused); }
+    .stamp--neutral { color: var(--tc-status-neutral); }
+    /* Compact "Status breakdown" strip (tc-r4n9.3): one row of the same
+       .stamp--granted/refused/neutral vocabulary and colours above, plus the
+       total, with any long tail folded behind the .statusSummary__other
+       <details> instead of a one-row-per-state list. */
     .statusSummary__strip { display: flex; flex-wrap: wrap; align-items: center; gap: var(--tc-space-sm); }
     .statusSummary__total { color: var(--tc-text-secondary); font-size: 0.875rem; }
     .statusSummary__other { margin-top: var(--tc-space-sm); color: var(--tc-text-secondary); font-size: 0.875rem; }
@@ -465,11 +578,13 @@ export function pageStyles() {
     .townLinks__list a:hover { color: var(--tc-amber-hover); border-color: var(--tc-amber); }
     /* /planning/ authority hub (tc-geq7h.1): an A-Z jump nav plus one
        <section> per letter, each holding a flat list of authority links with
-       a small metadata line (application/town counts). */
+       a small mono metadata line (application/town counts) — the same
+       hairline-ruled ledger rhythm as the applications list. */
     .azNav { display: flex; flex-wrap: wrap; gap: var(--tc-space-sm); margin: 0 0 var(--tc-space-lg); font-weight: 600; }
     .azNav a { color: var(--tc-amber); text-decoration: none; }
     .azNav a:hover { color: var(--tc-amber-hover); text-decoration: underline; }
     .hubGroup { scroll-margin-top: var(--tc-space-md); }
+    .hubGroup h2 { border-bottom: 1px solid var(--tc-border); padding-bottom: var(--tc-space-sm); }
     .hubList { list-style: none; margin: 0 0 var(--tc-space-lg); padding: 0; display: grid; gap: var(--tc-space-sm); }
     .hubList__item {
       display: flex;
@@ -482,7 +597,7 @@ export function pageStyles() {
     }
     .hubList__link { color: var(--tc-text-primary); font-weight: 600; text-decoration: none; }
     .hubList__link:hover { color: var(--tc-amber); text-decoration: underline; }
-    .hubList__meta { color: var(--tc-text-secondary); font-size: 0.875rem; white-space: nowrap; }
+    .hubList__meta { font-family: var(--tc-font-mono); color: var(--tc-text-secondary); font-size: 0.8125rem; white-space: nowrap; }
     .explainer p { color: var(--tc-text-secondary); }
     /* Inline alerts CTA pulled above the list (tc-r4n9.3): a lighter pill,
        visually distinct from the rectangular bottom banner button below. */
@@ -497,20 +612,41 @@ export function pageStyles() {
       font-weight: 700;
     }
     .ctaInline__button:hover { background: var(--tc-amber-hover); }
-    /* Mid-list CTA card (tc-fgoyj): shares the card chrome so it sits
-       naturally in the list, with centred copy and the pill button so it is
-       unmistakably a Town Crier pitch rather than an application. */
-    .appCard--cta { text-align: center; padding: var(--tc-space-lg); }
-    .appCard__ctaHeading { margin: 0 0 var(--tc-space-sm); }
-    .appCard__ctaBody { margin: 0 0 var(--tc-space-md); color: var(--tc-text-secondary); }
+    /* ---------- CTA bands: filed-notice card shape, 2px brass top rule,
+       Fraunces headline, one brass button — mid-list pitch (tc-fgoyj) and
+       bottom banner both use this treatment. ---------- */
+    .ledgerCta {
+      list-style: none;
+      margin-top: var(--tc-space-md);
+      padding: var(--tc-space-lg);
+      background: var(--tc-surface);
+      border: 1px solid var(--tc-border);
+      border-top: 2px solid var(--tc-amber);
+      border-radius: var(--tc-radius-md);
+      text-align: center;
+    }
+    .ledgerCta__heading { font-family: var(--tc-font-display); font-weight: 600; margin: 0 0 var(--tc-space-sm); }
+    .ledgerCta__body { margin: 0 0 var(--tc-space-md); color: var(--tc-text-secondary); }
+    .ledgerCta__button {
+      display: inline-block;
+      padding: var(--tc-space-sm) var(--tc-space-lg);
+      background: var(--tc-amber);
+      color: var(--tc-text-on-accent);
+      border-radius: var(--tc-radius-full);
+      text-decoration: none;
+      font-weight: 700;
+    }
+    .ledgerCta__button:hover { background: var(--tc-amber-hover); }
     .cta {
       margin: var(--tc-space-xl) 0;
       padding: var(--tc-space-lg);
       background: var(--tc-surface);
       border: 1px solid var(--tc-border);
+      border-top: 2px solid var(--tc-amber);
       border-radius: var(--tc-radius-md);
       text-align: center;
     }
+    .cta__heading { font-family: var(--tc-font-display); font-weight: 600; }
     /* Desktop-only QR (tc-fgoyj): pointer/hover media queries approximate
        "no App Store on this device" without any UA sniffing or JS. The SVG's
        own colours stay dark-on-light in dark mode (see qr.mjs) — only the

--- a/web/scripts/lib/render-shared.mjs
+++ b/web/scripts/lib/render-shared.mjs
@@ -2,7 +2,7 @@
  * Building blocks shared by the authority-page renderer (`render-page.mjs`) and
  * the town-page renderer (`render-town-page.mjs`). Both pages are the same
  * hydration-free static template — only the title, canonical URL, breadcrumb and
- * a little evergreen copy differ — so the application cards, status stats,
+ * a little evergreen copy differ — so the application ledger rows, status stats,
  * attribution footer and the inline stylesheet live here once.
  *
  * Everything emitted here is destined for raw HTML, so data-derived strings are
@@ -30,13 +30,13 @@ import { SEO_TOKEN_CSS } from './tokens.generated.mjs';
  * @property {string | null} appState
  * @property {string | null} startDate      yyyy-MM-dd
  * @property {string | null} [decidedDate]  yyyy-MM-dd; when present, takes precedence over
- *   `startDate` for the card's Started/Decided line (tc-s0yf, GH #819) — the more final,
+ *   `startDate` for the row's Started/Decided line (tc-s0yf, GH #819) — the more final,
  *   informative lifecycle event. Optional/nullable: absent on an undecided application.
  * @property {string} lastDifferent         ISO-8601 with offset; the DESC sort key
  * @property {string | null} link           PlanIt permalink (always a reliable per-application record). No longer rendered
- *   as a per-card link (decision 6); kept only as a JSON-LD `url` fallback when no share URL can be built.
+ *   as a per-row link (decision 6); kept only as a JSON-LD `url` fallback when no share URL can be built.
  * @property {string | null} url            council website (may be a generic portal page, not always a per-application deep link). No longer
- *   rendered as a per-card link (decision 6); kept only as a JSON-LD `url` fallback when no share URL can be built.
+ *   rendered as a per-row link (decision 6); kept only as a JSON-LD `url` fallback when no share URL can be built.
  */
 
 const MAX_DESCRIPTION_LENGTH = 160;
@@ -69,7 +69,7 @@ function statusColorModifier(appState) {
 }
 
 /**
- * Build the card's Started/Decided date line (tc-s0yf, GH #819 acceptance).
+ * Build the row's Started/Decided date line (tc-s0yf, GH #819 acceptance).
  * `decidedDate` is the more final, informative lifecycle event, so it takes
  * precedence over `startDate` when both are present ("Decided 9 Jul 2021").
  * With only a `startDate`, the application is still awaiting a decision
@@ -225,13 +225,13 @@ export function renderMidListCta(area, storeHref) {
 }
 
 /**
- * Render the recent-applications list body (the `<li>` cards joined by newlines).
+ * Render the recent-applications ledger body (the `<li>` rows joined by newlines).
  *
  * @param {PlanningApplicationItem[]} applications
  * @param {string} [authoritySlug] the page's authority slug, threaded through so
- *   each card can link to its share page. Omitted (or no ref on the app) -> the
- *   card renders without a link at all (decision 6 retired the external
- *   PlanIt/council per-card links, so there is no other href to fall back to).
+ *   each row can link to its share page. Omitted (or no ref on the app) -> the
+ *   row renders without a link at all (decision 6 retired the external
+ *   PlanIt/council per-row links, so there is no other href to fall back to).
  * @param {{ area: string, storeHref: string }} [midCta] when present and the
  *   list is long enough, a mid-list CTA card is slotted in after the
  *   {@link MID_LIST_CTA_AFTER}th application.

--- a/web/scripts/lib/render-town-page.mjs
+++ b/web/scripts/lib/render-town-page.mjs
@@ -157,11 +157,12 @@ ${pageStyles()}
   <body>
     <div class="wrap">
       <header class="siteHeader">
-        <a href="/">Town Crier</a>
-        <nav class="siteHeader__nav">
-          <a href="/">Home</a>
+        <div class="siteHeader__inner">
+          <a href="/" class="siteHeader__wordmark">Town Crier</a>
           <a class="siteHeader__cta" href="${appStoreUrl('seo-town-hdr')}" rel="noopener" target="_blank">Get the app</a>
-        </nav>
+        </div>
+        <div class="siteHeader__ruleHeavy"></div>
+        <div class="siteHeader__ruleHairline"></div>
       </header>
       <nav class="breadcrumb" aria-label="Breadcrumb">
         <ol>
@@ -178,8 +179,8 @@ ${renderInlineCta(data.townName, appStoreUrl('seo-town-inline'))}
 
 ${renderStatusSummary(data.statusBreakdown)}
 
-        <h2>Recent applications</h2>
-        <ul class="appList">
+        <h2 class="ledger__heading">Latest notices</h2>
+        <ul class="ledger">
 ${applicationsList}
         </ul>
 
@@ -202,7 +203,7 @@ ${applicationsList}
         </section>
 
         <section class="cta">
-          <h2>Get push alerts for ${town}</h2>
+          <h2 class="cta__heading">Get push alerts for ${town}</h2>
           <p>
             Draw a circle on the map and Town Crier will notify you the moment a new
             planning application is submitted or decided inside it. Most councils

--- a/web/scripts/lib/render-towns-index.mjs
+++ b/web/scripts/lib/render-towns-index.mjs
@@ -195,7 +195,7 @@ function townsIndexStyles() {
     .townsIndex__list { list-style: none; margin: 0; padding: 0; display: grid; gap: var(--tc-space-sm); }
     .townsIndex__item a { color: var(--tc-text-primary); font-weight: 600; text-decoration: none; }
     .townsIndex__item a:hover { color: var(--tc-amber); text-decoration: underline; }
-    .townsIndex__authority { color: var(--tc-text-secondary); font-size: 0.875rem; }`;
+    .townsIndex__authority { font-family: var(--tc-font-mono); color: var(--tc-text-secondary); font-size: 0.875rem; }`;
 }
 
 /**
@@ -251,11 +251,12 @@ ${townsIndexStyles()}
   <body>
     <div class="wrap">
       <header class="siteHeader">
-        <a href="/">Town Crier</a>
-        <nav class="siteHeader__nav">
-          <a href="/">Home</a>
+        <div class="siteHeader__inner">
+          <a href="/" class="siteHeader__wordmark">Town Crier</a>
           <a class="siteHeader__cta" href="${cta}" rel="noopener" target="_blank">Get the app</a>
-        </nav>
+        </div>
+        <div class="siteHeader__ruleHeavy"></div>
+        <div class="siteHeader__ruleHairline"></div>
       </header>
       <nav class="breadcrumb" aria-label="Breadcrumb">
         <ol>
@@ -271,7 +272,7 @@ ${renderInlineCta('your town', cta)}
 ${body}
 
         <section class="cta">
-          <h2>Get push alerts for your town</h2>
+          <h2 class="cta__heading">Get push alerts for your town</h2>
           <p>
             Draw a circle on the map and Town Crier will notify you the moment a new
             planning application is submitted or decided inside it.


### PR DESCRIPTION
## Summary

R2 of the Public Notice rebrand epic (#848): restyles the prerendered SEO `/planning/*` pages (authority, town, and both index pages) as a "Public Notice broadsheet" — masthead with double rule, monospace breadcrumb/dateline, ledger rows instead of card-grid, outlined status stamps, brass CTA bands, inline self-hosted Fraunces. Visual/class-name changes only; every #794 settled decision is preserved.

Closes #854

## What changed

- **Masthead** (`render-page.mjs`, `render-town-page.mjs`, `render-planning-index.mjs`, `render-towns-index.mjs`): small-caps letterspaced "Town Crier" wordmark, "Get the app" restyled from a filled pill to a plain brass text link (click-through unchanged), 2.5px + 1px double rule beneath.
- **Breadcrumb → mono dateline**: CSS-only restyle (`var(--tc-font-mono)`, `font-variant: small-caps`, `›` separator) — HTML structure and JSON-LD `BreadcrumbList` untouched. Authority pages already had the breadcrumb from #794 Phase 4 (tc-r4n9.4), so no HTML was added, only restyled.
- **H1** → `font-family: var(--tc-font-display)` (Fraunces via token; serif fallback stack verified to apply).
- **Applications list → ledger rows** (`render-shared.mjs`): `.appCard` boxes replaced with `.ledger`/`.ledgerRow*` — section opens with a small-caps brass "Latest notices" label over a heavy 2px rule; each row has a fixed-width mono ref+date column, Fraunces-600 address headline, description, and a right-aligned stamp; hairline rule between rows; the whole row stays a real `<a>` to the share page with the "View details →" affordance (decision 6 preserved).
- **Status chips → stamps** (`.stamp`/`.stamp--granted|refused|neutral`): outlined (1.5px `currentColor` border, no fill), uppercase, letterspaced, with a new inline SVG icon always paired with the label (accessibility invariant — colour is never the sole indicator). Applied to both per-row stamps and the aggregate "Status breakdown" strip. Same three-bucket vocabulary; `statusDisplayLabel` text unchanged.
- **CTA bands**: mid-list pitch card (`.ledgerCta`, was `.appCard--cta`) and the bottom banner (`.cta`) both get a 2px brass top rule and a Fraunces headline class; button copy/behaviour unchanged.
- **Fraunces**: two `@font-face` blocks (400/600) added to `pageStyles()`, pointing at the same-origin `/fonts/fraunces-latin-{400,600}-normal.woff2` files already committed by #853 — `font-display: swap`, zero external requests (verified by grepping rendered fixture output).
- **Index pages** get the same masthead treatment plus mono metadata styling for visual consistency with the ledger rows.

## Acceptance criteria

- [x] `npx vitest run` green (1235/1235) including rebaked fixture assertions
- [x] Rendered fixture page (built with `PRERENDER_FIXTURE=... node scripts/prerender-planning.mjs` and manually inspected) contains: masthead + double rule, mono breadcrumb, ledger rows with share links + "View details →", stamps with icon+label, both CTA placements (inline above list + bottom banner), single "Data updated" line
- [x] No regression of any already-shipped #794 acceptance item — went through the checklist explicitly:
  - Light-first CSS: untouched, still flows from `SEO_TOKEN_CSS`
  - Address is the headline / council ref is metadata: preserved in ledger rows
  - Whole-entry share-page link + "View details →": preserved
  - Three-bucket status vocabulary + `statusDisplayLabel` text: unchanged
  - Compact status summary strip, alerts CTA above list + bottom banner, single "Data updated" line: unchanged placement/content
  - Word-boundary description truncation: untouched (same `truncate()` helper/tests)
  - Authority breadcrumb: already present since #794 Phase 4, only restyled here
- [x] JSON-LD and meta/canonical output byte-identical apart from class names (one heading text change, "Recent applications" → "Latest notices", which is an explicit deliverable of this issue, not #794-load-bearing content — heading *level* unchanged)
- [x] Zero external requests: grepped rendered fixture HTML for `https://fonts` / `fonts.googleapis.com` / `fonts.gstatic.com` — none found; font URLs are same-origin `/fonts/...`
- [x] `npx tsc --noEmit` clean, `npm run build` clean, `eslint` clean

## Deviations / notes

- The share page (Go, R3/#855) still renders filled status chips, not stamps — expected, sequenced after this bead by the epic (#848 lists R3 as depending on R2/#852 but not vice versa).
- Did not investigate the #794 Phase 4 town-links data-gap (Croydon authority page showing zero town links) — out of scope per the bead brief, and nothing surfaced in passing.
- `.breadcrumb` and `.cta` kept their existing class names since only CSS needed to change (dateline styling, brass top rule) — renamed only where markup genuinely changed shape (`.appCard*` → `.ledgerRow*`/`.stamp*`, `.appCard--cta` → `.ledgerCta`).

## Test plan

- [x] `cd web && npx vitest run` (1235 passed)
- [x] `cd web && npx tsc --noEmit`
- [x] `cd web && npm run build`
- [ ] Orchestrator visual verification (agent-browser, light + dark, mobile + desktop) — not run by this worker per the escalation/verification protocol; do not merge until that passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated planning and towns pages with a refreshed header, new wordmark styling, and clearer call-to-action placement.
  * Reworked application listings into a cleaner “latest notices”/ledger-style layout with better date, status, and detail presentation.
  * Added richer status indicators and improved spacing/typography for easier scanning.

* **Bug Fixes**
  * Removed outdated per-item link elements and tightened layout consistency across list sections and summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->