### PR TITLE
chore(ios): bump MARKETING_VERSION 1.2.7 -> 1.2.8 (tc-i2v17)

### DIFF
--- a/mobile/ios/project.yml
+++ b/mobile/ios/project.yml
@@ -26,7 +26,7 @@ targets:
         DEVELOPMENT_TEAM: 4574VQ7N2X
         TARGETED_DEVICE_FAMILY: "1"
         INFOPLIST_GENERATION_MODE: GeneratedFile
-        MARKETING_VERSION: "1.2.7"
+        MARKETING_VERSION: "1.2.8"
         CURRENT_PROJECT_VERSION: "1"
         GENERATE_INFOPLIST_FILE: "YES"
         INFOPLIST_KEY_UIApplicationSceneManifest_Generation: "YES"


### PR DESCRIPTION
## Changes
- Bump `MARKETING_VERSION` `1.2.7` → `1.2.8` in `mobile/ios/project.yml`.

1.2.7 shipped to the live App Store, closing the TestFlight pre-release train. The `cd-ios-testflight` upload failed with altool **error 90186**: "Invalid Pre-Release Train ... version '1.2.7' is closed for new build submissions". Per CLAUDE.md, the CD beta lane only bumps the build number, so the fix is a manual `MARKETING_VERSION` bump. After merge, re-running `cd-ios-testflight` (workflow_dispatch) uploads onto the clean `1.2.8` train.

`CURRENT_PROJECT_VERSION` (build number) is untouched — that's the CD pipeline's responsibility, not this bead's.

Verified `xcodegen generate` regenerates cleanly and `swift build` succeeds after the bump (the generated `.xcodeproj` is gitignored, matching prior version-bump commits — only `project.yml` is committed).

Bead: tc-i2v17

---
*Not merging — reporting back to team lead for review.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the iOS app version to 1.2.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->