### PR TITLE
feat(digest): rebrand the digest email to Public Notice (email-safe) (tc-dn6hb)

### DIFF
--- a/api-go/internal/digest/email.go
+++ b/api-go/internal/digest/email.go
@@ -5,13 +5,103 @@ import (
 	"html"
 	"net/url"
 	"strings"
+	"time"
 
+	"github.com/AmyDe/town-crier/api-go/internal/designtokens"
 	"github.com/AmyDe/town-crier/api-go/internal/notifications"
 	"github.com/AmyDe/town-crier/api-go/internal/vocabulary"
 )
 
 // senderAddress is the verified ACS sender address all digest emails are sent from.
 const senderAddress = "hello@towncrierapp.uk"
+
+// Email-safe font stacks (Public Notice, issue 859). Email clients cannot
+// fetch the self-hosted webfonts the rest of the brand uses (Fraunces,
+// Inter), so the digest renders the type system's email-safe fallbacks
+// directly rather than pointing at a font the client will never load:
+// Georgia for headlines (the same fallback `--tc-font-display` names before
+// Fraunces on web), the existing system-sans stack for body copy, and
+// Courier New for the mono reference/date strip.
+const (
+	headlineFontStack = "Georgia, 'Times New Roman', serif"
+	bodyFontStack     = "-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif"
+	monoFontStack     = "'Courier New', monospace"
+)
+
+// pageTemplate is the outer Public Notice shell: a paper-toned page holding a
+// single 600px card, a lettered masthead over a double rule, the per-zone
+// notification blocks, an amber CTA, and a footer with the unsubscribe link.
+// It is light-only by design (the color-scheme/supported-color-schemes meta
+// pair): email client dark-mode colour inversion is unreliable enough that a
+// dark variant is out of scope for v1 (issue 859).
+const pageTemplate = `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width">
+<meta name="color-scheme" content="light">
+<meta name="supported-color-schemes" content="only light">
+</head>
+<body style="margin:0;padding:0;background:%s;font-family:%s;">
+<table width="100%%" cellpadding="0" cellspacing="0" role="presentation"><tr><td align="center" style="padding:24px;">
+<table width="600" cellpadding="0" cellspacing="0" role="presentation" style="background:%s;border:1px solid %s;border-top:2px solid %s;">
+  <tr><td style="background:%s;padding:24px;text-align:center;">
+    <div style="font-size:20px;font-weight:700;color:%s;font-variant:small-caps;letter-spacing:0.06em;">Town Crier</div>
+    <div style="color:%s;font-size:12px;margin-top:6px;text-transform:uppercase;letter-spacing:0.08em;">Live Planning Update</div>
+  </td></tr>
+  <tr><td data-testid="digest-masthead-rule-heavy" style="padding:0;height:3px;line-height:3px;font-size:0;background:%s;">&nbsp;</td></tr>
+  <tr><td data-testid="digest-masthead-rule-hairline" style="padding:0;height:1px;line-height:1px;font-size:0;background:%s;">&nbsp;</td></tr>
+  <tr><td style="padding:24px;">
+    <table width="100%%" cellpadding="0" cellspacing="0" role="presentation">
+      %s
+    </table>
+    <table width="100%%" cellpadding="0" cellspacing="0" role="presentation" style="margin-top:24px;">
+      <tr><td align="center">
+        <a href="https://towncrierapp.uk/applications" style="display:inline-block;background:%s;color:%s;padding:12px 32px;border-radius:6px;text-decoration:none;font-weight:600;">Open Town Crier</a>
+      </td></tr>
+    </table>
+  </td></tr>
+  <tr><td style="padding:16px 24px;text-align:center;color:%s;font-size:12px;border-top:1px solid %s;">
+    %d new application%s · <a href="https://towncrierapp.uk/settings" style="color:%s;">Unsubscribe</a>
+  </td></tr>
+</table>
+</td></tr></table>
+</body></html>`
+
+// sectionHeaderTemplate renders a zone or "Saved Applications" section label.
+const sectionHeaderTemplate = `<tr><td style="padding:16px 0 8px 0;font-size:14px;color:%s;text-transform:uppercase;letter-spacing:0.08em;">
+  %s %s
+</td></tr>
+`
+
+// cardTemplate is one "filed notice" card: a mono doc-header strip, then the
+// headline/type/description lines, each still wrapped in the detail-page
+// link. The per-card background sits one shade deeper than the outer card
+// (paper, not surface), giving each entry definition against the card body.
+const cardTemplate = `<tr><td style="padding:0 0 8px 0;">
+  <table width="100%%" cellpadding="0" cellspacing="0" role="presentation" style="background:%s;border-radius:6px;">
+    %s
+    <tr><td style="padding:12px;">
+      %s
+      %s
+      %s
+    </td></tr>
+  </table>
+</td></tr>`
+
+// docHeaderTemplate is the mono reference/date strip above each card's
+// headline, mirroring the docHeader row on ApplicationCard.tsx (reference
+// left, date right, both mono, a hairline rule beneath).
+const docHeaderTemplate = `<tr><td style="padding:0 0 6px 0;border-bottom:1px solid %s;">
+  <table width="100%%" cellpadding="0" cellspacing="0" role="presentation"><tr>
+    <td align="left" data-testid="digest-notification-reference" style="font-family:%s;font-size:11px;color:%s;">%s</td>
+    <td align="right" data-testid="digest-notification-date" style="font-family:%s;font-size:11px;color:%s;">%s</td>
+  </tr></table>
+</td></tr>`
+
+// decisionChipTemplate and savedIndicatorTemplate are the two "stamp" pills:
+// a solid 1px border in the relevant ink colour, uppercase, letterspaced, and
+// a transparent background (replacing the pre-brand filled chip/badge).
+const decisionChipTemplate = `<span style="display:inline-block;background:transparent;border:1px solid %s;color:%s;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.08em;padding:2px 6px;border-radius:4px;margin-right:6px;">[%s]</span>`
+
+const savedIndicatorTemplate = `<span data-saved-indicator style="display:inline-block;background:transparent;border:1px solid %s;color:%s;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.08em;padding:2px 6px;border-radius:4px;margin-left:6px;">★ saved</span>`
 
 // watchZoneDigest groups a watch zone's display name with the notifications that
 // fell inside it.
