### PR TITLE
feat(ios): radius at postcode entry + honest anon map (tc-b3nki.4)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousBrowseCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousBrowseCoordinator.swift
@@ -48,10 +48,9 @@ public final class AnonymousBrowseCoordinator: ObservableObject {
   /// `DeviceLocalZoneRepository`'s own docs for the migration relationship
   /// between the two.
   private let deviceLocalZoneRepository: DeviceLocalZoneRepository
-  /// The state backing the current map session, kept in sync with the live
-  /// radius picker so a slider drag re-persists the postcode/coordinate
-  /// alongside the newly chosen radius (GH#868 Phase 3 refinement). Also the
-  /// source for the Applications tab's list view model (GH#879 Phase 3).
+  /// The state backing the current map session — postcode, coordinate, and
+  /// the radius chosen on the postcode-entry screen (GH#912 Phase 4). Also
+  /// the source for the Applications tab's list view model (GH#879 Phase 3).
   private var currentState: AnonymousBrowseState?
   /// The live Applications list view model, cached the first time
   /// ``makeApplicationListViewModel()`` builds one, and returned unchanged on
@@ -276,32 +275,21 @@ public final class AnonymousBrowseCoordinator: ObservableObject {
     onRateApp?()
   }
 
+  /// Seeds the map from `state.radiusMetres` (GH#912 Phase 4: chosen once on
+  /// the postcode-entry screen, no longer re-persisted from a map-slider
+  /// change — the map has no radius control of its own any more; the only
+  /// way to change it afterwards is `DeviceLocalZoneEditorView` on the Zones
+  /// tab, which flows through ``AnonymousMapViewModel/updateActiveZone(_:)``
+  /// instead, via `onZonesChanged` below).
   private func makeMapViewModel(state: AnonymousBrowseState) -> AnonymousMapViewModel {
     let viewModel = AnonymousMapViewModel(
       repository: applicationsRepository,
       coordinate: state.coordinate,
       radiusMetres: state.radiusMetres)
     viewModel.onRequestSignUp = { [weak self] in self?.onRequestSignIn?() }
-    viewModel.onRadiusChanged = { [weak self] radius in self?.persistRadius(radius) }
     viewModel.onShowApplicationDetail = { [weak self] application in
       self?.onShowApplicationDetail?(application)
     }
     return viewModel
-  }
-
-  /// Re-saves the current session's postcode/coordinate with a newly chosen
-  /// radius (GH#868 Phase 3 refinement) so the post-signup handoff into
-  /// onboarding carries whatever the user last picked. No-op if called
-  /// before any state exists (shouldn't happen: the radius picker only shows
-  /// once the map — and therefore `currentState` — exists).
-  private func persistRadius(_ radiusMetres: Double) {
-    guard let state = currentState else { return }
-    let updated = AnonymousBrowseState(
-      postcode: state.postcode,
-      coordinate: state.coordinate,
-      radiusMetres: radiusMetres,
-      createdAt: state.createdAt)
-    currentState = updated
-    stateRepository.save(updated)
   }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousClusteredMapView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousClusteredMapView.swift
@@ -88,14 +88,14 @@
         coordinator.applyRadiusOverlay(
           to: mapView,
           anchor: currentViewModel.anchorCoordinate,
-          radius: currentViewModel.selectedRadiusMetres)
-        // Reframe only when the selected radius actually changed, so a pin
-        // refetch (pan/zoom exploring) never yanks the user's current
-        // viewport back — mirrors `ClusteredMapView.frameCameraIfZoneChanged`.
+          radius: currentViewModel.radiusMetres)
+        // Reframe only when the radius actually changed (an active-zone
+        // switch), so a pin refetch never yanks the user's current viewport
+        // back — mirrors `ClusteredMapView.frameCameraIfZoneChanged`.
         coordinator.reframeIfRadiusChanged(
           on: mapView,
           centre: Self.coordinate(for: currentViewModel.anchorCoordinate),
-          radius: currentViewModel.selectedRadiusMetres)
+          radius: currentViewModel.radiusMetres)
       }
     }
 

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousClusteredMapView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousClusteredMapView.swift
@@ -65,13 +65,13 @@
       coordinator.frameCamera(
         on: mapView,
         centre: Self.coordinate(for: viewModel.anchorCoordinate),
-        radius: viewModel.selectedRadiusMetres,
+        radius: viewModel.radiusMetres,
         animated: false)
       coordinator.syncAnnotations(on: mapView, desired: viewModel.applications)
       coordinator.applyRadiusOverlay(
         to: mapView,
         anchor: viewModel.anchorCoordinate,
-        radius: viewModel.selectedRadiusMetres)
+        radius: viewModel.radiusMetres)
       return mapView
     }
 
@@ -113,10 +113,10 @@
     /// members coincident (or the region is already at its zoom floor), to
     /// ``AnonymousMapViewModel/selectStack(_:)`` — there is no server-side
     /// "stacked/unsplittable" signal here, so the decision is made on-device
-    /// (GH#877). Also renders the radius preview circle and forwards viewport
-    /// changes to
-    /// ``AnonymousMapViewModel/regionDidChange(centreLat:centreLon:radiusMetres:)``,
-    /// which debounces internally.
+    /// (GH#877). Also renders the radius circle. GH#912 Phase 4: panning is
+    /// no longer forwarded to the ViewModel at all — the fetch radius is the
+    /// zone's fixed radius, so a pan/zoom gesture is purely a MapKit camera
+    /// move with no data or overlay side effect.
     @MainActor
     final class Coordinator: NSObject, MKMapViewDelegate {
       private let viewModel: AnonymousMapViewModel
@@ -286,19 +286,6 @@
         } else if let point = annotation as? AnonymousApplicationAnnotation {
           viewModel.selectApplication(point.application)
         }
-      }
-
-      func mapView(_ mapView: MKMapView, regionDidChangeAnimated animated: Bool) {
-        // `AnonymousMapViewModel.regionDidChange` debounces internally
-        // (cancels/reschedules its own pending fetch), so forwarding every
-        // intermediate `regionDidChangeAnimated` call here still collapses to
-        // one fetch once a pan/zoom gesture settles.
-        let region = mapView.region
-        let span = max(region.span.latitudeDelta, region.span.longitudeDelta)
-        viewModel.regionDidChange(
-          centreLat: region.center.latitude,
-          centreLon: region.center.longitude,
-          radiusMetres: span * 111_320 / 2)
       }
 
       func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMapView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMapView.swift
