### PR TITLE
feat(ios): full-bleed map — drop Map nav title, float settings cog over the map (tc-3b1hj)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMainTabView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMainTabView.swift
@@ -61,12 +61,15 @@ public struct AnonymousMainTabView: View {
 
   @ViewBuilder
   private var mapTab: some View {
+    // Full-bleed (tc-3b1hj): no nav title, no nav bar — the tab bar already
+    // says "Map". Nothing else is nav-bar-anchored on this screen; the CTA
+    // banner is a bottom `safeAreaInset` applied inside `AnonymousMapView`'s
+    // own content, unaffected by hiding the bar above it.
     NavigationStack {
       if let mapViewModel = coordinator.mapViewModel {
         AnonymousMapView(viewModel: mapViewModel)
-          .navigationTitle("Map")
           #if os(iOS)
-            .navigationBarTitleDisplayMode(.inline)
+            .toolbar(.hidden, for: .navigationBar)
           #endif
           .accountCTABanner(
             onCreateAccount: { coordinator.requestSignIn() },

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMapView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousMapView.swift
@@ -94,8 +94,11 @@ public struct AnonymousMapView: View {
   private var mapBody: some View {
     ZStack {
       #if canImport(UIKit)
+        // Full-bleed (tc-3b1hj): the caller (`AnonymousMainTabView`) hides
+        // the nav bar on this screen, so the map extends to every physical
+        // edge, including under the status bar/notch at the top.
         AnonymousClusteredMapView(viewModel: viewModel)
-          .ignoresSafeArea(edges: .bottom)
+          .ignoresSafeArea()
       #else
         macOSMapContent
       #endif

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapView.swift
@@ -3,8 +3,18 @@ import SwiftUI
 import TownCrierDomain
 
 /// Map view displaying planning application pins colour-coded by status.
+///
+/// tc-3b1hj: the screen is full-bleed — no `.navigationTitle`/nav bar (the
+/// tab bar already says "Map"; the caller hides the bar and this view's map
+/// layer ignores the safe area on every edge). The Settings entry point that
+/// used to live in the nav bar's trailing toolbar item is now a floating
+/// circular button this view owns directly, wired via `onSettingsTapped` —
+/// mirrors the callback-closure pattern already used elsewhere (e.g.
+/// `AnonymousApplicationListView`'s CTA banner) rather than reaching for the
+/// Coordinator directly, which would break the MVVM-C dependency rule.
 public struct MapView: View {
   @StateObject private var viewModel: MapViewModel
+  private let onSettingsTapped: () -> Void
   // mapPosition and updateMapPosition are only needed on macOS, where
   // ClusteredMapView (UIViewRepresentable) is unavailable and the SwiftUI
   // Map(position:) fallback handles camera framing.
@@ -12,8 +22,9 @@ public struct MapView: View {
     @State private var mapPosition: MapCameraPosition = .automatic
   #endif
 
-  public init(viewModel: MapViewModel) {
+  public init(viewModel: MapViewModel, onSettingsTapped: @escaping () -> Void) {
     _viewModel = StateObject(wrappedValue: viewModel)
+    self.onSettingsTapped = onSettingsTapped
   }
 
   public var body: some View {
@@ -34,14 +45,12 @@ public struct MapView: View {
   // MARK: - Shared content
 
   private var contentStack: some View {
-    VStack(spacing: 0) {
-      if viewModel.showZonePicker {
-        zonePickerSection
-      }
-      if viewModel.showStatusFilters {
-        filterHeader
-      }
+    ZStack(alignment: .topTrailing) {
       mapBody
+      floatingSettingsButton
+    }
+    .safeAreaInset(edge: .top, spacing: 0) {
+      headerSection
     }
     .background(Color.tcBackground)
     .task {
@@ -73,6 +82,49 @@ public struct MapView: View {
         StackedApplicationsSheet(stacked: stacked, onSelect: viewModel.selectFromStack)
       }
     )
+  }
+
+  // MARK: - Header (zone picker + status filters)
+
+  /// Donated as a `safeAreaInset` rather than a leading `VStack` sibling so
+  /// the map layer below keeps its full-bleed frame — edge to edge, behind
+  /// this header — instead of being squeezed down to whatever height
+  /// remains (tc-3b1hj: "the map gains real height"). A `VStack` with two
+  /// `if`-gated children that are both absent collapses to zero size, so an
+  /// empty header reserves no dead space either.
+  @ViewBuilder
+  private var headerSection: some View {
+    VStack(spacing: 0) {
+      if viewModel.showZonePicker {
+        zonePickerSection
+      }
+      if viewModel.showStatusFilters {
+        filterHeader
+      }
+    }
+  }
+
+  // MARK: - Floating Settings Button
+
+  /// Replaces the nav-bar gear (`.settingsToolbar`) now the nav bar is
+  /// hidden on this screen (tc-3b1hj). A `ZStack` sibling of the (safe-
+  /// area-ignoring) map, rather than an `.overlay` on top of it, so it
+  /// keeps the ordinary safe-area layout the map opts out of — it lands
+  /// below the status bar/notch, and below `headerSection` when that's
+  /// showing, with no manual geometry math. `.ultraThinMaterial` mirrors
+  /// the look of MapKit's own floating HUD controls (e.g. the compass).
+  private var floatingSettingsButton: some View {
+    Button(action: onSettingsTapped) {
+      Image(systemName: "gearshape")
+        .font(TCTypography.headline)
+        .foregroundStyle(Color.tcTextPrimary)
+        .frame(width: 44, height: 44)
+        .background(.ultraThinMaterial, in: Circle())
+        .shadow(color: .black.opacity(0.15), radius: 8, x: 0, y: 2)
+    }
+    .accessibilityLabel("Settings")
+    .padding(.top, TCSpacing.small)
+    .padding(.trailing, TCSpacing.medium)
   }
 
   // MARK: - Zone Picker
@@ -148,8 +200,14 @@ public struct MapView: View {
         // macOS (SPM compile target): fall back to SwiftUI Map so the package
         // still compiles for swift test without UIKit.
         #if canImport(UIKit)
+          // Full-bleed (tc-3b1hj): the nav bar is hidden on this screen, so
+          // the map extends to every physical edge, including under the
+          // status bar/notch at the top — `headerSection` and
+          // `floatingSettingsButton` still land in the ordinary safe area
+          // via `.safeAreaInset`, they just no longer force the map itself
+          // to stop short of the top edge.
           ClusteredMapView(viewModel: viewModel)
-            .ignoresSafeArea(edges: .bottom)
+            .ignoresSafeArea()
         #else
           mapContent
         #endif

--- a/mobile/ios/town-crier-app/Sources/MainTabView.swift
+++ b/mobile/ios/town-crier-app/Sources/MainTabView.swift
@@ -47,15 +47,19 @@ struct MainTabView: View {
       }
       .tag(MainTab.saved)
 
-      // 3. Map
+      // 3. Map — full-bleed (tc-3b1hj): no nav title, no nav bar. The tab
+      // bar already says "Map", so the title row was dead space; the
+      // Settings entry point moves from the (now-hidden) nav bar's gear
+      // into a floating circular button MapView owns, wired the same as
+      // every other tab's `coordinator.showSettings()`.
       NavigationStack {
-        MapView(viewModel: coordinator.makeMapViewModel())
-          .id(coordinator.subscriptionTier)
-          .navigationTitle("Map")
-          #if os(iOS)
-            .navigationBarTitleDisplayMode(.inline)
-          #endif
-          .settingsToolbar { coordinator.showSettings() }
+        MapView(viewModel: coordinator.makeMapViewModel()) {
+          coordinator.showSettings()
+        }
+        .id(coordinator.subscriptionTier)
+        #if os(iOS)
+          .toolbar(.hidden, for: .navigationBar)
+        #endif
       }
       .tabItem {
         Label("Map", systemImage: "map")

--- a/mobile/ios/town-crier-tests/Sources/Features/MapViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/MapViewTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+/// tc-3b1hj: the Map nav title was dropped so the map itself gains real
+/// screen height, and the settings gear moved off the (now-hidden) nav bar
+/// into a floating circular button MapView owns directly — the coordinator
+/// wiring moves from `.settingsToolbar` (applied by the caller) to an
+/// `onSettingsTapped` closure injected via `init`, mirroring the callback
+/// pattern already used for `AnonymousApplicationListView`'s CTA banner.
+@Suite("MapView")
+@MainActor
+struct MapViewTests {
+  private func makeSUT(
+    zones: [WatchZone] = [.cambridge]
+  ) -> (MapView, SpyPlanningApplicationRepository) {
+    let spy = SpyPlanningApplicationRepository()
+    let watchZoneSpy = SpyWatchZoneRepository()
+    watchZoneSpy.loadAllResult = .success(zones)
+    let viewModel = MapViewModel(repository: spy, watchZoneRepository: watchZoneSpy)
+    let sut = MapView(viewModel: viewModel, onSettingsTapped: {})
+    return (sut, spy)
+  }
+
+  @Test func body_renders() {
+    let (sut, _) = makeSUT()
+    _ = sut.body
+  }
+
+  /// Zero/one watch zones hides the zone picker chips (`showZonePicker`);
+  /// the floating settings button and full-bleed map must still render with
+  /// no header content above them.
+  @Test func body_renders_withNoZonePicker() {
+    let (sut, _) = makeSUT(zones: [])
+    _ = sut.body
+  }
+
+  /// Multiple watch zones show the zone-picker chip row — the map must
+  /// still render (as a `safeAreaInset`-donated header, not a VStack
+  /// sibling that would defeat the full-bleed map layer).
+  @Test func body_renders_withZonePicker() {
+    let (sut, _) = makeSUT(zones: [.cambridge, .london])
+    _ = sut.body
+  }
+
+  /// The injected `onSettingsTapped` closure is captured by reference, not
+  /// copied prematurely — mirrors `SettingsToolbarModifierTests`, which
+  /// verifies the equivalent nav-bar gear's action closure the same way.
+  @Test func init_capturesOnSettingsTappedClosure() {
+    let spy = SpyPlanningApplicationRepository()
+    let watchZoneSpy = SpyWatchZoneRepository()
+    watchZoneSpy.loadAllResult = .success([.cambridge])
+    let viewModel = MapViewModel(repository: spy, watchZoneRepository: watchZoneSpy)
+    var didFire = false
+    let sut = MapView(viewModel: viewModel, onSettingsTapped: { didFire = true })
+
+    _ = sut.body
+
+    #expect(!didFire)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/MapViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/MapViewTests.swift
@@ -20,7 +20,7 @@ struct MapViewTests {
     let watchZoneSpy = SpyWatchZoneRepository()
     watchZoneSpy.loadAllResult = .success(zones)
     let viewModel = MapViewModel(repository: spy, watchZoneRepository: watchZoneSpy)
-    let sut = MapView(viewModel: viewModel, onSettingsTapped: {})
+    let sut = MapView(viewModel: viewModel) {}
     return (sut, spy)
   }
 
@@ -54,7 +54,7 @@ struct MapViewTests {
     watchZoneSpy.loadAllResult = .success([.cambridge])
     let viewModel = MapViewModel(repository: spy, watchZoneRepository: watchZoneSpy)
     var didFire = false
-    let sut = MapView(viewModel: viewModel, onSettingsTapped: { didFire = true })
+    let sut = MapView(viewModel: viewModel) { didFire = true }
 
     _ = sut.body
 


### PR DESCRIPTION
## Summary

TestFlight feedback 2026-07-10: the "Map" nav title wastes a full band of vertical space on both map screens — the tab bar already labels the tab. The map is now full-bleed on both:

- **Logged-in map**: nav bar hidden, map extends under the status bar. The settings cog moves from the nav bar to a floating 44pt circular `.ultraThinMaterial` button over the map (matching MapKit's compass styling), per the owner's explicit request. The zone picker + status filter chips move to a `.safeAreaInset(edge: .top)` donation — the only arrangement where `.ignoresSafeArea()` genuinely reaches the top edge — keeping their opaque background for legibility. `MapView` gains an `onSettingsTapped` closure (MVVM-C callback, single call site).
- **Anonymous map**: nav title/bar removed, map full-bleed; the bottom account CTA banner is untouched.

Deliberate, documented departure: the floating cog keeps a subtle shadow in all themes (not light-only like Card) since it sits over unpredictable live map imagery.

## Verification

- `swift build` / `swift test` (1815 pass) / `swiftlint --strict` clean on changed files; app shell additionally compiled via `xcodegen generate` + `xcodebuild` (it's invisible to `swift build`).
- Agent-run simulator verification, both halves, light + dark: map reaches the top edge with no dead band on both screens; floating cog opens Settings (which gets its own chrome back); filter chips still filter; pan/zoom/radius circle intact; nav-bar hiding does not leak into other tabs or pushed screens; anon CTA banner unaffected.

Bead: tc-3b1hj

Release-Note: The map is now full screen, with the settings button floating on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CamN56bgL43Qn3ibGYVkt4