@@ -25,10 +115,13 @@ func buildDigestSubject(totalCount int) string {
 	return fmt.Sprintf("Planning update — %d new applications near you", totalCount)
 }
 
-// buildDigestHTML renders the full digest email body: a header, one block per
-// watch zone (each with its application cards), an optional Saved Applications
-// section, a CTA button, and a footer. All user-supplied content is
-// HTML-encoded.
+// buildDigestHTML renders the full digest email body as a Public Notice
+// masthead-and-card layout (issue 859): a paper-toned page, a lettered
+// masthead over a double rule, one filed-notice card per watch zone (plus an
+// optional Saved Applications section), an amber CTA, and a footer carrying
+// the count and the unsubscribe link. All user-supplied content is
+// HTML-encoded. The markup stays table-based with inline styles throughout —
+// email-client reality, no external stylesheet, no flexbox/grid.
 func buildDigestHTML(zoneSections []watchZoneDigest, savedApplications []notifications.DigestNotification, totalCount int) string {
 	var zoneBlocks strings.Builder
 	for _, section := range zoneSections {
@@ -36,11 +129,8 @@ func buildDigestHTML(zoneSections []watchZoneDigest, savedApplications []notific
 		for _, n := range section.notifications {
 			cards.WriteString(buildNotificationCard(n))
 		}
-		fmt.Fprintf(&zoneBlocks,
-			`<tr><td style="padding:16px 0 8px 0;font-size:14px;color:#666;text-transform:uppercase;letter-spacing:0.5px;">
-  📍 %s
-</td></tr>
-%s`, htmlEncode(section.name), cards.String())
+		fmt.Fprintf(&zoneBlocks, sectionHeaderTemplate, designtokens.TextSecondaryLightHex, "📍", htmlEncode(section.name))
+		zoneBlocks.WriteString(cards.String())
 	}
 
 	if len(savedApplications) > 0 {
@@ -48,11 +138,8 @@ func buildDigestHTML(zoneSections []watchZoneDigest, savedApplications []notific
 		for _, n := range savedApplications {
 			savedCards.WriteString(buildNotificationCard(n))
 		}
-		fmt.Fprintf(&zoneBlocks,
-			`<tr><td style="padding:16px 0 8px 0;font-size:14px;color:#666;text-transform:uppercase;letter-spacing:0.5px;">
-  ★ Saved Applications
-</td></tr>
-%s`, savedCards.String())
+		fmt.Fprintf(&zoneBlocks, sectionHeaderTemplate, designtokens.TextSecondaryLightHex, "★", "Saved Applications")
+		zoneBlocks.WriteString(savedCards.String())
 	}
 
 	plural := "s"
@@ -60,50 +147,61 @@ func buildDigestHTML(zoneSections []watchZoneDigest, savedApplications []notific
 		plural = ""
 	}
 
-	return fmt.Sprintf(`<!DOCTYPE html>
-<html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width"></head>
-<body style="margin:0;padding:0;background:#f0f0f0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
-<table width="100%%" cellpadding="0" cellspacing="0"><tr><td align="center" style="padding:24px;">
-<table width="600" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:8px;overflow:hidden;">
-  <tr><td style="background:#1a1a2e;padding:24px;text-align:center;">
-    <div style="font-size:20px;font-weight:700;color:#ffffff;">Town Crier</div>
-    <div style="color:#888;font-size:13px;margin-top:4px;">Live Planning Update</div>
-  </td></tr>
-  <tr><td style="padding:24px;">
-    <table width="100%%" cellpadding="0" cellspacing="0">
-      %s
-    </table>
-    <table width="100%%" cellpadding="0" cellspacing="0" style="margin-top:24px;">
-      <tr><td align="center">
-        <a href="https://towncrierapp.uk/applications" style="display:inline-block;background:#4a6cf7;color:#ffffff;padding:12px 32px;border-radius:6px;text-decoration:none;font-weight:600;">View All in App</a>
-      </td></tr>
-    </table>
-  </td></tr>
-  <tr><td style="padding:16px 24px;text-align:center;color:#999;font-size:12px;border-top:1px solid #eee;">
-    %d new application%s · <a href="https://towncrierapp.uk/settings" style="color:#999;">Unsubscribe</a>
-  </td></tr>
-</table>
-</td></tr></table>
-</body></html>`, zoneBlocks.String(), totalCount, plural)
+	return fmt.Sprintf(pageTemplate,
+		designtokens.BackgroundLightHex, bodyFontStack,
+		designtokens.SurfaceLightHex, designtokens.BorderLightHex, designtokens.TextPrimaryLightHex,
+		designtokens.BackgroundLightHex,
+		designtokens.TextPrimaryLightHex,
+		designtokens.TextSecondaryLightHex,
+		designtokens.TextPrimaryLightHex,
+		designtokens.BorderLightHex,
+		zoneBlocks.String(),
+		designtokens.AmberLightHex, designtokens.TextOnAccentLightHex,
+		designtokens.TextSecondaryLightHex, designtokens.BorderLightHex,
+		totalCount, plural,
+		designtokens.TextSecondaryLightHex,
+	)
 }
 
-// buildNotificationCard renders one application card for the digest body. A
-// decision update prepends the UK display-label badge; a zone notification that
-// is also saved appends a "★ saved" indicator. Each card line links to the
-// application detail page so iOS Universal Links open the app.
+// decisionChipHex maps a UK-facing decision label (vocabulary.UKDisplayString's
+// output) to the status ink colour its outlined stamp renders in, the same
+// status-colour buckets the iOS/Android/web cards use for the same four
+// decision states. An unrecognised label (not currently possible — the four
+// vocabulary outputs are exhaustive) falls back to the primary text colour
+// rather than an unstyled chip.
+func decisionChipHex(label string) string {
+	switch label {
+	case "Approved":
+		return designtokens.StatusPermittedLightHex
+	case "Approved with conditions":
+		return designtokens.StatusConditionsLightHex
+	case "Refused":
+		return designtokens.StatusRejectedLightHex
+	case "Refusal appealed":
+		return designtokens.StatusAppealedLightHex
+	default:
+		return designtokens.TextPrimaryLightHex
+	}
+}
+
+// buildNotificationCard renders one application card for the digest body: a
+// mono reference/date strip, a serif headline (the address, optionally
+// prefixed by the outlined decision-label stamp and suffixed by the outlined
+// "saved" stamp), the application type, and a truncated description. Each
+// line links to the application detail page so iOS Universal Links open the
+// app.
 func buildNotificationCard(n notifications.DigestNotification) string {
 	addressLine := htmlEncode(n.ApplicationAddress)
 	if n.EventType == notifications.EventDecisionUpdate {
 		if label := vocabulary.UKDisplayString(n.Decision); label != "" {
-			addressLine = fmt.Sprintf(
-				`<span style="display:inline-block;background:#eef1ff;color:#1a1a2e;font-size:11px;font-weight:700;letter-spacing:0.5px;padding:2px 6px;border-radius:4px;margin-right:6px;">[%s]</span>%s`,
-				htmlEncode(label), addressLine)
+			hex := decisionChipHex(label)
+			addressLine = fmt.Sprintf(decisionChipTemplate, hex, hex, htmlEncode(label)) + addressLine
 		}
 	}
 
 	savedIndicator := ""
 	if n.WatchZoneID != nil && n.HasSavedSource() {
-		savedIndicator = `<span data-saved-indicator style="display:inline-block;background:#fff3cd;color:#664d03;font-size:11px;font-weight:600;letter-spacing:0.3px;padding:2px 6px;border-radius:4px;margin-left:6px;">★ saved</span>`
+		savedIndicator = fmt.Sprintf(savedIndicatorTemplate, designtokens.AmberLightHex, designtokens.AmberLightHex)
 	}
 
 	appURL := buildApplicationDetailURL(n.ApplicationUID)
@@ -115,18 +213,28 @@ func buildNotificationCard(n notifications.DigestNotification) string {
 		appType = *n.ApplicationType
 	}
 
-	return fmt.Sprintf(`<tr><td style="padding:0 0 8px 0;">
-  <table width="100%%" cellpadding="0" cellspacing="0" style="background:#f8f9fa;border-radius:6px;">
-    <tr><td style="padding:12px;">
-      %s<div style="font-weight:600;color:#1a1a2e;">%s%s</div>%s
-      %s<div style="color:#4a6cf7;font-size:13px;">%s</div>%s
-      %s<div style="color:#666;font-size:13px;margin-top:4px;">%s</div>%s
-    </td></tr>
-  </table>
-</td></tr>`,
-		openLink, addressLine, savedIndicator, closeLink,
-		openLink, htmlEncode(appType), closeLink,
-		openLink, htmlEncode(truncate(n.ApplicationDescription, 120)), closeLink)
+	docHeader := fmt.Sprintf(docHeaderTemplate,
+		designtokens.BorderLightHex,
+		monoFontStack, designtokens.TextSecondaryLightHex, htmlEncode(n.ApplicationUID),
+		monoFontStack, designtokens.TextSecondaryLightHex, formatNotificationDate(n.CreatedAt))
+
+	headline := fmt.Sprintf(`%s<div style="font-family:%s;font-weight:700;color:%s;font-size:15px;">%s%s</div>%s`,
+		openLink, headlineFontStack, designtokens.TextPrimaryLightHex, addressLine, savedIndicator, closeLink)
+
+	typeLine := fmt.Sprintf(`%s<div style="color:%s;font-size:13px;margin-top:4px;">%s</div>%s`,
+		openLink, designtokens.TextSecondaryLightHex, htmlEncode(appType), closeLink)
+
+	descriptionLine := fmt.Sprintf(`%s<div style="color:%s;font-size:13px;margin-top:4px;">%s</div>%s`,
+		openLink, designtokens.TextSecondaryLightHex, htmlEncode(truncate(n.ApplicationDescription, 120)), closeLink)
+
+	return fmt.Sprintf(cardTemplate, designtokens.BackgroundLightHex, docHeader, headline, typeLine, descriptionLine)
+}
+
+// formatNotificationDate renders a notification's CreatedAt as the compact
+// day/short-month/year the Public Notice mono metadata strip uses elsewhere
+// (mirrors ApplicationCard.tsx's formatDate on web).
+func formatNotificationDate(t time.Time) string {
+	return t.Format("2 Jan 2006")
 }
 
 // buildApplicationDetailURL builds the application detail URL, keeping the

--- a/api-go/internal/digest/email_test.go
+++ b/api-go/internal/digest/email_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/AmyDe/town-crier/api-go/internal/designtokens"
 	"github.com/AmyDe/town-crier/api-go/internal/notifications"
 )
 
@@ -137,5 +138,151 @@ func TestBuildApplicationDetailURL_PreservesSlashesEncodesSegments(t *testing.T)
 	gotSpace := buildApplicationDetailURL("19/00 1")
 	if !strings.Contains(gotSpace, "/applications/19/00%201") {
 		t.Errorf("space in segment must be percent-encoded, got %q", gotSpace)
+	}
+}
+
+// --- Public Notice restyle (tc-dn6hb / #859) ---
+
+func TestBuildDigestHTML_NoLegacyBrandHexLiterals(t *testing.T) {
+	t.Parallel()
+	// The pre-brand navy/blue/grey literals must be fully gone: every colour
+	// now comes from designtokens.
+	n := testNotification("19/00123/FUL", "zone-1", "10 High St", "Householder", "Rear extension")
+	zones := []watchZoneDigest{{name: "Home", notifications: []notifications.DigestNotification{n}}}
+	html := buildDigestHTML(zones, nil, 1)
+
+	for _, legacy := range []string{"#1a1a2e", "#4a6cf7", "#f0f0f0", "#eef1ff", "#fff3cd", "#f8f9fa", "#666", "#999", "#888", "#eee"} {
+		if strings.Contains(html, legacy) {
+			t.Errorf("legacy brand-colour literal %q should be gone, got:\n%s", legacy, html)
+		}
+	}
+}
+
+func TestBuildDigestHTML_UsesDesignTokenColours(t *testing.T) {
+	t.Parallel()
+	n := testNotification("19/00123/FUL", "zone-1", "10 High St", "Householder", "Rear extension")
+	zones := []watchZoneDigest{{name: "Home", notifications: []notifications.DigestNotification{n}}}
+	html := buildDigestHTML(zones, nil, 1)
+
+	for _, want := range []string{
+		designtokens.BackgroundLightHex,
+		designtokens.SurfaceLightHex,
+		designtokens.BorderLightHex,
+		designtokens.TextPrimaryLightHex,
+		designtokens.TextSecondaryLightHex,
+		designtokens.AmberLightHex,
+		designtokens.TextOnAccentLightHex,
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("expected design token colour %q in digest HTML, got:\n%s", want, html)
+		}
+	}
+}
+
+func TestBuildDigestHTML_MastheadAndDoubleRule(t *testing.T) {
+	t.Parallel()
+	html := buildDigestHTML(nil, nil, 0)
+
+	if !strings.Contains(html, "Town Crier") {
+		t.Errorf("masthead should render the Town Crier wordmark, got:\n%s", html)
+	}
+	for _, testid := range []string{`data-testid="digest-masthead-rule-heavy"`, `data-testid="digest-masthead-rule-hairline"`} {
+		if !strings.Contains(html, testid) {
+			t.Errorf("masthead double rule missing %q, got:\n%s", testid, html)
+		}
+	}
+}
+
+func TestBuildDigestHTML_CTAIsVerbFirstAmber(t *testing.T) {
+	t.Parallel()
+	html := buildDigestHTML(nil, nil, 0)
+
+	if !strings.Contains(html, "Open Town Crier") {
+		t.Errorf("CTA label should be verb-first (\"Open Town Crier\"), got:\n%s", html)
+	}
+	if strings.Contains(html, "View All in App") {
+		t.Errorf("old non-verb-first CTA label should be gone, got:\n%s", html)
+	}
+	if !strings.Contains(html, "border-radius:6px") {
+		t.Errorf("CTA should have a 6px border radius, got:\n%s", html)
+	}
+}
+
+func TestBuildDigestHTML_HeadlinesUseSerifFallback(t *testing.T) {
+	t.Parallel()
+	n := testNotification("19/00123/FUL", "zone-1", "10 High St", "Householder", "Rear extension")
+	zones := []watchZoneDigest{{name: "Home", notifications: []notifications.DigestNotification{n}}}
+	html := buildDigestHTML(zones, nil, 1)
+
+	if !strings.Contains(html, "Georgia, 'Times New Roman', serif") {
+		t.Errorf("headlines should use the email-safe serif fallback stack, got:\n%s", html)
+	}
+}
+
+func TestBuildDigestHTML_ReferenceAndDateUseMonospace(t *testing.T) {
+	t.Parallel()
+	n := testNotification("19/00123/FUL", "zone-1", "10 High St", "Householder", "Rear extension")
+	zones := []watchZoneDigest{{name: "Home", notifications: []notifications.DigestNotification{n}}}
+	html := buildDigestHTML(zones, nil, 1)
+
+	if !strings.Contains(html, "'Courier New', monospace") {
+		t.Errorf("references/dates should use the Courier New monospace stack, got:\n%s", html)
+	}
+	if !strings.Contains(html, `data-testid="digest-notification-reference"`) {
+		t.Errorf("expected a mono reference element, got:\n%s", html)
+	}
+	if !strings.Contains(html, "1 Feb 2026") {
+		t.Errorf("expected the notification's created date rendered, got:\n%s", html)
+	}
+}
+
+func TestBuildDigestHTML_ChipsAreOutlinedTransparent(t *testing.T) {
+	t.Parallel()
+	n := testNotification("19/0009", "zone-1", "9 Oak Ave", "Householder", "Loft")
+	n.EventType = notifications.EventDecisionUpdate
+	n.Decision = strptr("Permitted")
+	n.Sources = "Zone, Saved"
+	zones := []watchZoneDigest{{name: "Home", notifications: []notifications.DigestNotification{n}}}
+	html := buildDigestHTML(zones, nil, 1)
+
+	if !strings.Contains(html, "background:transparent") {
+		t.Errorf("type chip and saved indicator should have a transparent background, got:\n%s", html)
+	}
+	if !strings.Contains(html, "border:1px solid "+designtokens.StatusPermittedLightHex) {
+		t.Errorf("Approved decision chip should be outlined in the permitted status colour, got:\n%s", html)
+	}
+	if !strings.Contains(html, "border:1px solid "+designtokens.AmberLightHex) {
+		t.Errorf("saved indicator should be outlined in amber, got:\n%s", html)
+	}
+}
+
+func TestBuildDigestHTML_LightOnlyMetaTags(t *testing.T) {
+	t.Parallel()
+	html := buildDigestHTML(nil, nil, 0)
+
+	if !strings.Contains(html, `<meta name="color-scheme" content="light">`) {
+		t.Errorf("expected a light-only color-scheme meta tag, got:\n%s", html)
+	}
+	if !strings.Contains(html, `<meta name="supported-color-schemes" content="only light">`) {
+		t.Errorf("expected an only-light supported-color-schemes hint, got:\n%s", html)
+	}
+}
+
+func TestBuildDigestHTML_StructuralSafety(t *testing.T) {
+	t.Parallel()
+	n := testNotification("19/00123/FUL", "zone-1", "10 High St", "Householder", "Rear extension")
+	zones := []watchZoneDigest{{name: "Home", notifications: []notifications.DigestNotification{n}}}
+	html := buildDigestHTML(zones, nil, 1)
+
+	if got := strings.Count(html, `width="600"`); got != 1 {
+		t.Errorf("expected exactly one 600-wide table, got %d in:\n%s", got, html)
+	}
+	for _, forbidden := range []string{"display:flex", "display: flex", "display:grid", "display: grid", "grid-template", "<img", "@font-face", "fonts.googleapis"} {
+		if strings.Contains(html, forbidden) {
+			t.Errorf("email HTML must not contain %q, got:\n%s", forbidden, html)
+		}
+	}
+	if !strings.Contains(html, "Unsubscribe") || !strings.Contains(html, "towncrierapp.uk/settings") {
+		t.Errorf("expected an unsubscribe link, got:\n%s", html)
 	}
 }