@@ -62,31 +62,31 @@ public struct AnonymousMapView: View {
         }
       #endif
       .sheet(
-      item: Binding(
-        get: { viewModel.selectedApplication },
-        set: { _ in viewModel.clearSelection() }
-      ),
-      onDismiss: { viewModel.presentPendingDetailIfNeeded() },
-      content: { application in
-        AnonymousApplicationSummaryView(application: application) {
-          viewModel.requestFullDetail()
+        item: Binding(
+          get: { viewModel.selectedApplication },
+          set: { _ in viewModel.clearSelection() }
+        ),
+        onDismiss: { viewModel.presentPendingDetailIfNeeded() },
+        content: { application in
+          AnonymousApplicationSummaryView(application: application) {
+            viewModel.requestFullDetail()
+          }
         }
-      }
-    )
-    // Disambiguation list for a coincident ("stacked") cluster tap (GH#877).
-    // Its `onDismiss` presents the chosen row's summary, so the list always
-    // finishes dismissing before the summary appears — the two `.sheet`s are
-    // never both up (mirrors `MapView.swift`).
-    .sheet(
-      item: Binding(
-        get: { viewModel.stackedApplications },
-        set: { _ in viewModel.clearStack() }
-      ),
-      onDismiss: { viewModel.presentPendingSummaryIfNeeded() },
-      content: { stacked in
-        StackedApplicationsSheet(stacked: stacked, onSelect: viewModel.selectFromStack)
-      }
-    )
+      )
+      // Disambiguation list for a coincident ("stacked") cluster tap (GH#877).
+      // Its `onDismiss` presents the chosen row's summary, so the list always
+      // finishes dismissing before the summary appears — the two `.sheet`s are
+      // never both up (mirrors `MapView.swift`).
+      .sheet(
+        item: Binding(
+          get: { viewModel.stackedApplications },
+          set: { _ in viewModel.clearStack() }
+        ),
+        onDismiss: { viewModel.presentPendingSummaryIfNeeded() },
+        content: { stacked in
+          StackedApplicationsSheet(stacked: stacked, onSelect: viewModel.selectFromStack)
+        }
+      )
   }
 
   // MARK: - Map body

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMapView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMapView.swift
@@ -4,10 +4,9 @@ import TownCrierDomain
 
 /// The Map tab of the anonymous (pre-signup) tab shell (GH#868 Phase 3;
 /// promoted from the sole anonymous screen to a tab in GH#879 Phase 3).
-/// Centred on the stored coordinate, fetches pins via
-/// ``AnonymousMapViewModel``, clusters them on-device (GH#868 Phase 3
-/// refinement), and pins a live monitoring-radius picker over the bottom
-/// safe area. The persistent ``AccountCTABanner`` is hosted once by
+/// Centred on the active device-local zone's coordinate, fetches pins via
+/// ``AnonymousMapViewModel``, and clusters them on-device (GH#868 Phase 3
+/// refinement). The persistent ``AccountCTABanner`` is hosted once by
 /// `AnonymousMainTabView` above the tab bar (GH#879 Phase 3) rather than
 /// here, so it appears over every tab, not just this one. A pin tap shows a
 /// reduced-feature summary preview; a cluster tap zooms in, unless its
@@ -15,6 +14,14 @@ import TownCrierDomain
 /// ``StackedApplicationsSheet`` disambiguation list instead (GH#877);
 /// anything deeper than the summary preview presents the full detail screen
 /// (GH#879 Phase 2).
+///
+/// GH#912 Phase 4 ("honest anon map"): the radius slider that used to float
+/// over the bottom safe area is gone — the monitoring radius is now chosen
+/// once, on the postcode-entry screen (``AnonymousPostcodeEntryView``), and
+/// afterwards only editable via `DeviceLocalZoneEditorView` on the Zones
+/// tab. The map is now a pure viewer: its drawn circle always exactly
+/// matches the actual `near-point` fetch boundary (``AnonymousMapViewModel/radiusMetres``),
+/// and panning never changes it.
 ///
 /// On iOS, pins render via ``AnonymousClusteredMapView`` (`MKMapView` +
 /// MapKit's built-in client-side clustering — near-point returns at most 200
@@ -37,27 +44,24 @@ public struct AnonymousMapView: View {
             center: CLLocationCoordinate2D(
               latitude: viewModel.anchorCoordinate.latitude,
               longitude: viewModel.anchorCoordinate.longitude),
-            latitudinalMeters: viewModel.selectedRadiusMetres * 2.5,
-            longitudinalMeters: viewModel.selectedRadiusMetres * 2.5
+            latitudinalMeters: viewModel.radiusMetres * 2.5,
+            longitudinalMeters: viewModel.radiusMetres * 2.5
           )))
     #endif
   }
 
   public var body: some View {
-    ZStack(alignment: .bottom) {
-      mapBody
-      radiusPickerCard
-    }
-    .background(Color.tcBackground)
-    .task { await viewModel.loadInitial() }
-    #if !canImport(UIKit)
-      .onChange(of: viewModel.selectedRadiusMetres) { _, _ in
-        withAnimation {
-          updateCameraPosition()
+    mapBody
+      .background(Color.tcBackground)
+      .task { await viewModel.loadInitial() }
+      #if !canImport(UIKit)
+        .onChange(of: viewModel.radiusMetres) { _, _ in
+          withAnimation {
+            updateCameraPosition()
+          }
         }
-      }
-    #endif
-    .sheet(
+      #endif
+      .sheet(
       item: Binding(
         get: { viewModel.selectedApplication },
         set: { _ in viewModel.clearSelection() }
@@ -83,51 +87,6 @@ public struct AnonymousMapView: View {
         StackedApplicationsSheet(stacked: stacked, onSelect: viewModel.selectFromStack)
       }
     )
-  }
-
-  // MARK: - Radius picker
-
-  /// Live monitoring-radius `Slider`, mirroring `RadiusPickerStepView`'s
-  /// paradigm (same `formatRadius` label, `tcAmber` tint) so the anonymous
-  /// preview and the post-signup wizard feel like one continuous control.
-  ///
-  /// GH#879 Phase 4 screen-space note: this card previously stacked its
-  /// value label above the slider inside `TCSpacing.medium` padding on all
-  /// sides — combined with the CTA banner and tab bar, sim verification
-  /// found the three together ate roughly 45% of the Map screen. Collapsing
-  /// the label and slider onto a single row, with tighter vertical padding,
-  /// meaningfully reduces that footprint without losing the ability to
-  /// adjust the radius from the map. It still previews the free-tier zone
-  /// size for the onboarding handoff (`AnonymousBrowseState`) rather than
-  /// writing through to the active `DeviceLocalZone` — that deeper question
-  /// (tc-zagg4) was assessed as more than a small change for this bead.
-  private var radiusPickerCard: some View {
-    HStack(spacing: TCSpacing.small) {
-      Text(formatRadius(viewModel.selectedRadiusMetres))
-        .font(TCTypography.captionEmphasis)
-        .foregroundStyle(Color.tcTextPrimary)
-        .frame(minWidth: 52, alignment: .leading)
-        .accessibilityHidden(true)
-
-      Slider(
-        value: Binding(
-          get: { viewModel.selectedRadiusMetres },
-          set: { viewModel.updateSelectedRadius($0) }
-        ),
-        in: AnonymousMapViewModel.minSelectedRadiusMetres...AnonymousMapViewModel
-          .maxSelectedRadiusMetres,
-        step: 100
-      )
-      .tint(Color.tcAmber)
-      .accessibilityLabel("Monitoring radius")
-      .accessibilityValue(formatRadius(viewModel.selectedRadiusMetres))
-    }
-    .padding(.horizontal, TCSpacing.medium)
-    .padding(.vertical, TCSpacing.small)
-    .background(Color.tcSurfaceElevated)
-    .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.large))
-    .padding(.horizontal, TCSpacing.medium)
-    .padding(.bottom, TCSpacing.small)
   }
 
   // MARK: - Map body
@@ -177,22 +136,12 @@ public struct AnonymousMapView: View {
             latitude: viewModel.anchorCoordinate.latitude,
             longitude: viewModel.anchorCoordinate.longitude
           ),
-          radius: viewModel.selectedRadiusMetres
+          radius: viewModel.radiusMetres
         )
         .foregroundStyle(Color.tcAmber.opacity(0.08))
         .stroke(Color.tcAmber.opacity(0.3), lineWidth: 1.5)
       }
       .mapStyle(.standard(elevation: .flat))
