### PR TITLE
fix(digest): dedupe email cards per application (tc-txkm1)

### DIFF
--- a/api-go/internal/digest/dedup.go
+++ b/api-go/internal/digest/dedup.go
@@ -1,0 +1,74 @@
+package digest
+
+import "github.com/AmyDe/town-crier/api-go/internal/notifications"
+
+// dedupApplicationKey identifies duplicate notification records for the same
+// application within one digest email. Identity is (ApplicationUID,
+// AuthorityID) — the same PlanIt uid under two different authorities is a
+// coincidence, not a duplicate.
+type dedupApplicationKey struct {
+	applicationUID string
+	authorityID    int
+}
+
+// dedupByApplication collapses notifications that share an (ApplicationUID,
+// AuthorityID) to a single winning record, so each application renders
+// exactly once in the digest email. Two records legitimately coexist per
+// application for the in-app feed (a NewApplication and a later
+// DecisionUpdate record), but the email must not render both.
+//
+// Preference is decided by preferNotification: DecisionUpdate beats
+// NewApplication (it carries the decision stamp); among equal event types, a
+// zone-attributed record beats a saved-only one; ties break on the latest
+// CreatedAt. The winning record is kept whole and placed wherever its own
+// WatchZoneID says — dedup never merges fields or borrows a zone from the
+// record it discarded.
+//
+// The result preserves the input's first-appearance order per application, so
+// callers that group by order of appearance (groupByZone) see a stable
+// section sequence.
+func dedupByApplication(notifs []notifications.DigestNotification) []notifications.DigestNotification {
+	order := make([]dedupApplicationKey, 0, len(notifs))
+	winners := make(map[dedupApplicationKey]notifications.DigestNotification, len(notifs))
+
+	for _, n := range notifs {
+		key := dedupApplicationKey{applicationUID: n.ApplicationUID, authorityID: n.AuthorityID}
+		incumbent, seen := winners[key]
+		if !seen {
+			order = append(order, key)
+			winners[key] = n
+			continue
+		}
+		if preferNotification(n, incumbent) {
+			winners[key] = n
+		}
+	}
+
+	deduped := make([]notifications.DigestNotification, 0, len(order))
+	for _, key := range order {
+		deduped = append(deduped, winners[key])
+	}
+	return deduped
+}
+
+// preferNotification reports whether candidate should replace incumbent as
+// the winning record for a duplicate (ApplicationUID, AuthorityID) pair.
+func preferNotification(candidate, incumbent notifications.DigestNotification) bool {
+	if candidateScore, incumbentScore := eventTypeScore(candidate.EventType), eventTypeScore(incumbent.EventType); candidateScore != incumbentScore {
+		return candidateScore > incumbentScore
+	}
+	if candidateZoned, incumbentZoned := candidate.WatchZoneID != nil, incumbent.WatchZoneID != nil; candidateZoned != incumbentZoned {
+		return candidateZoned
+	}
+	return candidate.CreatedAt.After(incumbent.CreatedAt)
+}
+
+// eventTypeScore ranks event types for dedup preference: DecisionUpdate
+// outranks NewApplication because it carries the decision stamp the email
+// must show when an application's outcome is already known.
+func eventTypeScore(t notifications.EventType) int {
+	if t == notifications.EventDecisionUpdate {
+		return 1
+	}
+	return 0
+}

--- a/api-go/internal/digest/dedup_test.go
+++ b/api-go/internal/digest/dedup_test.go
@@ -8,16 +8,17 @@ import (
 )
 
 // decisionNotif returns a DecisionUpdate record for the same application as
