### PR TITLE
feat(api): anonymous clusters endpoint GET /v1/applications/clusters (tc-9vnhg)

### DIFF
--- a/api-go/cmd/api/anonymous_patterns_test.go
+++ b/api-go/cmd/api/anonymous_patterns_test.go
@@ -58,6 +58,21 @@ func TestAnonymousPatterns_IncludesNearPoint(t *testing.T) {
 	}
 }
 
+// TestAnonymousPatterns_IncludesClusters pins the anonymity of the public
+// anonymous clusters endpoint (GH#924 Phase 1): a resident browsing the map
+// before creating an account sees the fully clustered set, mirroring
+// TestAnonymousPatterns_IncludesNearPoint. The middleware keys on the exact
+// registered pattern string, so this must match the route wired in
+// applications byte-for-byte.
+func TestAnonymousPatterns_IncludesClusters(t *testing.T) {
+	t.Parallel()
+
+	const clusters = "GET /v1/applications/clusters"
+	if _, ok := anonymousPatterns[clusters]; !ok {
+		t.Errorf("anonymousPatterns must include %q", clusters)
+	}
+}
+
 // TestAnonymousPatterns_IncludesSharePage pins the anonymity of the public
 // server-rendered share page (#738). The auth middleware keys on the exact
 // registered pattern string, so this must match the route wired in sharepage

