### PR TITLE
feat(ios): anonymous list requests sort=recent (tc-b3nki.3)

### DIFF
--- a/mobile/ios/packages/town-crier-data/Sources/Repositories/APIAnonymousApplicationsRepository.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Repositories/APIAnonymousApplicationsRepository.swift
@@ -21,7 +21,8 @@ public final class APIAnonymousApplicationsRepository: AnonymousApplicationsRepo
     latitude: Double,
     longitude: Double,
     radiusMetres: Double,
-    limit: Int
+    limit: Int,
+    sort: NearbyApplicationSortOrder
   ) async throws -> [PlanningApplication] {
     let dtos: [PlanningApplicationDTO]
     do {
@@ -36,6 +37,7 @@ public final class APIAnonymousApplicationsRepository: AnonymousApplicationsRepo
             URLQueryItem(name: "lng", value: String(longitude)),
             URLQueryItem(name: "radius", value: String(radiusMetres)),
             URLQueryItem(name: "limit", value: String(limit)),
+            URLQueryItem(name: "sort", value: sort.rawValue),
           ])
       )
     } catch let domainError as DomainError {

--- a/mobile/ios/packages/town-crier-domain/Sources/Protocols/AnonymousApplicationsRepository.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/Protocols/AnonymousApplicationsRepository.swift
@@ -1,15 +1,38 @@
-/// Port for the anonymous (pre-signup) map's data access (GH#868 Phase 3):
-/// fetches planning applications near a point with no account or session,
-/// backed by the public `GET /v1/applications/near-point` endpoint.
+/// Port for the anonymous (pre-signup) map/list's data access (GH#868 Phase
+/// 3): fetches planning applications near a point with no account or
+/// session, backed by the public `GET /v1/applications/near-point` endpoint.
 public protocol AnonymousApplicationsRepository: Sendable {
-  /// Fetches one nearest-first page of planning applications within
-  /// `radiusMetres` of (`latitude`, `longitude`), capped at `limit`. No
-  /// clustering or infinite scroll — the anonymous map is a deliberately
-  /// reduced feature set, so a single bounded page per query is sufficient.
+  /// Fetches one page of planning applications within `radiusMetres` of
+  /// (`latitude`, `longitude`), ordered per `sort` and capped at `limit`. No
+  /// clustering or infinite scroll — the anonymous browse surfaces are a
+  /// deliberately reduced feature set, so a single bounded page per query is
+  /// sufficient.
   func fetchNearby(
     latitude: Double,
     longitude: Double,
     radiusMetres: Double,
-    limit: Int
+    limit: Int,
+    sort: NearbyApplicationSortOrder
   ) async throws -> [PlanningApplication]
+}
+
+extension AnonymousApplicationsRepository {
+  /// Convenience overload preserving the pre-GH#912 call shape: defaults to
+  /// `.distance`, the server's own default and the semantics the anonymous
+  /// map relies on (GH#912 settled decision #5 — `near-point` keeps
+  /// `distance` as default, so the map's existing `fetchNearby(...)` call
+  /// sites need no change).
+  public func fetchNearby(
+    latitude: Double,
+    longitude: Double,
+    radiusMetres: Double,
+    limit: Int
+  ) async throws -> [PlanningApplication] {
+    try await fetchNearby(
+      latitude: latitude,
+      longitude: longitude,
+      radiusMetres: radiusMetres,
+      limit: limit,
+      sort: .distance)
+  }
 }

--- a/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/NearbyApplicationSortOrder.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/NearbyApplicationSortOrder.swift
@@ -1,0 +1,16 @@
+/// The server-supported sort orders for the public, unauthenticated
+/// `GET /v1/applications/near-point` endpoint (GH#912 Phase 2/3). Raw values
+/// are the `?sort=` query vocabulary the API accepts.
+public enum NearbyApplicationSortOrder: String, Sendable, CaseIterable {
+  /// Nearest-first via the KNN `<->` operator. The server's own default —
+  /// the anonymous map relies on this staying byte-for-byte unchanged
+  /// (GH#912 settled decision #5), so it keeps requesting this explicitly
+  /// via ``AnonymousApplicationsRepository``'s no-sort convenience overload.
+  case distance
+  /// `GREATEST(decided_date, start_date) DESC NULLS LAST`, most-recently-
+  /// updated first. The anonymous list's default (GH#912 settled decision
+  /// #3) — deliberately server-side: the list only ever holds a single
+  /// bounded page, so a client-side re-sort would silently swap "most
+  /// recent N" for "nearest N by date".
+  case recent
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousApplicationListViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousApplicationListViewModel.swift
@@ -2,10 +2,16 @@ import Foundation
 import TownCrierDomain
 
 /// Drives the anonymous (pre-signup) Applications tab (GH#879 Phase 3): a
-/// single nearest-first page of planning applications, reusing the same
+/// single page of planning applications, reusing the same
 /// ``ApplicationListRow`` the authenticated Applications tab uses. No
-/// sort/filter chips — matching the pre-resolved v1 scope decision
-/// (nearest-first only; parity can follow if anonymous usage justifies it).
+/// sort/filter chips — matching the pre-resolved v1 scope decision (parity
+/// can follow if anonymous usage justifies it).
+///
+/// GH#912 Phase 3: the fetch requests ``NearbyApplicationSortOrder/recent``
+/// (most-recently-updated-first) rather than the repository's default
+/// `.distance` — a fixed, silent default with no user-facing control (the
+/// anonymous map keeps `.distance`; see ``AnonymousMapViewModel``, which
+/// this change deliberately leaves untouched).
 ///
 /// GH#879 Phase 4: the query is now zone-driven. The persisted active
 /// ``DeviceLocalZone`` supplies the coordinate/radius; a zone picker mirrors
@@ -97,7 +103,8 @@ public final class AnonymousApplicationListViewModel: ObservableObject, ErrorHan
         latitude: latitude,
         longitude: longitude,
         radiusMetres: radiusMetres,
-        limit: Self.defaultLimit
+        limit: Self.defaultLimit,
+        sort: .recent
       )
     } catch {
       applications = []
@@ -121,7 +128,8 @@ public final class AnonymousApplicationListViewModel: ObservableObject, ErrorHan
         latitude: zone.centre.latitude,
         longitude: zone.centre.longitude,
         radiusMetres: zone.radiusMetres,
-        limit: Self.defaultLimit
+        limit: Self.defaultLimit,
+        sort: .recent
       )
     } catch {
       applications = []

--- a/mobile/ios/town-crier-tests/Sources/Features/APIAnonymousApplicationsRepositoryTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APIAnonymousApplicationsRepositoryTests.swift
@@ -158,4 +158,45 @@ struct APIAnonymousApplicationsRepositoryTests {
         latitude: 52.2053, longitude: 0.1218, radiusMetres: 2000, limit: 200)
     }
   }