-      .onMapCameraChange(frequency: .onEnd) { context in
-        let span = max(context.region.span.latitudeDelta, context.region.span.longitudeDelta)
-        viewModel.regionDidChange(
-          centreLat: context.region.center.latitude,
-          centreLon: context.region.center.longitude,
-          // Half the span's on-the-ground metres, matching MapViewModel's own
-          // degrees-to-metres approximation for a rough "visible radius".
-          radiusMetres: span * 111_320 / 2
-        )
-      }
     }
 
     private func pin(for application: PlanningApplication) -> some View {
@@ -214,8 +163,8 @@ public struct AnonymousMapView: View {
             latitude: viewModel.anchorCoordinate.latitude,
             longitude: viewModel.anchorCoordinate.longitude
           ),
-          latitudinalMeters: viewModel.selectedRadiusMetres * 2.5,
-          longitudinalMeters: viewModel.selectedRadiusMetres * 2.5
+          latitudinalMeters: viewModel.radiusMetres * 2.5,
+          longitudinalMeters: viewModel.radiusMetres * 2.5
         )
       )
     }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMapViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMapViewModel.swift
@@ -9,6 +9,18 @@ import TownCrierDomain
 /// the same same-address disambiguation list (GH#877) via ``selectStack(_:)``
 /// / ``selectFromStack(_:)``, reusing ``StackedApplications`` and
 /// ``StackedApplicationsSheet`` from the Map feature.
+///
+/// GH#912 Phase 4 ("honest anon map"): previously tracked TWO decoupled
+/// radii — a viewport-following `radiusMetres` driving the actual fetch as
+/// the user panned, and a free-tier-capped `selectedRadiusMetres` driving
+/// the drawn preview circle. That let the fetch boundary silently exceed the
+/// drawn circle, so pins could render outside it. This version mirrors the
+/// authenticated ``MapViewModel``'s pattern instead: ``anchorCoordinate`` and
+/// ``radiusMetres`` are zone-anchored and fixed — set once at init and again
+/// only by ``updateActiveZone(_:)`` — never by panning. The fetch radius IS
+/// the drawn circle's radius, always exactly, so a pin can never render
+/// outside the circle. Panning the map is now a pure MapKit camera gesture
+/// with no ViewModel involvement at all.
 @MainActor
 public final class AnonymousMapViewModel: ObservableObject, ErrorHandlingViewModel {
   @Published public private(set) var applications: [PlanningApplication] = []
@@ -33,45 +45,27 @@ public final class AnonymousMapViewModel: ObservableObject, ErrorHandlingViewMod
   /// sheet are never on screen at once — mirrors ``MapViewModel``'s
   /// `pendingDetailApplication` handoff.
   @Published public private(set) var pendingDetailApplication: PlanningApplication?
-  @Published public private(set) var centreLat: Double
-  @Published public private(set) var centreLon: Double
-  @Published public private(set) var radiusMetres: Double
-  /// The user-chosen live monitoring radius (GH#868 Phase 3 refinement),
-  /// decoupled from `radiusMetres`: this one drives the drawn preview circle
-  /// and is carried into onboarding, while `radiusMetres` drives the
-  /// viewport-following near-point fetch as the user pans/zooms — mirrors
-  /// the authenticated map, where the zone circle is fixed while pins follow
-  /// the viewport.
-  @Published public private(set) var selectedRadiusMetres: Double
-
-  /// Mirrors the near-point endpoint's own [100, 5000]m clamp client-side
-  /// (GH#868 Phase 2), so a pan/zoom gesture never requests a radius the
-  /// server would silently reject anyway.
-  public static let minRadiusMetres: Double = 100
-  public static let maxRadiusMetres: Double = 5000
-  public static let defaultLimit = 200
-
-  /// The live radius picker's bounds. The upper bound mirrors the free
-  /// tier's cap (`WatchZoneLimits(tier: .free).maxRadiusMetres`), so the
-  /// radius an anonymous user picks here is exactly what a free account gets
-  /// after signup — never a false preview of a bigger zone than they can
-  /// actually have.
-  public static let minSelectedRadiusMetres: Double = 100
-  public static let maxSelectedRadiusMetres: Double = WatchZoneLimits(tier: .free).maxRadiusMetres
-
-  /// The point the radius preview circle is drawn around and the camera
-  /// reframes to. Fixed across a `regionDidChange` pan/zoom (unlike
-  /// `centreLat`/`centreLon`, which follow the viewport) — but IS updated by
-  /// ``updateActiveZone(_:)`` when the active device-local zone changes
-  /// (GH#879 Phase 4), so it is `@Published private(set)`, not `let`.
+  /// The point the radius circle is drawn around, the camera reframes to,
+  /// and pins are fetched around. Fixed except when ``updateActiveZone(_:)``
+  /// changes the active device-local zone (GH#879 Phase 4) — never by
+  /// panning (GH#912 Phase 4), so it is `@Published private(set)`, not `let`.
   @Published public private(set) var anchorCoordinate: Coordinate
+  /// The zone's actual radius — drives both the drawn circle and the
+  /// `near-point` fetch boundary, always exactly the same value, so a pin
+  /// can never render outside the circle (GH#912 Phase 4). Deliberately NOT
+  /// clamped to the free-tier cap: the postcode-entry screen already bounds
+  /// the FIRST zone to that cap, but a zone subsequently edited larger via
+  /// `DeviceLocalZoneEditorView` (bound up to `DeviceLocalZone.maxRadiusMetres`)
+  /// must show its true radius, not a falsely small preview.
+  @Published public private(set) var radiusMetres: Double
+
+  public static let defaultLimit = 200
 
   private let repository: AnonymousApplicationsRepository
   private let debounceNanoseconds: UInt64
-  private var pendingRegionChangeTask: Task<Void, Never>?
-  /// Debounces ``updateActiveZone(_:)``'s fetch the same way
-  /// `pendingRegionChangeTask` debounces `regionDidChange` (GH#879 Phase 4
-  /// crash fix — see that method's docs).
+  /// Debounces ``updateActiveZone(_:)``'s fetch so a rapid run of zone
+  /// switches collapses to a single pin swap (GH#879 Phase 4 crash fix — see
+  /// that method's docs).
   private var pendingActiveZoneTask: Task<Void, Never>?
 
   /// Fired by the persistent CTA banner's "Create account"/"Sign in" buttons
@@ -84,11 +78,6 @@ public final class AnonymousMapViewModel: ObservableObject, ErrorHandlingViewMod
   /// already holds the full `PlanningApplication` from `near-point`.
   public var onShowApplicationDetail: ((PlanningApplication) -> Void)?
 
-  /// Fired whenever the live radius picker changes, so the coordinator can
-  /// persist the chosen radius into `AnonymousBrowseState` ahead of the
-  /// post-signup handoff into onboarding (GH#868 Phase 3 refinement).
-  public var onRadiusChanged: ((Double) -> Void)?
-
   public init(
     repository: AnonymousApplicationsRepository,
     coordinate: Coordinate,
@@ -96,48 +85,17 @@ public final class AnonymousMapViewModel: ObservableObject, ErrorHandlingViewMod
     debounceNanoseconds: UInt64 = 500_000_000
   ) {
     self.repository = repository
-    self.centreLat = coordinate.latitude
-    self.centreLon = coordinate.longitude
     self.anchorCoordinate = coordinate
     self.radiusMetres = radiusMetres
-    self.selectedRadiusMetres = Self.clampSelectedRadius(radiusMetres)
     self.debounceNanoseconds = debounceNanoseconds
   }
 
   /// Fetches pins for the seeded coordinate/radius. Called once from the
   /// map's `.task` on first appearance.
   public func loadInitial() async {
-    await fetch(latitude: centreLat, longitude: centreLon, radiusMetres: radiusMetres)
-  }
-
-  /// Called on a significant map-region change (pan/zoom settling). Clamps
-  /// the reported radius to the server's bound and debounces the refetch so a
-  /// continuous gesture issues a single fetch once it settles, not one per
-  /// frame.
-  public func regionDidChange(centreLat: Double, centreLon: Double, radiusMetres: Double) {
-    let clampedRadius = min(max(radiusMetres, Self.minRadiusMetres), Self.maxRadiusMetres)
-    self.centreLat = centreLat
-    self.centreLon = centreLon
-    self.radiusMetres = clampedRadius
-
-    pendingRegionChangeTask?.cancel()
-    // Mutual exclusion with an in-flight active-zone update (GH#879 Phase
-    // 4): a pan/zoom and a zone switch racing each other must never both
-    // land — "last request wins" — see `updateActiveZone(_:)`'s docs.
-    pendingActiveZoneTask?.cancel()
-    let debounceDuration = debounceNanoseconds
-    pendingRegionChangeTask = Task { [weak self] in
-      try? await Task.sleep(nanoseconds: debounceDuration)
-      guard !Task.isCancelled else { return }
-      await self?.fetch(latitude: centreLat, longitude: centreLon, radiusMetres: clampedRadius)
-    }
-  }
-
-  /// Test-only synchronisation: await the most recently scheduled debounced
-  /// region-change refetch, mirroring
-  /// `AppCoordinator.waitForPendingPostPurchasePrompt()`.
-  public func waitForPendingRegionChangeRefetch() async {
-    await pendingRegionChangeTask?.value
+    await fetch(
+      latitude: anchorCoordinate.latitude, longitude: anchorCoordinate.longitude,
+      radiusMetres: radiusMetres)
   }
 
   private func fetch(latitude: Double, longitude: Double, radiusMetres: Double) async {
@@ -151,9 +109,10 @@ public final class AnonymousMapViewModel: ObservableObject, ErrorHandlingViewMod
       )
       error = nil
     } catch {
-      // A transient refetch failure (pan/zoom) keeps the last good pins rather
-      // than blanking the map; a screen-level error is surfaced only when
-      // there is nothing to show yet — mirrors MapViewModel.loadClusters.
+      // A transient refetch failure (e.g. an active-zone switch) keeps the
+      // last good pins rather than blanking the map; a screen-level error is
+      // surfaced only when there is nothing to show yet — mirrors
+      // MapViewModel.loadClusters.
       if applications.isEmpty {
         handleError(error)
       }
@@ -236,39 +195,26 @@ public final class AnonymousMapViewModel: ObservableObject, ErrorHandlingViewMod
     onShowApplicationDetail?(pending)
   }
 
