### PR TITLE
feat(ios): live map preview with radius circle on anonymous postcode entry (tc-n56lx)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousPostcodeEntryView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousPostcodeEntryView.swift
@@ -16,7 +16,7 @@ struct AnonymousPostcodeEntryView: View {
   enum Copy {
     static let title = "Where should we look?"
     static let helper =
-      "Enter any UK postcode. We'll show planning applications nearby — no account needed."
+      "Enter any UK postcode. We'll show planning applications nearby. No account needed."
     static let placeholder = "e.g. CB1 2AD"
   }
 

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousPostcodeEntryView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousPostcodeEntryView.swift
@@ -1,10 +1,17 @@
 import SwiftUI
+import TownCrierDomain
 
 /// Postcode entry step of the anonymous browse flow (GH#868 Phase 3) — same
 /// styling/validation feel as the onboarding wizard's
 /// `PostcodeEntryStepView`, but geocoding goes through
 /// ``AnonymousPostcodeEntryViewModel`` (postcodes.io directly, no session)
 /// rather than the wizard's authenticated `/v1/geocode`.
+///
+/// A live ``ZoneMapPreview`` (GH#931) appears between the radius slider and
+/// Continue as soon as the typed postcode silently geocodes — debounced
+/// 500ms via `.task(id:)`, which auto-cancels the pending refresh on every
+/// keystroke and on dismissal (precedent: `ClusteredMapView`'s viewport
+/// refetch debounce).
 struct AnonymousPostcodeEntryView: View {
   enum Copy {
     static let title = "Where should we look?"
@@ -20,50 +27,68 @@ struct AnonymousPostcodeEntryView: View {
   }
 
   var body: some View {
-    VStack(spacing: TCSpacing.large) {
-      Text(Copy.title)
-        .font(TCTypography.displaySmall)
-        .foregroundStyle(Color.tcTextPrimary)
+    ScrollView {
+      VStack(spacing: TCSpacing.large) {
+        Text(Copy.title)
+          .font(TCTypography.displaySmall)
+          .foregroundStyle(Color.tcTextPrimary)
 
-      Text(Copy.helper)
-        .font(TCTypography.body)
-        .foregroundStyle(Color.tcTextSecondary)
-        .multilineTextAlignment(.center)
+        Text(Copy.helper)
+          .font(TCTypography.body)
+          .foregroundStyle(Color.tcTextSecondary)
+          .multilineTextAlignment(.center)
 
-      TextField(Copy.placeholder, text: $viewModel.postcodeInput)
-        .font(TCTypography.mono)
-        .textFieldStyle(.roundedBorder)
-        .autocorrectionDisabled()
-        #if os(iOS)
-          .textInputAutocapitalization(.characters)
-        #endif
+        TextField(Copy.placeholder, text: $viewModel.postcodeInput)
+          .font(TCTypography.mono)
+          .textFieldStyle(.roundedBorder)
+          .autocorrectionDisabled()
+          #if os(iOS)
+            .textInputAutocapitalization(.characters)
+          #endif
 
-      radiusControl
+        radiusControl
 
-      if let error = viewModel.error {
-        Text(error.userMessage)
-          .font(TCTypography.caption)
-          .foregroundStyle(Color.tcStatusRejected)
-      }
-
-      PrimaryButton {
-        Task { await viewModel.submitPostcode() }
-      } label: {
-        if viewModel.isLoading {
-          ProgressView()
-        } else {
-          Text("Continue")
+        if let coordinate = viewModel.previewCoordinate {
+          ZoneMapPreview(
+            centre: coordinate, radiusMetres: viewModel.selectedRadiusMetres, strokeWidth: 2
+          )
+          .frame(height: 200)
+          .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.medium))
+          .transition(.opacity)
         }
-      }
-      .disabled(viewModel.postcodeInput.isEmpty || viewModel.isLoading)
 
-      Button("Back", action: viewModel.goBack)
-        .font(TCTypography.body)
-        .foregroundStyle(Color.tcTextSecondary)
+        if let error = viewModel.error {
+          Text(error.userMessage)
+            .font(TCTypography.caption)
+            .foregroundStyle(Color.tcStatusRejected)
+        }
+
+        PrimaryButton {
+          Task { await viewModel.submitPostcode() }
+        } label: {
+          if viewModel.isLoading {
+            ProgressView()
+          } else {
+            Text("Continue")
+          }
+        }
+        .disabled(viewModel.postcodeInput.isEmpty || viewModel.isLoading)
+
+        Button("Back", action: viewModel.goBack)
+          .font(TCTypography.body)
+          .foregroundStyle(Color.tcTextSecondary)
+      }
+      .padding(TCSpacing.extraLarge)
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+      .background(Color.tcBackground)
     }
-    .padding(TCSpacing.extraLarge)
-    .frame(maxWidth: .infinity, maxHeight: .infinity)
-    .background(Color.tcBackground)
+    .scrollBounceBehavior(.basedOnSize)
+    .animation(.default, value: viewModel.previewCoordinate)
+    .task(id: viewModel.postcodeInput) {
+      try? await Task.sleep(nanoseconds: 500_000_000)
+      guard !Task.isCancelled else { return }
+      await viewModel.refreshPreview()
+    }
   }
 
   // MARK: - Radius picker (GH#912 Phase 4)

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousPostcodeEntryViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousPostcodeEntryViewModel.swift
@@ -19,6 +19,13 @@ public final class AnonymousPostcodeEntryViewModel: ObservableObject, ErrorHandl
   @Published public var selectedRadiusMetres: Double = 2000
   @Published public private(set) var isLoading = false
   @Published public internal(set) var error: DomainError?
+  /// The silently-geocoded coordinate for the current ``postcodeInput``
+  /// (GH#931) — drives the live ``ZoneMapPreview`` between the radius
+  /// slider and Continue. `nil` whenever the input doesn't parse as a
+  /// complete ``Postcode`` or the background geocode fails; failures here
+  /// are silent and never populate ``error``, which stays the exclusive
+  /// domain of ``submitPostcode()``.
+  @Published public private(set) var previewCoordinate: Coordinate?
 
   public let minRadiusMetres: Double = 100
   /// The free tier's radius cap — the anonymous flow has no session to
@@ -72,5 +79,18 @@ public final class AnonymousPostcodeEntryViewModel: ObservableObject, ErrorHandl
 
   public func goBack() {
     onBack?()
+  }
+
+  /// Silently (re-)geocodes ``postcodeInput`` for the live map preview
+  /// (GH#931). Debouncing lives in the view (`.task(id:)`); this method is
+  /// the deterministic core VM tests call directly.
+  public func refreshPreview() async {
+    guard let postcode = try? Postcode(postcodeInput) else {
+      previewCoordinate = nil
+      return
+    }
+    if let coordinate = try? await geocoder.geocode(postcode) {
+      previewCoordinate = coordinate
+    }
   }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousPostcodeEntryViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousPostcodeEntryViewModel.swift
@@ -67,7 +67,15 @@ public final class AnonymousPostcodeEntryViewModel: ObservableObject, ErrorHandl
     }
 
     do {
-      let coordinate = try await geocoder.geocode(postcode)
+      // Reuse a coordinate the live preview already resolved for this exact
+      // postcode (GH#931) — politeness to postcodes.io, a free third-party
+      // service, and a zero-cost cache hit.
+      let coordinate: Coordinate
+      if postcode == lastPreviewedPostcode, let previewedCoordinate = previewCoordinate {
+        coordinate = previewedCoordinate
+      } else {
+        coordinate = try await geocoder.geocode(postcode)
+      }
       let state = AnonymousBrowseState(
         postcode: postcode,
         coordinate: coordinate,

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousPostcodeEntryViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousPostcodeEntryViewModel.swift
@@ -92,14 +92,21 @@ public final class AnonymousPostcodeEntryViewModel: ObservableObject, ErrorHandl
   public func refreshPreview() async {
     guard let postcode = try? Postcode(postcodeInput) else {
       previewCoordinate = nil
+      lastPreviewedPostcode = nil
       return
     }
     if postcode == lastPreviewedPostcode, previewCoordinate != nil {
       return
     }
-    if let coordinate = try? await geocoder.geocode(postcode) {
-      previewCoordinate = coordinate
+    do {
+      previewCoordinate = try await geocoder.geocode(postcode)
       lastPreviewedPostcode = postcode
+    } catch {
+      // Preview geocode failures are silent (GH#931) — `error` stays the
+      // exclusive domain of `submitPostcode()`; a transient failure here
+      // must not flash a misleading error while the user is still typing.
+      previewCoordinate = nil
+      lastPreviewedPostcode = nil
     }
   }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousPostcodeEntryViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/AnonymousBrowse/AnonymousPostcodeEntryViewModel.swift
@@ -35,6 +35,11 @@ public final class AnonymousPostcodeEntryViewModel: ObservableObject, ErrorHandl
 
   private let geocoder: PostcodeGeocoder
   private let stateRepository: AnonymousBrowseStateRepository
+  /// The last postcode successfully previewed — lets ``refreshPreview()``
+  /// skip a duplicate geocode while the input is unchanged, and lets
+  /// ``submitPostcode()`` reuse the coordinate instead of a second call
+  /// (GH#931).
+  private var lastPreviewedPostcode: Postcode?
 
   /// Fired when the user taps "Back" — the coordinator returns to welcome.
   public var onBack: (() -> Void)?
@@ -89,8 +94,12 @@ public final class AnonymousPostcodeEntryViewModel: ObservableObject, ErrorHandl
       previewCoordinate = nil
       return
     }
+    if postcode == lastPreviewedPostcode, previewCoordinate != nil {
+      return
+    }
     if let coordinate = try? await geocoder.geocode(postcode) {
       previewCoordinate = coordinate
+      lastPreviewedPostcode = postcode
     }
   }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousPostcodeEntryViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousPostcodeEntryViewModelTests.swift
@@ -98,4 +98,17 @@ struct AnonymousPostcodeEntryViewModelTests {
     #expect(stateRepository.saveCalls.last?.radiusMetres == 1500)
     #expect(resolved?.radiusMetres == 1500)
   }
+
+  // MARK: - Live preview (GH#931)
+
+  @Test func refreshPreview_validPostcode_setsPreviewCoordinate() async {
+    let (sut, geocoder, _) = makeSUT()
+    geocoder.geocodeResult = .success(.cambridge)
+    sut.postcodeInput = "CB1 2AD"
+
+    await sut.refreshPreview()
+
+    #expect(geocoder.geocodeCalls.count == 1)
+    #expect(sut.previewCoordinate == .cambridge)
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousPostcodeEntryViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousPostcodeEntryViewModelTests.swift
@@ -111,4 +111,18 @@ struct AnonymousPostcodeEntryViewModelTests {
     #expect(geocoder.geocodeCalls.count == 1)
     #expect(sut.previewCoordinate == .cambridge)
   }
+
+  @Test func refreshPreview_invalidInput_clearsPreviewWithoutGeocoding() async {
+    let (sut, geocoder, _) = makeSUT()
+    geocoder.geocodeResult = .success(.cambridge)
+    sut.postcodeInput = "CB1 2AD"
+    await sut.refreshPreview()
+    #expect(sut.previewCoordinate == .cambridge)
+
+    sut.postcodeInput = "INVALID"
+    await sut.refreshPreview()
+
+    #expect(sut.previewCoordinate == nil)
+    #expect(geocoder.geocodeCalls.count == 1)
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousPostcodeEntryViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousPostcodeEntryViewModelTests.swift
@@ -137,4 +137,19 @@ struct AnonymousPostcodeEntryViewModelTests {
     #expect(geocoder.geocodeCalls.count == 1)
     #expect(sut.previewCoordinate == .cambridge)
   }
+
+  @Test func refreshPreview_geocodeFailure_clearsPreviewAndSetsNoError() async {
+    let (sut, geocoder, _) = makeSUT()
+    geocoder.geocodeResult = .success(.cambridge)
+    sut.postcodeInput = "CB1 2AD"
+    await sut.refreshPreview()
+    #expect(sut.previewCoordinate == .cambridge)
+
+    geocoder.geocodeResult = .failure(DomainError.geocodingFailed("SW1A 1AA"))
+    sut.postcodeInput = "SW1A 1AA"
+    await sut.refreshPreview()
+
+    #expect(sut.previewCoordinate == nil)
+    #expect(sut.error == nil)
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousPostcodeEntryViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousPostcodeEntryViewModelTests.swift
@@ -162,4 +162,21 @@ struct AnonymousPostcodeEntryViewModelTests {
     await sut.refreshPreview()
     #expect(!sut.isLoading)
   }
+
+  @Test func submitPostcode_afterSuccessfulPreview_reusesCoordinateWithoutSecondGeocode() async {
+    let (sut, geocoder, stateRepository) = makeSUT()
+    geocoder.geocodeResult = .success(.cambridge)
+    sut.postcodeInput = "CB1 2AD"
+    await sut.refreshPreview()
+    var resolved: AnonymousBrowseState?
+    sut.onResolved = { resolved = $0 }
+
+    await sut.submitPostcode()
+
+    #expect(geocoder.geocodeCalls.count == 1)
+    #expect(stateRepository.saveCalls.count == 1)
+    #expect(stateRepository.saveCalls.first?.coordinate == .cambridge)
+    #expect(resolved?.coordinate == .cambridge)
+    #expect(resolved?.radiusMetres == sut.selectedRadiusMetres)
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousPostcodeEntryViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousPostcodeEntryViewModelTests.swift
@@ -125,4 +125,16 @@ struct AnonymousPostcodeEntryViewModelTests {
     #expect(sut.previewCoordinate == nil)
     #expect(geocoder.geocodeCalls.count == 1)
   }
+
+  @Test func refreshPreview_samePostcodeTwice_geocodesOnlyOnce() async {
+    let (sut, geocoder, _) = makeSUT()
+    geocoder.geocodeResult = .success(.cambridge)
+    sut.postcodeInput = "CB1 2AD"
+
+    await sut.refreshPreview()
+    await sut.refreshPreview()
+
+    #expect(geocoder.geocodeCalls.count == 1)
+    #expect(sut.previewCoordinate == .cambridge)
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/AnonymousPostcodeEntryViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AnonymousPostcodeEntryViewModelTests.swift
@@ -152,4 +152,14 @@ struct AnonymousPostcodeEntryViewModelTests {
     #expect(sut.previewCoordinate == nil)
     #expect(sut.error == nil)
   }
+
+  @Test func refreshPreview_doesNotChangeIsLoading() async {
+    let (sut, geocoder, _) = makeSUT()
+    geocoder.geocodeResult = .success(.cambridge)
+    sut.postcodeInput = "CB1 2AD"
+
+    #expect(!sut.isLoading)
+    await sut.refreshPreview()
+    #expect(!sut.isLoading)
+  }
 }


### PR DESCRIPTION
## What

Closes #931.

The pre-login postcode + radius screen now shows a live `ZoneMapPreview` (the same amber dashed circle as the zone editors) as soon as the typed postcode geocodes — debounced 500ms, gated on `Postcode` parsing, silent on failure. The slider resizes the circle live; invalid input hides the preview; Continue reuses the already-geocoded coordinate so postcodes.io isn't called twice for the same postcode. Also drops the em dash from the screen's helper copy (tc-1c0zd, voice-skill compliance).

Release-Note: See your area on a live map preview when choosing a postcode and radius before signing up.

## Design decisions (pre-resolved in #931)

- Preview geocoding is device-side postcodes.io (existing injected geocoder) — never server-side.
- `refreshPreview()` never touches `error` or `isLoading`; Continue remains the sole validation/error path.
- `ZoneMapPreview` reused unchanged — static-camera-on-radius-change parity with the authed editor.
- Screen wrapped in a ScrollView so Continue stays reachable with the keyboard up once the 200pt map is present.

## Verification

- TDD (Swift Testing): 6 new VM tests covering preview set/clear/dedupe/silent-failure/isLoading-invariant/coordinate-reuse; full suite 1835 green; `swiftlint --strict` clean; `swift-format` applied.
- Live simulator verification (agent-driven, iPhone 17 Pro): all 6 checks PASS — preview appears ~1s after a full postcode is typed, circle tracks the slider, invalid input hides it with no error flash, Continue reachable with keyboard up, and the full Continue flow lands on a "CB1 2AD" 2 km zone with genuine Cambridge listings.
- Verification detour worth knowing about: an initial check-6 failure ("Coventry" zone appearing on fresh installs) was root-caused to stale seeded state in the simulator's device-level defaults domain (survives uninstall; now deleted) — not this branch. Gotcha recorded in session memory.
- Follow-up polish tracked separately: tc-vu1kr (min-radius circle nearly invisible at fixed zoom), tc-x2k8i (pre-geocode layout now top-aligned; scroll affordance with keyboard up).

Beads: tc-n56lx, tc-1c0zd

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X3Qj8yN94HEeSPySBUFNT2