### PR DESCRIPTION
## Summary

Rewrites `api-go/internal/digest/email.go` from the pre-brand navy/blue/grey email into a Public Notice masthead-and-card layout consuming `internal/designtokens` hex constants throughout. Same table-based, inline-styled, light-only email — no template package migration, no dark-mode variant.

Closes #859

## What changed

- **Masthead** replaces the navy header block: `Town Crier` small-caps letterspaced wordmark (mirrors web `Navbar.module.css` `.logo` exactly: `font-variant:small-caps; letter-spacing:0.06em`) on the paper background, over a **double rule** (3px `TextPrimaryLightHex` + 1px `BorderLightHex`, built as two dedicated spacer table rows — the bulletproof email technique, not stacked `border-bottom`s).
- **Card table**: `SurfaceLightHex` background, `1px solid BorderLightHex` border, `2px solid TextPrimaryLightHex` border-top (same pattern as `ApplicationCard.module.css` `.card`).
- **Per-notification "filed notice" cards**: sit on `BackgroundLightHex` (paper), one shade deeper than the surrounding `SurfaceLightHex` card, for definition without a new hex.
- **New mono doc-header strip** (reference left / date right, `'Courier New', monospace`, `TextSecondaryLightHex`) above each card's headline — mirrors `ApplicationCard.tsx`'s `docHeader` (reference + `formatDate`), using data already on `DigestNotification` (`ApplicationUID`, `CreatedAt`). See "Deviations" below — this is the one content addition, not purely restyling.
- **Headlines** (the application address) in `Georgia, 'Times New Roman', serif` — the email-safe Fraunces fallback.
- **CTA**: `AmberLightHex` background, `TextOnAccentLightHex` text, `border-radius:6px`, relabelled **"Open Town Crier"** (was "View All in App" — not verb-first; rewritten per the `voice` skill).
- **Type (decision-label) chip + saved indicator**: restyled from filled badges (`#eef1ff` / `#fff3cd`) to outlined "stamp" pills — `1px solid` border in the relevant ink colour (decision chip: status-permitted/conditions/rejected/appealed hex per label; saved indicator: `AmberLightHex`), uppercase, letterspaced, **transparent background**.
- **Light-only**: `<meta name="color-scheme" content="light">` + `<meta name="supported-color-schemes" content="only light">`. No dark variant, per the issue's pre-resolved decision.
- Zero hand-written brand hex literals remain — every colour comes from `designtokens.*Hex` constants.

