### PR TITLE
fix: strip em dashes from user-facing copy (tc-1c0zd)

### DIFF
--- a/api-go/internal/digest/email.go
+++ b/api-go/internal/digest/email.go
@@ -115,7 +115,7 @@ type watchZoneDigest struct {
 
 // buildDigestSubject renders the digest email subject line.
 func buildDigestSubject(totalCount int) string {
-	return fmt.Sprintf("Planning update — %d new applications near you", totalCount)
+	return fmt.Sprintf("Planning update: %d new applications near you", totalCount)
 }
 
 // buildDigestHTML renders the full digest email body as a Public Notice

--- a/api-go/internal/digest/email_test.go
+++ b/api-go/internal/digest/email_test.go
@@ -36,7 +36,7 @@ func testNotification(uid, zoneID, address, appType, desc string) notifications.
 func TestBuildDigestSubject(t *testing.T) {
 	t.Parallel()
 	got := buildDigestSubject(3)
-	want := "Planning update — 3 new applications near you"
+	want := "Planning update: 3 new applications near you"
 	if got != want {
 		t.Errorf("subject: got %q, want %q", got, want)
 	}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/NotificationPreferences/NotificationPreferencesView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/NotificationPreferences/NotificationPreferencesView.swift
@@ -144,7 +144,7 @@ public struct NotificationPreferencesView: View {
         )
       )
       .tint(Color.tcAmber)
-      .accessibilityLabel("Saved applications — push")
+      .accessibilityLabel("Saved applications, push")
 
       Toggle(
         "Email",
@@ -156,7 +156,7 @@ public struct NotificationPreferencesView: View {
         )
       )
       .tint(Color.tcAmber)
-      .accessibilityLabel("Saved applications — email")
+      .accessibilityLabel("Saved applications, email")
     } header: {
       Text("Saved applications")
         .font(TCTypography.captionEmphasis)

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/ZonePreferencesView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/ZonePreferencesView.swift
@@ -4,8 +4,8 @@ import TownCrierDomain
 /// Per-zone notification preferences screen with four per-channel toggles
 /// (push/email × new-application/decision) grouped under two semantic sections.
 ///
-/// Mirrors the web counterpart's accessibility shape — each toggle exposes an
-/// em-dash-separated accessibility label (e.g. "New applications — push") so
+/// Mirrors the web counterpart's accessibility shape — each toggle exposes a
+/// comma-separated accessibility label (e.g. "New applications, push") so
 /// VoiceOver and UI tests can address each control unambiguously.
 public struct ZonePreferencesView: View {
   @StateObject private var viewModel: ZonePreferencesViewModel
@@ -56,11 +56,11 @@ public struct ZonePreferencesView: View {
     Section {
       Toggle("Push", isOn: $viewModel.newApplicationPush)
         .tint(Color.tcAmber)
-        .accessibilityLabel("New applications — push")
+        .accessibilityLabel("New applications, push")
 
       Toggle("Email", isOn: $viewModel.newApplicationEmail)
         .tint(Color.tcAmber)
-        .accessibilityLabel("New applications — email")
+        .accessibilityLabel("New applications, email")
     } header: {
       Text("New applications")
     } footer: {
@@ -74,11 +74,11 @@ public struct ZonePreferencesView: View {
     Section {
       Toggle("Push", isOn: $viewModel.decisionPush)
         .tint(Color.tcAmber)
-        .accessibilityLabel("Decision updates — push")
+        .accessibilityLabel("Decision updates, push")
 
       Toggle("Email", isOn: $viewModel.decisionEmail)
         .tint(Color.tcAmber)
-        .accessibilityLabel("Decision updates — email")
+        .accessibilityLabel("Decision updates, email")
     } header: {
       Text("Decision updates")
     } footer: {

--- a/web/src/features/Search/SearchPage.tsx
+++ b/web/src/features/Search/SearchPage.tsx
@@ -91,7 +91,7 @@ export function SearchPage({ port }: Props) {
       {error !== null && <p className={styles.error}>{error}</p>}
       {refineQuery && (
         <p className={styles.notice}>
-          Showing the first 20 matches — try a more specific search to narrow the results.
+          Showing the first 20 matches. Try a more specific search to narrow the results.
         </p>
       )}
       {showEmptyState && <p className={styles.status}>No applications matched your search.</p>}

--- a/web/src/features/Search/components/SearchResultCard.tsx
+++ b/web/src/features/Search/components/SearchResultCard.tsx
@@ -60,7 +60,7 @@ export function SearchResultCard({ result }: Props) {
         </button>
         <span aria-live="polite" className={styles.copyStatus}>
           {copyState === 'copied' && 'Share link copied to clipboard'}
-          {copyState === 'error' && "Couldn't copy link — try selecting it from the address bar."}
+          {copyState === 'error' && "Couldn't copy the link. Try selecting it from the address bar."}
         </span>
       </div>
     </li>

--- a/web/src/features/Settings/SettingsPage.tsx
+++ b/web/src/features/Settings/SettingsPage.tsx
@@ -140,7 +140,7 @@ export function SettingsPage({ repository, redeemOfferCodeClient, onRedeemSucces
             <Toggle
               checked={profile?.savedDecisionPush ?? true}
               onChange={(checked) => updatePreferences({ savedDecisionPush: checked })}
-              label="Saved applications — push"
+              label="Saved applications, push"
             />
           </div>
           <div className={styles.toggleRow}>
@@ -148,7 +148,7 @@ export function SettingsPage({ repository, redeemOfferCodeClient, onRedeemSucces
             <Toggle
               checked={profile?.savedDecisionEmail ?? true}
               onChange={(checked) => updatePreferences({ savedDecisionEmail: checked })}
-              label="Saved applications — email"
+              label="Saved applications, email"
             />
           </div>
         </div>

--- a/web/src/features/WatchZones/WatchZoneEditPage.tsx
+++ b/web/src/features/WatchZones/WatchZoneEditPage.tsx
@@ -141,7 +141,7 @@ export function WatchZoneEditPage({ repository, zone, tier = 'Free' }: Props) {
               type="checkbox"
               checked={preferences.newApplicationPush}
               onChange={() => handleToggle('newApplicationPush')}
-              aria-label="New applications — push"
+              aria-label="New applications, push"
             />
             <span className={styles.toggleLabel}>Push</span>
           </label>
@@ -151,7 +151,7 @@ export function WatchZoneEditPage({ repository, zone, tier = 'Free' }: Props) {
               type="checkbox"
               checked={preferences.newApplicationEmail}
               onChange={() => handleToggle('newApplicationEmail')}
-              aria-label="New applications — email"
+              aria-label="New applications, email"
             />
             <span className={styles.toggleLabel}>Email</span>
           </label>
@@ -162,7 +162,7 @@ export function WatchZoneEditPage({ repository, zone, tier = 'Free' }: Props) {
               type="checkbox"
               checked={preferences.decisionPush}
               onChange={() => handleToggle('decisionPush')}
-              aria-label="Decision updates — push"
+              aria-label="Decision updates, push"
             />
             <span className={styles.toggleLabel}>Push</span>
           </label>
@@ -172,7 +172,7 @@ export function WatchZoneEditPage({ repository, zone, tier = 'Free' }: Props) {
               type="checkbox"
               checked={preferences.decisionEmail}
               onChange={() => handleToggle('decisionEmail')}
-              aria-label="Decision updates — email"
+              aria-label="Decision updates, email"
             />
             <span className={styles.toggleLabel}>Email</span>
           </label>


### PR DESCRIPTION
## What

Voice-skill compliance sweep: removes every em dash from user-facing copy. Em and en dashes are banned AI tells (owner feedback, 2026-07-11).

- **iOS** — VoiceOver labels in `NotificationPreferencesView` (2) and `ZonePreferencesView` (4) switch from em dash to comma separation ("Saved applications, push"); the doc comment describing the label shape updated to match.
- **web** — Settings toggle labels (2) and `WatchZoneEditPage` aria-labels (4) likewise; `SearchPage` results notice and `SearchResultCard` copy-failure message rewritten as plain sentences.
- **api** — weekly digest email subject: "Planning update: %d new applications near you" (was an em dash); unit test updated.

The visible em dash on the anonymous postcode screen (the one spotted in a screenshot) rides the in-flight #931 branch since it touches the same file.

Code comments and log lines are exempt and untouched. Sweep covered iOS, web, api-go (incl. share page templates, push copy, legal JSON — all clean).

## Gates

- Go: `go test ./internal/digest/...` 44 passed, `go vet` + `gofmt` clean
- Web: `tsc --noEmit` clean, `vitest run` 1235 passed
- iOS: targeted `swift test` 54 passed, `swiftlint --strict` clean on changed files

No live UI drive for this one: the six visible-string changes are punctuation-only rewordings in states that need artificial staging (clipboard failure, >20 search matches), and the rest is screen-reader-only. Tests and typecheck cover render integrity.

Bead: tc-1c0zd (discovered-from tc-n56lx)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X3Qj8yN94HEeSPySBUFNT2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved screen reader labels for notification preferences across web and iOS.
  * Standardized punctuation in saved application, new application, and decision update controls.

* **Copy Improvements**
  * Clarified search result notices and copy-link error messages.
  * Updated digest email subject punctuation for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->