-// zoneNotif(uid, zoneID), with its own record ID and a UK-displayable
-// decision. This mirrors the real duplicate the polling ingester can produce
-// when an application is first seen already-decided (tc-txkm1 root cause):
-// both a NewApplication and a DecisionUpdate record land for one
-// (ApplicationUID, AuthorityID) pair.
-func decisionNotif(uid, zoneID, decision string) notifications.DigestNotification {
+// zoneNotif("uid-A", zoneID), with its own record ID and a UK-displayable
+// "Permitted" decision (renders as the "[Approved]" stamp). This mirrors the
+// real duplicate the polling ingester can produce when an application is
+// first seen already-decided (tc-txkm1 root cause): both a NewApplication and
+// a DecisionUpdate record land for one (ApplicationUID, AuthorityID) pair.
+func decisionNotif(zoneID string) notifications.DigestNotification {
+	const uid = "uid-A"
 	n := zoneNotif(uid, zoneID)
 	n.ID = "n-" + uid + "-decision"
 	n.EventType = notifications.EventDecisionUpdate
-	n.Decision = strptr(decision)
+	n.Decision = strptr("Permitted")
 	n.CreatedAt = n.CreatedAt.Add(time.Hour) // decision arrives after the new-application record
 	return n
 }
@@ -25,7 +26,7 @@ func decisionNotif(uid, zoneID, decision string) notifications.DigestNotificatio
 func TestDedupByApplication_DecisionUpdateWinsOverNewApplication(t *testing.T) {
 	t.Parallel()
 	newApp := zoneNotif("uid-A", "zone-1")
-	decision := decisionNotif("uid-A", "zone-1", "Permitted")
+	decision := decisionNotif("zone-1")
 
 	got := dedupByApplication([]notifications.DigestNotification{newApp, decision})
 
@@ -90,7 +91,7 @@ func TestDedupByApplication_DecisionUpdateWinsRegardlessOfZoneAttribution(t *tes
 	// preference. The winner keeps its own WatchZoneID (nil here), it does not
 	// borrow the loser's zone.
 	zoneAttributedNew := zoneNotif("uid-A", "zone-1")
-	savedOnlyDecision := decisionNotif("uid-A", "", "Permitted")
+	savedOnlyDecision := decisionNotif("")
 	savedOnlyDecision.WatchZoneID = nil
 
 	got := dedupByApplication([]notifications.DigestNotification{zoneAttributedNew, savedOnlyDecision})
@@ -129,7 +130,7 @@ func TestDedupByApplication_PreservesFirstAppearanceOrderForSections(t *testing.
 	// stable sequence; dedup must not reorder surviving applications.
 	first := zoneNotif("uid-A", "zone-1")
 	second := zoneNotif("uid-B", "zone-2")
-	decisionForFirst := decisionNotif("uid-A", "zone-1", "Permitted")
+	decisionForFirst := decisionNotif("zone-1")
 
 	got := dedupByApplication([]notifications.DigestNotification{first, second, decisionForFirst})
 

--- a/api-go/internal/digest/dedup_test.go
+++ b/api-go/internal/digest/dedup_test.go
@@ -1,0 +1,150 @@
+package digest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/notifications"
+)
+
+// decisionNotif returns a DecisionUpdate record for the same application as
+// zoneNotif(uid, zoneID), with its own record ID and a UK-displayable
+// decision. This mirrors the real duplicate the polling ingester can produce
+// when an application is first seen already-decided (tc-txkm1 root cause):
+// both a NewApplication and a DecisionUpdate record land for one
+// (ApplicationUID, AuthorityID) pair.
+func decisionNotif(uid, zoneID, decision string) notifications.DigestNotification {
+	n := zoneNotif(uid, zoneID)
+	n.ID = "n-" + uid + "-decision"
+	n.EventType = notifications.EventDecisionUpdate
+	n.Decision = strptr(decision)
+	n.CreatedAt = n.CreatedAt.Add(time.Hour) // decision arrives after the new-application record
+	return n
+}
+
+func TestDedupByApplication_DecisionUpdateWinsOverNewApplication(t *testing.T) {
+	t.Parallel()
+	newApp := zoneNotif("uid-A", "zone-1")
+	decision := decisionNotif("uid-A", "zone-1", "Permitted")
+
+	got := dedupByApplication([]notifications.DigestNotification{newApp, decision})
+
+	if len(got) != 1 {
+		t.Fatalf("deduped count: got %d, want 1", len(got))
+	}
+	if got[0].EventType != notifications.EventDecisionUpdate {
+		t.Errorf("winner event type: got %v, want DecisionUpdate", got[0].EventType)
+	}
+}
+
+func TestDedupByApplication_DistinctApplicationsUnaffected(t *testing.T) {
+	t.Parallel()
+	a := zoneNotif("uid-A", "zone-1")
+	b := zoneNotif("uid-B", "zone-1")
+
+	got := dedupByApplication([]notifications.DigestNotification{a, b})
+
+	if len(got) != 2 {
+		t.Fatalf("deduped count: got %d, want 2 (distinct applications)", len(got))
+	}
+}
+
+func TestDedupByApplication_DifferentAuthorityIsNotADuplicate(t *testing.T) {
+	t.Parallel()
+	// Identity is (ApplicationUID, AuthorityID) — the same uid under two
+	// authorities is a coincidence, not a duplicate (project convention).
+	a := zoneNotif("uid-A", "zone-1")
+	b := zoneNotif("uid-A", "zone-1")
+	b.ID = "n-uid-A-other-authority"
+	b.AuthorityID = 2
+
+	got := dedupByApplication([]notifications.DigestNotification{a, b})
+
+	if len(got) != 2 {
+		t.Fatalf("different authorities must not collapse: got %d, want 2", len(got))
+	}
+}
+
+func TestDedupByApplication_ZoneAttributedWinsOverSavedOnlyWhenEventTypesEqual(t *testing.T) {
+	t.Parallel()
+	savedOnly := zoneNotif("uid-A", "")
+	savedOnly.WatchZoneID = nil
+	savedOnly.ID = "n-uid-A-saved"
+	zoneAttributed := zoneNotif("uid-A", "zone-1")
+	zoneAttributed.ID = "n-uid-A-zone"
+
+	got := dedupByApplication([]notifications.DigestNotification{savedOnly, zoneAttributed})
+
+	if len(got) != 1 {
+		t.Fatalf("deduped count: got %d, want 1", len(got))
+	}
+	if got[0].WatchZoneID == nil {
+		t.Errorf("winner should be the zone-attributed record, got saved-only: %+v", got[0])
+	}
+}
+
+func TestDedupByApplication_DecisionUpdateWinsRegardlessOfZoneAttribution(t *testing.T) {
+	t.Parallel()
+	// A saved-only DecisionUpdate must still beat a zone-attributed
+	// NewApplication — event-type preference outranks zone-attribution
+	// preference. The winner keeps its own WatchZoneID (nil here), it does not
+	// borrow the loser's zone.
+	zoneAttributedNew := zoneNotif("uid-A", "zone-1")
+	savedOnlyDecision := decisionNotif("uid-A", "", "Permitted")
+	savedOnlyDecision.WatchZoneID = nil
+
+	got := dedupByApplication([]notifications.DigestNotification{zoneAttributedNew, savedOnlyDecision})
+
+	if len(got) != 1 {
+		t.Fatalf("deduped count: got %d, want 1", len(got))
+	}
+	if got[0].EventType != notifications.EventDecisionUpdate {
+		t.Errorf("winner should be the DecisionUpdate record even though saved-only: got %+v", got[0])
+	}
+	if got[0].WatchZoneID != nil {
+		t.Errorf("winner should keep its own nil WatchZoneID, not borrow the loser's zone: got %v", got[0].WatchZoneID)
+	}
+}
+
+func TestDedupByApplication_LatestCreatedAtWinsAmongEqualEventTypeAndZoneAttribution(t *testing.T) {
+	t.Parallel()
+	older := zoneNotif("uid-A", "zone-1")
+	newer := zoneNotif("uid-A", "zone-1")
+	newer.ID = "n-uid-A-later"
+	newer.CreatedAt = older.CreatedAt.Add(time.Hour)
+
+	got := dedupByApplication([]notifications.DigestNotification{older, newer})
+
+	if len(got) != 1 {
+		t.Fatalf("deduped count: got %d, want 1", len(got))
+	}
+	if got[0].ID != newer.ID {
+		t.Errorf("winner should be the later record: got ID %q, want %q", got[0].ID, newer.ID)
+	}
+}
+
+func TestDedupByApplication_PreservesFirstAppearanceOrderForSections(t *testing.T) {
+	t.Parallel()
+	// groupByZone relies on first-appearance order to build sections in a
+	// stable sequence; dedup must not reorder surviving applications.
+	first := zoneNotif("uid-A", "zone-1")
+	second := zoneNotif("uid-B", "zone-2")
+	decisionForFirst := decisionNotif("uid-A", "zone-1", "Permitted")
+
+	got := dedupByApplication([]notifications.DigestNotification{first, second, decisionForFirst})
+
+	if len(got) != 2 {
+		t.Fatalf("deduped count: got %d, want 2", len(got))
+	}
+	if got[0].ApplicationUID != "uid-A" || got[1].ApplicationUID != "uid-B" {
+		t.Errorf("order not preserved: got %+v", got)
+	}
+}
+
+func TestDedupByApplication_EmptyInput(t *testing.T) {
+	t.Parallel()
+	got := dedupByApplication(nil)
+	if len(got) != 0 {
+		t.Errorf("deduped count: got %d, want 0", len(got))
+	}
+}

--- a/api-go/internal/digest/handler.go
+++ b/api-go/internal/digest/handler.go
@@ -321,13 +321,20 @@ func markSent(n notifications.DigestNotification) notifications.DigestNotificati
 	return n
 }
 
-// sendDigestEmail groups the notifications by watch zone (with a saved-only
-// section for zone-less notifications), renders the email body, and hands it to
-// the transport-only email sender. It logs and returns any failure so the caller
-// can decide whether to proceed: the hourly cycle must NOT flip emailSent when the
-// send fails (otherwise the email is silently lost and never retried — tc-qvds),
-// while the weekly cycle simply moves on to the next user. A failed email never
-// aborts the rest of the cycle either way.
+// sendDigestEmail collapses duplicate per-application records (see
+// dedupByApplication — an application can legitimately have both a
+// NewApplication and a DecisionUpdate record for the in-app feed, but the
+// email must render each application once), groups the survivors by watch
+// zone (with a saved-only section for zone-less notifications), renders the
+// email body, and hands it to the transport-only email sender. Callers pass
+// the full pre-dedup slice (RunHourly's MarkEmailSent loop relies on that: it
+// walks its own pre-dedup `included` slice after this call returns, so the
+// duplicate this function suppresses from the render is still marked sent and
+// never resurfaces in a later cycle). It logs and returns any failure so the
+// caller can decide whether to proceed: the hourly cycle must NOT flip
+// emailSent when the send fails (otherwise the email is silently lost and
+// never retried — tc-qvds), while the weekly cycle simply moves on to the next
+// user. A failed email never aborts the rest of the cycle either way.
 func (h *Handler) sendDigestEmail(ctx context.Context, userID, email string, notifs []notifications.DigestNotification) error {
 	zones, err := h.zones.GetByUserID(ctx, userID)
 	if err != nil {
@@ -339,7 +346,8 @@ func (h *Handler) sendDigestEmail(ctx context.Context, userID, email string, not
 		zoneName[z.ID] = z.Name
 	}
 
-	sections, saved, total := groupByZone(notifs, zoneName)
+	deduped := dedupByApplication(notifs)
+	sections, saved, total := groupByZone(deduped, zoneName)
 
 	msg := acsemail.Message{
 		Sender:    senderAddress,

--- a/api-go/internal/digest/handler.go
+++ b/api-go/internal/digest/handler.go
@@ -147,7 +147,10 @@ func (h *Handler) RunWeekly(ctx context.Context) error {
 		}
 
 		if wantsPush {
-			h.sendWeeklyPush(ctx, profile, len(notifs))
+			// Dedup before counting: a NewApplication+DecisionUpdate pair for the same
+			// application is ONE application, so the push body count must match the
+			// deduped email application count, not the raw record count (tc-txkm1).
+			h.sendWeeklyPush(ctx, profile, len(dedupByApplication(notifs)))
 		}
 		if wantsEmail {
 			// The weekly cycle does not track emailSent (it re-derives the digest from

--- a/api-go/internal/digest/handler_test.go
+++ b/api-go/internal/digest/handler_test.go
@@ -636,7 +636,7 @@ func TestRunHourly_DuplicateNewApplicationAndDecisionUpdate_RendersOnceAndMarksB
 	p := mkProfile(t, profiles.TierPro, prefs)
 
 	newApp := zoneNotif("uid-A", "zone-1")
-	decision := decisionNotif("uid-A", "zone-1", "Permitted")
+	decision := decisionNotif("zone-1")
 
 	fp := &fakeProfiles{byID: map[string]*profiles.UserProfile{"user-1": p}}
 	fn := &fakeNotifications{
@@ -677,7 +677,7 @@ func TestRunWeekly_DuplicateNewApplicationAndDecisionUpdate_RendersOnceWithUniqu
 	p := mkProfile(t, profiles.TierFree, prefs)
 
 	newApp := zoneNotif("uid-A", "zone-1")
-	decision := decisionNotif("uid-A", "zone-1", "Permitted")
+	decision := decisionNotif("zone-1")
 
 	fp := &fakeProfiles{byDay: map[time.Weekday][]*profiles.UserProfile{time.Wednesday: {p}}}
 	fn := &fakeNotifications{sinceByUser: map[string][]notifications.DigestNotification{

--- a/api-go/internal/digest/handler_test.go
+++ b/api-go/internal/digest/handler_test.go
@@ -620,3 +620,124 @@ func TestRunHourly_NoOpSenderDropsEmailButStillMarksSent(t *testing.T) {
 func contains(haystack, needle string) bool {
 	return strings.Contains(haystack, needle)
 }
+
+// ---- duplicate-card dedup tests (tc-txkm1) ----
+
+func TestRunHourly_DuplicateNewApplicationAndDecisionUpdate_RendersOnceAndMarksBothSent(t *testing.T) {
+	t.Parallel()
+	// Root cause: the poll cycle can dispatch BOTH a NewApplication and a
+	// DecisionUpdate record for the same application in one cycle (an
+	// already-decided application seen for the first time). The rendered email
+	// must collapse them to one card carrying the decision stamp, but BOTH
+	// pre-dedup records must still be marked emailSent — otherwise the
+	// suppressed NewApplication row resurfaces in a later hourly cycle.
+	prefs := profiles.DefaultPreferences()
+	prefs.EmailDigestEnabled = true
+	p := mkProfile(t, profiles.TierPro, prefs)
+
+	newApp := zoneNotif("uid-A", "zone-1")
+	decision := decisionNotif("uid-A", "zone-1", "Permitted")
+
+	fp := &fakeProfiles{byID: map[string]*profiles.UserProfile{"user-1": p}}
+	fn := &fakeNotifications{
+		unsentUserIDs: []string{"user-1"},
+		unsentByUser:  map[string][]notifications.DigestNotification{"user-1": {newApp, decision}},
+	}
+	fz := &fakeZones{byUser: map[string][]watchzones.WatchZone{
+		"user-1": {mkZone(t, "zone-1", "Home", true)},
+	}}
+	email := &spyEmail{}
+	h := newHandler(fp, fn, fz, &fakeState{}, &fakeDevices{}, email, &spyPush{})
+
+	if err := h.RunHourly(context.Background()); err != nil {
+		t.Fatalf("RunHourly: %v", err)
+	}
+	if len(email.sent) != 1 {
+		t.Fatalf("emails sent: got %d, want 1", len(email.sent))
+	}
+	body := email.sent[0].HTMLBody
+	if got := strings.Count(body, "addr uid-A"); got != 1 {
+		t.Errorf("address should render exactly once, got %d occurrences in:\n%s", got, body)
+	}
+	if !contains(body, "[Approved]") {
+		t.Errorf("surviving card should carry the decision stamp:\n%s", body)
+	}
+	// CRITICAL regression guard: both pre-dedup records must be marked sent, or
+	// the suppressed NewApplication resurfaces next cycle.
+	if len(fn.marked) != 2 {
+		t.Fatalf("marked email-sent: got %v, want both records marked", fn.marked)
+	}
+}
+
+func TestRunWeekly_DuplicateNewApplicationAndDecisionUpdate_RendersOnceWithUniqueCount(t *testing.T) {
+	t.Parallel()
+	prefs := profiles.DefaultPreferences()
+	prefs.EmailDigestEnabled = true
+	prefs.PushEnabled = false
+	p := mkProfile(t, profiles.TierFree, prefs)
+
+	newApp := zoneNotif("uid-A", "zone-1")
+	decision := decisionNotif("uid-A", "zone-1", "Permitted")
+
+	fp := &fakeProfiles{byDay: map[time.Weekday][]*profiles.UserProfile{time.Wednesday: {p}}}
+	fn := &fakeNotifications{sinceByUser: map[string][]notifications.DigestNotification{
+		"user-1": {newApp, decision},
+	}}
+	fz := &fakeZones{byUser: map[string][]watchzones.WatchZone{
+		"user-1": {mkZone(t, "zone-1", "Home", true)},
+	}}
+	email := &spyEmail{}
+	push := &spyPush{}
+	h := newHandler(fp, fn, fz, &fakeState{}, &fakeDevices{}, email, push)
+
+	if err := h.RunWeekly(context.Background()); err != nil {
+		t.Fatalf("RunWeekly: %v", err)
+	}
+	if len(email.sent) != 1 {
+		t.Fatalf("emails sent: got %d, want 1", len(email.sent))
+	}
+	msg := email.sent[0]
+	if got := strings.Count(msg.HTMLBody, "addr uid-A"); got != 1 {
+		t.Errorf("address should render exactly once, got %d occurrences in:\n%s", got, msg.HTMLBody)
+	}
+	if want := buildDigestSubject(1); msg.Subject != want {
+		t.Errorf("subject should count unique applications: got %q, want %q", msg.Subject, want)
+	}
+	if !contains(msg.HTMLBody, "1 new application ") {
+		t.Errorf("footer should count unique applications (singular), got:\n%s", msg.HTMLBody)
+	}
+}
+
+func TestRunHourly_DistinctApplicationsStillBothRenderAndBothMarkSent(t *testing.T) {
+	t.Parallel()
+	// Regression guard: dedup must only collapse genuine duplicates. Two
+	// distinct applications must both render and both be marked sent.
+	prefs := profiles.DefaultPreferences()
+	prefs.EmailDigestEnabled = true
+	p := mkProfile(t, profiles.TierPro, prefs)
+
+	a := zoneNotif("uid-A", "zone-1")
+	b := zoneNotif("uid-B", "zone-1")
+
+	fp := &fakeProfiles{byID: map[string]*profiles.UserProfile{"user-1": p}}
+	fn := &fakeNotifications{
+		unsentUserIDs: []string{"user-1"},
+		unsentByUser:  map[string][]notifications.DigestNotification{"user-1": {a, b}},
+	}
+	fz := &fakeZones{byUser: map[string][]watchzones.WatchZone{
+		"user-1": {mkZone(t, "zone-1", "Home", true)},
+	}}
+	email := &spyEmail{}
+	h := newHandler(fp, fn, fz, &fakeState{}, &fakeDevices{}, email, &spyPush{})
+
+	if err := h.RunHourly(context.Background()); err != nil {
+		t.Fatalf("RunHourly: %v", err)
+	}
+	body := email.sent[0].HTMLBody
+	if !contains(body, "addr uid-A") || !contains(body, "addr uid-B") {
+		t.Errorf("both distinct applications should render:\n%s", body)
+	}
+	if len(fn.marked) != 2 {
+		t.Errorf("marked email-sent: got %v, want both distinct records marked", fn.marked)
+	}
+}

--- a/api-go/internal/digest/handler_test.go
+++ b/api-go/internal/digest/handler_test.go
@@ -708,6 +708,51 @@ func TestRunWeekly_DuplicateNewApplicationAndDecisionUpdate_RendersOnceWithUniqu
 	}
 }
 
+func TestRunWeekly_DuplicatePairCollapsesPushCountToUniqueApplications(t *testing.T) {
+	t.Parallel()
+	// The weekly PUSH body count must match the deduped email application
+	// count: a NewApplication+DecisionUpdate pair for the same application is
+	// ONE application, not two (tc-txkm1).
+	prefs := profiles.DefaultPreferences()
+	prefs.EmailDigestEnabled = false
+	prefs.PushEnabled = true
+	p := mkProfile(t, profiles.TierPro, prefs)
+
+	newApp := zoneNotif("uid-A", "zone-1")
+	decision := decisionNotif("zone-1")
+
+	fp := &fakeProfiles{byDay: map[time.Weekday][]*profiles.UserProfile{time.Wednesday: {p}}}
+	fn := &fakeNotifications{sinceByUser: map[string][]notifications.DigestNotification{
+		"user-1": {newApp, decision},
+	}}
+	devices := &fakeDevices{byUser: map[string][]devicetokens.DeviceRegistration{
+		"user-1": {{UserID: "user-1", Token: "tok-1", Platform: devicetokens.PlatformIos}},
+	}}
+	email := &spyEmail{}
+	push := &spyPush{}
+	h := newHandler(fp, fn, &fakeZones{}, &fakeState{}, devices, email, push)
+
+	if err := h.RunWeekly(context.Background()); err != nil {
+		t.Fatalf("RunWeekly: %v", err)
+	}
+	if push.calls != 1 {
+		t.Fatalf("push calls: got %d, want 1", push.calls)
+	}
+	var parsed struct {
+		Aps struct {
+			Alert struct {
+				Body string `json:"body"`
+			} `json:"alert"`
+		} `json:"aps"`
+	}
+	if err := json.Unmarshal(push.payload, &parsed); err != nil {
+		t.Fatalf("payload unmarshal: %v", err)
+	}
+	if want := "1 new application this week"; parsed.Aps.Alert.Body != want {
+		t.Errorf("push body: got %q, want %q (unique application count, singular)", parsed.Aps.Alert.Body, want)
+	}
+}
+
 func TestRunHourly_DistinctApplicationsStillBothRenderAndBothMarkSent(t *testing.T) {
 	t.Parallel()
 	// Regression guard: dedup must only collapse genuine duplicates. Two


### PR DESCRIPTION
## Problem

User feedback: when a digest email contains a status update for a planning application, the same address appears twice — once with the decision stamp (e.g. `[Approved]`) and once without.

## Root cause

Dispatch dedup keys include the event type, so a `NewApplication` and a `DecisionUpdate` record legitimately coexist per (user, application, authority) — intentional for the in-app feed. The email builder rendered one card per record with no cross-record collapse. Both records land in one email when an application is first seen already-decided (the ingester fires both dispatch paths in the same poll cycle) or when both events fall inside the weekly 7-day look-back / same hourly window.

## Fix (render layer only — dispatch untouched)

- New `dedupByApplication` in `internal/digest`: collapses records sharing (ApplicationUID, AuthorityID) to one winner — `DecisionUpdate` beats `NewApplication` (it carries the decision stamp); among equal event types, zone-attributed beats saved-only; ties break on latest `CreatedAt`. First-appearance order preserved so zone-section ordering is stable.
- `sendDigestEmail` dedups before grouping, fixing both the weekly and hourly cycles at one point; the email subject/footer count now reflects unique applications.
- The weekly push body count ("N new applications this week") also uses the deduped count.
- Regression guard: `RunHourly`'s `MarkEmailSent` loop still walks the full pre-dedup slice, so the suppressed duplicate is still marked sent and never resurfaces in a later cycle — covered by a dedicated test.

## Tests

8 unit tests on `dedupByApplication` (preference order, authority scoping, ordering, empty input) + 4 handler tests: hourly pair renders once and marks both records sent; weekly pair renders once with unique count; weekly push count collapses to unique applications; distinct applications unaffected.

Gates: `go build` / `go vet` / `gofmt -l` clean; `go test -race` full suite 1685 passed across 49 packages; `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017c6sz9kvhySiw6bJsHGNZy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Digest emails now show each application only once when multiple notifications refer to it.
  * Weekly email and push counts now reflect unique applications.
  * Duplicate notifications are still tracked correctly as sent.
  * Distinct applications and authority-specific records remain separate.
  * Notification selection prioritizes meaningful updates, zone-attributed records, and the latest available timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->