-  /// Updates the live radius picker, clamping to
-  /// `[minSelectedRadiusMetres, maxSelectedRadiusMetres]` and notifying
-  /// `onRadiusChanged` so the coordinator can persist it. Called from the
-  /// map's radius `Slider` (GH#868 Phase 3 refinement).
-  public func updateSelectedRadius(_ metres: Double) {
-    selectedRadiusMetres = Self.clampSelectedRadius(metres)
-    onRadiusChanged?(selectedRadiusMetres)
-  }
-
-  private static func clampSelectedRadius(_ metres: Double) -> Double {
-    min(max(metres, minSelectedRadiusMetres), maxSelectedRadiusMetres)
-  }
-
   /// Re-centres this SAME view model on `zone` (GH#879 Phase 4 defect fix)
   /// when the active device-local zone changes — e.g. a zone-picker chip tap
-  /// on the Applications tab. Deliberately mutates in place rather than the
-  /// coordinator replacing the whole `AnonymousMapViewModel` instance:
-  /// `AnonymousMapView` holds this object in a `@StateObject`, which SwiftUI
-  /// keeps bound to the FIRST instance passed to it — a same-position
-  /// `AnonymousMapView(viewModel:)` re-init with a NEW instance is silently
-  /// ignored, which is exactly what live simulator verification caught (the
-  /// map stayed on the previous zone until a full relaunch). Mutating
-  /// `@Published` state on the existing instance instead triggers a normal
-  /// SwiftUI re-render, and preserves any live pan/zoom camera state rather
-  /// than tearing the map view down.
+  /// on the Applications tab, or a save in `DeviceLocalZoneEditorView`.
+  /// Deliberately mutates in place rather than the coordinator replacing the
+  /// whole `AnonymousMapViewModel` instance: `AnonymousMapView` holds this
+  /// object in a `@StateObject`, which SwiftUI keeps bound to the FIRST
+  /// instance passed to it — a same-position `AnonymousMapView(viewModel:)`
+  /// re-init with a NEW instance is silently ignored, which is exactly what
+  /// live simulator verification caught (the map stayed on the previous zone
+  /// until a full relaunch). Mutating `@Published` state on the existing
+  /// instance instead triggers a normal SwiftUI re-render, and preserves any
+  /// live pan/zoom camera state rather than tearing the map view down.
   ///
