### PR TITLE
feat(api): near-point gains sort=recent param (tc-b3nki.2)

### DIFF
--- a/api-go/cmd/api/wiring_test.go
+++ b/api-go/cmd/api/wiring_test.go
@@ -118,6 +118,9 @@ func (fakeAppStore) BreakdownByAuthority(context.Context, string) ([]application
 func (fakeAppStore) FindNearbyPage(context.Context, float64, float64, float64, int, string) ([]applications.PlanningApplication, string, error) {
 	return nil, "", nil
 }
+func (fakeAppStore) RecentNearPoint(context.Context, float64, float64, float64, int) ([]applications.PlanningApplication, error) {
+	return nil, nil
+}
 func (fakeAppStore) FindInZonePage(context.Context, applications.InZoneQuery) ([]applications.PlanningApplication, string, error) {
 	return nil, "", nil
 }

--- a/api-go/internal/applications/nearpoint.go
+++ b/api-go/internal/applications/nearpoint.go
@@ -36,6 +36,20 @@ const (
 	nearPointMaxLimit     = 200
 )
 
+// nearPointSortDistance and nearPointSortRecent are the two ?sort= values GH#912
+// Phase 2 accepts. nearPointSortDistance is the default and preserves the
+// legacy nearest-first KNN behaviour byte-for-byte, including keyset pagination
+// via ?cursor=/X-Next-Cursor. nearPointSortRecent orders by recentRealDateOrder
+// (store_postgres.go) — most-recently-decided, falling back to
+// most-recently-submitted, NULLS LAST — the same real-lifecycle-date ordering
+// #819 introduced for the SEO authority reads, applied here to an
+// authority-agnostic radius read. It does NOT paginate (see RecentNearPoint's
+// doc comment for why): a full page never sets X-Next-Cursor.
+const (
+	nearPointSortDistance = "distance"
+	nearPointSortRecent   = "recent"
+)
+
 // nearPointTimeout bounds a single near-point call end-to-end, matching
 // search.go's searchTimeout: this is a public, unauthenticated endpoint
 // sharing a Postgres pool with prod's core watch-zone/notification reads
@@ -45,12 +59,15 @@ const (
 // clamps above, not a substitute for them.
 const nearPointTimeout = 8 * time.Second
 
-// nearPointStore is the consumer-side store the near-point handler needs: the
-// same generic KNN + ST_DWithin keyset page already used by the authed
-// watch-zone nearby endpoints and the anonymous demo account. *PostgresStore
-// satisfies it structurally.
+// nearPointStore is the consumer-side store the near-point handler needs:
+// FindNearbyPage is the generic KNN + ST_DWithin keyset page already used by
+// the authed watch-zone nearby endpoints and the anonymous demo account
+// (?sort=distance, the default); RecentNearPoint is the real-lifecycle-date
+// ordered, ST_DWithin-filtered single page (?sort=recent, GH#912 Phase 2).
+// *PostgresStore satisfies it structurally.
 type nearPointStore interface {
 	FindNearbyPage(ctx context.Context, latitude, longitude, radiusMetres float64, limit int, cursor string) ([]PlanningApplication, string, error)
+	RecentNearPoint(ctx context.Context, latitude, longitude, radiusMetres float64, limit int) ([]PlanningApplication, error)
 }
 
 // nearPointHandler serves the public applications-near-a-point endpoint.
@@ -73,13 +90,17 @@ func NearPointRoutes(mux *http.ServeMux, store nearPointStore, resolver authorit
 	mux.HandleFunc("GET /v1/applications/near-point", h.nearPoint)
 }
 
-// nearPoint validates lat/lng (required), radius/limit (optional, clamped),
-// and cursor (optional, opaque), then returns one nearest-first page of
-// applications within radius of (lat, lng). A missing/invalid lat/lng or a
-// malformed cursor is a bodyless 400; a store failure is a bodyless 500 (both
-// envelopes backfilled by middleware.ErrorBody). The response body is a bare
-// JSON array of NearbyResult, with the continuation token (when present) in
-// the X-Next-Cursor header — exact parity with the authed nearby list.
+// nearPoint validates lat/lng (required), sort (optional, one of
+// nearPointSortDistance/nearPointSortRecent), radius/limit (optional,
+// clamped), and cursor (optional, opaque — meaningful only for
+// nearPointSortDistance), then returns one page of applications within radius
+// of (lat, lng), ordered per sort. A missing/invalid lat/lng, an unrecognised
+// sort, or a malformed cursor is a bodyless 400; a store failure is a bodyless
+// 500 (both envelopes backfilled by middleware.ErrorBody). The response body
+// is a bare JSON array of NearbyResult, with the continuation token (when
+// present) in the X-Next-Cursor header — exact parity with the authed nearby
+// list for the distance sort; the recent sort never sets it (RecentNearPoint
+// does not paginate, see its doc comment).
 func (h *nearPointHandler) nearPoint(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 
@@ -89,11 +110,19 @@ func (h *nearPointHandler) nearPoint(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	sort, ok := parseNearPointSort(q.Get("sort"))
+	if !ok {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
 	radius := parseNearPointRadius(q.Get("radius"))
 	limit := parseNearPointLimit(q.Get("limit"))
 
 	// decodeNearPointCursor strips the transport-layer base64 wrapping; a
-	// malformed wrapper is a clean 400, never a silent reset to page one.
+	// malformed wrapper is a clean 400, never a silent reset to page one. It
+	// runs unconditionally (even for sort=recent, which ignores the decoded
+	// value) so cursor validation stays uniform and independent of sort.
 	cursor, ok := decodeNearPointCursor(q.Get("cursor"))
 	if !ok {
 		w.WriteHeader(http.StatusBadRequest)
@@ -103,7 +132,16 @@ func (h *nearPointHandler) nearPoint(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), nearPointTimeout)
 	defer cancel()
 
-	apps, nextCursor, err := h.store.FindNearbyPage(ctx, lat, lng, radius, limit, cursor)
+	var (
+		apps       []PlanningApplication
+		nextCursor string
+		err        error
+	)
+	if sort == nearPointSortRecent {
+		apps, err = h.store.RecentNearPoint(ctx, lat, lng, radius, limit)
+	} else {
+		apps, nextCursor, err = h.store.FindNearbyPage(ctx, lat, lng, radius, limit, cursor)
+	}
 	if err != nil {
 		serverError(w, r, h.logger, "find applications near point", err)
 		return
@@ -199,6 +237,25 @@ func parseNearPointLimit(raw string) int {
 		return nearPointMaxLimit
 	}
 	return n
+}
+
+// parseNearPointSort validates the optional ?sort= query param. An empty value
+// or "distance" normalises to nearPointSortDistance (the default, byte-identical
+// to pre-GH#912-Phase-2 behaviour); "recent" normalises to nearPointSortRecent.
+// Any other value is rejected (ok == false) — unlike parseNearPointRadius/
+// parseNearPointLimit, which CLAMP an out-of-range value instead of rejecting
+// it, there is no sensible "nearest legal sort" to clamp an unrecognised value
+// to, so this mirrors parseNearPointCoordinates/decodeNearPointCursor's
+// reject-don't-guess convention instead.
+func parseNearPointSort(raw string) (string, bool) {
+	switch raw {
+	case "", nearPointSortDistance:
+		return nearPointSortDistance, true
+	case nearPointSortRecent:
+		return nearPointSortRecent, true
+	default:
+		return "", false
+	}
 }
 
 // decodeNearPointCursor base64url-decodes an opaque ?cursor= value into the

--- a/api-go/internal/applications/nearpoint_integration_test.go
+++ b/api-go/internal/applications/nearpoint_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"testing"
+	"time"
 )
 
 // TestNearPointHandler_Integration_RealPostGIS drives the full HTTP handler —
@@ -80,5 +81,66 @@ func TestNearPointHandler_Integration_RealPostGIS(t *testing.T) {
 	}
 	if got := rec2.Header().Get("X-Next-Cursor"); got != "" {
 		t.Fatalf("expected empty X-Next-Cursor at exhaustion, got %q", got)
+	}
+}
+
+// TestNearPointHandler_Integration_SortRecent drives the full HTTP handler with
+// ?sort=recent against real PostGIS (GH#912 Phase 2): recentRealDateOrder
+// ordering (including a NULL decided_date row sorting last, NULLS LAST) and the
+// ST_DWithin radius filter both apply, and no X-Next-Cursor header is ever set
+// (RecentNearPoint does not paginate — see its doc comment, store_postgres.go).
+func TestNearPointHandler_Integration_SortRecent(t *testing.T) {
+	// Not run with t.Parallel(): newAppPGStore's pgtest.New holds a
+	// process-wide advisory lock for the test's duration (see pgtest.New).
+	store := newAppPGStore(t)
+	ctx := context.Background()
+
+	decidedRecent := at(pgApp("DECIDED-RECENT", 100), 100)
+	decidedRecent.DecidedDate = pgPtr(time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC))
+
+	startedOnly := at(pgApp("STARTED-ONLY", 100), 200)
+	startedOnly.StartDate = pgPtr(time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC))
+
+	noDates := at(pgApp("NO-DATES", 100), 300) // neither date set: NULLS LAST tail
+
+	farOutsideRadius := at(pgApp("APP-FAR", 100), 50000)
+	farOutsideRadius.DecidedDate = pgPtr(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)) // would sort first if not excluded
+
+	for _, a := range []PlanningApplication{decidedRecent, startedOnly, noDates, farOutsideRadius} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	mux := http.NewServeMux()
+	NearPointRoutes(mux, store, testResolver(), slog.New(slog.DiscardHandler))
+
+	url := "/v1/applications/near-point?lat=" + strconv.FormatFloat(pgCentreLat, 'f', -1, 64) +
+		"&lng=" + strconv.FormatFloat(pgCentreLon, 'f', -1, 64) + "&radius=6000&sort=recent"
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequestWithContext(ctx, http.MethodGet, url, nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	var results []NearbyResult
+	if err := json.Unmarshal(rec.Body.Bytes(), &results); err != nil {
+		t.Fatalf("body not a bare JSON array: %v; body = %s", err, rec.Body.String())
+	}
+	gotNames := make([]string, len(results))
+	for i, r := range results {
+		gotNames[i] = r.Name
+	}
+	want := []string{"DECIDED-RECENT", "STARTED-ONLY", "NO-DATES"}
+	if len(gotNames) != len(want) {
+		t.Fatalf("names = %v, want %v", gotNames, want)
+	}
+	for i := range want {
+		if gotNames[i] != want[i] {
+			t.Fatalf("names = %v, want %v", gotNames, want)
+		}
+	}
+	if got := rec.Header().Get("X-Next-Cursor"); got != "" {
+		t.Fatalf("expected no X-Next-Cursor for sort=recent, got %q", got)
 	}
 }

--- a/api-go/internal/applications/nearpoint_test.go
+++ b/api-go/internal/applications/nearpoint_test.go
@@ -11,7 +11,9 @@ import (
 )
 
 // fakeNearPointStore is a hand-written nearPointStore fake that records the
-// last call's arguments and returns caller-configured results.
+// last call's arguments and returns caller-configured results. It tracks the
+// distance path (FindNearbyPage) and the recent path (RecentNearPoint, GH#912
+// Phase 2) separately, so a test can assert which one the handler routed to.
 type fakeNearPointStore struct {
 	apps       []PlanningApplication
 	nextCursor string
@@ -22,6 +24,15 @@ type fakeNearPointStore struct {
 	calledRadius float64
 	calledLimit  int
 	calledCursor string
+
+	recentApps []PlanningApplication
+	recentErr  error
+
+	recentCalled       bool
+	recentCalledLat    float64
+	recentCalledLng    float64
+	recentCalledRadius float64
+	recentCalledLimit  int
 }
 
 func (f *fakeNearPointStore) FindNearbyPage(_ context.Context, latitude, longitude, radiusMetres float64, limit int, cursor string) ([]PlanningApplication, string, error) {
@@ -34,6 +45,18 @@ func (f *fakeNearPointStore) FindNearbyPage(_ context.Context, latitude, longitu
 		return nil, "", f.err
 	}
 	return f.apps, f.nextCursor, nil
+}
+
+func (f *fakeNearPointStore) RecentNearPoint(_ context.Context, latitude, longitude, radiusMetres float64, limit int) ([]PlanningApplication, error) {
+	f.recentCalled = true
+	f.recentCalledLat = latitude
+	f.recentCalledLng = longitude
+	f.recentCalledRadius = radiusMetres
+	f.recentCalledLimit = limit
+	if f.recentErr != nil {
+		return nil, f.recentErr
+	}
+	return f.recentApps, nil
 }
 
 // newNearPointTestHandler builds a near-point mux wired to the given fake
@@ -382,6 +405,203 @@ func TestNearPointHandler_StoreError(t *testing.T) {
 	h := newNearPointTestHandler(store)
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/applications/near-point?lat=51.5&lng=-0.1", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("body = %q, want empty (bodyless 500)", rec.Body.String())
+	}
+}
+
+// TestParseNearPointSort proves the ?sort= vocabulary: omitted/"distance" is the
+// default (ok, normalised to nearPointSortDistance), "recent" is accepted, and
+// anything else is rejected (ok == false) so the handler can return a clean 400
+// — mirroring parseNearPointCoordinates/decodeNearPointCursor's reject-don't-guess
+// convention rather than the radius/limit clamp-don't-reject convention (GH#912
+// Phase 2: there is no sensible "nearest legal sort" to clamp an unknown value to).
+func TestParseNearPointSort(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		raw      string
+		wantSort string
+		wantOK   bool
+	}{
+		{"empty defaults to distance", "", nearPointSortDistance, true},
+		{"explicit distance", "distance", nearPointSortDistance, true},
+		{"recent", "recent", nearPointSortRecent, true},
+		{"unknown value rejected", "banana", "", false},
+		{"case sensitive: uppercase rejected", "Recent", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := parseNearPointSort(tc.raw)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if ok && got != tc.wantSort {
+				t.Errorf("sort = %q, want %q", got, tc.wantSort)
+			}
+		})
+	}
+}
+
+// TestNearPointHandler_InvalidSortIsBadRequest proves an unrecognised ?sort=
+// value is a bodyless 400 and never reaches either store method (GH#912 Phase 2).
+func TestNearPointHandler_InvalidSortIsBadRequest(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		sort string
+	}{
+		{"unknown word", "banana"},
+		{"wrong case", "Recent"},
+		{"legacy activity sort not accepted here", "recent-activity"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := &fakeNearPointStore{}
+			h := newNearPointTestHandler(store)
+
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+				"/v1/applications/near-point?lat=51.5&lng=-0.1&sort="+tc.sort, nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400", rec.Code)
+			}
+			if rec.Body.Len() != 0 {
+				t.Errorf("body = %q, want empty (bodyless 400)", rec.Body.String())
+			}
+			if store.calledLimit != 0 || store.recentCalled {
+				t.Error("an invalid sort must never reach either store method")
+			}
+		})
+	}
+}
+
+// TestNearPointHandler_SortDistanceIsDefaultAndByteIdentical proves an omitted
+// ?sort= and an explicit ?sort=distance both take the legacy FindNearbyPage path
+// and produce byte-identical response bodies — the acceptance requirement that
+// the API change is fully backward compatible for every existing caller (GH#912
+// Phase 2).
+func TestNearPointHandler_SortDistanceIsDefaultAndByteIdentical(t *testing.T) {
+	t.Parallel()
+
+	app := PlanningApplication{Name: "24/0001/FUL", UID: "uid-1", AreaName: "Testshire", AreaID: 100}
+
+	omittedStore := &fakeNearPointStore{apps: []PlanningApplication{app}}
+	hOmitted := newNearPointTestHandler(omittedStore)
+	reqOmitted := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/applications/near-point?lat=51.5&lng=-0.1", nil)
+	recOmitted := httptest.NewRecorder()
+	hOmitted.ServeHTTP(recOmitted, reqOmitted)
+
+	explicitStore := &fakeNearPointStore{apps: []PlanningApplication{app}}
+	hExplicit := newNearPointTestHandler(explicitStore)
+	reqExplicit := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/applications/near-point?lat=51.5&lng=-0.1&sort=distance", nil)
+	recExplicit := httptest.NewRecorder()
+	hExplicit.ServeHTTP(recExplicit, reqExplicit)
+
+	if recOmitted.Code != http.StatusOK || recExplicit.Code != http.StatusOK {
+		t.Fatalf("status = %d/%d, want 200/200", recOmitted.Code, recExplicit.Code)
+	}
+	if recOmitted.Body.String() != recExplicit.Body.String() {
+		t.Errorf("body mismatch: omitted = %q, explicit = %q", recOmitted.Body.String(), recExplicit.Body.String())
+	}
+	if omittedStore.recentCalled || explicitStore.recentCalled {
+		t.Error("distance sort (default or explicit) must never call RecentNearPoint")
+	}
+}
+
+// TestNearPointHandler_SortRecentCallsRecentNearPoint proves ?sort=recent routes
+// to the store's RecentNearPoint (not FindNearbyPage), passes lat/lng through
+// unchanged, returns the recent-path results as the bare JSON array, and never
+// sets X-Next-Cursor (RecentNearPoint is a single bounded page, mirroring
+// RecentByAuthority/RecentNearestTown — see RecentNearPoint's doc comment).
+func TestNearPointHandler_SortRecentCallsRecentNearPoint(t *testing.T) {
+	t.Parallel()
+
+	app := PlanningApplication{Name: "24/0002/FUL", UID: "uid-2", AreaName: "Testshire", AreaID: 100}
+	store := &fakeNearPointStore{
+		apps:       []PlanningApplication{{Name: "wrong-path", UID: "should-not-appear"}},
+		recentApps: []PlanningApplication{app},
+	}
+	h := newNearPointTestHandler(store)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/applications/near-point?lat=51.5&lng=-0.1&sort=recent", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	if !store.recentCalled {
+		t.Fatal("expected RecentNearPoint to be called")
+	}
+	if store.calledLimit != 0 {
+		t.Error("sort=recent must never call the legacy FindNearbyPage path")
+	}
+	if store.recentCalledLat != 51.5 || store.recentCalledLng != -0.1 {
+		t.Errorf("RecentNearPoint called with (%v, %v), want (51.5, -0.1)", store.recentCalledLat, store.recentCalledLng)
+	}
+
+	var results []NearbyResult
+	if err := json.Unmarshal(rec.Body.Bytes(), &results); err != nil {
+		t.Fatalf("body is not a bare JSON array: %v; body = %s", err, rec.Body.String())
+	}
+	if len(results) != 1 || results[0].Name != app.Name {
+		t.Errorf("results = %+v, want one NearbyResult matching %+v", results, app)
+	}
+	if got := rec.Header().Get("X-Next-Cursor"); got != "" {
+		t.Errorf("X-Next-Cursor = %q, want absent for sort=recent", got)
+	}
+}
+
+// TestNearPointHandler_SortRecentAppliesRadiusAndLimitClamp proves the radius
+// and limit clamps still apply on the recent path exactly as on the distance
+// path (GH#912 Phase 2: "radius clamp [100,5000]/default 2000 and limit clamp
+// [1,200]/default 100 unchanged").
+func TestNearPointHandler_SortRecentAppliesRadiusAndLimitClamp(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeNearPointStore{}
+	h := newNearPointTestHandler(store)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/v1/applications/near-point?lat=51.5&lng=-0.1&sort=recent&radius=9000&limit=500", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	if store.recentCalledRadius != nearPointMaxRadiusMetres {
+		t.Errorf("radius = %v, want clamped max %v", store.recentCalledRadius, nearPointMaxRadiusMetres)
+	}
+	if store.recentCalledLimit != nearPointMaxLimit {
+		t.Errorf("limit = %v, want clamped max %v", store.recentCalledLimit, nearPointMaxLimit)
+	}
+}
+
+// TestNearPointHandler_SortRecentStoreError proves a RecentNearPoint failure is
+// a bodyless 500, mirroring TestNearPointHandler_StoreError for the distance path.
+func TestNearPointHandler_SortRecentStoreError(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeNearPointStore{recentErr: errors.New("boom")}
+	h := newNearPointTestHandler(store)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/applications/near-point?lat=51.5&lng=-0.1&sort=recent", nil)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 

--- a/api-go/internal/applications/store_postgres.go
+++ b/api-go/internal/applications/store_postgres.go
@@ -36,6 +36,7 @@ type Store interface {
 	RecentByAuthority(ctx context.Context, authorityCode string, cap int) ([]PlanningApplication, error)
 	BreakdownByAuthority(ctx context.Context, authorityCode string) ([]StateCount, error)
 	FindNearbyPage(ctx context.Context, latitude, longitude, radiusMetres float64, limit int, cursor string) ([]PlanningApplication, string, error)
+	RecentNearPoint(ctx context.Context, latitude, longitude, radiusMetres float64, limit int) ([]PlanningApplication, error)
 	FindInZonePage(ctx context.Context, q InZoneQuery) ([]PlanningApplication, string, error)
 	FindClustersInZone(ctx context.Context, q ClusterQuery) ([]Cluster, error)
 	RecentNearestTown(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64, siblings []TownCentroid, cap int) ([]PlanningApplication, error)
@@ -328,6 +329,43 @@ func (s *PostgresStore) FindNearbyPage(ctx context.Context, latitude, longitude,
 			return enc, nil
 		},
 		limit, wrap)
+}
+
+// pgRecentNearPointQuery mirrors pgRecentByAuthorityQuery's recentRealDateOrder
+// but is authority-agnostic and radius-bounded (ST_DWithin over nearbyPoint,
+// exactly like findNearbyFirstPageQuery) instead of authority-scoped — the
+// public near-point browse endpoint's ?sort=recent (GH#912 Phase 2). It returns
+// a single ordered page with NO keyset continuation, unlike FindNearbyPage:
+// recentRealDateOrder's primary key, GREATEST(decided_date, start_date), and its
+// secondary key, start_date, are each independently nullable, so a correct
+// keyset predicate needs a per-NULL-combination branch (see statusKeysetQuery
+// and its three siblings in zonepage.go for the shape that takes) for an
+// ordering nothing has needed to paginate before now — RecentByAuthority and
+// RecentNearestTown, the two other recentRealDateOrder call sites, are both
+// single-page cap-only reads too. The near-point recent sort's only consumer
+// (the anonymous browse list, GH#912 Phase 3) fetches one bounded page
+// (<= nearPointMaxLimit), so this mirrors that existing single-page shape
+// rather than building an unused continuation.
+const pgRecentNearPointQuery = "SELECT " + appColumns +
+	" FROM applications WHERE ST_DWithin(location, " + nearbyPoint + ", $3) " +
+	"ORDER BY " + recentRealDateOrder + " LIMIT $4"
+
+// RecentNearPoint returns up to limit applications within radiusMetres of
+// (latitude, longitude), ordered by recentRealDateOrder (most-recently-decided,
+// falling back to most-recently-submitted, NULLS LAST) — the near-point browse
+// endpoint's ?sort=recent (GH#912 Phase 2). It is authority-agnostic like
+// FindNearbyPage, which remains the sole paginated (?sort=distance) path; see
+// pgRecentNearPointQuery for why this one does not paginate.
+func (s *PostgresStore) RecentNearPoint(ctx context.Context, latitude, longitude, radiusMetres float64, limit int) ([]PlanningApplication, error) {
+	rows, err := s.db.Query(ctx, pgRecentNearPointQuery, longitude, latitude, radiusMetres, limit)
+	if err != nil {
+		return nil, fmt.Errorf("recent applications near (%v, %v): %w", latitude, longitude, err)
+	}
+	apps, err := pgx.CollectRows(rows, scanAppRow)
+	if err != nil {
+		return nil, fmt.Errorf("recent applications near (%v, %v): %w", latitude, longitude, err)
+	}
+	return apps, nil
 }
 
 // seoNearbyPoint is the query point for the authority-scoped SEO spatial reads,

