### PR TITLE
fix: exclude deleted files from SwiftLint pre-commit staged list (tc-7gl26)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -78,7 +78,7 @@
             "type": "command"
           },
           {
-            "command": "jq -r '.tool_input.command' | grep -qE '^git\\s+commit' || exit 0; root=$(git rev-parse --show-toplevel); staged=$(git diff --cached --name-only -- '*.swift' | grep '^mobile/ios/' | sed \"s|^|$root/|\" || true); [ -z \"$staged\" ] \u0026\u0026 exit 0; lint=$(cd \"$root/mobile/ios\" \u0026\u0026 DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swiftlint lint $staged --quiet 2\u003e/dev/null | grep -E ':[0-9]+:[0-9]+: (error|warning):'); [ -z \"$lint\" ] \u0026\u0026 exit 0; jq -n --arg reason \"SwiftLint violations in staged files — fix before committing:\\n$lint\" '{\"decision\":\"block\",\"reason\":$reason}'",
+            "command": "jq -r '.tool_input.command' | grep -qE '^git\\s+commit' || exit 0; root=$(git rev-parse --show-toplevel); staged=$(git diff --cached --name-only --diff-filter=d -- '*.swift' | grep '^mobile/ios/' | sed \"s|^|$root/|\" || true); [ -z \"$staged\" ] \u0026\u0026 exit 0; lint=$(cd \"$root/mobile/ios\" \u0026\u0026 DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swiftlint lint $staged --quiet 2\u003e/dev/null | grep -E ':[0-9]+:[0-9]+: (error|warning):'); [ -z \"$lint\" ] \u0026\u0026 exit 0; jq -n --arg reason \"SwiftLint violations in staged files — fix before committing:\\n$lint\" '{\"decision\":\"block\",\"reason\":$reason}'",
             "statusMessage": "SwiftLint pre-commit check...",
             "timeout": 30,
             "type": "command"


### PR DESCRIPTION
## Changes
`.claude/settings.json`'s SwiftLint pre-commit hook builds its staged-file list via `git diff --cached --name-only -- '*.swift' | grep '^mobile/ios/'`, with no `--diff-filter`. That includes files DELETED in the staged changes, not just added/modified. When the resulting `$staged` list contains a path to a file that no longer exists on disk, SwiftLint 0.65.0's CLI silently ignores the entire path argument list and falls back to a full-project lint (honouring `.swiftlint.yml`'s default `included` paths), which floods the hook with ~90 pre-existing, unrelated baseline violations — blocking any commit that deletes a `.swift` file regardless of what else is in the commit.

Fix: add `--diff-filter=d` to the `git diff --cached --name-only` call, excluding deleted files from the diff output (they can't have lint violations since they no longer exist). Scoped to this one hook line only — the ESLint pre-commit hook is a similarly-shaped hook a few lines below but has no confirmed evidence of the same bug, so it's untouched.

Discovered 2026-07-10 by a worker on GH #912 (tc-b3nki.5, iOS sans-serif swap) while deleting `FontRegistrar.swift`/`FontRegistrarTests.swift` — every commit attempt tripped the fallback flood.

## Verification
- `jq empty .claude/settings.json` passes (valid JSON) before and after.
- Reproduced the bug directly: staged a throwaway file's deletion, confirmed the deleted path leaked into `$staged` without the fix, confirmed `--diff-filter=d` excludes it.
- The `swiftlint lint $staged --quiet` invocation itself is byte-for-byte unchanged — normal violation detection on modified/added files is unaffected.

Note: Claude Code hooks are read once at session start, so already-running Claude Code sessions won't pick up this change until a fresh session reads the merged config.

---
*Auto-shipped via ship skill*