-  /// Centre/anchor/radius update IMMEDIATELY (synchronously) so the camera
-  /// and radius overlay reframe as soon as the zone switches. The FETCH —
-  /// and therefore the full pin/annotation-set swap it produces — is
-  /// debounced the same way `regionDidChange` debounces a pan/zoom, and
-  /// mutually cancels any in-flight `regionDidChange`/`updateActiveZone`
-  /// fetch of the other kind. This is a crash fix (GH#879 Phase 4): live
-  /// simulator verification hit a MapKit-internal SIGABRT
+  /// Anchor/radius update IMMEDIATELY (synchronously) so the camera and
+  /// radius overlay reframe as soon as the zone switches, to the zone's
+  /// ACTUAL radius (GH#912 Phase 4 — never clamped to any preview cap, so
+  /// the drawn circle always matches the fetch boundary exactly). The FETCH
+  /// — and therefore the full pin/annotation-set swap it produces — is
+  /// debounced. This is a crash fix (GH#879 Phase 4): live simulator
+  /// verification hit a MapKit-internal SIGABRT
   /// (`-[MKMapView annotationContainer:requestAddingClusterForAnnotationViews:]`
   /// → `doesNotRecognizeSelector:`) reproducibly when the active zone was
   /// switched rapidly — MapKit's own deferred clustering pass cannot
