### PR TITLE
fix(ios): Saved list — stray grey separator line under the last card row (tc-dvc1q)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/SavedApplicationList/SavedApplicationListView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/SavedApplicationList/SavedApplicationListView.swift
@@ -97,7 +97,7 @@ public struct SavedApplicationListView: View {
     } else {
       ForEach(viewModel.filteredApplications) { application in
         ApplicationListRow(application: application)
-          .listRowBackground(Color.tcSurface)
+          .cardRowInsets()
           .contentShape(Rectangle())
           .onTapGesture {
             // Pass the full payload so the detail sheet opens instantly from


### PR DESCRIPTION
## Summary

TestFlight feedback 2026-07-10: a grey hairline renders at the bottom edge of the white card box on the Saved tab. The card-row `ForEach` in `SavedApplicationListView` was the only content-row block in the app not suppressing the default `List` separator, so the system hairline drew under every row — visible beneath the last card.

One-line fix: adopt the shared `.cardRowInsets()` (hidden separator + clear row background + standard insets), exactly as the Applications tab already does for the identical `ApplicationListRow`, dropping the now-redundant `.listRowBackground` (the card surface comes from `NoticeCardStyle`).

## Verification

- `swift build` / `swift test` (1811 pass; one known tracked flake reproduced identically on unmodified baseline) / `swiftlint --strict` clean on the changed file.
- Agent-run simulator verification, signed in with ≥1 saved application: no hairline under the last card, no separators between cards, card geometry identical to the Applications tab, light + dark mode.

Bead: tc-dvc1q

Release-Note: Removed a stray grey line under the last saved application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CamN56bgL43Qn3ibGYVkt4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the saved applications list row layout with revised card spacing and insets.
  * Removed the explicit row background styling for a cleaner, more consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->