--- a/api-go/internal/applications/store_postgres_test.go
+++ b/api-go/internal/applications/store_postgres_test.go
@@ -548,6 +548,60 @@ func TestPostgresStore_FindNearbyPage(t *testing.T) {
 	// APP-FAR (50 km) is excluded by the 6 km radius.
 }
 
+// TestPostgresStore_RecentNearPoint_OrdersByRealDateDescNullsLast proves
+// RecentNearPoint (GH#912 Phase 2, ?sort=recent) orders by recentRealDateOrder —
+// most-recently-decided, falling back to most-recently-submitted, with NULLS
+// LAST on both — while still applying the ST_DWithin radius filter, mirroring
+// TestPostgresStore_RecentByAuthority_OrdersByRealDateDescNullsLast but
+// authority-agnostic and spatially bounded instead of authority-scoped.
+func TestPostgresStore_RecentNearPoint_OrdersByRealDateDescNullsLast(t *testing.T) {
+	ctx := context.Background()
+	store := newAppPGStore(t)
+
+	decidedRecent := at(pgApp("DECIDED-RECENT", 100), 100)
+	decidedRecent.StartDate = pgPtr(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	decidedRecent.DecidedDate = pgPtr(time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC))
+	decidedRecent.LastDifferent = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) // NOT the sort key
+
+	startedOnly := at(pgApp("STARTED-ONLY", 100), 200)
+	startedOnly.StartDate = pgPtr(time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC))
+
+	// Decided but never dated by PlanIt's own re-index marker: must sort on its
+	// real decided_date, not float via LastDifferent (the #819 bug this
+	// ordering exists to avoid).
+	staleReindexed := at(pgApp("STALE-REINDEXED", 100), 300)
+	staleReindexed.StartDate = pgPtr(time.Date(2021, 5, 28, 0, 0, 0, 0, time.UTC))
+	staleReindexed.DecidedDate = pgPtr(time.Date(2021, 7, 9, 0, 0, 0, 0, time.UTC))
+	staleReindexed.LastDifferent = time.Date(2026, 6, 30, 0, 0, 0, 0, time.UTC) // bumped "now"
+
+	noDates := at(pgApp("NO-DATES", 100), 400) // neither start nor decided set: NULLS LAST tail
+
+	farOutsideRadius := at(pgApp("APP-FAR", 100), 50000)
+	farOutsideRadius.DecidedDate = pgPtr(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)) // would sort first if not excluded
+
+	for _, a := range []PlanningApplication{decidedRecent, startedOnly, staleReindexed, noDates, farOutsideRadius} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	got, err := store.RecentNearPoint(ctx, pgCentreLat, pgCentreLon, 6000, 10)
+	if err != nil {
+		t.Fatalf("RecentNearPoint: %v", err)
+	}
+	// DECIDED-RECENT (2026-05-01) > STARTED-ONLY (2026-02-01) > STALE-REINDEXED
+	// (2021-07-09, despite the "now" LastDifferent) > NO-DATES (NULL, NULLS
+	// LAST). APP-FAR is excluded by the 6 km radius despite its 2026-06-01
+	// decided_date, which would otherwise sort it first.
+	assertNames(t, appNames(got), []string{"DECIDED-RECENT", "STARTED-ONLY", "STALE-REINDEXED", "NO-DATES"})
+
+	capped, err := store.RecentNearPoint(ctx, pgCentreLat, pgCentreLon, 6000, 2)
+	if err != nil {
+		t.Fatalf("RecentNearPoint capped: %v", err)
+	}
+	assertNames(t, appNames(capped), []string{"DECIDED-RECENT", "STARTED-ONLY"})
+}
+
 // TestPostgresStore_FindNearbyPage_TieBreak proves the planit_name tie-break
 // keeps keyset pagination correct when two applications share an exact distance.
 func TestPostgresStore_FindNearbyPage_TieBreak(t *testing.T) {


### PR DESCRIPTION
## Changes
- `GET /v1/applications/near-point` gains an optional `sort` query param: `distance` (default, byte-identical to today) | `recent` (`GREATEST(decided_date, start_date) DESC NULLS LAST, start_date DESC NULLS LAST, planit_name`, same `ST_DWithin` radius bound). Invalid value → `400` bodyless, matching the endpoint's existing param-validation convention.
- `internal/applications/nearpoint.go`: new `parseNearPointSort`, dispatches to the existing `FindNearbyPage` (distance) or a new `RecentNearPoint` store method.
- `internal/applications/store_postgres.go`: `RecentNearPoint` query, added to the `Store` and `nearPointStore` interfaces.
- Unit tests (fakes) for both sort values + the invalid-value 400 case; a `pgtest` (`//go:build integration`) test asserting `recent` ordering including NULL `decided_date` rows.
- Radius clamp [100,5000]/default 2000 and limit clamp [1,200]/default 100 unchanged. No new env/secrets.

**Scope note:** `sort=recent` does not paginate (always one bounded page, no `X-Next-Cursor`) — the two independently-nullable ordering columns would need a 3-way keyset predicate, and nothing in GH #912 Phase 2/3 calls for continuation on this sort (iOS Phase 3 treats it as a one-shot fetch). Flag if a future need for infinite-scroll on recent sort surfaces.

**Verification:** `go build`/`vet`/`gofmt`/`golangci-lint` clean, `go test -race ./...` green (1673 tests). Docker wasn't reachable in the dev worktree to exercise `pgtest` locally — CI's Integration tests stage will validate the NULLS LAST ordering for real.

Part of GH #912 (Phase 2, api sort param) — unblocks Phase 3 (iOS anon list sort=recent).

---
*Auto-shipped via ship skill*