+
+  // MARK: - sort (GH#912 Phase 3)
+
+  @Test("fetchNearby sends sort=recent when explicitly requested")
+  func fetchNearby_sortRecent_sendsSortQueryParam() async throws {
+    let (sut, transport) = makeSUT(responses: [(Data("[]".utf8), httpResponse(statusCode: 200))])
+
+    _ = try await sut.fetchNearby(
+      latitude: 52.2053, longitude: 0.1218, radiusMetres: 2000, limit: 200, sort: .recent)
+
+    let url = try #require(transport.requests[0].url)
+    let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+    let queryItems = try #require(components.queryItems)
+    #expect(queryItems.contains(URLQueryItem(name: "sort", value: "recent")))
+  }
+
+  @Test("fetchNearby sends sort=distance when explicitly requested")
+  func fetchNearby_sortDistance_sendsSortQueryParam() async throws {
+    let (sut, transport) = makeSUT(responses: [(Data("[]".utf8), httpResponse(statusCode: 200))])
+
+    _ = try await sut.fetchNearby(
+      latitude: 52.2053, longitude: 0.1218, radiusMetres: 2000, limit: 200, sort: .distance)
+
+    let url = try #require(transport.requests[0].url)
+    let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+    let queryItems = try #require(components.queryItems)
+    #expect(queryItems.contains(URLQueryItem(name: "sort", value: "distance")))
+  }
+
+  @Test("fetchNearby without an explicit sort defaults to distance (map-path compatibility)")
+  func fetchNearby_noExplicitSort_defaultsToDistance() async throws {
+    let (sut, transport) = makeSUT(responses: [(Data("[]".utf8), httpResponse(statusCode: 200))])
+
+    _ = try await sut.fetchNearby(
+      latitude: 52.2053, longitude: 0.1218, radiusMetres: 2000, limit: 200)
+
+    let url = try #require(transport.requests[0].url)
+    let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+    let queryItems = try #require(components.queryItems)
+    #expect(queryItems.contains(URLQueryItem(name: "sort", value: "distance")))
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousApplicationListViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousApplicationListViewModelTests.swift
@@ -66,6 +66,18 @@ struct AnonymousApplicationListViewModelTests {
     #expect(sut.applications == [.pendingReview, .permitted])
   }
 
+  /// GH#912 Phase 3: the anon list reads most-recent-first, unlike the anon
+  /// map (which stays distance-ordered — see `AnonymousMapViewModelTests`,
+  /// deliberately untouched by this bead).
+  @Test func loadApplications_requestsRecentSort() async {
+    let (sut, repository, _) = makeSUT()
+    repository.fetchNearbyResult = .success([])
+
+    await sut.loadApplications()
+
+    #expect(repository.fetchNearbyCalls.last?.sort == .recent)
+  }
+
   @Test func loadApplications_setsIsLoadingFalseAfterCompletion() async {
     let (sut, _, _) = makeSUT()
 
@@ -244,6 +256,7 @@ struct AnonymousApplicationListViewModelTests {
     #expect(sut.selectedZone == zoneB)
     #expect(zoneRepository.setActiveZoneIdCalls.last == zoneB.id)
     #expect(repository.fetchNearbyCalls.last?.radiusMetres == 4000)
+    #expect(repository.fetchNearbyCalls.last?.sort == .recent)
     #expect(sut.applications == [.pendingReview])
   }
 

--- a/mobile/ios/town-crier-tests/Sources/Spies/SpyAnonymousApplicationsRepository.swift
+++ b/mobile/ios/town-crier-tests/Sources/Spies/SpyAnonymousApplicationsRepository.swift
@@ -1,23 +1,27 @@
 import Foundation
 import TownCrierDomain
 
-final class SpyAnonymousApplicationsRepository: AnonymousApplicationsRepository, @unchecked Sendable {
+final class SpyAnonymousApplicationsRepository: AnonymousApplicationsRepository, @unchecked Sendable
+{
   struct FetchNearbyCall: Equatable {
     let latitude: Double
     let longitude: Double
     let radiusMetres: Double
     let limit: Int
+    let sort: NearbyApplicationSortOrder
   }
 
   private(set) var fetchNearbyCalls: [FetchNearbyCall] = []
   var fetchNearbyResult: Result<[PlanningApplication], Error> = .success([])
 
   func fetchNearby(
-    latitude: Double, longitude: Double, radiusMetres: Double, limit: Int
+    latitude: Double, longitude: Double, radiusMetres: Double, limit: Int,
+    sort: NearbyApplicationSortOrder
   ) async throws -> [PlanningApplication] {
     fetchNearbyCalls.append(
       FetchNearbyCall(
-        latitude: latitude, longitude: longitude, radiusMetres: radiusMetres, limit: limit))
+        latitude: latitude, longitude: longitude, radiusMetres: radiusMetres, limit: limit,
+        sort: sort))
     return try fetchNearbyResult.get()
   }
 }

--- a/mobile/ios/town-crier-tests/Sources/Spies/SpyAnonymousApplicationsRepository.swift
+++ b/mobile/ios/town-crier-tests/Sources/Spies/SpyAnonymousApplicationsRepository.swift
@@ -1,8 +1,7 @@
 import Foundation
 import TownCrierDomain
 
-final class SpyAnonymousApplicationsRepository: AnonymousApplicationsRepository, @unchecked Sendable
-{
+final class SpyAnonymousApplicationsRepository: AnonymousApplicationsRepository, @unchecked Sendable {
   struct FetchNearbyCall: Equatable {
     let latitude: Double
     let longitude: Double
@@ -15,12 +14,18 @@ final class SpyAnonymousApplicationsRepository: AnonymousApplicationsRepository,
   var fetchNearbyResult: Result<[PlanningApplication], Error> = .success([])
 
   func fetchNearby(
-    latitude: Double, longitude: Double, radiusMetres: Double, limit: Int,
+    latitude: Double,
+    longitude: Double,
+    radiusMetres: Double,
+    limit: Int,
     sort: NearbyApplicationSortOrder
   ) async throws -> [PlanningApplication] {
     fetchNearbyCalls.append(
       FetchNearbyCall(
-        latitude: latitude, longitude: longitude, radiusMetres: radiusMetres, limit: limit,
+        latitude: latitude,
+        longitude: longitude,
+        radiusMetres: radiusMetres,
+        limit: limit,
         sort: sort))
     return try fetchNearbyResult.get()
   }


### PR DESCRIPTION
## Changes
- New `NearbyApplicationSortOrder` enum (`town-crier-domain`) with `distance`/`recent` cases matching the near-point `?sort=` vocabulary.
- `AnonymousApplicationsRepository.fetchNearby` protocol requirement gains a `sort:` param; a protocol-extension convenience overload defaults to `.distance` so `AnonymousMapViewModel.swift` needed zero edits (its 4-arg call sites resolve to the extension default, preserving today's map behaviour byte-for-byte).
- `APIAnonymousApplicationsRepository` appends `?sort=` using the enum's raw value.
- `AnonymousApplicationListViewModel`'s two `fetchNearby` call sites (`loadApplications`, `selectZone`) now pass `sort: .recent`.
- No sort chips or sort UI added — silent default-behaviour change per GH #912's settled decisions.

`Release-Note: Browsing planning applications without an account now shows the most recently updated ones first.`

Part of GH #912 (Phase 3, iOS anon list sort), depends on Phase 2 (#914, merged + deployed to dev).

## Verification
`swift test`: 1824/1824 green. `swiftlint lint --strict` diffed against origin/main baseline: zero new violations. Live sanity check against the dev API confirmed a real ordering difference between `sort=recent` and default.

Visually verified via mobile-mcp (iOS Simulator, anon browse mode — no auth needed for this feature): confirmed the Applications tab renders strictly descending by date (15 Jun → 11 Jun → 21 May → 20 May), Map tab unaffected (pins/clusters/radius slider unchanged, no crash), and no new sort UI anywhere.

---
*Auto-shipped via ship skill*