### PR TITLE
fix(digest): headline font stack drops serif stand-in, mirrors body sans (tc-b3nki.8)

### DIFF
--- a/api-go/internal/digest/email.go
+++ b/api-go/internal/digest/email.go
@@ -15,15 +15,18 @@ import (
 // senderAddress is the verified ACS sender address all digest emails are sent from.
 const senderAddress = "hello@towncrierapp.uk"
 
-// Email-safe font stacks (Public Notice, issue 859). Email clients cannot
-// fetch the self-hosted webfonts the rest of the brand uses (Fraunces,
-// Inter), so the digest renders the type system's email-safe fallbacks
-// directly rather than pointing at a font the client will never load:
-// Georgia for headlines (the same fallback `--tc-font-display` names before
-// Fraunces on web), the existing system-sans stack for body copy, and
-// Courier New for the mono reference/date strip.
+// Email-safe font stacks (Public Notice, issue 859; sans standardisation,
+// issue 912 phase 5). Email clients cannot fetch the self-hosted webfonts
+// the rest of the brand uses, so the digest renders the type system's
+// email-safe fallbacks directly rather than pointing at a font the client
+// will never load. Headlines and body share one system-sans stack — this
+// surface never rendered the brand's display webfont itself, only a
+// deliberate email-safe serif stand-in, which the 2026-07-10
+// sans-everywhere decision retired along with every other display-serif
+// treatment across the app — and Courier New covers the mono
+// reference/date strip.
 const (
-	headlineFontStack = "Georgia, 'Times New Roman', serif"
+	headlineFontStack = bodyFontStack
 	bodyFontStack     = "-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif"
 	monoFontStack     = "'Courier New', monospace"
 )
@@ -185,7 +188,7 @@ func decisionChipHex(label string) string {
 }
 
 // buildNotificationCard renders one application card for the digest body: a
-// mono reference/date strip, a serif headline (the address, optionally
+// mono reference/date strip, a sans headline (the address, optionally
 // prefixed by the outlined decision-label stamp and suffixed by the outlined
 // "saved" stamp), the application type, and a truncated description. Each
 // line links to the application detail page so iOS Universal Links open the

--- a/api-go/internal/digest/email_test.go
+++ b/api-go/internal/digest/email_test.go
@@ -211,15 +211,17 @@ func TestBuildDigestHTML_CTAIsVerbFirstAmber(t *testing.T) {
 
 func TestBuildDigestHTML_HeadlinesUseSansStack(t *testing.T) {
 	t.Parallel()
+
+	if headlineFontStack != bodyFontStack {
+		t.Errorf("headlineFontStack should equal bodyFontStack, got headlineFontStack=%q bodyFontStack=%q", headlineFontStack, bodyFontStack)
+	}
+
 	n := testNotification("19/00123/FUL", "zone-1", "10 High St", "Householder", "Rear extension")
 	zones := []watchZoneDigest{{name: "Home", notifications: []notifications.DigestNotification{n}}}
 	html := buildDigestHTML(zones, nil, 1)
 
 	if !strings.Contains(html, fmt.Sprintf(`font-family:%s;font-weight:700`, bodyFontStack)) {
-		t.Errorf("headlines should use the sans stack (headlineFontStack == bodyFontStack), got:\n%s", html)
-	}
-	if strings.Contains(html, "Georgia") || strings.Contains(html, "Times New Roman") {
-		t.Errorf("serif fallback should be fully removed, got:\n%s", html)
+		t.Errorf("headlines should render with the sans stack, got:\n%s", html)
 	}
 }
 

--- a/api-go/internal/digest/email_test.go
+++ b/api-go/internal/digest/email_test.go
@@ -1,6 +1,7 @@
 package digest
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -208,14 +209,17 @@ func TestBuildDigestHTML_CTAIsVerbFirstAmber(t *testing.T) {
 	}
 }
 
-func TestBuildDigestHTML_HeadlinesUseSerifFallback(t *testing.T) {
+func TestBuildDigestHTML_HeadlinesUseSansStack(t *testing.T) {
 	t.Parallel()
 	n := testNotification("19/00123/FUL", "zone-1", "10 High St", "Householder", "Rear extension")
 	zones := []watchZoneDigest{{name: "Home", notifications: []notifications.DigestNotification{n}}}
 	html := buildDigestHTML(zones, nil, 1)
 
-	if !strings.Contains(html, "Georgia, 'Times New Roman', serif") {
-		t.Errorf("headlines should use the email-safe serif fallback stack, got:\n%s", html)
+	if !strings.Contains(html, fmt.Sprintf(`font-family:%s;font-weight:700`, bodyFontStack)) {
+		t.Errorf("headlines should use the sans stack (headlineFontStack == bodyFontStack), got:\n%s", html)
+	}
+	if strings.Contains(html, "Georgia") || strings.Contains(html, "Times New Roman") {
+		t.Errorf("serif fallback should be fully removed, got:\n%s", html)
 	}
 }
 


### PR DESCRIPTION
## Changes
- `headlineFontStack` in `api-go/internal/digest/email.go` is now a const alias of `bodyFontStack` (identical sans value) instead of the `Georgia, 'Times New Roman', serif` stand-in used because email clients can't load custom webfonts.
- Rewrote the rationale comment above the font-stack consts and the `buildNotificationCard` doc-comment to explain headline+body now share one sans stack.
- `monoFontStack` (refs/dates/distances) is unchanged.
- Test renamed `TestBuildDigestHTML_HeadlinesUseSerifFallback` → `TestBuildDigestHTML_HeadlinesUseSansStack`, now asserting `headlineFontStack == bodyFontStack`.

Part of the sans-serif standardisation in GH #912 (Phase 5, digest email). Backend-only — no `Release-Note:` trailer.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated digest email headlines to use the same sans-serif font style as the body text.
  * Improved visual consistency across email content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->