@@ -281,8 +227,6 @@ public final class AnonymousMapViewModel: ObservableObject, ErrorHandlingViewMod
   /// leaving a stale summary/disambiguation sheet open over a map that has
   /// already moved to a new area would be its own bug.
   public func updateActiveZone(_ zone: DeviceLocalZone) {
-    pendingRegionChangeTask?.cancel()
-    pendingRegionChangeTask = nil
     pendingActiveZoneTask?.cancel()
 
     selectedApplication = nil
@@ -290,11 +234,8 @@ public final class AnonymousMapViewModel: ObservableObject, ErrorHandlingViewMod
     pendingSummaryApplication = nil
     pendingDetailApplication = nil
 
-    centreLat = zone.centre.latitude
-    centreLon = zone.centre.longitude
     anchorCoordinate = zone.centre
     radiusMetres = zone.radiusMetres
-    selectedRadiusMetres = Self.clampSelectedRadius(zone.radiusMetres)
 
     let debounceDuration = debounceNanoseconds
     pendingActiveZoneTask = Task { [weak self] in
@@ -308,7 +249,7 @@ public final class AnonymousMapViewModel: ObservableObject, ErrorHandlingViewMod
   }
 
   /// Test-only synchronisation: await the most recently scheduled debounced
-  /// active-zone refetch, mirroring ``waitForPendingRegionChangeRefetch()``.
+  /// active-zone refetch.
   public func waitForPendingActiveZoneUpdate() async {
     await pendingActiveZoneTask?.value
   }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMapViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMapViewModel.swift
@@ -94,7 +94,8 @@ public final class AnonymousMapViewModel: ObservableObject, ErrorHandlingViewMod
   /// map's `.task` on first appearance.
   public func loadInitial() async {
     await fetch(
-      latitude: anchorCoordinate.latitude, longitude: anchorCoordinate.longitude,
+      latitude: anchorCoordinate.latitude,
+      longitude: anchorCoordinate.longitude,
       radiusMetres: radiusMetres)
   }
 

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousPostcodeEntryView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousPostcodeEntryView.swift
@@ -38,6 +38,8 @@ struct AnonymousPostcodeEntryView: View {
           .textInputAutocapitalization(.characters)
         #endif
 
+      radiusControl
+
       if let error = viewModel.error {
         Text(error.userMessage)
           .font(TCTypography.caption)
@@ -62,5 +64,38 @@ struct AnonymousPostcodeEntryView: View {
     .padding(TCSpacing.extraLarge)
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(Color.tcBackground)
+  }
+
+  // MARK: - Radius picker (GH#912 Phase 4)
+
+  /// Mirrors the onboarding wizard's `RadiusPickerStepView.radiusControl` —
+  /// same label/slider/min-max layout — so choosing a radius feels identical
+  /// whether it happens here (pre-signup) or in the wizard (post-signup).
+  /// Replaces the anonymous map's removed live slider as the sole way to set
+  /// the initial monitoring radius.
+  private var radiusControl: some View {
+    VStack(alignment: .leading, spacing: TCSpacing.small) {
+      Text(formatRadius(viewModel.selectedRadiusMetres))
+        .font(TCTypography.bodyEmphasis)
+        .foregroundStyle(Color.tcTextPrimary)
+        .frame(maxWidth: .infinity, alignment: .center)
+
+      Slider(
+        value: $viewModel.selectedRadiusMetres,
+        in: viewModel.minRadiusMetres...viewModel.maxRadiusMetres,
+        step: 100
+      )
+      .tint(Color.tcAmber)
+      .accessibilityLabel("Search radius")
+      .accessibilityValue(formatRadius(viewModel.selectedRadiusMetres))
+
+      HStack {
+        Text(formatRadius(viewModel.minRadiusMetres))
+        Spacer()
+        Text(formatRadius(viewModel.maxRadiusMetres))
+      }
+      .font(TCTypography.caption)
+      .foregroundStyle(Color.tcTextSecondary)
+    }
   }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousPostcodeEntryViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousPostcodeEntryViewModel.swift
@@ -10,8 +10,21 @@ import TownCrierDomain
 @MainActor
 public final class AnonymousPostcodeEntryViewModel: ObservableObject, ErrorHandlingViewModel {
   @Published public var postcodeInput: String = ""
+  /// The monitoring radius chosen on this screen (GH#912 Phase 4), persisted
+  /// into ``AnonymousBrowseState`` on submit and seeding both the first
+  /// ``DeviceLocalZone`` and the anonymous map's fetch/drawn-circle radius —
+  /// replacing the removed map-slider as the sole way to set the initial
+  /// radius pre-signup. Defaults to the free tier's cap, matching the
+  /// eventual real limit a fresh account would get.
+  @Published public var selectedRadiusMetres: Double = 2000
   @Published public private(set) var isLoading = false
   @Published public internal(set) var error: DomainError?
+
+  public let minRadiusMetres: Double = 100
+  /// The free tier's radius cap — the anonymous flow has no session to
+  /// resolve a real subscription tier against, so it always bounds the
+  /// picker to what a brand-new free account would get.
+  public let maxRadiusMetres: Double = WatchZoneLimits(tier: .free).maxRadiusMetres
 
   private let geocoder: PostcodeGeocoder
   private let stateRepository: AnonymousBrowseStateRepository
@@ -44,7 +57,10 @@ public final class AnonymousPostcodeEntryViewModel: ObservableObject, ErrorHandl
     do {
       let coordinate = try await geocoder.geocode(postcode)
       let state = AnonymousBrowseState(
-        postcode: postcode, coordinate: coordinate, createdAt: Date())
+        postcode: postcode,
+        coordinate: coordinate,
+        radiusMetres: selectedRadiusMetres,
+        createdAt: Date())
       stateRepository.save(state)
       onResolved?(state)
     } catch {

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousBrowseCoordinatorTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousBrowseCoordinatorTests.swift
@@ -49,7 +49,7 @@ struct AnonymousBrowseCoordinatorTests {
 
     #expect(sut.screen == .tabs)
     #expect(sut.mapViewModel != nil)
-    #expect(sut.mapViewModel?.centreLat == Coordinate.cambridge.latitude)
+    #expect(sut.mapViewModel?.anchorCoordinate == .cambridge)
   }
 
   // MARK: - Welcome -> postcode entry
@@ -126,30 +126,13 @@ struct AnonymousBrowseCoordinatorTests {
     #expect(captured == [.pendingReview])
   }
 
-  // MARK: - Live radius picker persistence (GH#868 Phase 3 refinement)
+  // MARK: - Postcode-entry radius seeding (GH#912 Phase 4)
 
-  @Test func mapViewModel_radiusChange_persistsUpdatedStateWithSamePostcodeAndCoordinate() {
-    let (sut, _, stateRepository, _, _) = makeSUT(persistedState: testState)
-
-    sut.mapViewModel?.updateSelectedRadius(1500)
-
-    #expect(stateRepository.saveCalls.last?.radiusMetres == 1500)
-    #expect(stateRepository.saveCalls.last?.postcode == testState.postcode)
-    #expect(stateRepository.saveCalls.last?.coordinate == testState.coordinate)
-  }
-
-  @Test func postcodeEntryViewModel_onResolved_thenRadiusChange_persistsAgainstResolvedState() {
-    let (sut, _, stateRepository, _, _) = makeSUT()
-    let postcodeVM = sut.makePostcodeEntryViewModel()
-    postcodeVM.onResolved?(testState)
-
-    sut.mapViewModel?.updateSelectedRadius(500)
-
-    #expect(stateRepository.saveCalls.last?.radiusMetres == 500)
-    #expect(stateRepository.saveCalls.last?.postcode == testState.postcode)
-  }
-
-  @Test func init_withPersistedState_seedsMapViewModelSelectedRadiusFromPersistedRadius() {
+  /// The map has no radius control of its own any more — its radius comes
+  /// entirely from the persisted `AnonymousBrowseState`, which the
+  /// postcode-entry screen's own radius picker now sets (see
+  /// `AnonymousPostcodeEntryViewModelTests`).
+  @Test func init_withPersistedState_seedsMapViewModelRadiusFromPersistedRadius() {
     let stateWithRadius = AnonymousBrowseState(
       postcode: testState.postcode,
       coordinate: testState.coordinate,
@@ -159,7 +142,22 @@ struct AnonymousBrowseCoordinatorTests {
 
     let (sut, _, _, _, _) = makeSUT(persistedState: stateWithRadius)
 
-    #expect(sut.mapViewModel?.selectedRadiusMetres == 1500)
+    #expect(sut.mapViewModel?.radiusMetres == 1500)
+  }
+
+  @Test func postcodeEntryViewModel_onResolved_seedsMapViewModelRadiusFromResolvedState() {
+    let (sut, _, _, _, _) = makeSUT()
+    let postcodeVM = sut.makePostcodeEntryViewModel()
+    let resolvedState = AnonymousBrowseState(
+      postcode: testState.postcode,
+      coordinate: testState.coordinate,
+      radiusMetres: 500,
+      createdAt: testState.createdAt
+    )
+
+    postcodeVM.onResolved?(resolvedState)
+
+    #expect(sut.mapViewModel?.radiusMetres == 500)
   }
 
   // MARK: - Appearance (GH#878)
@@ -335,7 +333,6 @@ struct AnonymousBrowseCoordinatorTests {
     await listViewModel?.selectZone(zoneB)
 
     #expect(sut.mapViewModel === originalMapViewModel)
-    #expect(sut.mapViewModel?.centreLat == zoneB.centre.latitude)
     #expect(sut.mapViewModel?.anchorCoordinate == zoneB.centre)
     #expect(sut.mapViewModel?.radiusMetres == zoneB.radiusMetres)
   }
@@ -358,7 +355,6 @@ struct AnonymousBrowseCoordinatorTests {
     zonesVM.onZonesChanged?(editedZone)
 
     #expect(sut.mapViewModel === originalMapViewModel)
-    #expect(sut.mapViewModel?.centreLat == editedZone.centre.latitude)
     #expect(sut.mapViewModel?.anchorCoordinate == editedZone.centre)
     #expect(sut.mapViewModel?.radiusMetres == editedZone.radiusMetres)
   }

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousMapViewModelActiveZoneTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousMapViewModelActiveZoneTests.swift
@@ -16,10 +16,14 @@ import TownCrierDomain
 /// A second live-simulator-verified defect (crash) followed: switching
 /// zones rapidly could SIGABRT inside MapKit's own deferred clustering pass.
 /// `updateActiveZone(_:)`'s fetch (and therefore the annotation-set swap it
-/// drives) is now debounced the same way `regionDidChange` debounces a
-/// pan/zoom — proven here; the MapKit-internal timing itself is
+/// drives) is debounced — proven here; the MapKit-internal timing itself is
 /// UIKit/on-sim-only and covered separately (see
 /// `AnonymousClusteredMapView`'s file header).
+///
+/// GH#912 Phase 4: panning no longer drives a fetch at all (the fetch radius
+/// IS the zone radius now, matching the drawn circle exactly), so the old
+/// pan/zone-switch mutual-cancellation test that lived here is gone along
+/// with `regionDidChange` itself.
 @Suite("AnonymousMapViewModel — active-zone re-centring in place (GH#879 Phase 4)")
 @MainActor
 struct AnonymousMapViewModelActiveZoneTests {
@@ -48,14 +52,12 @@ struct AnonymousMapViewModelActiveZoneTests {
 
   // MARK: - Immediate (non-debounced) state
 
-  @Test func updateActiveZone_updatesCentreAndAnchorToZoneCentreImmediately() throws {
+  @Test func updateActiveZone_updatesAnchorToZoneCentreImmediately() throws {
     let (sut, _) = makeSUT(coordinate: .cambridge)
     let zone = try makeZone()
 
     sut.updateActiveZone(zone)
 
-    #expect(sut.centreLat == zone.centre.latitude)
-    #expect(sut.centreLon == zone.centre.longitude)
     #expect(sut.anchorCoordinate == zone.centre)
   }
 
@@ -68,13 +70,17 @@ struct AnonymousMapViewModelActiveZoneTests {
     #expect(sut.radiusMetres == 4000)
   }
 
-  @Test func updateActiveZone_clampsSelectedRadiusToFreeTierPreviewCapImmediately() throws {
+  /// GH#912 Phase 4 (honest anon map): the drawn circle/fetch radius takes
+  /// the zone's ACTUAL radius, never clamped to the free-tier preview cap —
+  /// otherwise pins between the cap and the zone's real radius would render
+  /// outside the drawn circle, exactly the bug this phase fixes.
+  @Test func updateActiveZone_setsRadiusToZonesActualRadius_evenAboveFreeTierCap() throws {
     let (sut, _) = makeSUT()
     let zone = try makeZone(radiusMetres: 5000)
 
     sut.updateActiveZone(zone)
 
-    #expect(sut.selectedRadiusMetres == AnonymousMapViewModel.maxSelectedRadiusMetres)
+    #expect(sut.radiusMetres == 5000)
   }
 
   @Test func updateActiveZone_clearsAnyPendingSelectionStateImmediately() throws {
@@ -121,22 +127,5 @@ struct AnonymousMapViewModelActiveZoneTests {
     // The final state reflects zone B throughout, not a stale zone A value.
     #expect(sut.radiusMetres == 4000)
     #expect(sut.anchorCoordinate == zoneB.centre)
-  }
-
-  @Test func updateActiveZone_cancelsAnInFlightRegionChangeFetch() async throws {
-    let (sut, repository) = makeSUT()
-    repository.fetchNearbyResult = .success([.permitted])
-    sut.regionDidChange(centreLat: 10, centreLon: 10, radiusMetres: 2000)
-    let zone = try makeZone(radiusMetres: 4000)
-
-    sut.updateActiveZone(zone)
-    await sut.waitForPendingRegionChangeRefetch()
-    await sut.waitForPendingActiveZoneUpdate()
-
-    // Only the zone update's fetch should have landed — the pan/zoom fetch
-    // was cancelled, so its `latitude: 10, longitude: 10` never overwrites
-    // the zone's coordinate.
-    #expect(repository.fetchNearbyCalls.count == 1)
-    #expect(repository.fetchNearbyCalls[0].radiusMetres == 4000)
   }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousMapViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousMapViewModelTests.swift
@@ -24,12 +24,22 @@ struct AnonymousMapViewModelTests {
 
   // MARK: - Initial state
 
-  @Test func init_seedsCentreAndRadiusFromCoordinate() {
+  @Test func init_seedsAnchorAndRadiusFromCoordinate() {
     let (sut, _) = makeSUT(coordinate: .cambridge, radiusMetres: 2000)
 
-    #expect(sut.centreLat == Coordinate.cambridge.latitude)
-    #expect(sut.centreLon == Coordinate.cambridge.longitude)
+    #expect(sut.anchorCoordinate == .cambridge)
     #expect(sut.radiusMetres == 2000)
+  }
+
+  /// GH#912 Phase 4: the map no longer previews a free-tier-capped radius —
+  /// the drawn circle and fetch boundary are always the zone's actual
+  /// radius, even above the 2km free-tier cap (reachable via
+  /// `DeviceLocalZoneEditorView`, whose bound is `DeviceLocalZone.maxRadiusMetres`
+  /// = 5000m).
+  @Test func init_seedsRadiusUnclamped_evenAboveFreeTierCap() {
+    let (sut, _) = makeSUT(radiusMetres: 5000)
+
+    #expect(sut.radiusMetres == 5000)
   }
 
   // MARK: - loadInitial
@@ -66,63 +76,6 @@ struct AnonymousMapViewModelTests {
     #expect(sut.applications.isEmpty)
   }
 
-  // MARK: - regionDidChange
-
-  @Test func regionDidChange_clampsRadiusToServerMax() async {
-    let (sut, repository) = makeSUT()
-    repository.fetchNearbyResult = .success([])
-
-    sut.regionDidChange(centreLat: 51.5, centreLon: -0.1, radiusMetres: 9000)
-    await sut.waitForPendingRegionChangeRefetch()
-
-    #expect(sut.radiusMetres == 5000)
-    #expect(repository.fetchNearbyCalls.last?.radiusMetres == 5000)
-  }
-
-  @Test func regionDidChange_clampsRadiusToServerMin() async {
-    let (sut, repository) = makeSUT()
-    repository.fetchNearbyResult = .success([])
-
-    sut.regionDidChange(centreLat: 51.5, centreLon: -0.1, radiusMetres: 10)
-    await sut.waitForPendingRegionChangeRefetch()
-
-    #expect(sut.radiusMetres == 100)
-    #expect(repository.fetchNearbyCalls.last?.radiusMetres == 100)
-  }
-
-  @Test func regionDidChange_updatesCentre() async {
-    let (sut, _) = makeSUT()
-
-    sut.regionDidChange(centreLat: 51.5, centreLon: -0.1, radiusMetres: 2000)
-    await sut.waitForPendingRegionChangeRefetch()
-
-    #expect(sut.centreLat == 51.5)
-    #expect(sut.centreLon == -0.1)
-  }
-
-  @Test func regionDidChange_debounces_rapidCallsIssueOneRefetch() async {
-    let (sut, repository) = makeSUT()
-    repository.fetchNearbyResult = .success([])
-
-    sut.regionDidChange(centreLat: 51.0, centreLon: -0.1, radiusMetres: 2000)
-    sut.regionDidChange(centreLat: 52.0, centreLon: -0.2, radiusMetres: 3000)
-    await sut.waitForPendingRegionChangeRefetch()
-
-    #expect(repository.fetchNearbyCalls.count == 1)
-    #expect(repository.fetchNearbyCalls[0].latitude == 52.0)
-    #expect(repository.fetchNearbyCalls[0].radiusMetres == 3000)
-  }
-
-  @Test func regionDidChange_populatesApplicationsAfterDebounce() async {
-    let (sut, repository) = makeSUT()
-    repository.fetchNearbyResult = .success([.permitted])
-
-    sut.regionDidChange(centreLat: 51.5, centreLon: -0.1, radiusMetres: 2000)
-    await sut.waitForPendingRegionChangeRefetch()
-
-    #expect(sut.applications == [.permitted])
-  }
-
   // MARK: - Selection
 
   @Test func selectApplication_setsSelectedApplication() {
@@ -152,74 +105,6 @@ struct AnonymousMapViewModelTests {
     sut.requestSignUp()
 
     #expect(invoked)
-  }
-
-  // MARK: - Live radius picker (GH#868 Phase 3 refinement)
-
-  @Test func selectedRadiusMetres_seedsFromInitialRadius() {
-    let (sut, _) = makeSUT(radiusMetres: 1500)
-
-    #expect(sut.selectedRadiusMetres == 1500)
-  }
-
-  @Test func selectedRadiusMetres_clampsToFreeTierMaxWhenInitialRadiusIsLarger() {
-    // The fetch radius (server clamp: [100, 5000]) can exceed the free-tier
-    // cap the live picker is bounded to — the seeded picker value must never
-    // preview a zone bigger than a free account can actually have.
-    let (sut, _) = makeSUT(radiusMetres: 5000)
-
-    #expect(sut.selectedRadiusMetres == 2000)
-  }
-
-  @Test func maxSelectedRadiusMetres_matchesFreeTierCap() {
-    #expect(AnonymousMapViewModel.maxSelectedRadiusMetres == 2000)
-  }
-
-  @Test func updateSelectedRadius_updatesValue() {
-    let (sut, _) = makeSUT()
-
-    sut.updateSelectedRadius(750)
-
-    #expect(sut.selectedRadiusMetres == 750)
-  }
-
-  @Test func updateSelectedRadius_clampsAboveFreeTierMax() {
-    let (sut, _) = makeSUT()
-
-    sut.updateSelectedRadius(3000)
-
-    #expect(sut.selectedRadiusMetres == 2000)
-  }
-
-  @Test func updateSelectedRadius_clampsBelowMinimum() {
-    let (sut, _) = makeSUT()
-
-    sut.updateSelectedRadius(10)
-
-    #expect(sut.selectedRadiusMetres == 100)
-  }
-
-  @Test func updateSelectedRadius_invokesOnRadiusChangedWithClampedValue() {
-    let (sut, _) = makeSUT()
-    var received: Double?
-    sut.onRadiusChanged = { received = $0 }
-
-    sut.updateSelectedRadius(9000)
-
-    #expect(received == 2000)
-  }
-
-  @Test func anchorCoordinate_staysFixedAcrossRegionChanges() async {
-    let (sut, repository) = makeSUT(coordinate: .cambridge)
-    repository.fetchNearbyResult = .success([])
-
-    sut.regionDidChange(centreLat: 10, centreLon: 10, radiusMetres: 2000)
-    await sut.waitForPendingRegionChangeRefetch()
-
-    #expect(sut.anchorCoordinate == .cambridge)
-    // The viewport-following centre moved, but the anchor the radius circle
-    // is drawn around did not — the two are deliberately decoupled.
-    #expect(sut.centreLat == 10)
   }
 
   // MARK: - Stacked (same-address) cluster disambiguation (GH#877)

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousPostcodeEntryViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousPostcodeEntryViewModelTests.swift
@@ -74,4 +74,28 @@ struct AnonymousPostcodeEntryViewModelTests {
 
     #expect(invoked)
   }
+
+  // MARK: - Radius picker (GH#912 Phase 4)
+
+  @Test func init_defaultsSelectedRadiusToFreeTierMax() {
+    let (sut, _, _) = makeSUT()
+
+    #expect(sut.selectedRadiusMetres == 2000)
+    #expect(sut.maxRadiusMetres == 2000)
+    #expect(sut.minRadiusMetres == 100)
+  }
+
+  @Test func submitPostcode_persistsStateWithTheSelectedRadius() async {
+    let (sut, geocoder, stateRepository) = makeSUT()
+    geocoder.geocodeResult = .success(.cambridge)
+    sut.postcodeInput = "CB1 2AD"
+    sut.selectedRadiusMetres = 1500
+    var resolved: AnonymousBrowseState?
+    sut.onResolved = { resolved = $0 }
+
+    await sut.submitPostcode()
+
+    #expect(stateRepository.saveCalls.last?.radiusMetres == 1500)
+    #expect(resolved?.radiusMetres == 1500)
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousPostcodeEntryViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousPostcodeEntryViewTests.swift
@@ -23,4 +23,14 @@ struct AnonymousPostcodeEntryViewTests {
     let sut = AnonymousPostcodeEntryView(viewModel: viewModel)
     _ = sut.body
   }
+
+  /// GH#912 Phase 4: the radius picker moved here from the (now-removed)
+  /// anonymous map slider — a render smoke test with a non-default radius
+  /// selected.
+  @Test func body_renders_withSelectedRadius() {
+    let viewModel = makeViewModel()
+    viewModel.selectedRadiusMetres = 1500
+    let sut = AnonymousPostcodeEntryView(viewModel: viewModel)
+    _ = sut.body
+  }
 }


### PR DESCRIPTION
## Changes
- The anonymous-browse radius picker moved from the map (where it only drove a decorative circle) to the postcode-entry screen (range 100m–2000m, default 2000m, mono readout via `RadiusFormatter`, tcAmber tint — mirrors `RadiusPickerStepView`'s existing style). Persisted into `AnonymousBrowseState` and seeds the `DeviceLocalZone`'s radius.
- `AnonymousMapViewModel`'s dual-radius model (a viewport-following fetch radius + a separately-clamped "selected" radius for the drawn circle) is collapsed into one zone-anchored `anchorCoordinate`/`radiusMetres`, set once at init and only updated via `updateActiveZone(_:)` — mirroring the authenticated `MapViewModel` pattern. The drawn circle and the server's `ST_DWithin` fetch boundary now read the exact same value, so they structurally cannot diverge again.
- Removed: `regionDidChange`, `centreLat`/`centreLon`, `updateSelectedRadius`, `onRadiusChanged`, the free-tier viewport clamp, `AnonymousMapView`'s `radiusPickerCard`, and `AnonymousClusteredMapView`'s pan-forward `regionDidChangeAnimated` — panning the map no longer triggers a refetch.
- Onboarding carry-through (radius → free-tier zone size at sign-up) needed no code changes — it already read from `AnonymousBrowseState`/`DeviceLocalZone`, which item 1 now correctly seeds.
- `DeviceLocalZoneEditorView` deliberately untouched — still the sole post-hoc radius-edit path.

Includes a fix for a real bug caught by pre-merge visual verification: `AnonymousClusteredMapView.updateUIView` referenced a stale `selectedRadiusMetres` property left over from the radius-model collapse. This slipped past `swift test` because the whole file is wrapped in `#if canImport(UIKit)`, which evaluates false on macOS (the SPM CLI's host platform) — so `swift test`/`swift build` never parse or type-check it, clean `.build` or not. Only an actual `xcodebuild` build against an iOS simulator SDK compiles it. Recorded as a durable memory (`reference_ios_uikit_gated_files_invisible_to_swift_test.md`) so future work touching `UIViewRepresentable`/`MKMapView` wrapper files runs an `xcodebuild` pass, not just `swift test`, before being called done.

`Release-Note: You now pick your search radius when entering your postcode, and the map shows exactly the area being searched.`

Part of GH #912 (Phase 4, iOS radius + honest anon map).

## Verification
`swift test`: 1813/1813 green (from a genuinely clean `.build`). `swiftlint lint --strict` diffed against origin/main baseline: zero new violations. `xcodebuild ... clean build` for `TownCrierApp`: BUILD SUCCEEDED.

Visually verified via mobile-mcp (iOS Simulator, anon browse — no auth needed), fresh install, light mode:
- Postcode-entry slider: PASS — defaults to 2km, live mono readout, tcAmber styling.
- Map slider absent: PASS — no radius control anywhere on the map screen.
- Pins inside circle: PASS — every cluster pin sits within the drawn boundary.
- Pan test (the core fix): PASS — panning far away from the anchor revealed zero new pins (no viewport refetch); panning back reproduced identical circle position and pin counts (anchored, not viewport-following).

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a monitoring-radius picker to postcode entry.
  * The selected radius is saved and used when opening the anonymous map.

* **Improvements**
  * Anonymous map radius is now fixed after postcode setup.
  * Map panning and zooming only adjust the camera and no longer change the monitoring area.
  * Map updates now remain anchored to the selected zone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->