--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -75,6 +75,16 @@ var anonymousPatterns = map[string]struct{}{
 	// point+radius read is a far more attractive whole-table scraping target
 	// than the text search below).
 	"GET /v1/applications/near-point": {},
+	// The anonymous clusters endpoint (GH#924 Phase 1) is anonymous to Auth0: it
+	// backs the iOS anonymous browse map with the same PostGIS grid-aggregated
+	// clusters the authed watch-zone map renders (applications.FindClustersInZone,
+	// issue #698), so a fresh install sees the fully clustered set across its
+	// radius circle instead of a client-side cluster over the near-point route's
+	// truncated 200-row page. Grid aggregates are LESS granular than near-point's
+	// raw rows, so this is no new scraping surface; it is metered solely by the
+	// per-IP AnonRateLimit (GH#868 Phase 1) plus its own radius clamp, identical
+	// to near-point's.
+	"GET /v1/applications/clusters": {},
 	// The by-slug application read is anonymous (public planning data only, no
 	// user/subscriber data, no refresh-on-tap): it resolves an authority slug to
 	// its area id and point-reads the application, feeding the public share page
@@ -328,6 +338,14 @@ func newRouter(
 		// metered by the per-IP AnonRateLimit (GH#868 Phase 1) plus its own
 		// radius/limit clamps.
 		applications.NearPointRoutes(mux, appStore, authorities.NewLookup(), logger)
+		// The public anonymous clusters endpoint (GH#924 Phase 1) reads from the same
+		// store: it calls the same FindClustersInZone grid-aggregation primitive as
+		// the authed watch-zone clusters route (watchzones.NearbyRoutes above), with
+		// the centre/radius/viewport supplied by the caller instead of a stored zone.
+		// It is anonymous to Auth0 (see anonymousPatterns) and, like every other
+		// anonymous route, metered by the per-IP AnonRateLimit (GH#868 Phase 1) plus
+		// its own radius clamp (identical to near-point's).
+		applications.ClustersRoutes(mux, appStore, authorities.NewLookup(), logger)
 		// The public share page (#738): an anonymous, server-rendered HTML page for a
 		// single application at GET /a/{authoritySlug}/{ref...}. It point-reads the
 		// same applications store and resolves the authority slug via the static

--- a/api-go/cmd/api/wiring_test.go
+++ b/api-go/cmd/api/wiring_test.go
@@ -169,6 +169,22 @@ func (f foundAppStore) FindNearbyPage(context.Context, float64, float64, float64
 	return []applications.PlanningApplication{f.app}, "", nil
 }
 
+// FindClustersInZone unconditionally returns one single-member cluster carrying
+// the fixture application's identity, ignoring the query args — this fake
+// exists only to give the anonymous clusters route's end-to-end wiring test
+// (GH#924 Phase 1) a real record to render, serialise, and slug-enrich.
+func (f foundAppStore) FindClustersInZone(context.Context, applications.ClusterQuery) ([]applications.Cluster, error) {
+	return []applications.Cluster{
+		{
+			Latitude:     51.5,
+			Longitude:    -0.1,
+			Count:        1,
+			StatusCounts: map[string]int{"Permitted": 1},
+			Member:       &applications.PlanningApplicationID{Authority: "301", Name: f.app.Name},
+		},
+	}, nil
+}
+
 // fakeSavedStore is a savedapplications.Store returning the empty path.
 type fakeSavedStore struct{}
 
@@ -471,6 +487,50 @@ func TestRouter_NearPointAnonymous(t *testing.T) {
 	badReq := serveReq(t, h, http.MethodGet, "/v1/applications/near-point", "", "")
 	if badReq.Code != http.StatusBadRequest {
 		t.Fatalf("GET /v1/applications/near-point (no lat/lng) status = %d, want 400", badReq.Code)
+	}
+}
+
+// GET /v1/applications/clusters serves anonymously (no token, 200
+// application/json) with a bare-array body of PostGIS grid-aggregated clusters
+// (GH#924 Phase 1), each member identity carrying a resolved authoritySlug so
+// the anonymous map can point-read a tapped pin by slug, mirroring
+// TestRouter_NearPointAnonymous. The pattern string match is a drift guard: a
+// rename here without updating anonymousPatterns would silently 401 the route.
+func TestRouter_ClustersAnonymous(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.DiscardHandler)
+	app := applications.PlanningApplication{
+		Name:     "23/03456/FUL",
+		UID:      "croydon-23-03456-FUL",
+		AreaName: "Croydon",
+		AreaID:   301, // the real Croydon id, so SlugForAreaID(301) == "croydon"
+		Address:  "10 Downing Street, London",
+	}
+	appStore := foundAppStore{app: app}
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, appStore, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", "", nil, nil, "", nil, nil, nil, 60, 60, logger)
+
+	url := "/v1/applications/clusters?lat=51.5&lng=-0.1&bbox=-0.2,51.4,-0.05,51.6&zoom=14"
+	rec := serveReq(t, h, http.MethodGet, url, "", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /v1/applications/clusters status = %d, want 200 (anonymous); body = %s", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	if !strings.Contains(rec.Body.String(), `"name":"23/03456/FUL"`) {
+		t.Errorf("body missing planit_name 23/03456/FUL; body = %s", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"authoritySlug":"croydon"`) {
+		t.Errorf("body missing authoritySlug croydon; body = %s", rec.Body.String())
+	}
+	if !strings.HasPrefix(strings.TrimSpace(rec.Body.String()), "[") {
+		t.Errorf("body must be a bare JSON array, got: %s", rec.Body.String())
+	}
+
+	badReq := serveReq(t, h, http.MethodGet, "/v1/applications/clusters", "", "")
+	if badReq.Code != http.StatusBadRequest {
+		t.Fatalf("GET /v1/applications/clusters (no params) status = %d, want 400", badReq.Code)
 	}
 }
 

--- a/api-go/internal/applications/anonclusters.go
+++ b/api-go/internal/applications/anonclusters.go
@@ -1,0 +1,179 @@
+package applications
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// clustersTimeout bounds a single anonymous clusters call end-to-end, mirroring
+// nearPointTimeout (same rationale: a public, unauthenticated endpoint sharing
+// a Postgres pool with prod's core watch-zone/notification reads must fail
+// fast with a 500 rather than hold a pool connection open indefinitely —
+// tc-z5i5j precedent; also relevant given tc-ai55's bimodal clusters latency).
+// It is defense-in-depth alongside the radius clamp, not a substitute for it.
+const clustersTimeout = 8 * time.Second
+
+// clustersStore is the consumer-side store the anonymous clusters handler
+// needs: the same grid-aggregation primitive the authed watch-zone clusters
+// endpoint uses, taking a caller-supplied centre/radius instead of a stored
+// zone. *PostgresStore satisfies it structurally.
+type clustersStore interface {
+	FindClustersInZone(ctx context.Context, q ClusterQuery) ([]Cluster, error)
+}
+
+// clustersHandler serves the public anonymous clusters endpoint.
+type clustersHandler struct {
+	store    clustersStore
+	resolver authoritySlugResolver
+	logger   *slog.Logger
+}
+
+// ClustersRoutes registers the public GET /v1/applications/clusters endpoint
+// (GH#924 Phase 1). It backs the iOS anonymous browse map with the same
+// PostGIS grid-aggregated clusters the authed watch-zone map renders
+// (FindClustersInZone, issue #698), so an anonymous visitor sees the fully
+// clustered set across their radius circle instead of a client-side cluster
+// over a truncated near-point page. It is kept in cmd/api/wiring.go's
+// anonymousPatterns, mirroring NearPointRoutes.
+func ClustersRoutes(mux *http.ServeMux, store clustersStore, resolver authoritySlugResolver, logger *slog.Logger) {
+	h := &clustersHandler{store: store, resolver: resolver, logger: logger}
+	mux.HandleFunc("GET /v1/applications/clusters", h.clusters)
+}
+
+// clusters validates lat/lng (required), bbox (required), zoom (required, 0..
+// maxZoom), radius (optional, clamped like near-point) and status (optional,
+// same vocabulary as the authed zone-clusters endpoint), then returns the
+// grid-aggregated clusters for the caller-supplied centre/radius/viewport as a
+// bare JSON array (never null). A missing/invalid lat/lng, bbox, zoom, or
+// status is a bodyless 400; a store failure is a bodyless 500 (both envelopes
+// backfilled by middleware.ErrorBody, mirroring nearPointHandler.nearPoint).
+// Every result identity (Member and every Members entry) is enriched with its
+// AuthoritySlug before encoding.
+func (h *clustersHandler) clusters(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+
+	lat, lng, ok := parseNearPointCoordinates(q.Get("lat"), q.Get("lng"))
+	if !ok {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	box, ok := ParseBBox(q.Get("bbox"))
+	if !ok {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	gridSize, ok := parseClustersZoom(q.Get("zoom"))
+	if !ok {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	status, ok := parseClustersStatus(q.Get("status"))
+	if !ok {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	radius := parseNearPointRadius(q.Get("radius"))
+
+	ctx, cancel := context.WithTimeout(r.Context(), clustersTimeout)
+	defer cancel()
+
+	clusters, err := h.store.FindClustersInZone(ctx, ClusterQuery{
+		Latitude:        lat,
+		Longitude:       lng,
+		RadiusMetres:    radius,
+		West:            box.West,
+		South:           box.South,
+		East:            box.East,
+		North:           box.North,
+		GridSizeDegrees: gridSize,
+		Status:          status,
+		// The coalesce threshold is always the finest (zoom-20) grid cell size,
+		// independent of the request's own zoom/grid — see FinestGridDegrees's
+		// doc comment, mirroring watchzones' clusters handler.
+		CoalesceThresholdDegrees: FinestGridDegrees(),
+	})
+	if err != nil {
+		serverError(w, r, h.logger, "find clusters near point", err)
+		return
+	}
+
+	// Encode a bare JSON array, never null, for an empty viewport.
+	if clusters == nil {
+		clusters = []Cluster{}
+	}
+	h.enrichAuthoritySlugs(r.Context(), clusters)
+	writeJSON(w, r, h.logger, clusters)
+}
+
+// parseClustersZoom resolves the required ?zoom= to a grid cell size via
+// GridDegreesForZoom. Unlike parseNearPointRadius (which clamps), zoom has no
+// sensible default: an absent, non-integer, or out-of-range value is a clean
+// 400, mirroring watchzones' parseZoom.
+func parseClustersZoom(raw string) (float64, bool) {
+	if raw == "" {
+		return 0, false
+	}
+	z, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, false
+	}
+	return GridDegreesForZoom(z)
+}
+
+// parseClustersStatus resolves the optional ?status= to an app_state filter,
+// mirroring watchzones' parseStatus (same vocabulary; "All"/absent both mean
+// no filter). The anonymous map does not send this param today (GH#924 keeps
+// its reduced feature set — no filter chips) but the endpoint supports it for
+// symmetry with the authed clusters endpoint.
+func parseClustersStatus(raw string) (string, bool) {
+	if raw == "" || raw == "All" {
+		return "", true
+	}
+	if StatusSupported(raw) {
+		return raw, true
+	}
+	return "", false
+}
+
+// enrichAuthoritySlugs populates AuthoritySlug on every member identity in
+// clusters: a single-member cell's Member, and every entry of an unsplittable
+// multi-member cell's Members disambiguation list.
+func (h *clustersHandler) enrichAuthoritySlugs(ctx context.Context, clusters []Cluster) {
+	for i := range clusters {
+		if clusters[i].Member != nil {
+			h.attachAuthoritySlug(ctx, clusters[i].Member)
+		}
+		for j := range clusters[i].Members {
+			h.attachAuthoritySlug(ctx, &clusters[i].Members[j])
+		}
+	}
+}
+
+// attachAuthoritySlug resolves id.Authority (the area_id rendered as a decimal
+// string, see PlanningApplicationID's doc comment) to its URL slug via
+// resolver.SlugForAreaID and sets id.AuthoritySlug. A malformed authority
+// string, or an area id absent from the static authorities table (should
+// never happen — the table covers every real authority), is a warn-logged
+// miss that leaves the slug empty, mirroring resolveAuthoritySlugFor's warn
+// posture but with no AreaName to fall back to slugifying (a Cluster member
+// carries none).
+func (h *clustersHandler) attachAuthoritySlug(ctx context.Context, id *PlanningApplicationID) {
+	areaID, err := strconv.Atoi(id.Authority)
+	if err != nil {
+		h.logger.WarnContext(ctx, "authority slug enrichment: authority is not a valid area id", "authority", id.Authority, "name", id.Name)
+		return
+	}
+	slug, ok := h.resolver.SlugForAreaID(areaID)
+	if !ok {
+		h.logger.WarnContext(ctx, "authority slug enrichment: area id not in static authorities", "areaId", areaID, "name", id.Name)
+		return
+	}
+	id.AuthoritySlug = slug
+}

--- a/api-go/internal/applications/anonclusters_integration_test.go
+++ b/api-go/internal/applications/anonclusters_integration_test.go
@@ -1,0 +1,141 @@
+//go:build integration
+
+package applications
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+)
+
+// clustersWideBBoxParam renders the shared wide viewport (zoneclusters_integration_test.go)
+// as a ?bbox= query value.
+const clustersWideBBoxParam = "-0.2,51.48,-0.05,51.55"
+
+// clustersBaseURL builds the anonymous clusters URL over the fixture centre
+// with a generous radius and the shared wide viewport, so membership below is
+// governed by the grid/zoom under test, not by the centre/radius/bbox.
+func clustersBaseURL() string {
+	return "/v1/applications/clusters?lat=" + strconv.FormatFloat(pgCentreLat, 'f', -1, 64) +
+		"&lng=" + strconv.FormatFloat(pgCentreLon, 'f', -1, 64) +
+		"&radius=10000&bbox=" + clustersWideBBoxParam
+}
+
+func doClustersReq(t *testing.T, mux http.Handler, url string) []Cluster {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, url, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	var clusters []Cluster
+	if err := json.Unmarshal(rec.Body.Bytes(), &clusters); err != nil {
+		t.Fatalf("body not a bare JSON array: %v; body = %s", err, rec.Body.String())
+	}
+	return clusters
+}
+
+// TestClustersHandler_Integration_GridAggregation drives the full anonymous
+// HTTP handler — param parsing, the ?zoom= -> grid-size translation, the
+// store's real PostGIS grid aggregation, and JSON encoding — against real
+// PostGIS (ADR 0032), mirroring TestPostgresStore_FindClustersInZone_ZoomCellBehaviour
+// but through the anonymous query path (a caller-supplied centre/radius/bbox
+// instead of a stored watch zone): the coarsest zoom collapses the eight
+// spread points into one cell, a mid zoom spreads them into four (one per
+// tight pair), and the finest zoom (20) yields one cell per point.
+func TestClustersHandler_Integration_GridAggregation(t *testing.T) {
+	// Not run with t.Parallel(): newAppPGStore's pgtest.New holds a
+	// process-wide advisory lock for the test's duration (see pgtest.New).
+	store := newAppPGStore(t)
+	seedSpread(t, store)
+
+	mux := http.NewServeMux()
+	ClustersRoutes(mux, store, testResolver(), slog.New(slog.DiscardHandler))
+
+	coarse := doClustersReq(t, mux, clustersBaseURL()+"&zoom=0")
+	if len(coarse) != 1 || coarse[0].Count != 8 {
+		t.Fatalf("zoom=0 (coarsest): got %d cells (first count %v), want 1 cell of 8", len(coarse), firstCount(coarse))
+	}
+
+	medium := doClustersReq(t, mux, clustersBaseURL()+"&zoom=12")
+	if len(medium) != 4 {
+		t.Fatalf("zoom=12: got %d cells, want 4 (one per tight pair)", len(medium))
+	}
+	for _, c := range medium {
+		if c.Count != 2 {
+			t.Errorf("zoom=12: cell count = %d, want 2", c.Count)
+		}
+	}
+	if !(len(coarse) < len(medium)) {
+		t.Errorf("a finer zoom must spread into more cells: zoom=0 -> %d, zoom=12 -> %d", len(coarse), len(medium))
+	}
+
+	tiny := doClustersReq(t, mux, clustersBaseURL()+"&zoom=20")
+	if len(tiny) != 8 {
+		t.Fatalf("zoom=20 (finest): got %d cells, want 8 (one per point)", len(tiny))
+	}
+	for _, c := range tiny {
+		if c.Count != 1 {
+			t.Errorf("zoom=20: cell count = %d, want 1", c.Count)
+		}
+		if c.Member == nil {
+			t.Errorf("zoom=20: single-member cell must carry a member id, got nil")
+		}
+	}
+	if !(len(medium) < len(tiny)) {
+		t.Errorf("the finest zoom must spread furthest: zoom=12 -> %d, zoom=20 -> %d", len(medium), len(tiny))
+	}
+}
+
+// TestClustersHandler_Integration_StackedCoalescing drives the full anonymous
+// HTTP handler against real PostGIS to prove the unsplittable-cell member list
+// (applicationIds) survives the anonymous query path end-to-end: three
+// applications at an IDENTICAL coordinate always share a cell (their extent is
+// always below FinestGridDegrees, regardless of the request's own zoom), so
+// the cell carries the full member list, slug-enriched by the anonymous
+// handler — mirroring TestFindClustersInZone_CoincidentApplications_ReturnsMemberList's
+// first subtest, through the HTTP handler, with the GH#924 slug enrichment
+// layered on top.
+func TestClustersHandler_Integration_StackedCoalescing(t *testing.T) {
+	// Not run with t.Parallel(): newAppPGStore's pgtest.New holds a
+	// process-wide advisory lock for the test's duration (see pgtest.New).
+	store := newAppPGStore(t)
+	ctx := context.Background()
+	// City of London (area id 471, the id testResolver() round-trips to
+	// "city-of-london") so the anonymous slug enrichment is exercised for
+	// real, not just left empty by a resolver miss.
+	for _, name := range []string{"24/001", "24/002", "24/003"} {
+		if err := store.Upsert(ctx, clusterApp(name, 471, 0.0, 0.0)); err != nil {
+			t.Fatalf("Upsert %s: %v", name, err)
+		}
+	}
+
+	mux := http.NewServeMux()
+	ClustersRoutes(mux, store, testResolver(), slog.New(slog.DiscardHandler))
+
+	// A mid zoom: the coalesce threshold the handler applies is always the
+	// finest grid (FinestGridDegrees), independent of this request zoom.
+	clusters := doClustersReq(t, mux, clustersBaseURL()+"&zoom=10")
+	if len(clusters) != 1 {
+		t.Fatalf("got %d clusters, want 1 (coincident points share a cell)", len(clusters))
+	}
+	c := clusters[0]
+	if c.Count != 3 {
+		t.Fatalf("count: got %d, want 3", c.Count)
+	}
+	if len(c.Members) != 3 {
+		t.Fatalf("applicationIds: got %d entries, want 3", len(c.Members))
+	}
+	for _, m := range c.Members {
+		if m.Authority != "471" {
+			t.Errorf("member authority: got %q, want %q", m.Authority, "471")
+		}
+		if m.AuthoritySlug != "city-of-london" {
+			t.Errorf("member authoritySlug: got %q, want %q (anonymous slug enrichment)", m.AuthoritySlug, "city-of-london")
+		}
+	}
+}

--- a/api-go/internal/applications/anonclusters_test.go
+++ b/api-go/internal/applications/anonclusters_test.go
@@ -1,0 +1,401 @@
+package applications
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// fakeClustersStore is a hand-written clustersStore fake that records the last
+// call's query and returns caller-configured results.
+type fakeClustersStore struct {
+	clusters []Cluster
+	err      error
+
+	calledQuery ClusterQuery
+	called      bool
+}
+
+func (f *fakeClustersStore) FindClustersInZone(_ context.Context, q ClusterQuery) ([]Cluster, error) {
+	f.called = true
+	f.calledQuery = q
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.clusters, nil
+}
+
+// newClustersTestHandler builds an anonymous clusters mux wired to the given
+// fake store and resolver, discarding log output.
+func newClustersTestHandler(store *fakeClustersStore, resolver authoritySlugResolver) http.Handler {
+	mux := http.NewServeMux()
+	ClustersRoutes(mux, store, resolver, slog.New(slog.DiscardHandler))
+	return mux
+}
+
+// validClustersQuery is a well-formed query string covering every required
+// param, reused as a base by tests that only want to vary one thing.
+const validClustersQuery = "?lat=51.5074&lng=-0.1278&bbox=-0.2,51.4,-0.05,51.6&zoom=14"
+
+// TestClustersHandler_RequiresLatLng proves a missing or unparseable lat/lng is
+// a bodyless 400 and never reaches the store.
+func TestClustersHandler_RequiresLatLng(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{"missing both", "/v1/applications/clusters?bbox=-0.2,51.4,-0.05,51.6&zoom=14"},
+		{"missing lng", "/v1/applications/clusters?lat=51.5&bbox=-0.2,51.4,-0.05,51.6&zoom=14"},
+		{"missing lat", "/v1/applications/clusters?lng=-0.1&bbox=-0.2,51.4,-0.05,51.6&zoom=14"},
+		{"non-numeric lat", "/v1/applications/clusters?lat=abc&lng=-0.1&bbox=-0.2,51.4,-0.05,51.6&zoom=14"},
+		{"lat out of range", "/v1/applications/clusters?lat=91&lng=-0.1&bbox=-0.2,51.4,-0.05,51.6&zoom=14"},
+		{"lat is NaN literal", "/v1/applications/clusters?lat=NaN&lng=-0.1&bbox=-0.2,51.4,-0.05,51.6&zoom=14"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			store := &fakeClustersStore{}
+			h := newClustersTestHandler(store, testResolver())
+
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, tc.url, nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400", rec.Code)
+			}
+			if rec.Body.Len() != 0 {
+				t.Errorf("body = %q, want empty (bodyless 400)", rec.Body.String())
+			}
+			if store.called {
+				t.Error("store must not be called on invalid lat/lng")
+			}
+		})
+	}
+}
+
+// TestClustersHandler_RequiresBBox proves a missing or malformed bbox is a
+// bodyless 400 and never reaches the store.
+func TestClustersHandler_RequiresBBox(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{"missing bbox", "/v1/applications/clusters?lat=51.5&lng=-0.1&zoom=14"},
+		{"wrong field count", "/v1/applications/clusters?lat=51.5&lng=-0.1&bbox=-0.2,51.4,-0.05&zoom=14"},
+		{"degenerate rectangle", "/v1/applications/clusters?lat=51.5&lng=-0.1&bbox=-0.05,51.4,-0.2,51.6&zoom=14"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			store := &fakeClustersStore{}
+			h := newClustersTestHandler(store, testResolver())
+
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, tc.url, nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400", rec.Code)
+			}
+			if rec.Body.Len() != 0 {
+				t.Errorf("body = %q, want empty (bodyless 400)", rec.Body.String())
+			}
+			if store.called {
+				t.Error("store must not be called on invalid bbox")
+			}
+		})
+	}
+}
+
+// TestClustersHandler_RequiresZoom proves a missing, non-integer, or
+// out-of-range zoom is a bodyless 400 and never reaches the store.
+func TestClustersHandler_RequiresZoom(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{"missing zoom", "/v1/applications/clusters?lat=51.5&lng=-0.1&bbox=-0.2,51.4,-0.05,51.6"},
+		{"non-integer zoom", "/v1/applications/clusters?lat=51.5&lng=-0.1&bbox=-0.2,51.4,-0.05,51.6&zoom=abc"},
+		{"negative zoom", "/v1/applications/clusters?lat=51.5&lng=-0.1&bbox=-0.2,51.4,-0.05,51.6&zoom=-1"},
+		{"zoom above maxZoom", "/v1/applications/clusters?lat=51.5&lng=-0.1&bbox=-0.2,51.4,-0.05,51.6&zoom=21"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			store := &fakeClustersStore{}
+			h := newClustersTestHandler(store, testResolver())
+
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, tc.url, nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400", rec.Code)
+			}
+			if rec.Body.Len() != 0 {
+				t.Errorf("body = %q, want empty (bodyless 400)", rec.Body.String())
+			}
+			if store.called {
+				t.Error("store must not be called on invalid zoom")
+			}
+		})
+	}
+}
+
+// TestClustersHandler_UnknownStatusIs400 proves an unrecognised ?status= is a
+// bodyless 400, while an absent status or "All" both mean no filter.
+func TestClustersHandler_UnknownStatusIs400(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeClustersStore{}
+	h := newClustersTestHandler(store, testResolver())
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/applications/clusters"+validClustersQuery+"&status=NotARealStatus", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("body = %q, want empty (bodyless 400)", rec.Body.String())
+	}
+	if store.called {
+		t.Error("store must not be called on invalid status")
+	}
+}
+
+// TestClustersHandler_StatusAllIsNoFilter proves ?status=All and an absent
+// ?status= both pass an empty Status filter through to the store.
+func TestClustersHandler_StatusAllIsNoFilter(t *testing.T) {
+	t.Parallel()
+
+	tests := []string{"", "&status=All"}
+	for _, suffix := range tests {
+		store := &fakeClustersStore{}
+		h := newClustersTestHandler(store, testResolver())
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/applications/clusters"+validClustersQuery+suffix, nil)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("suffix=%q status = %d, want 200; body = %s", suffix, rec.Code, rec.Body.String())
+		}
+		if store.calledQuery.Status != "" {
+			t.Errorf("suffix=%q status filter: got %q, want empty", suffix, store.calledQuery.Status)
+		}
+	}
+}
+
+// TestClustersHandler_RadiusClamping proves the optional ?radius= is clamped
+// into [100, 5000] with a default of 2000, identical to near-point.
+func TestClustersHandler_RadiusClamping(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		suffix string
+		want   float64
+	}{
+		{"absent defaults to 2000", "", 2000},
+		{"below minimum clamps to 100", "&radius=10", 100},
+		{"above maximum clamps to 5000", "&radius=99999", 5000},
+		{"in range passes through", "&radius=3000", 3000},
+		{"non-numeric defaults to 2000", "&radius=abc", 2000},
+		{"negative clamps to 100", "&radius=-50", 100},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			store := &fakeClustersStore{}
+			h := newClustersTestHandler(store, testResolver())
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/applications/clusters"+validClustersQuery+tc.suffix, nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+			}
+			if store.calledQuery.RadiusMetres != tc.want {
+				t.Errorf("radius: got %v, want %v", store.calledQuery.RadiusMetres, tc.want)
+			}
+		})
+	}
+}
+
+// TestClustersHandler_PassesParamsToStore proves a well-formed request
+// translates every param into the ClusterQuery the store receives, including
+// the finest-grid coalesce threshold (independent of the request's own zoom).
+func TestClustersHandler_PassesParamsToStore(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeClustersStore{}
+	h := newClustersTestHandler(store, testResolver())
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/v1/applications/clusters?lat=51.5074&lng=-0.1278&radius=2500&bbox=-0.2,51.4,-0.05,51.6&zoom=10&status=Permitted", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	q := store.calledQuery
+	if q.Latitude != 51.5074 || q.Longitude != -0.1278 {
+		t.Errorf("centre: got (%v, %v), want (51.5074, -0.1278)", q.Latitude, q.Longitude)
+	}
+	if q.RadiusMetres != 2500 {
+		t.Errorf("radius: got %v, want 2500", q.RadiusMetres)
+	}
+	if q.West != -0.2 || q.South != 51.4 || q.East != -0.05 || q.North != 51.6 {
+		t.Errorf("viewport: got %+v, want {-0.2, 51.4, -0.05, 51.6}", q)
+	}
+	wantGrid, ok := GridDegreesForZoom(10)
+	if !ok || q.GridSizeDegrees != wantGrid {
+		t.Errorf("grid size: got %v, want %v (zoom 10)", q.GridSizeDegrees, wantGrid)
+	}
+	if q.Status != "Permitted" {
+		t.Errorf("status: got %q, want %q", q.Status, "Permitted")
+	}
+	if q.CoalesceThresholdDegrees != FinestGridDegrees() {
+		t.Errorf("coalesce threshold: got %v, want %v (finest grid, independent of request zoom)", q.CoalesceThresholdDegrees, FinestGridDegrees())
+	}
+}
+
+// TestClustersHandler_SlugEnrichment proves the handler populates AuthoritySlug
+// on a single-member cell's Member and on every entry of a stacked cell's
+// Members, via the resolver.
+func TestClustersHandler_SlugEnrichment(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeClustersStore{clusters: []Cluster{
+		{ // single-member cell
+			Latitude: 51.51, Longitude: -0.12, Count: 1,
+			StatusCounts: map[string]int{"Permitted": 1},
+			Member:       &PlanningApplicationID{Authority: "471", Name: "24/001"},
+		},
+		{ // unsplittable multi-member (stacked) cell
+			Latitude: 51.52, Longitude: -0.13, Count: 2,
+			StatusCounts: map[string]int{"Permitted": 2},
+			Members: []PlanningApplicationID{
+				{Authority: "471", Name: "24/002"},
+				{Authority: "471", Name: "24/003"},
+			},
+		},
+	}}
+	h := newClustersTestHandler(store, testResolver())
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/applications/clusters"+validClustersQuery, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	var got []Cluster
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v; raw=%s", err, rec.Body.String())
+	}
+	if len(got) != 2 {
+		t.Fatalf("clusters: got %d, want 2", len(got))
+	}
+	if got[0].Member == nil || got[0].Member.AuthoritySlug != "city-of-london" {
+		t.Errorf("single-member slug: got %+v, want AuthoritySlug=city-of-london", got[0].Member)
+	}
+	if len(got[1].Members) != 2 {
+		t.Fatalf("stacked members: got %d, want 2", len(got[1].Members))
+	}
+	for i, m := range got[1].Members {
+		if m.AuthoritySlug != "city-of-london" {
+			t.Errorf("stacked member[%d] slug: got %q, want city-of-london", i, m.AuthoritySlug)
+		}
+	}
+}
+
+// TestClustersHandler_SlugEnrichmentMiss proves a resolver miss (area id absent
+// from the static authorities table, or a malformed authority string) leaves
+// AuthoritySlug empty rather than erroring the request.
+func TestClustersHandler_SlugEnrichmentMiss(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeClustersStore{clusters: []Cluster{
+		{
+			Latitude: 51.51, Longitude: -0.12, Count: 1,
+			StatusCounts: map[string]int{"Permitted": 1},
+			Member:       &PlanningApplicationID{Authority: "999999", Name: "24/999"}, // unknown area id
+		},
+		{
+			Latitude: 51.53, Longitude: -0.14, Count: 1,
+			StatusCounts: map[string]int{"Permitted": 1},
+			Member:       &PlanningApplicationID{Authority: "not-a-number", Name: "24/998"}, // malformed
+		},
+	}}
+	h := newClustersTestHandler(store, testResolver())
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/applications/clusters"+validClustersQuery, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	var got []Cluster
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v; raw=%s", err, rec.Body.String())
+	}
+	if len(got) != 2 {
+		t.Fatalf("clusters: got %d, want 2", len(got))
+	}
+	for _, c := range got {
+		if c.Member == nil {
+			t.Fatalf("expected a member on every cell, got nil: %+v", c)
+		}
+		if c.Member.AuthoritySlug != "" {
+			t.Errorf("expected empty slug on a resolver miss, got %q", c.Member.AuthoritySlug)
+		}
+	}
+}
+
+// TestClustersHandler_EmptyResultEncodesEmptyArray proves a nil store result
+// encodes as a bare JSON array, never null.
+func TestClustersHandler_EmptyResultEncodesEmptyArray(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeClustersStore{clusters: nil}
+	h := newClustersTestHandler(store, testResolver())
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/applications/clusters"+validClustersQuery, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Body.String(); got != "[]" {
+		t.Errorf("body = %q, want \"[]\"", got)
+	}
+}
+
+// TestClustersHandler_StoreErrorIs500 proves a store failure is a bodyless 500.
+func TestClustersHandler_StoreErrorIs500(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeClustersStore{err: errors.New("boom")}
+	h := newClustersTestHandler(store, testResolver())
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/applications/clusters"+validClustersQuery, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("body = %q, want empty (bodyless 500)", rec.Body.String())
+	}
+}

--- a/api-go/internal/applications/gridzoom.go
+++ b/api-go/internal/applications/gridzoom.go
@@ -1,0 +1,99 @@
+package applications
+
+import (
+	"math"
+	"strconv"
+	"strings"
+)
+
+// maxZoom is the inclusive upper bound on the standard slippy-map zoom range a
+// client may request; baseGridDegrees is the grid cell size (in degrees) at
+// zoom 0. Each cell is 1/8 of a zoom tile (a tile is 360/2^z degrees wide), so
+// a screenful of a few tiles yields a bounded handful of cluster cells.
+//
+// This table (and the exported GridDegreesForZoom/FinestGridDegrees below)
+// moved here from watchzones/nearby.go (GH#924): the zoom -> grid policy is a
+// client-visible density contract shared by both the authed watch-zone map and
+// the anonymous map (anonclusters.go) — duplicating it invites drift where the
+// two maps cluster differently at the same zoom. watchzones already imports
+// this package, so the dependency direction was already established.
+const (
+	maxZoom         = 20
+	baseGridDegrees = 45.0 // 360 / 2^3 (eight cells per tile at zoom 0)
+)
+
+// zoomGridDegrees is the server-owned zoom -> grid-cell-size lookup. Index z
+// holds the cell size in degrees for slippy zoom z: baseGridDegrees / 2^z, so
+// the cell halves with every zoom level (45 deg at z=0 down to ~4.3e-5 deg at
+// z=20, where each application is effectively its own cell). Keeping this
+// table here lets density be retuned without touching a store or shipping a
+// client release.
+var zoomGridDegrees = func() [maxZoom + 1]float64 {
+	var table [maxZoom + 1]float64
+	for z := range table {
+		table[z] = baseGridDegrees / float64(uint64(1)<<uint(z))
+	}
+	return table
+}()
+
+// GridDegreesForZoom resolves a slippy-map zoom level to its grid cell size in
+// degrees via zoomGridDegrees. ok is false for a zoom outside [0, maxZoom] —
+// there is no sensible "nearest legal zoom" to clamp an out-of-range value to,
+// so callers turn a false ok into a clean 400 rather than guessing.
+func GridDegreesForZoom(zoom int) (float64, bool) {
+	if zoom < 0 || zoom > maxZoom {
+		return 0, false
+	}
+	return zoomGridDegrees[zoom], true
+}
+
+// FinestGridDegrees returns the zoom-20 (finest) grid cell size in degrees:
+// the coalesce threshold below which a multi-member cluster cell can never be
+// split by further zooming, so it carries a capped applicationIds member list
+// (see ClusterQuery.CoalesceThresholdDegrees). It is independent of the
+// request's own zoom/grid size — every cluster query derives its coalesce
+// threshold from this same finest cell, not from its own GridSizeDegrees.
+func FinestGridDegrees() float64 {
+	return zoomGridDegrees[maxZoom]
+}
+
+// BBox is a parsed ?bbox=west,south,east,north viewport rectangle in WGS84
+// decimal degrees, as produced by ParseBBox.
+type BBox struct {
+	West, South, East, North float64
+}
+
+// ParseBBox resolves ?bbox=west,south,east,north into a BBox. It rejects
+// (ok == false) anything that is not exactly four finite decimal degrees, with
+// coordinates in range (lng [-180,180], lat [-90,90]) and strictly ordered
+// (west < east, south < north), so a malformed viewport is a clean 400 rather
+// than a degenerate or world-spanning query. Moved from watchzones/nearby.go's
+// unexported parseBBox (GH#924) — byte-identical semantics, now shared.
+func ParseBBox(raw string) (BBox, bool) {
+	if raw == "" {
+		return BBox{}, false
+	}
+	parts := strings.Split(raw, ",")
+	if len(parts) != 4 {
+		return BBox{}, false
+	}
+	vals := make([]float64, 4)
+	for i, p := range parts {
+		v, err := strconv.ParseFloat(strings.TrimSpace(p), 64)
+		if err != nil || math.IsNaN(v) || math.IsInf(v, 0) {
+			return BBox{}, false
+		}
+		vals[i] = v
+	}
+	box := BBox{West: vals[0], South: vals[1], East: vals[2], North: vals[3]}
+	if box.West < -180 || box.West > 180 || box.East < -180 || box.East > 180 {
+		return BBox{}, false
+	}
+	if box.South < -90 || box.South > 90 || box.North < -90 || box.North > 90 {
+		return BBox{}, false
+	}
+	if box.West >= box.East || box.South >= box.North {
+		return BBox{}, false
+	}
+	return box, true
+}

--- a/api-go/internal/applications/gridzoom_test.go
+++ b/api-go/internal/applications/gridzoom_test.go
@@ -1,0 +1,87 @@
+package applications
+
+import (
+	"testing"
+)
+
+// TestGridDegreesForZoom pins the zoom -> grid-cell-size lookup this package
+// now owns (moved from watchzones, GH#924): each cell halves per zoom level
+// (baseGridDegrees / 2^z), and a zoom outside [0, maxZoom] is rejected.
+func TestGridDegreesForZoom(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		zoom int
+		want float64
+		ok   bool
+	}{
+		{"zoom 0 is the base grid", 0, 45.0, true},
+		{"zoom 1 halves the base grid", 1, 22.5, true},
+		{"zoom 20 is the finest grid", 20, 45.0 / float64(uint64(1)<<20), true},
+		{"negative zoom is rejected", -1, 0, false},
+		{"zoom above maxZoom is rejected", 21, 0, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := GridDegreesForZoom(tc.zoom)
+			if ok != tc.ok {
+				t.Fatalf("GridDegreesForZoom(%d) ok = %v, want %v", tc.zoom, ok, tc.ok)
+			}
+			if ok && got != tc.want {
+				t.Errorf("GridDegreesForZoom(%d) = %v, want %v", tc.zoom, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFinestGridDegrees proves the coalesce-threshold helper always returns the
+// zoom-20 cell size, independent of any request zoom.
+func TestFinestGridDegrees(t *testing.T) {
+	t.Parallel()
+	want := 45.0 / float64(uint64(1)<<20)
+	if got := FinestGridDegrees(); got != want {
+		t.Errorf("FinestGridDegrees() = %v, want %v", got, want)
+	}
+}
+
+// TestParseBBox mirrors the coverage watchzones' parseBBox previously had
+// entirely through the HTTP handler, exercising the moved parser directly:
+// well-formed rectangles parse, and malformed/out-of-range/degenerate input is
+// rejected.
+func TestParseBBox(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+		want BBox
+		ok   bool
+	}{
+		{"valid rectangle", "-0.2,51.4,-0.05,51.6", BBox{West: -0.2, South: 51.4, East: -0.05, North: 51.6}, true},
+		{"empty is rejected", "", BBox{}, false},
+		{"wrong field count is rejected", "-0.2,51.4,-0.05", BBox{}, false},
+		{"non-numeric field is rejected", "-0.2,51.4,x,51.6", BBox{}, false},
+		{"NaN literal is rejected", "-0.2,51.4,NaN,51.6", BBox{}, false},
+		{"Inf literal is rejected", "-0.2,51.4,Inf,51.6", BBox{}, false},
+		{"west out of range is rejected", "-181,51.4,-0.05,51.6", BBox{}, false},
+		{"east out of range is rejected", "-0.2,51.4,181,51.6", BBox{}, false},
+		{"south out of range is rejected", "-0.2,-91,-0.05,51.6", BBox{}, false},
+		{"north out of range is rejected", "-0.2,51.4,-0.05,91", BBox{}, false},
+		{"west >= east is rejected", "-0.05,51.4,-0.2,51.6", BBox{}, false},
+		{"south >= north is rejected", "-0.2,51.6,-0.05,51.4", BBox{}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := ParseBBox(tc.raw)
+			if ok != tc.ok {
+				t.Fatalf("ParseBBox(%q) ok = %v, want %v", tc.raw, ok, tc.ok)
+			}
+			if ok && got != tc.want {
+				t.Errorf("ParseBBox(%q) = %+v, want %+v", tc.raw, got, tc.want)
+			}
+		})
+	}
+}

--- a/api-go/internal/applications/zoneclusters.go
+++ b/api-go/internal/applications/zoneclusters.go
@@ -14,9 +14,17 @@ import (
 // PlanningApplicationId off exactly these two fields, so a single-member cluster
 // can route a map-pin tap straight to the application summary sheet with no
 // re-fetch.
+//
+// AuthoritySlug (GH#924 Phase 1) is populated ONLY by the anonymous clusters
+// handler (anonclusters.go): the anonymous client's only point-read is the
+// by-slug endpoint, and cluster members otherwise carry only the authority
+// area id, not its slug. omitempty keeps the authed watch-zone clusters
+// response byte-identical (that handler never sets it) — a parallel response
+// type would duplicate the whole Cluster shape for one field.
 type PlanningApplicationID struct {
-	Authority string `json:"authority"`
-	Name      string `json:"name"`
+	Authority     string `json:"authority"`
+	Name          string `json:"name"`
+	AuthoritySlug string `json:"authoritySlug,omitempty"`
 }
 
 // Cluster is one grid-aggregated bucket of in-zone, in-viewport applications, as

--- a/api-go/internal/applications/zoneclusters_test.go
+++ b/api-go/internal/applications/zoneclusters_test.go
@@ -96,6 +96,51 @@ func TestScanClusterRow_Members(t *testing.T) {
 	})
 }
 
+// TestPlanningApplicationID_AuthoritySlugJSONShape pins the wire contract for
+// the GH#924 AuthoritySlug addition: omitted when empty (byte-identical to the
+// pre-GH#924 authed zone-clusters response, which never populates it) and
+// present when the anonymous handler has set it.
+func TestPlanningApplicationID_AuthoritySlugJSONShape(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty slug is omitted", func(t *testing.T) {
+		t.Parallel()
+		id := PlanningApplicationID{Authority: "100", Name: "24/001"}
+		raw, err := json.Marshal(id)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var got map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &got); err != nil {
+			t.Fatalf("unmarshal: %v; raw=%s", err, raw)
+		}
+		if _, ok := got["authoritySlug"]; ok {
+			t.Errorf("authoritySlug must be omitted when empty, got %s", raw)
+		}
+	})
+
+	t.Run("present slug is serialised", func(t *testing.T) {
+		t.Parallel()
+		id := PlanningApplicationID{Authority: "100", Name: "24/001", AuthoritySlug: "testshire"}
+		raw, err := json.Marshal(id)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var got map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &got); err != nil {
+			t.Fatalf("unmarshal: %v; raw=%s", err, raw)
+		}
+		slug, ok := got["authoritySlug"]
+		if !ok {
+			t.Fatalf("authoritySlug missing from %s", raw)
+		}
+		var s string
+		if err := json.Unmarshal(slug, &s); err != nil || s != "testshire" {
+			t.Errorf("authoritySlug: got %s, want \"testshire\"", slug)
+		}
+	})
+}
+
 // TestCluster_MembersJSONShape pins the wire contract for the new member list:
 // applicationIds is present (an array) when Members is populated, and is omitted
 // entirely (omitempty) for a splittable cell whose Members is nil.

--- a/api-go/internal/watchzones/nearby.go
+++ b/api-go/internal/watchzones/nearby.go
@@ -469,7 +469,7 @@ func (h *handler) clusters(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	box, ok := parseBBox(r.URL.Query().Get("bbox"))
+	box, ok := applications.ParseBBox(r.URL.Query().Get("bbox"))
 	if !ok {
 		h.writeError(w, r, http.StatusBadRequest, invalidBBoxMessage)
 		return
@@ -493,18 +493,18 @@ func (h *handler) clusters(w http.ResponseWriter, r *http.Request) {
 		Latitude:        zone.Latitude,
 		Longitude:       zone.Longitude,
 		RadiusMetres:    zone.RadiusMetres,
-		West:            box.west,
-		South:           box.south,
-		East:            box.east,
-		North:           box.north,
+		West:            box.West,
+		South:           box.South,
+		East:            box.East,
+		North:           box.North,
 		GridSizeDegrees: gridSize,
 		Status:          status,
 		// The coalesce threshold is the finest (zoom-20) grid cell size, not the
 		// request's own grid: a multi-member cell whose member points already span
 		// less than this can never be split by zooming, so the store attaches an
-		// applicationIds member list. Deriving it from the same zoomGridDegrees
-		// table keeps it tracking the zoom -> grid policy with no separate constant.
-		CoalesceThresholdDegrees: zoomGridDegrees[maxZoom],
+		// applicationIds member list. applications.FinestGridDegrees() keeps it
+		// tracking the shared zoom -> grid policy (GH#924) with no separate constant.
+		CoalesceThresholdDegrees: applications.FinestGridDegrees(),
 	})
 	if err != nil {
 		h.serverError(w, r, "find clusters in zone", err)
@@ -517,79 +517,20 @@ func (h *handler) clusters(w http.ResponseWriter, r *http.Request) {
 	h.writeJSON(w, r, http.StatusOK, clusters)
 }
 
-// viewport is the parsed ?bbox= rectangle in WGS84 decimal degrees.
-type viewport struct {
-	west, south, east, north float64
-}
-
-// parseBBox resolves ?bbox=west,south,east,north into a viewport. It rejects
-// (ok == false) anything that is not exactly four finite decimal degrees, with
-// coordinates in range (lng [-180,180], lat [-90,90]) and strictly ordered
-// (west < east, south < north), so a malformed viewport is a clean 400 rather
-// than a degenerate or world-spanning query.
-func parseBBox(raw string) (viewport, bool) {
-	if raw == "" {
-		return viewport{}, false
-	}
-	parts := strings.Split(raw, ",")
-	if len(parts) != 4 {
-		return viewport{}, false
-	}
-	vals := make([]float64, 4)
-	for i, p := range parts {
-		v, err := strconv.ParseFloat(strings.TrimSpace(p), 64)
-		if err != nil || math.IsNaN(v) || math.IsInf(v, 0) {
-			return viewport{}, false
-		}
-		vals[i] = v
-	}
-	box := viewport{west: vals[0], south: vals[1], east: vals[2], north: vals[3]}
-	if box.west < -180 || box.west > 180 || box.east < -180 || box.east > 180 {
-		return viewport{}, false
-	}
-	if box.south < -90 || box.south > 90 || box.north < -90 || box.north > 90 {
-		return viewport{}, false
-	}
-	if box.west >= box.east || box.south >= box.north {
-		return viewport{}, false
-	}
-	return box, true
-}
-
-// maxZoom is the inclusive upper bound on the standard slippy-map zoom range a
-// client may request; baseGridDegrees is the grid cell size (in degrees) at zoom
-// 0. Each cell is 1/8 of a zoom tile (a tile is 360/2^z degrees wide), so a
-// screenful of a few tiles yields a bounded handful of cluster cells.
-const (
-	maxZoom         = 20
-	baseGridDegrees = 45.0 // 360 / 2^3 (eight cells per tile at zoom 0)
-)
-
-// zoomGridDegrees is the server-owned zoom -> grid-cell-size lookup. Index z holds
-// the cell size in degrees for slippy zoom z: baseGridDegrees / 2^z, so the cell
-// halves with every zoom level (45 deg at z=0 down to ~4.8e-5 deg at z=20, where
-// each application is effectively its own cell). Keeping this table in the handler
-// lets us retune density without touching the store or shipping a client release.
-var zoomGridDegrees = func() [maxZoom + 1]float64 {
-	var table [maxZoom + 1]float64
-	for z := range table {
-		table[z] = baseGridDegrees / float64(uint64(1)<<uint(z))
-	}
-	return table
-}()
-
-// parseZoom resolves ?zoom= to a grid cell size via zoomGridDegrees. An absent,
-// non-integer, or out-of-range (outside 0..maxZoom) value is rejected
-// (ok == false) so a garbage zoom is a clean 400, never a silent default.
+// parseZoom resolves ?zoom= to a grid cell size via applications.GridDegreesForZoom
+// (GH#924 — the zoom -> grid table moved to applications/gridzoom.go, shared with
+// the anonymous clusters endpoint). An absent or non-integer value is rejected
+// locally; an out-of-range one is rejected by GridDegreesForZoom — either way a
+// garbage zoom is a clean 400, never a silent default.
 func parseZoom(raw string) (float64, bool) {
 	if raw == "" {
 		return 0, false
 	}
 	z, err := strconv.Atoi(raw)
-	if err != nil || z < 0 || z > maxZoom {
+	if err != nil {
 		return 0, false
 	}
-	return zoomGridDegrees[z], true
+	return applications.GridDegreesForZoom(z)
 }
 
 // parseLimit resolves ?limit= to a bounded page size: absent, non-numeric, or


### PR DESCRIPTION
## Summary

Phase 1 of #924: the anonymous (pre-login) iOS map currently fetches only the 200 nearest applications and clusters them on-device, so dense areas render a centre-hugging blob instead of covering the radius circle. This adds the anonymous server-side clusters endpoint so the anon map can render the same PostGIS grid aggregates as the logged-in map.

- `GET /v1/applications/clusters` (new, `internal/applications/anonclusters.go`) — mirrors `nearpoint.go`: lat/lng required, radius clamped [100,5000]m default 2000, bbox + zoom (0–20) required, optional status; 8s timeout; bare `[]` never null; per-IP `AnonRateLimit` via `anonymousPatterns`.
- Reuses `FindClustersInZone`/`ClusterQuery` unchanged — the store was always a pure spatial primitive; the watch zone was only the parameter source.
- Zoom→grid table + bbox parsing extracted from `watchzones` into exported `applications` helpers (`GridDegreesForZoom`, `FinestGridDegrees`, `ParseBBox`) so the two maps can never drift in density policy; authed zone-clusters behaviour and response bytes unchanged (all 405 existing tests pass unmodified).
- `PlanningApplicationID` gains `authoritySlug,omitempty`, populated only by the anonymous handler via the static authorities lookup — the anonymous client's point-read is the by-slug endpoint, and cluster members carry area ids, not slugs. Authed responses stay byte-identical.

## Verification

- TDD throughout (10 red/green/refactor commits).
- `gofmt` / `go vet` / `golangci-lint` clean; `go test -race ./...` 1728 pass; `make test-integration` green (real PostGIS: grid aggregation across zooms, stacked-cell coalescing, slug enrichment through the HTTP handler).

Closes #924 Phase 1. Bead: tc-9vnhg. iOS switch (Phase 2) follows as tc-2wu29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CamN56bgL43Qn3ibGYVkt4