### PR TITLE
feat(sharepage): Public Notice share page + OG card restyle

### DIFF
--- a/api-go/internal/sharepage/card.go
+++ b/api-go/internal/sharepage/card.go
@@ -40,14 +40,48 @@ const (
 )
 
 var (
-	pinFill    = designtokens.AmberDark  // amber pin body
-	pinOutline = designtokens.White      // white pin border
-	fallbackBg = designtokens.AmberLight // brand amber field
-	textWhite  = designtokens.White
+	pinFill = designtokens.AmberDark // amber pin body: brand contrast over any map tile
+	// pinOutline is the paper SurfaceLight rather than a hand-rolled pure
+	// white, so the pin's border consumes the same token as every other
+	// Public Notice surface (tc-fmrx3, #855).
+	pinOutline = designtokens.SurfaceLight
+	// fallbackBg is the v2 paper field (was the flat brand-amber poster) —
+	// the no-map card now reads as a filed notice, not a brand advert.
+	fallbackBg = designtokens.BackgroundLight
+	// fallbackText is the ink wordmark colour on the paper fallbackBg field
+	// (was white-on-amber).
+	fallbackText = designtokens.TextPrimaryLight
+	// mastheadInk is the masthead band's rule + wordmark colour, burned over
+	// the paper mastheadBg strip.
+	mastheadInk = designtokens.TextPrimaryLight
+	// mastheadBg is the paper band colour behind the masthead wordmark.
+	mastheadBg = designtokens.SurfaceLight
+	// textWhite renders the OSM attribution credit: it MUST stay white
+	// regardless of theme/palette changes elsewhere — legibility over the
+	// dark attribShade strip is an OSM-attribution requirement, not a brand
+	// choice, so this is deliberately untouched by the v2 restyle.
+	textWhite = designtokens.White
 	// attribShade is a half-opaque black strip behind the OSM credit so it stays
 	// legible over any tile. color.RGBA is alpha-premultiplied, so a black tint at
 	// alpha 0xA0 darkens whatever it composites over via draw.Over.
 	attribShade = color.RGBA{R: 0x00, G: 0x00, B: 0x00, A: 0xA0}
+)
+
+// Masthead geometry: the paper band burned across the top of the map card,
+// mirroring the web masthead's double-rule language (SPA Navbar / SEO
+// render-shared.mjs — small-caps wordmark over a heavy rule) in the raster OG
+// image. It overlays the already-composited tiles rather than reserving a gap
+// in the map projection, so mapCard's centring math and OSM tile budget are
+// untouched by its addition.
+const (
+	mastheadHeight = 56
+	mastheadRuleH  = 2
+	mastheadFontPx = 22
+
+	// mastheadWordmark is tracked via trackedText before drawing — see its
+	// doc comment for why (no small-caps/letter-spacing support in
+	// golang.org/x/image/font).
+	mastheadWordmark = "TOWN CRIER"
 )
 
 // The Go fonts are embedded, compile-time-constant assets; parsing them can only
@@ -130,6 +164,7 @@ func mapCard(ctx context.Context, tiles tileClient, lat, lng float64) ([]byte, e
 	}
 
 	drawPin(canvas, cardWidth/2, cardHeight/2)
+	drawMasthead(canvas)
 	drawAttribution(canvas)
 
 	return encodePNG(canvas)
