### PR TITLE
feat(ios): Public Notice — anonymous browse (pre-account) surfaces (R4b) (tc-5c0ic)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AccountCTABanner.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AccountCTABanner.swift
@@ -7,6 +7,13 @@ import SwiftUI
 /// say "instant": that's a paid-tier word (free accounts get the weekly
 /// digest only; instant alerts are a paid, server-enforced entitlement
 /// pitched on the wizard's own upsell step, not here).
+///
+/// Public Notice (GH#857/#896): a plain notice-card container (1px
+/// `tcBorder`, `TCCornerRadius.medium`, `tcSurface` background) with a
+/// Fraunces headline — NOT the upsell treatment (no amber border/eyebrow).
+/// On every screen this banner appears on, its own `PrimaryButton` is
+/// already that screen's one filled-amber container (amber-rationing rule);
+/// see the epic's pre-resolved decision on this in GH#896.
 public struct AccountCTABanner: View {
   public enum Copy {
     public static let headline = "Want to know when something changes here?"
@@ -42,8 +49,12 @@ public struct AccountCTABanner: View {
       }
     }
     .padding(TCSpacing.medium)
-    .background(Color.tcSurfaceElevated)
-    .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.large))
+    .background(Color.tcSurface)
+    .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.medium))
+    .overlay(
+      RoundedRectangle(cornerRadius: TCCornerRadius.medium)
+        .strokeBorder(Color.tcBorder, lineWidth: 1)
+    )
     .padding(.horizontal, TCSpacing.medium)
     .padding(.bottom, TCSpacing.small)
   }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousApplicationListView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousApplicationListView.swift