## Acceptance criteria

- [x] `go build ./... && go test ./...` green (also ran `go test -race ./...` — 1659 passed across 49 packages)
- [x] `grep -nE '#[0-9a-fA-F]{3,6}' api-go/internal/digest/email.go` → zero matches
- [x] Rendered the digest HTML for a realistic fixture and manually inspected it — see "How I verified the render" below
- [x] Structural email-safety checklist asserted in tests: single 600px table (`TestBuildDigestHTML_StructuralSafety` counts exactly one `width="600"`), no flexbox/grid CSS, no `<img>`/`@font-face`/external font requests, unsubscribe link present. No `<img>` tags exist in the email, so "alt text on any `<img>` tag" is vacuously satisfied (asserted via absence).
- [x] Existing behavioural tests (application counts, saved-indicator logic, unsubscribe URL generation, decision-label badge, HTML-escaping, detail-URL slash preservation) pass **unchanged** — all 5 original test functions kept verbatim and green.

## How I verified the render

Added a scratch `_test.go` (removed before the final commit — not part of the permanent suite) that calls `buildDigestHTML` with a realistic multi-zone/saved-applications/decision-update fixture and writes the HTML to `/tmp/digest-preview.html`. Opened it with the `agent-browser` CLI, took a full-page screenshot, and inspected it directly, then cross-checked computed styles via `agent-browser eval` for every element the acceptance criteria call out:

- Masthead double rule: heavy row `height:3px` / `background-color: rgb(36,32,26)` (`TextPrimaryLightHex`), hairline row `height:1px` / `rgb(218,210,194)` (`BorderLightHex`).
- Card border: `border-top: 2px rgb(36,32,26)` + `border-left: 1px rgb(218,210,194)`.
- Masthead wordmark: `font-variant: small-caps`, `letter-spacing: 1.2px` (0.06em @ 20px), on `rgb(245,240,230)` (paper) vs the card's `rgb(255,253,246)` (surface) — visibly distinct bands.
- Headline: `font-family: Georgia, "Times New Roman", serif`.
- Reference/date: `font-family: "Courier New", monospace`.
- CTA: `background-color: rgb(158,103,9)` (amber), `color: rgb(255,253,248)` (on-accent), `border-radius: 6px`, text `"Open Town Crier"`.
- Decision chip (`[Approved]`): `border-color: rgb(26,125,55)` (status-permitted green), `background-color: rgba(0,0,0,0)` (transparent), `text-transform: uppercase`.
- Saved indicator: `border-color: rgb(158,103,9)` (amber), transparent background.

Screenshot matched every one of the above by eye as well (masthead, double rule, paper/surface layering, serif headlines, mono doc-header, outlined transparent chips, brass CTA all rendering correctly).