@@ -142,10 +177,10 @@ func fallbackCard() ([]byte, error) {
 	canvas := image.NewRGBA(image.Rect(0, 0, cardWidth, cardHeight))
 	draw.Draw(canvas, canvas.Bounds(), image.NewUniform(fallbackBg), image.Point{}, draw.Src)
 
-	if err := drawCentredText(canvas, boldFont, "Town Crier", 72, cardHeight/2-16); err != nil {
+	if err := drawCentredText(canvas, boldFont, "Town Crier", 72, cardHeight/2-16, fallbackText); err != nil {
 		return nil, err
 	}
-	if err := drawCentredText(canvas, regularFont, "Planning alerts for your area", 30, cardHeight/2+52); err != nil {
+	if err := drawCentredText(canvas, regularFont, "Planning alerts for your area", 30, cardHeight/2+52, fallbackText); err != nil {
 		return nil, err
 	}
 	return encodePNG(canvas)
@@ -200,6 +235,60 @@ func setPixel(img *image.RGBA, x, y int, col color.RGBA) {
 	}
 }
 
+// trackedText approximates a tracked, small-caps-style wordmark using the
+// embedded (non-small-caps) Go fonts: golang.org/x/image/font has no
+// small-caps glyph substitution or letter-spacing/tracking support, so this
+// inserts a thin space (U+2009) between the runes of an already-uppercase
+// string. It produces the same widely tracked, formal read as the web
+// masthead's `font-variant:small-caps; letter-spacing` treatment (SPA Navbar,
+// SEO render-shared.mjs) without embedding a new font — a deliberate
+// stdlib-only approximation, not the real small-caps feature.
+func trackedText(s string) string {
+	runes := []rune(s)
+	out := make([]rune, 0, len(runes)*2)
+	for i, r := range runes {
+		if i > 0 {
+			out = append(out, ' ')
+		}
+		out = append(out, r)
+	}
+	return string(out)
+}
+
+// drawMasthead burns the Public Notice masthead band across the top of the
+// map card: a paper strip holding the tracked "TOWN CRIER" wordmark, over a
+// 2px ink rule — the same wordmark-over-double-rule language as the web
+// masthead, rendered here with the existing embedded Go fonts (no new font
+// embedding). It draws directly onto the already-composited tile canvas
+// rather than reserving a gap in the map projection, so the map + brass pin
+// stay the hero visual below the strip and mapCard's centring math / OSM
+// tile budget are untouched. Best-effort like drawAttribution: a font-face
+// build failure must not sink the whole card.
+func drawMasthead(img *image.RGBA) {
+	draw.Draw(img, image.Rect(0, 0, cardWidth, mastheadHeight), image.NewUniform(mastheadBg), image.Point{}, draw.Src)
+	draw.Draw(img, image.Rect(0, mastheadHeight, cardWidth, mastheadHeight+mastheadRuleH), image.NewUniform(mastheadInk), image.Point{}, draw.Src)
+
+	face, err := newFace(boldFont, mastheadFontPx)
+	if err != nil {
+		return
+	}
+	defer func() { _ = face.Close() }()
+
+	text := trackedText(mastheadWordmark)
+	width := font.MeasureString(face, text).Ceil()
+	metrics := face.Metrics()
+	textH := metrics.Ascent.Ceil() + metrics.Descent.Ceil()
+	baselineY := (mastheadHeight-textH)/2 + metrics.Ascent.Ceil()
+
+	drawer := &font.Drawer{
+		Dst:  img,
+		Src:  image.NewUniform(mastheadInk),
+		Face: face,
+		Dot:  fixed.P((cardWidth-width)/2, baselineY),
+	}
+	drawer.DrawString(text)
+}
+
 // drawAttribution burns the OSM credit into the bottom-right corner over a
 // semi-transparent dark strip sized from the measured string. Attribution is
 // best-effort: a face-construction failure must not sink the whole card, so it
@@ -241,9 +330,9 @@ func drawAttribution(img *image.RGBA) {
 	drawer.DrawString(osmAttribution)
 }
 
-// drawCentredText draws text in white, horizontally centred, with its baseline at
+// drawCentredText draws text in col, horizontally centred, with its baseline at
 // baselineY, using font f at sizePx pixels.
-func drawCentredText(img *image.RGBA, f *opentype.Font, text string, sizePx float64, baselineY int) error {
+func drawCentredText(img *image.RGBA, f *opentype.Font, text string, sizePx float64, baselineY int, col color.RGBA) error {
 	face, err := newFace(f, sizePx)
 	if err != nil {
 		return fmt.Errorf("build font face: %w", err)
@@ -253,7 +342,7 @@ func drawCentredText(img *image.RGBA, f *opentype.Font, text string, sizePx floa
 	width := font.MeasureString(face, text).Ceil()
 	drawer := &font.Drawer{
 		Dst:  img,
-		Src:  image.NewUniform(textWhite),
+		Src:  image.NewUniform(col),
 		Face: face,
 		Dot:  fixed.P((cardWidth-width)/2, baselineY),
 	}

--- a/api-go/internal/sharepage/card.go
+++ b/api-go/internal/sharepage/card.go
@@ -238,17 +238,20 @@ func setPixel(img *image.RGBA, x, y int, col color.RGBA) {
 // trackedText approximates a tracked, small-caps-style wordmark using the
 // embedded (non-small-caps) Go fonts: golang.org/x/image/font has no
 // small-caps glyph substitution or letter-spacing/tracking support, so this
-// inserts a thin space (U+2009) between the runes of an already-uppercase
-// string. It produces the same widely tracked, formal read as the web
+// inserts a plain ASCII space between the runes of an already-uppercase
+// string. It produces a similarly widely tracked, formal read to the web
 // masthead's `font-variant:small-caps; letter-spacing` treatment (SPA Navbar,
 // SEO render-shared.mjs) without embedding a new font — a deliberate
-// stdlib-only approximation, not the real small-caps feature.
+// stdlib-only approximation, not the real small-caps feature. A typographic
+// thin space (U+2009) would track more tightly, but neither embedded Go font
+// (goregular/gobold) carries a glyph for it, so it renders as .notdef —
+// the plain ASCII space is a deliberate, font-safe substitute.
 func trackedText(s string) string {
 	runes := []rune(s)
 	out := make([]rune, 0, len(runes)*2)
 	for i, r := range runes {
 		if i > 0 {
-			out = append(out, ' ')
+			out = append(out, '\x20')
 		}
 		out = append(out, r)
 	}

--- a/api-go/internal/sharepage/card_test.go
+++ b/api-go/internal/sharepage/card_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/designtokens"
 )
 
 // fakeTiles is a hand-written double for the tile client. Every tile is a single
@@ -138,6 +139,61 @@ func TestMapCard_RendersMapWithPinAndAttribution(t *testing.T) {
 	}
 }
 
+// TestMapCard_RendersMastheadStripWithInkRule pins the Public Notice masthead
+// band (tc-fmrx3, #855): a paper-coloured strip burned across the top of the
+// map card, with a 2px ink rule beneath it, so the card carries the same
+// wordmark-over-double-rule language as the web masthead (#853/#854) even
+// though it composites onto a raster PNG rather than CSS. The band overlays
+// the already-composited tiles rather than reserving a gap in the map
+// projection, so this only changes THIS function's pixels — the map centring
+// math and OSM tile budget are untouched.
+func TestMapCard_RendersMastheadStripWithInkRule(t *testing.T) {
+	t.Parallel()
+	fill := color.RGBA{0x88, 0xCC, 0xFF, 0xFF}
+	tiles := &fakeTiles{fill: fill}
+
+	data, err := mapCard(t.Context(), tiles, 51.5074, -0.1278)
+	if err != nil {
+		t.Fatalf("mapCard: %v", err)
+	}
+	img := decodePNG(t, data)
+
+	if !hasPixelUnlike(img, image.Rect(0, 0, cardWidth, mastheadHeight), fill) {
+		t.Error("masthead band region still shows the raw tile fill")
+	}
+	// Away from the centred wordmark, the band is flat paper.
+	if !sameRGB(t, img, 1100, 10, designtokens.SurfaceLight) {
+		t.Error("masthead band is not the paper SurfaceLight colour")
+	}
+	// The ink rule beneath the band spans the full card width.
+	if !sameRGB(t, img, 50, mastheadHeight, designtokens.TextPrimaryLight) {
+		t.Error("masthead ink rule missing at its expected row (left)")
+	}
+	if !sameRGB(t, img, 1150, mastheadHeight, designtokens.TextPrimaryLight) {
+		t.Error("masthead ink rule missing at its expected row (right)")
+	}
+}
+
+// TestMapCard_PinOutlineIsPaperNotWhite pins the pin-outline token swap
+// (tc-fmrx3, #855): the outline goes from pure white to the paper
+// designtokens.SurfaceLight, consuming the token package rather than a
+// hand-rolled white. (600,277) sits 14px from the pin head's centre (291),
+// inside the outline ring (13px fill radius < 14 <= 16px outline radius).
+func TestMapCard_PinOutlineIsPaperNotWhite(t *testing.T) {
+	t.Parallel()
+	tiles := &fakeTiles{fill: color.RGBA{0x88, 0xCC, 0xFF, 0xFF}}
+
+	data, err := mapCard(t.Context(), tiles, 51.5074, -0.1278)
+	if err != nil {
+		t.Fatalf("mapCard: %v", err)
+	}
+	img := decodePNG(t, data)
+
+	if !sameRGB(t, img, 600, 277, designtokens.SurfaceLight) {
+		t.Error("pin outline is not the paper SurfaceLight colour")
+	}
+}
+
 // TestMapCard_TileFetchError propagates a tile-client failure as an error rather
 // than serving a half-painted card.
 func TestMapCard_TileFetchError(t *testing.T) {
@@ -168,6 +224,26 @@ func TestFallbackCard_BrandedNoTiles(t *testing.T) {
 	// The centred wordmark drew white text over the amber field.
 	if !hasPixelUnlike(img, image.Rect(400, 260, 800, 360), fallbackBg) {
 		t.Error("no wordmark drawn: centre band is still the flat background")
+	}
+}
+
+// TestFallbackCard_PaperFieldWithInkText pins the v2 fallback restyle
+// (tc-fmrx3, #855): the flat brand-amber field becomes the paper
+// designtokens.BackgroundLight, with ink (not white) wordmark text — the
+// no-map card now reads as a filed notice rather than a brand-amber poster.
+func TestFallbackCard_PaperFieldWithInkText(t *testing.T) {
+	t.Parallel()
+	data, err := fallbackCard()
+	if err != nil {
+		t.Fatalf("fallbackCard: %v", err)
+	}
+	img := decodePNG(t, data)
+
+	if !sameRGB(t, img, 4, 4, designtokens.BackgroundLight) {
+		t.Error("fallback corner is not the paper BackgroundLight field")
+	}
+	if sameRGB(t, img, 4, 4, designtokens.AmberLight) {
+		t.Error("fallback corner is still the old flat brand-amber field")
 	}
 }
 

--- a/api-go/internal/sharepage/handler_test.go
+++ b/api-go/internal/sharepage/handler_test.go
@@ -147,11 +147,16 @@ func TestServe_KnownApplication_RendersMetaAndVisibleContent(t *testing.T) {
 		"Erection of a two-storey rear extension.",
 		// Reference and application type each get their own explicit metadata row
 		// (tc-r4n9.6) — no longer squashed into a cryptic "Reference … · Type" line.
-		`<span class="meta-label">Reference</span><span class="meta-value">23/03456/FUL</span>`,
+		// The reference now leads the mono document-header strip ("No. {ref}"),
+		// with the authority name on the right (tc-fmrx3, #855 filed-notice
+		// restyle) -- Reference is no longer a meta-list row.
+		`<span class="doc-header-ref">No. 23/03456/FUL</span>`,
+		`<span class="doc-header-authority">Croydon</span>`,
 		`<span class="meta-label">Type</span><span class="meta-value">Full planning permission</span>`,
 		// "Under Consideration" is not in the shared status vocabulary, so it passes
 		// through as its own label with the neutral colour bucket — never dropped.
-		`class="chip chip--neutral">Under Consideration</span>`,
+		`class="stamp stamp--neutral">`,
+		`<span class="stamp-label">Under Consideration</span>`,
 		// Key-dates timeline (doubles as status history): the heading and every
 		// row's LABEL and human-formatted VALUE. fullApp sets all three dates, so a
 		// missing timeline or a mis-formatted date is caught here.
@@ -317,6 +322,95 @@ func TestServe_RendersHeaderAboveHeroWithBrandLockup(t *testing.T) {
 	}
 	if headerIdx > heroIdx {
 		t.Error("header must render above the hero image, not below it")
+	}
+}
+
+// TestServe_MastheadIsSmallCapsWithDoubleRule pins the Public Notice masthead
+// restyle (tc-fmrx3, #855): the brand lockup reads in small-caps with tracked
+// letter-spacing, and a double rule (2.5px heavy rule over a 1px hairline)
+// sits beneath it — the same visual language as the web masthead (SPA
+// Navbar, #853/#854 broadsheet restyle), consuming the generated token vars
+// rather than any hand-added hex.
+func TestServe_MastheadIsSmallCapsWithDoubleRule(t *testing.T) {
+	t.Parallel()
+	store := &fakeStore{app: fullApp(t), found: true}
+	resolver := &fakeResolver{slugs: map[string]int{"croydon": 165}}
+
+	rec := serve(t, store, resolver, "/a/croydon/23/03456/FUL")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+
+	if !strings.Contains(body, `<div class="rule-heavy">`) {
+		t.Error(`body missing the masthead's heavy rule <div class="rule-heavy">`)
+	}
+	if !strings.Contains(body, `<div class="rule-hairline">`) {
+		t.Error(`body missing the masthead's hairline rule <div class="rule-hairline">`)
+	}
+	if !strings.Contains(body, `.rule-heavy{height:2.5px;background:var(--text-primary);}`) {
+		t.Error("heavy-rule CSS missing or not consuming var(--text-primary)")
+	}
+	if !strings.Contains(body, `font-variant:small-caps`) {
+		t.Error("brand-link CSS missing the small-caps treatment")
+	}
+}
+
+// TestServe_CardIsFiledNoticeWithDocHeaderStrip pins the filed-notice card
+// restyle (tc-fmrx3, #855): the card carries a 2px ink top rule (not the
+// amber rule used elsewhere), and a monospace document-header strip — "No.
+// {ref}" left, authority name right — renders ABOVE the address H1, whose
+// own font switches to the display-serif stack.
+func TestServe_CardIsFiledNoticeWithDocHeaderStrip(t *testing.T) {
+	t.Parallel()
+	store := &fakeStore{app: fullApp(t), found: true}
+	resolver := &fakeResolver{slugs: map[string]int{"croydon": 165}}
+
+	rec := serve(t, store, resolver, "/a/croydon/23/03456/FUL")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+
+	if !strings.Contains(body, `border-top:2px solid var(--text-primary)`) {
+		t.Error(".card CSS missing the 2px ink top rule")
+	}
+
+	docHeaderIdx := strings.Index(body, `<div class="doc-header">`)
+	if docHeaderIdx == -1 {
+		t.Fatal(`body missing <div class="doc-header">`)
+	}
+	addressIdx := strings.Index(body, `<h1 class="address">`)
+	if addressIdx == -1 {
+		t.Fatal(`body missing <h1 class="address">`)
+	}
+	if docHeaderIdx > addressIdx {
+		t.Error("doc-header strip must render above the address H1, not below it")
+	}
+	if !strings.Contains(body, `h1.address{font-family:var(--font-display)`) {
+		t.Error("h1.address CSS missing the display-serif font-family")
+	}
+}
+
+// TestServe_KeyDatesValuesUseMonospace pins the key-dates timeline restyle
+// (tc-fmrx3, #855): labels stay in the sans body font, but values render in
+// the monospace stack.
+func TestServe_KeyDatesValuesUseMonospace(t *testing.T) {
+	t.Parallel()
+	store := &fakeStore{app: fullApp(t), found: true}
+	resolver := &fakeResolver{slugs: map[string]int{"croydon": 165}}
+
+	rec := serve(t, store, resolver, "/a/croydon/23/03456/FUL")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+
+	if !strings.Contains(body, `.date-value{font-weight:600;font-family:var(--font-mono);}`) {
+		t.Error(".date-value CSS missing font-family:var(--font-mono)")
 	}
 }
 
@@ -584,8 +678,8 @@ func TestServe_NilOptionalFields_Renders200WithoutPanic(t *testing.T) {
 		t.Error("ref missing")
 	}
 	// Omitted sections must be absent.
-	if strings.Contains(body, `class="chip"`) {
-		t.Error("status chip rendered despite nil AppState")
+	if strings.Contains(body, `class="stamp stamp--`) {
+		t.Error("status stamp rendered despite nil AppState")
 	}
 	if strings.Contains(body, `rel="nofollow noopener noreferrer"`) {
 		t.Error("official-record link rendered despite nil URL/Link")

--- a/api-go/internal/sharepage/ogimage_test.go
+++ b/api-go/internal/sharepage/ogimage_test.go
@@ -152,6 +152,32 @@ func TestImageServe_CacheOnce_SecondRequestSkipsTiles(t *testing.T) {
 	}
 }
 
+// TestImageServe_NilCache_RendersByteIdenticalPNGAcrossTwoRequests is a
+// characterisation guard for the v2 restyle (tc-fmrx3, #855): the masthead
+// strip and pin-outline token swap must stay fully deterministic, and the
+// og:image route's caching mechanism must still produce byte-stable output
+// across two renders of the same application, exactly as it did before the
+// restyle. A nil cache regenerates on every request (Slice 2, pre-Blob), so
+// this drives the rendering path twice and asserts the bytes match, without
+// touching ogimage.go's caching/routing logic at all.
+func TestImageServe_NilCache_RendersByteIdenticalPNGAcrossTwoRequests(t *testing.T) {
+	t.Parallel()
+	store := &fakeStore{app: coordApp(t), found: true}
+	resolver := &fakeResolver{slugs: map[string]int{"croydon": 165}}
+	tiles := &fakeTiles{fill: color.RGBA{R: 0x88, G: 0xCC, B: 0xFF, A: 0xFF}}
+	mux := wireOG(t, store, resolver, tiles, nil)
+
+	first := serveOG(t, mux, "/og/croydon/23/03456/FUL.png")
+	second := serveOG(t, mux, "/og/croydon/23/03456/FUL.png")
+
+	if first.Code != http.StatusOK || second.Code != http.StatusOK {
+		t.Fatalf("statuses = %d, %d, want 200, 200", first.Code, second.Code)
+	}
+	if !bytes.Equal(first.Body.Bytes(), second.Body.Bytes()) {
+		t.Error("regenerated PNG bytes differ across two renders of the same application; the restyle must stay deterministic")
+	}
+}
+
 func TestImageServe_NoCoordinates_FallbackWithoutTiles(t *testing.T) {
 	t.Parallel()
 	store := &fakeStore{app: fullApp(t), found: true} // fullApp has no coordinates

--- a/api-go/internal/sharepage/templates/page.gohtml
+++ b/api-go/internal/sharepage/templates/page.gohtml
@@ -23,15 +23,18 @@
 <body>
 <header class="site-header">
 <a class="brand-link" href="{{.HomeURL}}">Town Crier</a>
+<div class="rule-heavy"></div>
+<div class="rule-hairline"></div>
 </header>
 <main class="page">
 <img class="hero" src="{{.OGImage}}" alt="Map showing the approximate location of {{if .Address}}{{.Address}}{{else}}this planning application{{end}}" width="1200" height="630" loading="eager">
 <article class="card">
-<div class="meta-list">
-<div class="meta-row"><span class="meta-label">Reference</span><span class="meta-value">{{.Ref}}</span></div>
-{{if .AppType}}<div class="meta-row"><span class="meta-label">Type</span><span class="meta-value">{{.AppType}}</span></div>{{end}}
+<div class="doc-header">
+<span class="doc-header-ref">No. {{.Ref}}</span>
+{{if .AuthorityName}}<span class="doc-header-authority">{{.AuthorityName}}</span>{{end}}
 </div>
-{{if .StatusLabel}}<span class="chip chip--{{.StatusModifier}}">{{.StatusLabel}}</span>{{end}}
+{{if .AppType}}<div class="meta-list"><div class="meta-row"><span class="meta-label">Type</span><span class="meta-value">{{.AppType}}</span></div></div>{{end}}
+{{if .StatusLabel}}<span class="stamp stamp--{{.StatusModifier}}">{{if eq .StatusModifier "granted"}}<svg class="stamp-icon" width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3.5 8.5 6.5 11.5 12.5 4.5"/></svg>{{else if eq .StatusModifier "refused"}}<svg class="stamp-icon" width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 4 12 12"/><path d="M12 4 4 12"/></svg>{{else}}<svg class="stamp-icon" width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 8H12"/></svg>{{end}}<span class="stamp-label">{{.StatusLabel}}</span></span>{{end}}
 <h1 class="address">{{.Address}}{{if .Postcode}}, {{.Postcode}}{{end}}</h1>
 {{if .Description}}<h2>Proposal</h2><p class="proposal">{{.Description}}</p>{{end}}
 {{if .Dates}}<h2>Key dates</h2><ol class="timeline">{{range .Dates}}<li><span class="date-label">{{.Label}}</span><span class="date-value">{{.Value}}</span></li>{{end}}</ol>{{end}}

--- a/api-go/internal/sharepage/templates/styles.gohtml
+++ b/api-go/internal/sharepage/templates/styles.gohtml
@@ -7,11 +7,18 @@ body{
   font-size:17px;line-height:1.4;
 }
 .site-header{max-width:600px;margin:0 auto;padding:var(--space-md) var(--space-md) 0;}
+/* Masthead (tc-fmrx3, issue 855): small-caps tracked wordmark over a double
+   rule — a 2.5px heavy rule over a 1px hairline, 3px gap — the same Public
+   Notice masthead language as the SPA Navbar / SEO broadsheet restyle
+   (issues 853/854). */
 .brand-link{
-  display:inline-block;font-size:19px;font-weight:700;color:var(--text-primary);
-  text-decoration:none;letter-spacing:-0.01em;
+  display:inline-block;margin-bottom:var(--space-sm);font-size:19px;font-weight:700;
+  color:var(--text-primary);text-decoration:none;
+  font-variant:small-caps;letter-spacing:0.08em;
 }
 .brand-link:hover{color:var(--text-primary);}
+.rule-heavy{height:2.5px;background:var(--text-primary);}
+.rule-hairline{height:1px;background:var(--border);margin-top:3px;}
 .page{max-width:600px;margin:0 auto;padding:var(--space-lg) var(--space-md) 148px;}
 /* Hero (tc-r4n9.7): this reuses the SAME cached OSM map-card PNG served as
    og:image (card.go bakes it once per application; ogimage.go caches it) — this
@@ -31,11 +38,23 @@ body{
   color:var(--text-secondary);letter-spacing:0.01em;
 }
 .brand .dot{width:10px;height:10px;border-radius:9999px;background:var(--amber);}
+/* Filed notice (tc-fmrx3, issue 855): the card's border-top switches to a
+   2px ink rule (not the amber rule used elsewhere) — a document, not a
+   pitch. */
 .card{
   background:var(--surface);border:1px solid var(--border);
+  border-top:2px solid var(--text-primary);
   border-radius:var(--radius-md);padding:var(--space-md);
   box-shadow:0 2px 8px rgba(0,0,0,0.05);
 }
+/* Monospace document-header strip: "No. {ref}" left, authority right, above
+   the address H1. */
+.doc-header{
+  display:flex;align-items:baseline;justify-content:space-between;gap:var(--space-sm);
+  font-family:var(--font-mono);font-size:12px;letter-spacing:0.02em;
+  color:var(--text-secondary);margin-bottom:var(--space-sm);
+}
+.doc-header-authority{text-transform:uppercase;letter-spacing:0.06em;}
 @media (prefers-color-scheme:dark){.card{box-shadow:none;}}
 /* Standard OSM tiles render on a near-white/cream basemap, so the raw hero PNG
    would sit as a jarring bright rectangle on the dark canvas. invert+hue-rotate
@@ -54,14 +73,21 @@ body{
 }
 .meta-label{color:var(--text-secondary);font-weight:500;}
 .meta-value{color:var(--text-primary);font-weight:500;}
-.chip{
-  display:inline-block;margin-bottom:var(--space-md);padding:4px 12px;
-  border-radius:9999px;font-size:13px;font-weight:600;
+/* Status stamp (tc-fmrx3, issue 855): outlined, uppercase, letterspaced,
+   icon + label ALWAYS — colour is never the sole indicator (accessibility
+   invariant). Same three-bucket vocabulary/colours as before, no longer a
+   filled pill. */
+.stamp{
+  display:inline-flex;align-items:center;gap:4px;margin-bottom:var(--space-md);
+  padding:2px var(--space-sm);border:1.5px solid currentColor;border-radius:var(--radius-sm);
+  background:transparent;font-size:11px;font-weight:700;
 }
-.chip--granted{background:var(--status-granted-bg);color:var(--status-granted);}
-.chip--refused{background:var(--status-refused-bg);color:var(--status-refused);}
-.chip--neutral{background:var(--status-neutral-bg);color:var(--status-neutral);}
-h1.address{font-size:24px;line-height:1.25;font-weight:700;margin:0 0 var(--space-md);}
+.stamp-label{text-transform:uppercase;letter-spacing:0.12em;}
+.stamp-icon{flex-shrink:0;}
+.stamp--granted{color:var(--status-granted);}
+.stamp--refused{color:var(--status-refused);}
+.stamp--neutral{color:var(--status-neutral);}
+h1.address{font-family:var(--font-display);font-weight:600;font-size:24px;line-height:1.25;margin:0 0 var(--space-md);}
 .card h2{
   margin:var(--space-lg) 0 var(--space-sm);font-size:13px;font-weight:600;
   text-transform:uppercase;letter-spacing:0.04em;color:var(--text-secondary);
@@ -74,7 +100,7 @@ h1.address{font-size:24px;line-height:1.25;font-weight:700;margin:0 0 var(--spac
 }
 .timeline li:last-child{border-bottom:none;}
 .date-label{color:var(--text-secondary);flex:0 0 auto;}
-.date-value{font-weight:600;}
+.date-value{font-weight:600;font-family:var(--font-mono);}
 .app-cta{margin-top:var(--space-lg);text-align:center;}
 .btn-primary{
   display:block;width:100%;box-sizing:border-box;padding:14px var(--space-md);


### PR DESCRIPTION
## Summary

Restyles the server-rendered share page (`api-go/internal/sharepage/`) as a single "filed notice" and redraws the OG card PNG in the Public Notice v2 palette with a masthead strip, per the R3 slice of the rebrand epic (#848).

Closes #855

- **`page.gohtml`**: header is now a small-caps masthead with a double rule (2.5px heavy rule over a 1px hairline) beneath, mirroring the SPA Navbar / SEO broadsheet restyle (#853/#854). The card is a filed notice: 2px ink top rule, a monospace document-header strip (`No. {ref}` left, authority name right) above the address H1, H1 in the display-serif stack. Status chip is now an outlined stamp (icon + label always — accessibility invariant), still the same three-bucket vocabulary. Key-date values are now monospace, labels stay sans. App CTA / official-record hierarchy (#794 decision 2), sticky mobile CTA bar + desktop column alignment (decision 8), and the authority backlink are all unchanged.
- **`styles.gohtml`**: structural CSS only — colours keep flowing from the generated `tokenVars` include; zero hand-added hex literals (verified by grep; the only `#[0-9a-fA-F]`-shaped matches were GitHub issue references in comments like `#855`, reworded to `issue 855` to avoid ambiguity with the check). Serif stays the `var(--font-display)` fallback stack only — no font asset added to this surface (deliberate, unchanged decision).
- **Dark-mode hero filter**: re-evaluated the existing `filter: invert(90%) hue-rotate(180deg)` map-hero trick against the new warm-dark palette (#852) — still reads acceptably, left unchanged.
- **`card.go`**: fallback (no-map) field is now the v2 paper `designtokens.BackgroundLight` with ink text (was flat amber + white). Added a masthead strip to the map-path card: a paper band + 2px ink rule + tracked "TOWN CRIER" wordmark, using the *existing* embedded goregular/gobold fonts (no new font embedded) — it overlays the already-composited tiles rather than reserving a gap, so the map's centring math and OSM tile budget are untouched. Pin outline switches white → `designtokens.SurfaceLight` (paper); pin fill stays brass. The OSM attribution shade band is untouched.
- **`view.go`**: **not touched.** The stamp only needed the existing `StatusModifier` bucket key — the icon is selected in-template via `{{if eq .StatusModifier ...}}`, so no new view-model field was needed.

## Acceptance criteria

- [x] `go build ./... && go test ./... && go vet ./... && gofmt -l .` all clean (also ran `go test -race ./...` and `golangci-lint run ./...` — both clean)
- [x] Rendered share page for a fixture view model confirms: masthead + double rule, filed-notice card with mono doc-header strip, stamp with icon+label, app CTA visually primary (brass fill), official-record links visually secondary, mobile sticky CTA bar present (verified by rendering the fixture HTML directly, in addition to the test suite)
- [x] Zero new hex literals in the hand-written portion of `styles.gohtml` (grep confirmed; see note above re: issue-number comments)
- [x] OG card: new PNG shows the paper masthead strip + brass pin with paper outline (visually confirmed by rendering to disk during development). No binary golden PNG fixtures exist in this repo — the established convention here is pixel-region/token sampling in Go tests (see `card_test.go`), which I extended rather than introducing a new fixture format. Added an explicit test asserting the `og:image` route still produces byte-identical output across two renders with a nil cache, confirming the caching mechanism (untouched) still holds under the restyle.
- [x] Postcode-dedup and type-label behaviours (#794 Phase 6) still function correctly — untouched, all existing tests green (`TestBuildPageView_PostcodeDeduplication`, `TestAddressIncludesPostcode`, the `Type` meta-row assertion, `TestBuildPageView_AuthorityBacklink`, `TestStatusChip`).

## Note on the OG image "golden" pixel diff

This PR does not carry a binary golden PNG fixture (none existed pre-restyle either) — OG card correctness is asserted via pixel-region/token sampling in `card_test.go` (e.g. masthead band colour, ink rule row, pin outline colour, fallback field colour), which is the existing convention in this file. Anyone diffing the *rendered* PNG output against a prior manual capture will see the pixel colours change (paper masthead strip, paper pin outline, paper fallback field) — that's the intended v2 restyle, not a regression.

## Deviations / things flagged, not fixed

- **Masthead wordmark bug caught and fixed during development, not by the unit tests**: my first pass at the "TOWN CRIER" masthead wordmark tracking used a literal U+2009 (thin space) as the letter separator. Neither embedded Go font (goregular/gobold) has a glyph for U+2009, so it rendered as a visible `.notdef` tofu box between every letter. The pixel-region unit tests (which only sample band/rule colours, not glyph shapes) did not catch this — I found it by rendering the card to a PNG and looking at it. Fixed by switching to a plain ASCII space separator before committing; final commit history includes the fix as its own commit for traceability.
- **Masthead strip scope**: added only to the map-path card (`mapCard`), not the fallback card — the fallback already carries its own centred "Town Crier" wordmark, and the bead's wording ties the strip to "the map + brass pin remain the hero visual below this strip", which only applies when there's a map.
- No #794 Phase 6 gaps found in passing — postcode dedup, type labelling, status vocabulary, and the authority backlink were all already shipped and covered by tests; nothing needed fixing here.

## Test plan

- [x] `cd api-go && go build ./... && go test ./... && go vet ./... && gofmt -l .`
- [x] `go test -race ./...` (1650 tests, all packages)
- [x] `golangci-lint run ./...`
- [ ] Orchestrator visual verification (agent-browser on the local share page + OG PNG inspection) — this is an R-phase PR per instructions, not merging until that passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)