@@ -113,8 +113,13 @@ public struct AnonymousApplicationListView: View {
       .listRowBackground(Color.tcBackground)
     } else {
       ForEach(viewModel.applications) { application in
+        // Filed-notice card (GH#857/#896): `ApplicationListRow` already
+        // applies `NoticeCardStyle` internally — `cardRowInsets()` clears
+        // the List's own row padding/background/separator so the card's
+        // rounded corners and border actually show, mirroring the authed
+        // `ApplicationListView`.
         ApplicationListRow(application: application)
-          .listRowBackground(Color.tcSurface)
+          .cardRowInsets()
           .contentShape(Rectangle())
           .onTapGesture {
             viewModel.selectApplication(application)

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousApplicationSummaryView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousApplicationSummaryView.swift
@@ -13,25 +13,7 @@ struct AnonymousApplicationSummaryView: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: TCSpacing.medium) {
-      HStack {
-        StatusBadgeView(status: application.status)
-        Spacer()
-        Text(application.reference.value)
-          .font(.system(.caption))
-          .foregroundStyle(Color.tcTextSecondary)
-      }
-
-      Text(application.description)
-        .font(.system(.headline, weight: .semibold))
-        .foregroundStyle(Color.tcTextPrimary)
-
-      Label(application.address, systemImage: "mappin.and.ellipse")
-        .font(.system(.body))
-        .foregroundStyle(Color.tcTextSecondary)
-
-      Text("Received \(application.receivedDate.formatted(date: .abbreviated, time: .omitted))")
-        .font(.system(.caption))
-        .foregroundStyle(Color.tcTextTertiary)
+      noticeCard
 
       PrimaryButton {
         onViewFullDetails()
@@ -48,5 +30,37 @@ struct AnonymousApplicationSummaryView: View {
     .background(Color.tcSurfaceElevated)
     .presentationDetents([.medium, .fraction(0.3)])
     .presentationDragIndicator(.visible)
+  }
+
+  // MARK: - Filed-notice card (GH#857/#896)
+
+  private var noticeCard: some View {
+    VStack(alignment: .leading, spacing: TCSpacing.small) {
+      // Mono document-header strip: reference leading, received date
+      // trailing — mirrors `ApplicationListRow`'s mono metadata line.
+      HStack(alignment: .top) {
+        Text(application.reference.value)
+          .font(TCTypography.monoEmphasis)
+        Spacer()
+        Text("Received \(application.receivedDate.formatted(date: .abbreviated, time: .omitted))")
+          .font(TCTypography.mono)
+          .multilineTextAlignment(.trailing)
+      }
+      .foregroundStyle(Color.tcTextSecondary)
+
+      // Stamp status (GH#857) — the same `StatusBadgeView` the R4 restyle
+      // built, never a forked copy.
+      StatusBadgeView(status: application.status)
+
+      Text(application.description)
+        .font(TCTypography.headline)
+        .foregroundStyle(Color.tcTextPrimary)
+
+      Label(application.address, systemImage: "mappin.and.ellipse")
+        .font(TCTypography.body)
+        .foregroundStyle(Color.tcTextSecondary)
+    }
+    .padding(TCSpacing.medium)
+    .noticeCardStyle()
   }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMapView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMapView.swift
@@ -197,7 +197,7 @@ public struct AnonymousMapView: View {
 
     private func pin(for application: PlanningApplication) -> some View {
       Image(systemName: "mappin.circle.fill")
-        .font(.system(.title2))
+        .font(TCTypography.displaySmall)
         .foregroundStyle(application.status.displayColor)
         .background(
           Circle()

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousPostcodeEntryView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousPostcodeEntryView.swift
@@ -31,6 +31,7 @@ struct AnonymousPostcodeEntryView: View {
         .multilineTextAlignment(.center)
 
       TextField(Copy.placeholder, text: $viewModel.postcodeInput)
+        .font(TCTypography.mono)
         .textFieldStyle(.roundedBorder)
         .autocorrectionDisabled()
         #if os(iOS)

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousSettingsView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousSettingsView.swift
@@ -68,9 +68,13 @@ public struct AnonymousSettingsView: View {
       Button {
         onCreateAccount()
       } label: {
+        // Amber rationing (GH#857/#896): this row is a List navigation
+        // action, not a filled CTA container, so it takes the same
+        // tcTextPrimary treatment as the authed SettingsView's "Manage
+        // Subscription" row rather than amber.
         Text("Create free account")
           .font(TCTypography.bodyEmphasis)
-          .foregroundStyle(Color.tcAmber)
+          .foregroundStyle(Color.tcTextPrimary)
       }
       Button {
         onSignIn()
@@ -80,8 +84,7 @@ public struct AnonymousSettingsView: View {
           .foregroundStyle(Color.tcTextPrimary)
       }
     } header: {
-      Text("Account")
-        .font(TCTypography.captionEmphasis)
+      sectionHeader("Account")
     } footer: {
       Text(
         "Create a free account to save applications, set up alerts, and manage watch zones."
@@ -105,8 +108,7 @@ public struct AnonymousSettingsView: View {
           .foregroundStyle(Color.tcTextPrimary)
       }
     } header: {
-      Text("Appearance")
-        .font(TCTypography.captionEmphasis)
+      sectionHeader("Appearance")
     }
   }
 
@@ -123,8 +125,7 @@ public struct AnonymousSettingsView: View {
         }
       }
     } header: {
-      Text("Data Attribution")
-        .font(TCTypography.captionEmphasis)
+      sectionHeader("Data Attribution")
     }
   }
 
@@ -139,8 +140,7 @@ public struct AnonymousSettingsView: View {
         onTermsOfService()
       }
     } header: {
-      Text("Legal")
-        .font(TCTypography.captionEmphasis)
+      sectionHeader("Legal")
     }
   }
 
@@ -157,8 +157,22 @@ public struct AnonymousSettingsView: View {
         SettingsRowStyling.settingCaption(viewModel.appVersion)
       }
     } header: {
-      Text("About")
-        .font(TCTypography.captionEmphasis)
+      sectionHeader("About")
     }
+  }
+
+  // MARK: - Section header styling (GH#857/#896)
+
+  /// Small-caps kerned section label — the same eyebrow/stamp text
+  /// treatment used elsewhere in the design language (``MastheadView``,
+  /// ``StatusBadgeView``), applied here to plain `List` section headers.
+  /// Scoped to this file only: the authenticated `SettingsView` shares row
+  /// chrome via `SettingsRowStyling`, but its section headers are untouched
+  /// by this bead (out of scope — that surface was #857's).
+  private func sectionHeader(_ title: String) -> some View {
+    Text(title)
+      .font(TCTypography.captionEmphasis)
+      .textCase(.uppercase)
+      .kerning(0.6)
   }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/DeviceLocalZoneEditorView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/DeviceLocalZoneEditorView.swift
@@ -69,7 +69,7 @@ public struct DeviceLocalZoneEditorView: View {
       Text("Area Name")
     } footer: {
       Text("A friendly name to identify this area.")
-        .font(.system(.caption))
+        .font(TCTypography.caption)
         .foregroundStyle(Color.tcTextSecondary)
     }
   }
@@ -78,6 +78,7 @@ public struct DeviceLocalZoneEditorView: View {
     Section {
       HStack {
         TextField("Postcode", text: $viewModel.postcodeInput)
+          .font(TCTypography.mono)
           .textContentType(.postalCode)
           .autocorrectionDisabled()
           #if os(iOS)
@@ -97,7 +98,7 @@ public struct DeviceLocalZoneEditorView: View {
       Text("Postcode")
     } footer: {
       Text("Enter a UK postcode to centre this area.")
-        .font(.system(.caption))
+        .font(TCTypography.caption)
         .foregroundStyle(Color.tcTextSecondary)
     }
   }
@@ -105,8 +106,10 @@ public struct DeviceLocalZoneEditorView: View {
   private var radiusSection: some View {
     Section("Radius") {
       VStack(alignment: .leading, spacing: TCSpacing.small) {
+        // Radius values render in mono (GH#857/#896), matching every other
+        // metadata value (postcodes, refs, dates, distances).
         Text(formatRadius(viewModel.selectedRadiusMetres))
-          .font(TCTypography.bodyEmphasis)
+          .font(TCTypography.monoEmphasis)
           .foregroundStyle(Color.tcTextPrimary)
 
         Slider(
@@ -123,7 +126,7 @@ public struct DeviceLocalZoneEditorView: View {
           Spacer()
           Text(formatRadius(viewModel.maxRadiusMetres))
         }
-        .font(TCTypography.caption)
+        .font(TCTypography.mono)
         .foregroundStyle(Color.tcTextSecondary)
       }
     }
@@ -152,7 +155,7 @@ public struct DeviceLocalZoneEditorView: View {
     Section {
       Label {
         Text(error.userMessage)
-          .font(.system(.body))
+          .font(TCTypography.body)
           .foregroundStyle(Color.tcStatusRejected)
       } icon: {
         Image(systemName: "exclamationmark.triangle.fill")

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/DeviceLocalZoneListView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/DeviceLocalZoneListView.swift
@@ -11,6 +11,15 @@ import TownCrierDomain
 /// "instant", since instant alerts are a paid, server-enforced entitlement
 /// (#868/#879 precedent).
 public struct DeviceLocalZoneListView: View {
+  /// Sign-up pitch copy not otherwise covered by an existing shared `Copy`
+  /// enum. The eyebrow is new microcopy introduced by the upsell-card
+  /// treatment (GH#857/#896); exposed here (rather than left inline) so it's
+  /// unit-testable, matching this codebase's convention for CTA-bearing
+  /// views (``AccountCTABanner/Copy``, ``DeviceLocalZoneSignUpCTAView/Copy``).
+  enum Copy {
+    static let eyebrow = "Free Account"
+  }
+
   @StateObject private var viewModel: DeviceLocalZoneListViewModel
 
   public init(viewModel: DeviceLocalZoneListViewModel) {
@@ -21,6 +30,7 @@ public struct DeviceLocalZoneListView: View {
     List {
       if let zone = viewModel.zones.first {
         DeviceLocalZoneRow(zone: zone) { viewModel.requestAlertsSignUp() }
+          .cardRowInsets()
           .contentShape(Rectangle())
           .onTapGesture { viewModel.editZone(zone) }
         signUpPitchSection
@@ -49,17 +59,30 @@ public struct DeviceLocalZoneListView: View {
 
   /// Load-bearing sign-up pitch (GH#888): this is the only remaining route to
   /// another area now the cap is one.
+  ///
+  /// Public Notice (GH#857/#896): styled as the anonymous-mode analogue of
+  /// ``WatchZoneInlineUpsellCard`` — a brass small-caps eyebrow and a 1.5pt
+  /// amber border, no fill. The "Create free account" `PrimaryButton` stays
+  /// the only filled-amber container on this screen (amber-rationing rule).
   private var signUpPitchSection: some View {
     Section {
-      VStack(alignment: .leading, spacing: TCSpacing.small) {
-        Text("Want more areas or alerts?")
-          .font(TCTypography.headline)
-          .foregroundStyle(Color.tcTextPrimary)
-        Text(
-          "Create a free account to save more areas and get notified when things change."
-        )
-        .font(TCTypography.body)
-        .foregroundStyle(Color.tcTextSecondary)
+      VStack(alignment: .leading, spacing: TCSpacing.medium) {
+        VStack(alignment: .leading, spacing: TCSpacing.small) {
+          Text(Copy.eyebrow)
+            .font(TCTypography.captionEmphasis)
+            .textCase(.uppercase)
+            .kerning(1.2)
+            .foregroundStyle(Color.tcAmber)
+
+          Text("Want more areas or alerts?")
+            .font(TCTypography.headline)
+            .foregroundStyle(Color.tcTextPrimary)
+          Text(
+            "Create a free account to save more areas and get notified when things change."
+          )
+          .font(TCTypography.body)
+          .foregroundStyle(Color.tcTextSecondary)
+        }
 
         HStack(spacing: TCSpacing.medium) {
           PrimaryButton("Create free account") { viewModel.requestSignUpFromPitch() }
@@ -69,21 +92,27 @@ public struct DeviceLocalZoneListView: View {
             .foregroundStyle(Color.tcTextSecondary)
         }
       }
-      .padding(.vertical, TCSpacing.small)
+      .padding(TCSpacing.medium)
+      .background(Color.tcSurfaceElevated)
+      .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.medium))
+      .overlay(
+        RoundedRectangle(cornerRadius: TCCornerRadius.medium)
+          .strokeBorder(Color.tcAmber, lineWidth: 1.5)
+      )
     }
-    .listRowBackground(Color.tcSurface)
+    .cardRowInsets()
   }
 
   private var emptyState: some View {
     Section {
       VStack(spacing: TCSpacing.medium) {
         Image(systemName: "mappin.and.ellipse")
-          .font(.system(.largeTitle))
+          .font(TCTypography.displayLarge)
           .foregroundStyle(Color.tcTextTertiary)
         Text("No Area Set Up")
-          .font(.system(.headline).weight(.semibold))
+          .font(TCTypography.headline)
         Text("Complete onboarding to set up your area.")
-          .font(.system(.body))
+          .font(TCTypography.body)
           .foregroundStyle(Color.tcTextSecondary)
           .multilineTextAlignment(.center)
       }
@@ -104,11 +133,14 @@ private struct DeviceLocalZoneRow: View {
         .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.small))
 
       VStack(alignment: .leading, spacing: TCSpacing.extraSmall) {
-        Text(zone.name)
-          .font(.system(.headline).weight(.semibold))
+        // Mono header strip: radius reads as the zone's metadata line, ahead
+        // of its name (GH#857/#896) — mirrors the authed `WatchZoneRow`'s
+        // own strip.
         Text(formatRadius(zone.radiusMetres))
-          .font(.system(.caption))
+          .font(TCTypography.mono)
           .foregroundStyle(Color.tcTextSecondary)
+        Text(zone.name)
+          .font(TCTypography.headline)
       }
 
       Spacer()
@@ -123,10 +155,10 @@ private struct DeviceLocalZoneRow: View {
       .accessibilityLabel("Alerts require a free account")
 
       Image(systemName: "chevron.right")
-        .font(.system(.caption))
+        .font(TCTypography.caption)
         .foregroundStyle(Color.tcTextTertiary)
     }
-    .padding(.vertical, TCSpacing.extraSmall)
-    .listRowBackground(Color.tcSurface)
+    .padding(TCSpacing.medium)
+    .noticeCardStyle()
   }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/DeviceLocalZoneSignUpCTAView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/DeviceLocalZoneSignUpCTAView.swift
@@ -8,8 +8,16 @@ import SwiftUI
 /// ``AccountCTABanner``'s rationale: pitches the account, never promises
 /// more on-device areas (the free tier is one server zone), and never says
 /// "instant" — instant alerts are a paid, server-enforced entitlement.
+///
+/// Public Notice (GH#857/#896): this sheet is one of the two anonymous-mode
+/// surfaces that gets the upsell-card treatment (the other is
+/// ``DeviceLocalZoneListView``'s sign-up pitch section) — a brass small-caps
+/// eyebrow plus a 1.5pt amber border. Amber rationing still holds: the
+/// border + eyebrow are the sheet's only accent besides the "Create free
+/// account" `PrimaryButton`, its one filled-amber container.
 public struct DeviceLocalZoneSignUpCTAView: View {
   public enum Copy {
+    public static let eyebrow = "Free Account"
     public static let headline = "Create a free account"
     public static let subline =
       "Get notified when things change in your areas, and keep them saved beyond this device."
@@ -38,7 +46,14 @@ public struct DeviceLocalZoneSignUpCTAView: View {
         .frame(height: TCSpacing.medium)
 
       Image(systemName: "bell.badge")
-        .font(.system(.largeTitle))
+        .font(TCTypography.displayLarge)
+        .foregroundStyle(Color.tcAmber)
+
+      // Brass small-caps eyebrow (upsell treatment, GH#857/#896).
+      Text(Copy.eyebrow)
+        .font(TCTypography.captionEmphasis)
+        .textCase(.uppercase)
+        .kerning(1.2)
         .foregroundStyle(Color.tcAmber)
 
       Text(Copy.headline)
@@ -76,6 +91,13 @@ public struct DeviceLocalZoneSignUpCTAView: View {
     }
     .padding(.horizontal, TCSpacing.medium)
     .background(Color.tcSurfaceElevated)
+    .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.large))
+    .overlay(
+      // Upsell treatment border (GH#857/#896) — no fill, matching the
+      // design language's "outline carries the accent" rule.
+      RoundedRectangle(cornerRadius: TCCornerRadius.large)
+        .strokeBorder(Color.tcAmber, lineWidth: 1.5)
+    )
   }
 
   // MARK: - Test Helpers

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/WelcomeView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/WelcomeView.swift
@@ -20,7 +20,7 @@ public struct WelcomeView: View {
       Spacer()
 
       Image(systemName: "bell.badge")
-        .font(.system(.largeTitle))
+        .font(TCTypography.displayLarge)
         .foregroundStyle(Color.tcAmber)
 
       Text("Town Crier")
@@ -69,7 +69,7 @@ public struct WelcomeView: View {
       }
     } label: {
       Image(systemName: "circle.lefthalf.filled")
-        .font(.system(.body))
+        .font(TCTypography.body)
         .foregroundStyle(Color.tcTextSecondary)
         // Apple HIG minimum tap target, matching the Buttons component spec.
         .frame(width: 44, height: 44)

--- a/mobile/ios/town-crier-tests/Sources/Features/DeviceLocalZoneListViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/DeviceLocalZoneListViewTests.swift
@@ -49,4 +49,10 @@ struct DeviceLocalZoneListViewTests {
     let sut = DeviceLocalZoneListView(viewModel: vm)
     _ = sut.body
   }
+
+  // MARK: - Sign-up pitch upsell treatment (GH#896)
+
+  @Test func copy_eyebrowMatchesApprovedText() {
+    #expect(DeviceLocalZoneListView.Copy.eyebrow == "Free Account")
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/DeviceLocalZoneSignUpCTAViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/DeviceLocalZoneSignUpCTAViewTests.swift
@@ -12,6 +12,12 @@ struct DeviceLocalZoneSignUpCTAViewTests {
     _ = sut.body
   }
 
+  // MARK: - Upsell treatment (GH#896)
+
+  @Test func copy_eyebrowMatchesApprovedText() {
+    #expect(DeviceLocalZoneSignUpCTAView.Copy.eyebrow == "Free Account")
+  }
+
   @Test func onCreateAccount_isCalled_whenCreateAccountTapped() {
     var called = false
     let sut = DeviceLocalZoneSignUpCTAView(


### PR DESCRIPTION
## Summary

Pure adoption of #857's Public Notice primitives (`NoticeCardStyle`, the `StatusBadgeView`/`ApplicationStatusPill` stamp, `TCTypography` Fraunces/`mono`/`monoEmphasis` roles, `TCCornerRadius`) across the anonymous-browse (pre-account) flow — the surfaces that shipped after epic #848 was specced and were therefore excluded from #857's scope.

- **Typography sweep**: all 17 `.font(.system(...))` call sites across the 6 flagged files move to `TCTypography` roles. Whole-repo `grep -rn '\.font(\.system(' --include='*.swift'` is now **zero**, completing the sweep #857 started outside this directory.
- **WelcomeView**: icon fonts swept (title was already Fraunces `displayLarge`); "Get started" remains the screen's one filled-amber `PrimaryButton`.
- **AnonymousPostcodeEntryView**: entered postcode renders in `mono`.
- **AnonymousApplicationListView**: adopts `cardRowInsets()` so `ApplicationListRow`'s existing `NoticeCardStyle` actually renders as a bordered filed-notice card (previously flattened by `.listRowBackground`). Zone chip + "Add area" chip stay capsules (the deliberate filter-pill exception).
- **AnonymousApplicationSummaryView**: filed-notice card via `NoticeCardStyle` with a mono document-header strip (reference leading, received date trailing — `PlanningApplication` carries no distance field, so the strip's third slot is the date); status via the shared `StatusBadgeView` stamp, unchanged.
- **AnonymousMapView / AnonymousClusteredMapView**: the one remaining font site (macOS fallback pin) now matches the authed `MapView`'s pin exactly (`TCTypography.displaySmall`); the map chrome (amber cluster bubbles, status-coloured pins, amber radius ring) already matched `ClusteredMapView`'s token paths — no changes needed there.
- **AnonymousMainTabView**: already amber-only via `.tint(Color.tcAmber)` — no change needed.
- **AnonymousSettingsView**: section headers get the small-caps kerned eyebrow treatment; "Create free account" sweeps from amber to `tcTextPrimary`, matching how the authed `SettingsView` already treats its equivalent "Manage Subscription" row (a List navigation action, not a filled CTA).
- **DeviceLocalZoneListView**: the zone row becomes a filed-notice card (radius in the mono metadata strip); the sign-up pitch section below it gets the upsell-card treatment (1.5pt amber border + brass small-caps eyebrow), the anonymous-mode analogue of `WatchZoneInlineUpsellCard`.
- **DeviceLocalZoneSignUpCTAView**: same upsell treatment as the pitch section (explicit pre-resolved decision in #896).
- **AccountCTABanner**: becomes a plain notice-card container (1px `tcBorder`, `TCCornerRadius.medium`, `tcSurface`) — deliberately NOT the upsell treatment, since its own `PrimaryButton` is already each banner-bearing screen's one filled-amber container. Placement mechanics (the documented `safeAreaInset`-on-`TabView` workaround) are untouched.
- **DeviceLocalZoneEditorView**: remaining font sites swept; postcode field and radius values (current + min/max) render in mono.

All CTA/product copy is byte-identical to before (#868/#888 decisions). Two new short UI labels were introduced as part of the upsell-card treatment (the "FREE ACCOUNT" eyebrow on both upsell surfaces) since #896 mandates the treatment but doesn't specify exact wording — reused "free account", a phrase already present in each screen's own approved copy. Easy to rename if a different word is preferred.

Closes #896

## Acceptance criteria

- [x] `swift build`, `swift test` green (1817/1817 tests pass)
- [x] `swift-format` clean on every file this PR touches
- [x] `grep -rn '\.font(\.system(' --include='*.swift'` returns **zero** hits repo-wide
- [x] Every status indicator renders icon + label via the shared `StatusBadgeView`/`ApplicationStatusPill` stamp (no forked copy)
- [x] At most one filled-amber container per screen, audited screen-by-screen (see PR notes below)
- [x] Existing Swift Testing suites for AnonymousBrowse pass unchanged; only additions are two new `Copy.eyebrow` tests for the new upsell microcopy (no existing accessibility identifiers/labels changed)
- [x] Every user-facing commit carries a `Release-Note:` trailer
- [ ] `swiftlint lint --strict` — **not fully green at the whole-repo level**: 92 *pre-existing* violations across ~40 files this PR never touches (variable_shadowing, superfluous_disable_command, discouraged_default_parameter). Verified file-by-file that none of the 12 files this PR touches appear in the violation list. Filed as tc-2dxe8 (discovered-from tc-5c0ic) rather than fixed here — out of scope, large blast radius.
- [ ] Subagent mobile-mcp visual verification (signed-out, light/dark/OLED) — reserved for the orchestrator's mandatory R-phase visual pass per this repo's process, not run from this PR.

## Amber-rationing audit (one filled-amber container per screen)

- Welcome: "Get started" `PrimaryButton`
- Postcode entry: "Continue" `PrimaryButton`
- Applications tab: `AccountCTABanner`'s button (zone-picker capsule chips are the acceptance criteria's own carve-out, not counted)
- Map tab: `AccountCTABanner`'s button (cluster bubbles/radius ring are map chrome, not counted)
- Zones tab: sign-up pitch's "Create free account" `PrimaryButton`
- Zone editor sheet: zero filled-amber containers (fine — "at most one")
- Sign-up CTA sheet: "Create free account" `PrimaryButton`
- Settings: zero filled-amber containers (fine)

## Test plan

- [x] `swift test` — full suite, 1817/1817 pass
- [x] `swiftlint lint --strict` / `swift-format --in-place --recursive .` — verified clean on the 12 files this PR touches (see acceptance criteria note on the pre-existing repo-wide debt)
- [ ] Orchestrator-run mobile-mcp visual pass (signed-out / fresh install) before merge, per this repo's R-phase process

Release-Note: The welcome screen, postcode entry, and application summary sheet now match Town Crier's Public Notice look.
Release-Note: The Zones screen and sign-up sheet now match Town Crier's Public Notice look.
Release-Note: The Settings screen now matches Town Crier's Public Notice look.
Release-Note: The area editor and the "Create a free account" banner now match Town Crier's Public Notice look.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved anonymous browsing screens with clearer card-based layouts, updated section headers, and more consistent typography.
  * Added more prominent free-account messaging in signup prompts and empty states.

* **Bug Fixes**
  * Fixed spacing and border rendering so notice cards and list rows display more cleanly and consistently.
  * Standardized several text elements for better readability, including postcode entry, zone details, and map labels.

* **Tests**
  * Added coverage for the new free-account prompt text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->