## Copy changes (voice skill)

Only the CTA label changed: **"View All in App" → "Open Town Crier"** (verb-first, matches the issue's suggested wording). No other copy touched — subject line, section headers, footer count/unsubscribe text, and application content are all byte-identical to before.

## Deviations / decisions worth a second look

1. **Added a mono reference + date line** (doc-header strip) above each card's headline. This isn't explicitly listed in the issue's closed "same information architecture" enumeration, but the acceptance criteria explicitly ask to visually confirm "mono refs" render — which requires *something* rendered in mono to check. I mirrored the shipped `ApplicationCard.tsx` `docHeader` component (reference left, date right, both mono) using fields already on `DigestNotification` (`ApplicationUID`, `CreatedAt`) — no new data plumbing, no `handler.go`/`payload.go` changes. Flagging this explicitly in case the intent was narrower.
2. Masthead wordmark keeps mixed-case `Town Crier` + `font-variant: small-caps` (matching the web `Navbar` component byte-for-byte) rather than a `text-transform: uppercase` fallback — clients that ignore `font-variant` (many do) degrade gracefully to plain letterspaced mixed-case text rather than a jarring different treatment.
3. Read the "light-only meta" instruction literally: `color-scheme` content is `"light"`, `supported-color-schemes` content is `"only light"`, per the issue's exact wording.

## Out of scope (untouched, per issue)

`handler.go`, `payload.go` (sending-path logic), the plain-text email part, any dark-mode variant, any new images.

## Test plan

- `cd api-go && gofmt -l . && go vet ./... && golangci-lint run ./... && go test -race ./... && go build ./...` — all clean.
- Scope check (`git diff --name-only HEAD $(git merge-base HEAD origin/main)`) touches only `api-go/internal/digest/email.go` and `api-go/internal/digest/email_test.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)