### PR TITLE
feat(ios): logged-in polish — masthead dedupe, Saved masthead, zones background, no-space distances (tc-b3nki.1)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/MastheadView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/MastheadView.swift
@@ -2,14 +2,14 @@ import SwiftUI
 
 /// The Public Notice masthead (GH#857): a small-caps wordmark title set over
 /// a double rule, echoing a printed notice's banner. Used on top-level
-/// screen titles — the Applications feed and Watch Zones screens
-/// definitely; other screens adopt it on a case-by-case basis.
+/// screen titles — Applications, Saved, and Watch Zones.
 ///
 /// Rendered as ordinary scrollable content (not a toolbar principal item) so
 /// it composes with the existing `List`-based screens without disturbing
 /// their `.navigationTitle` (still present for VoiceOver/back-button
-/// correctness) or, on the Applications screen, the large-title collapse
-/// animation that a single unambiguous scroll view depends on.
+/// correctness). The system nav bar's own rendered title text is separately
+/// suppressed on each of those screens via `View.mastheadNavigationBar()`
+/// (GH#912 Phase 1), so this masthead row is the single VISIBLE title.
 public struct MastheadView: View {
   public let title: String
 

--- a/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Modifiers/MastheadNavigationBar.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Modifiers/MastheadNavigationBar.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+/// Suppresses the system navigation bar's own rendered title text on
+/// masthead screens (Applications, Saved, Watch Zones — GH#912 Phase 1),
+/// while keeping `.navigationTitle` wired so VoiceOver still announces the
+/// screen and any screen pushed on top still gets a correctly labelled back
+/// button.
+///
+/// `MastheadView`'s doc comment records the original intent: the masthead
+/// row is the sole *visible* title, with the system title kept only for
+/// VoiceOver/back-button correctness. That suppression was never wired up,
+/// so Applications and Watch Zones rendered both titles and Saved never grew
+/// a masthead at all. `.inline` plus an empty `.principal` toolbar item
+/// removes the rendered bar text without touching the underlying
+/// `navigationItem.title` that VoiceOver and the back button read from.
+private struct MastheadNavigationBarModifier: ViewModifier {
+  func body(content: Content) -> some View {
+    content
+      #if os(iOS)
+      .navigationBarTitleDisplayMode(.inline)
+      .toolbar {
+        ToolbarItem(placement: .principal) {
+          Color.clear.frame(width: 0, height: 0)
+        }
+      }
+      #endif
+  }
+}
+
+extension View {
+  /// Applies the masthead-screen navigation bar treatment: `.navigationTitle`
+  /// stays set for accessibility and back-button labelling, but the system's
+  /// own rendered title text is suppressed so the `MastheadView` row in the
+  /// list is the single visible title.
+  public func mastheadNavigationBar() -> some View {
+    modifier(MastheadNavigationBarModifier())
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Modifiers/MastheadNavigationBar.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Modifiers/MastheadNavigationBar.swift
@@ -17,12 +17,12 @@ private struct MastheadNavigationBarModifier: ViewModifier {
   func body(content: Content) -> some View {
     content
       #if os(iOS)
-      .navigationBarTitleDisplayMode(.inline)
-      .toolbar {
-        ToolbarItem(placement: .principal) {
-          Color.clear.frame(width: 0, height: 0)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+          ToolbarItem(placement: .principal) {
+            Color.clear.frame(width: 0, height: 0)
+          }
         }
-      }
       #endif
   }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListView.swift
@@ -3,13 +3,15 @@ import TownCrierDomain
 
 /// Filterable list of planning applications within a watch zone.
 ///
-/// Uses a single `List` as the sole scroll container so that
-/// `.navigationBarTitleDisplayMode(.large)` has one unambiguous
-/// scroll view to track. Previous designs stacked horizontal
-/// `ScrollView`s in a `VStack` above the `List`; the large-title
-/// navigation bar hijacked the first one for its collapse
-/// animation, corrupting its rendering (chips invisible but
-/// still tappable).
+/// Uses a single `List` as the sole scroll container. Previous designs
+/// stacked horizontal `ScrollView`s in a `VStack` above the `List`; back when
+/// this screen used `.navigationBarTitleDisplayMode(.large)`, the large-title
+/// navigation bar hijacked the first scroll view for its collapse animation,
+/// corrupting its rendering (chips invisible but still tappable). The
+/// single-`List` architecture avoids that regardless of title mode, and the
+/// screen now renders `.inline` with the system title suppressed — see
+/// `mastheadNavigationBar()` — so the `MastheadView` row is the single
+/// visible title (GH#912 Phase 1).
 ///
 /// The unread-watermark UI (tc-1nsa.8) layers on:
 /// - an Unread filter chip (visible only when `hasUnread`) that mirrors the
@@ -37,9 +39,7 @@ public struct ApplicationListView: View {
     .scrollContentBackground(.hidden)
     .background(Color.tcBackground)
     .navigationTitle("Applications")
-    #if os(iOS)
-      .navigationBarTitleDisplayMode(.large)
-    #endif
+    .mastheadNavigationBar()
     .toolbar {
       sortToolbarItem
       markAllReadToolbarItem

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/SavedApplicationList/SavedApplicationListView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/SavedApplicationList/SavedApplicationListView.swift
@@ -13,6 +13,7 @@ public struct SavedApplicationListView: View {
 
   public var body: some View {
     List {
+      mastheadRow
       filterRow
       contentRows
     }
@@ -20,15 +21,25 @@ public struct SavedApplicationListView: View {
     .scrollContentBackground(.hidden)
     .background(Color.tcBackground)
     .navigationTitle("Saved")
-    #if os(iOS)
-      .navigationBarTitleDisplayMode(.large)
-    #endif
+    .mastheadNavigationBar()
     .task {
       await viewModel.loadAll()
     }
     .refreshable {
       await viewModel.loadAll()
     }
+  }
+
+  // MARK: - Masthead
+
+  private var mastheadRow: some View {
+    MastheadView(title: "Saved")
+      .padding(.horizontal, TCSpacing.medium)
+      .padding(.top, TCSpacing.small)
+      .padding(.bottom, TCSpacing.extraSmall)
+      .listRowSeparator(.hidden)
+      .listRowInsets(EdgeInsets())
+      .listRowBackground(Color.tcBackground)
   }
 
   // MARK: - Filter Row

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListView.swift
@@ -53,7 +53,11 @@ public struct WatchZoneListView: View {
         }
       }
     }
+    .listStyle(.plain)
+    .scrollContentBackground(.hidden)
+    .background(Color.tcBackground)
     .navigationTitle("Watch Zones")
+    .mastheadNavigationBar()
     .toolbar {
       ToolbarItem(placement: .primaryAction) {
         if viewModel.showUpgradeBadge {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Formatters/RadiusFormatter.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Formatters/RadiusFormatter.swift
@@ -2,17 +2,21 @@ import Foundation
 
 /// Formats a radius in metres for user-facing display.
 ///
-/// - Values under 1000 m show as whole metres (e.g. "500 m").
+/// - Values under 1000 m show as whole metres (e.g. "500m").
 /// - Values of 1000 m or above show as kilometres, with one decimal
-///   place for fractional values (e.g. "1.5 km") and no decimal
-///   for whole values (e.g. "2 km").
+///   place for fractional values (e.g. "1.5km") and no decimal
+///   for whole values (e.g. "2km").
+///
+/// No space before the unit: this string renders in `TCTypography.mono`
+/// (SF Mono), where the space glyph is digit-width and reads as a visible
+/// double space (GH#912 Phase 1).
 public func formatRadius(_ metres: Double) -> String {
   if metres >= 1000 {
     let km = metres / 1000
     if km.truncatingRemainder(dividingBy: 1) == 0 {
-      return "\(Int(km)) km"
+      return "\(Int(km))km"
     }
-    return String(format: "%.1f km", km)
+    return String(format: "%.1fkm", km)
   }
-  return "\(Int(metres)) m"
+  return "\(Int(metres))m"
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/MastheadNavigationBarTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/MastheadNavigationBarTests.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+import Testing
+
+@testable import TownCrierPresentation
+
+/// Regression coverage for `View.mastheadNavigationBar()` (GH#912 Phase 1):
+/// Applications, Saved, and Watch Zones were each rendering both the system
+/// nav-bar title and the `MastheadView` row, doubling the title.
+///
+/// SwiftUI view trees aren't introspectable in this codebase (no
+/// ViewInspector — see `AccountCTABannerHostingTests`), so this is a
+/// construction/render smoke test. The meaningful regression guard is
+/// architectural: every masthead screen calls `.mastheadNavigationBar()`
+/// alongside `.navigationTitle`, asserted directly on those views'
+/// `body_renders` tests.
+@Suite("View.mastheadNavigationBar")
+@MainActor
+struct MastheadNavigationBarTests {
+  @Test func body_renders_onArbitraryContent() {
+    let sut = ProbeContent()
+
+    _ = sut.body
+  }
+}
+
+private struct ProbeContent: View {
+  var body: some View {
+    Text("screen content")
+      .navigationTitle("Probe")
+      .mastheadNavigationBar()
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/RadiusFormattingTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/RadiusFormattingTests.swift
@@ -7,26 +7,26 @@ import Testing
 struct RadiusFormattingTests {
 
   @Test func formatRadius_under1000_showsMetres() {
-    #expect(formatRadius(500) == "500 m")
+    #expect(formatRadius(500) == "500m")
   }
 
   @Test func formatRadius_exactly1000_showsWholeKm() {
-    #expect(formatRadius(1000) == "1 km")
+    #expect(formatRadius(1000) == "1km")
   }
 
   @Test func formatRadius_over1000_wholeKm_showsWholeKm() {
-    #expect(formatRadius(2000) == "2 km")
+    #expect(formatRadius(2000) == "2km")
   }
 
   @Test func formatRadius_fractionalKm_showsOneDecimal() {
-    #expect(formatRadius(1500) == "1.5 km")
+    #expect(formatRadius(1500) == "1.5km")
   }
 
   @Test func formatRadius_5000_shows5Km() {
-    #expect(formatRadius(5000) == "5 km")
+    #expect(formatRadius(5000) == "5km")
   }
 
   @Test func formatRadius_smallValue_shows250m() {
-    #expect(formatRadius(250) == "250 m")
+    #expect(formatRadius(250) == "250m")
   }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/SavedApplicationListViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/SavedApplicationListViewTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import SwiftUI
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+/// View-level regression coverage for the Saved masthead fix (GH#912 Phase
+/// 1): the tab previously showed only the system nav-bar title in the system
+/// font, with no `MastheadView` row wired in at all. `WatchZoneListViewTests`
+/// establishes the pattern this suite mirrors — SwiftUI view trees aren't
+/// introspectable in this codebase (no ViewInspector), so these are
+/// construction/render smoke tests; the meaningful regression guard is
+/// architectural: `SavedApplicationListView.body` now composes a
+/// `mastheadRow` as the first row of the `List`, alongside
+/// `.mastheadNavigationBar()`.
+@Suite("SavedApplicationListView")
+@MainActor
+struct SavedApplicationListViewTests {
+
+  private func makeViewModel() -> (
+    SavedApplicationListViewModel, SpySavedApplicationRepository
+  ) {
+    let repo = SpySavedApplicationRepository()
+    let vm = SavedApplicationListViewModel(savedApplicationRepository: repo)
+    return (vm, repo)
+  }
+
+  @Test func body_renders_whenEmpty() {
+    let (vm, _) = makeViewModel()
+    let sut = SavedApplicationListView(viewModel: vm)
+    _ = sut.body
+  }
+
+  @Test func body_renders_withApplications() async {
+    let (vm, repo) = makeViewModel()
+    repo.loadAllResult = .success([.fixture(uid: "APP-A")])
+    await vm.loadAll()
+
+    let sut = SavedApplicationListView(viewModel: vm)
+    _ = sut.body
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/WatchZoneEditorViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WatchZoneEditorViewTests.swift
@@ -98,17 +98,17 @@ struct WatchZoneEditorViewTests {
     let vm = makeViewModel()
     vm.selectedRadiusMetres = 1500
     // The live label above the slider renders formatRadius(selectedRadiusMetres).
-    #expect(formatRadius(vm.selectedRadiusMetres) == "1.5 km")
+    #expect(formatRadius(vm.selectedRadiusMetres) == "1.5km")
 
     vm.selectedRadiusMetres = 750
-    #expect(formatRadius(vm.selectedRadiusMetres) == "750 m")
+    #expect(formatRadius(vm.selectedRadiusMetres) == "750m")
   }
 
   @Test func endLabelsFormatTierRange() {
     let vm = makeViewModel(tier: .pro)
     // Min label is fixed at the UI floor (100 m); max label tracks tier.
-    #expect(formatRadius(100) == "100 m")
-    #expect(formatRadius(vm.maxRadiusMetres) == "10 km")
+    #expect(formatRadius(100) == "100m")
+    #expect(formatRadius(vm.maxRadiusMetres) == "10km")
   }
 
   // MARK: - Per-zone notification toggles (tc-kh1s)


### PR DESCRIPTION
## Changes
- New `View.mastheadNavigationBar()` ViewModifier (`DesignSystem/Modifiers/MastheadNavigationBar.swift`): sets `.navigationBarTitleDisplayMode(.inline)` + an empty `.principal` toolbar item, applied alongside `.navigationTitle` so VoiceOver/back-button labelling survives but only the masthead row renders visually. Applied to Applications and Watch Zones to fix the doubled title.
- Saved tab gains a masthead row mirroring ApplicationListView's, `MastheadView(title: "Saved")`, plus the same title-suppression fix.
- Watch Zones' `List` gains `.listStyle(.plain)`, `.scrollContentBackground(.hidden)`, `.background(Color.tcBackground)` — the trio Applications/Saved already had — fixing the system-grey background fallback in light mode.
- `RadiusFormatter` drops the space in all three branches: `2km`, `1.5km`, `500m` (was `2 km` etc., which read as a double space in `TCTypography.mono`/SF Mono where the space glyph is digit-width).

`Release-Note: Applications, Saved, and Watch Zones now show a single clean title instead of a doubled-up one, Watch Zones' background is fixed in light mode, and distances read more compactly (2km instead of 2 km).`

Part of GH #912 (Phase 1, iOS logged-in polish).

## Verification
`swift test`: 1820 tests, 233 suites, 0 failures.

Visually verified via mobile-mcp (iOS Simulator, light/dark/OLED dark) against a genuinely clean rebuild:
- **Applications tab**: PASS across all three themes — single visible title, uniform background, no grey strip.
- **Distance formatting**: PASS — confirmed "1.5km"/no-space rendering live on-device (anon Zones tab, which shares the `RadiusFormatter`).
- **Watch Zones' specific background-modifier fix**: NOT directly visually verified — the simulator had no persisted authenticated session (anon browse mode only), and the anon "Zones" tab is backed by a different view (`DeviceLocalZoneListView`) than the authenticated `WatchZoneListView` this fix touches. It reuses the identical `.listStyle(.plain)`/`.scrollContentBackground(.hidden)`/`.background(Color.tcBackground)` trio already visually proven correct on Applications, so confidence is reasonably high, but this is pattern-matching, not a direct on-device check.
- **Saved tab masthead**: NOT directly visually verified for the same no-auth-session reason. Covered by a new `SavedApplicationListViewTests.swift` construction/render smoke test (matching this codebase's established `AccountCTABannerHostingTests` pattern for SwiftUI view-configuration assertions XCTest can't otherwise make).

**Flagging this gap explicitly rather than blocking on it** — a signed-in on-device check of Watch Zones + Saved would close it out; happy to arrange if wanted.

Side-quest filed, not fixed: tc-nbuwq (92 pre-existing `swiftlint --strict` violations in files this bead never touched — confirmed none overlap with this diff).

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent masthead title presentation across Applications, Saved Applications, and Watch Zones screens.
  * Preserved accessibility and back-button labeling while removing duplicate navigation titles.
  * Added a dedicated masthead to the Saved Applications screen.

* **Bug Fixes**
  * Updated distance formatting to use compact units, such as `500m` and `1.5km`.

* **Tests**
  * Added regression coverage for masthead rendering and Saved Applications screen states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->