### PR TITLE
feat(ios): masthead titles on anonymous Applications and Zones tabs (tc-0t1c2)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousApplicationListView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousApplicationListView.swift
@@ -24,6 +24,7 @@ public struct AnonymousApplicationListView: View {
 
   public var body: some View {
     List {
+      mastheadRow
       zonePickerRow
       contentRows
     }
@@ -31,9 +32,7 @@ public struct AnonymousApplicationListView: View {
     .scrollContentBackground(.hidden)
     .background(Color.tcBackground)
     .navigationTitle("Applications")
-    #if os(iOS)
-      .navigationBarTitleDisplayMode(.large)
-    #endif
+    .mastheadNavigationBar()
     .task {
       await viewModel.loadApplications()
     }
@@ -48,6 +47,18 @@ public struct AnonymousApplicationListView: View {
       )
       .selfSizingSheet()
     }
+  }
+
+  // MARK: - Masthead
+
+  private var mastheadRow: some View {
+    MastheadView(title: "Applications")
+      .padding(.horizontal, TCSpacing.medium)
+      .padding(.top, TCSpacing.small)
+      .padding(.bottom, TCSpacing.extraSmall)
+      .listRowSeparator(.hidden)
+      .listRowInsets(EdgeInsets())
+      .listRowBackground(Color.tcBackground)
   }
 
   // MARK: - Zone picker (GH#879 Phase 4)

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/DeviceLocalZoneListView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/DeviceLocalZoneListView.swift
@@ -28,6 +28,7 @@ public struct DeviceLocalZoneListView: View {
 
   public var body: some View {
     List {
+      mastheadRow
       if let zone = viewModel.zones.first {
         DeviceLocalZoneRow(zone: zone) { viewModel.requestAlertsSignUp() }
           .cardRowInsets()
@@ -41,6 +42,7 @@ public struct DeviceLocalZoneListView: View {
     .scrollContentBackground(.hidden)
     .background(Color.tcBackground)
     .navigationTitle("Zones")
+    .mastheadNavigationBar()
     .task {
       viewModel.load()
     }
@@ -55,6 +57,18 @@ public struct DeviceLocalZoneListView: View {
       )
       .selfSizingSheet()
     }
+  }
+
+  // MARK: - Masthead
+
+  private var mastheadRow: some View {
+    MastheadView(title: "Zones")
+      .padding(.horizontal, TCSpacing.medium)
+      .padding(.top, TCSpacing.small)
+      .padding(.bottom, TCSpacing.extraSmall)
+      .listRowSeparator(.hidden)
+      .listRowInsets(EdgeInsets())
+      .listRowBackground(Color.tcBackground)
   }
 
   /// Load-bearing sign-up pitch (GH#888): this is the only remaining route to


### PR DESCRIPTION
## Summary

TestFlight feedback 2026-07-10: the new masthead treatment (uppercase kerned title over a double rule) looked good logged in but never carried over to the pre-login screens. The sans-serif tokens did carry over — the gap was the masthead component itself, scoped logged-in-only in the tc-b3nki epic.

- `AnonymousApplicationListView`: replaces the plain large system nav title with the same `MastheadView("Applications")` + `.mastheadNavigationBar()` recipe as the logged-in Applications feed, byte-for-byte identical row styling.
- `DeviceLocalZoneListView`: same masthead pattern with title "Zones", mirroring `WatchZoneListView`.
- Anonymous Map tab and Settings deliberately untouched (Map is handled by tc-3b1hj; Settings is plain in the authed app too).

## Verification

- `swift build` / `swift test` (1811/1811) / `swiftlint --strict` clean.
- Agent-run simulator verification passed all checks: masthead renders and scrolls as first list row on both tabs, light + dark mode, no layout defects; Settings/Map unchanged.

Bead: tc-0t1c2

Release-Note: The screens you see before signing in now carry the same masthead style as the rest of the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CamN56bgL43Qn3ibGYVkt4