### PR TITLE
fix(ios): let users delete pre-signup saved areas from the zones banner (tc-luq4u)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListView.swift
@@ -46,9 +46,23 @@ public struct WatchZoneListView: View {
             UnconvertedLocalZoneRow(
               count: viewModel.unconvertedLocalZones.count,
               onTap: { viewModel.convertLocalZones() },
-              onDismiss: { viewModel.dismissLocalZoneRow() }
+              onDismiss: { viewModel.presentDiscardConfirmation() }
             )
             .cardRowInsets()
+          }
+          .confirmationDialog(
+            discardConfirmationTitle,
+            isPresented: $viewModel.isDiscardConfirmationPresented,
+            titleVisibility: .visible
+          ) {
+            Button("Delete", role: .destructive) {
+              viewModel.discardLocalZones()
+            }
+            Button("Keep for later", role: .cancel) {
+              viewModel.dismissLocalZoneRow()
+            }
+          } message: {
+            Text(discardConfirmationMessage)
           }
         }
       }
@@ -91,6 +105,20 @@ public struct WatchZoneListView: View {
       )
       .selfSizingSheet()
     }
+  }
+
+  // MARK: - Discard confirmation (tc-luq4u)
+
+  private var discardConfirmationTitle: String {
+    viewModel.unconvertedLocalZones.count == 1
+      ? "Delete this saved area?"
+      : "Delete these saved areas?"
+  }
+
+  private var discardConfirmationMessage: String {
+    viewModel.unconvertedLocalZones.count == 1
+      ? "It only exists on this phone and is not being monitored. Delete it, or keep it to add later."
+      : "They only exist on this phone and are not being monitored. Delete them, or keep them to add later."
   }
 
   // MARK: - Masthead
@@ -191,9 +219,10 @@ private struct WatchZoneRow: View {
 
 /// Dismissible row surfaced while device-local zones (GH#879 Phase 4) remain
 /// unconverted after sign-up. Tapping the body reopens the "Add your other
-/// areas" conversion sheet; the trailing "x" dismisses the row for the
-/// session only — it reappears next launch while zones still remain, and
-/// clears entirely once none do (never silently discard user-created data).
+/// areas" conversion sheet; the trailing "x" opens a delete-confirmation
+/// dialog (tc-luq4u) offering an explicit "Delete" (permanent) or "Keep for
+/// later" (session-only dismissal, reappears next launch while zones still
+/// remain) — the row previously had no permanent way to decline.
 private struct UnconvertedLocalZoneRow: View {
   let count: Int
   let onTap: () -> Void

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListView.swift
@@ -50,10 +50,9 @@ public struct WatchZoneListView: View {
             )
             .cardRowInsets()
           }
-          .confirmationDialog(
+          .alert(
             discardConfirmationTitle,
-            isPresented: $viewModel.isDiscardConfirmationPresented,
-            titleVisibility: .visible
+            isPresented: $viewModel.isDiscardConfirmationPresented
           ) {
             Button("Delete", role: .destructive) {
               viewModel.discardLocalZones()
@@ -108,6 +107,14 @@ public struct WatchZoneListView: View {
   }
 
   // MARK: - Discard confirmation (tc-luq4u)
+  //
+  // An `.alert`, not a `.confirmationDialog` — on iOS 26 the dialog renders
+  // as a compact anchored popover next to the "x" button, and popover
+  // presentation drops `.cancel`-role buttons entirely (tap-outside is
+  // treated as the cancel affordance), leaving "Keep for later"
+  // undiscoverable and unreachable by VoiceOver. An alert renders every
+  // button in every presentation style and is the HIG-appropriate container
+  // for a destructive confirmation.
 
   private var discardConfirmationTitle: String {
     viewModel.unconvertedLocalZones.count == 1
@@ -220,7 +227,7 @@ private struct WatchZoneRow: View {
 /// Dismissible row surfaced while device-local zones (GH#879 Phase 4) remain
 /// unconverted after sign-up. Tapping the body reopens the "Add your other
 /// areas" conversion sheet; the trailing "x" opens a delete-confirmation
-/// dialog (tc-luq4u) offering an explicit "Delete" (permanent) or "Keep for
+/// alert (tc-luq4u) offering an explicit "Delete" (permanent) or "Keep for
 /// later" (session-only dismissal, reappears next launch while zones still
 /// remain) — the row previously had no permanent way to decline.
 private struct UnconvertedLocalZoneRow: View {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListViewModel.swift
@@ -120,9 +120,10 @@ public final class WatchZoneListViewModel: ObservableObject, ErrorHandlingViewMo
   }
 
   /// Local-vs-server centre match tolerance for duplicate cleanup (tc-luq4u)
-  /// — 1e-4 degrees is well under one metre at UK latitudes, generous enough
-  /// to absorb floating-point drift from a conversion round-trip while never
-  /// matching two genuinely distinct areas.
+  /// — 1e-4 degrees is roughly 11 m of latitude (~7 m of longitude at UK
+  /// latitudes): generous enough to absorb floating-point drift from a
+  /// conversion round-trip while never matching two genuinely distinct areas,
+  /// which also need an identical radius to count as duplicates.
   private static let duplicateCentreToleranceDegrees: Double = 1e-4
 
   public func load() async {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListViewModel.swift
@@ -22,6 +22,11 @@ public final class WatchZoneListViewModel: ObservableObject, ErrorHandlingViewMo
   /// Never persisted — a fresh `WatchZoneListViewModel` (next app launch)
   /// always starts un-dismissed, so the row reappears while zones remain.
   @Published public private(set) var isLocalZoneRowDismissed = false
+  /// Drives the row's delete-confirmation dialog (tc-luq4u) — set by
+  /// ``presentDiscardConfirmation()`` when the user taps the row's "x", and
+  /// cleared by whichever choice they make (``discardLocalZones()`` or
+  /// ``dismissLocalZoneRow()``).
+  @Published public var isDiscardConfirmationPresented = false
 
   /// The proactive feature gate derived from the user's subscription tier.
   public let featureGate: FeatureGate
@@ -57,9 +62,32 @@ public final class WatchZoneListViewModel: ObservableObject, ErrorHandlingViewMo
   /// Hides the unconverted-zones row for the rest of this session. The row
   /// reappears on next launch (a fresh view model) while zones still remain
   /// — local zones are never silently discarded, only converted or
-  /// explicitly deleted.
+  /// explicitly deleted. This is the "keep for later" choice in the
+  /// delete-confirmation dialog (tc-luq4u).
   public func dismissLocalZoneRow() {
     isLocalZoneRowDismissed = true
+    isDiscardConfirmationPresented = false
+  }
+
+  /// Opens the row's delete-confirmation dialog (tc-luq4u) — the "x" button
+  /// no longer dismisses directly, since dismissal alone gave a pre-signup
+  /// user with no onboarding-wizard run no way to ever decline the zones the
+  /// row nags about.
+  public func presentDiscardConfirmation() {
+    isDiscardConfirmationPresented = true
+  }
+
+  /// Permanently deletes every unconverted device-local zone (tc-luq4u) —
+  /// the explicit "no" the row previously lacked. Deletes each from the
+  /// injected repository, then clears the published list so
+  /// ``showsLocalZoneRow`` becomes false immediately and stays false on
+  /// every later ``load()`` (the repository itself is now empty).
+  public func discardLocalZones() {
+    for zone in unconvertedLocalZones {
+      deviceLocalZoneRepository?.delete(zone.id)
+    }
+    unconvertedLocalZones = []
+    isDiscardConfirmationPresented = false
   }
 
   /// Reopens the post-signup conversion sheet from the row's tap target.
@@ -91,18 +119,52 @@ public final class WatchZoneListViewModel: ObservableObject, ErrorHandlingViewMo
     featureGate.tier == .free && !canAddZone
   }
 
+  /// Local-vs-server centre match tolerance for duplicate cleanup (tc-luq4u)
+  /// — 1e-4 degrees is well under one metre at UK latitudes, generous enough
+  /// to absorb floating-point drift from a conversion round-trip while never
+  /// matching two genuinely distinct areas.
+  private static let duplicateCentreToleranceDegrees: Double = 1e-4
+
   public func load() async {
     isLoading = true
     error = nil
 
+    var serverLoadSucceeded = true
     do {
       zones = try await repository.loadAll()
     } catch {
       handleError(error)
+      serverLoadSucceeded = false
     }
-    unconvertedLocalZones = deviceLocalZoneRepository?.loadAll() ?? []
+
+    let localZones = deviceLocalZoneRepository?.loadAll() ?? []
+    unconvertedLocalZones =
+      serverLoadSucceeded
+      ? localZones.filter { !discardIfDuplicatesServerZone($0) }
+      : localZones
 
     isLoading = false
+  }
+
+  /// Deletes `localZone` from the repository and returns true when it
+  /// duplicates an already-converted server zone (same radius, centre
+  /// within ``duplicateCentreToleranceDegrees`` on both latitude and
+  /// longitude) — a redundant leftover from a conversion that saved
+  /// server-side but never cleaned up its local copy. Only ever called
+  /// after a successful server load (tc-luq4u): a local zone is never
+  /// deleted against an unknown server state.
+  private func discardIfDuplicatesServerZone(_ localZone: DeviceLocalZone) -> Bool {
+    let isDuplicate = zones.contains { serverZone in
+      serverZone.radiusMetres == localZone.radiusMetres
+        && abs(serverZone.centre.latitude - localZone.centre.latitude)
+          <= Self.duplicateCentreToleranceDegrees
+        && abs(serverZone.centre.longitude - localZone.centre.longitude)
+          <= Self.duplicateCentreToleranceDegrees
+    }
+    if isDuplicate {
+      deviceLocalZoneRepository?.delete(localZone.id)
+    }
+    return isDuplicate
   }
 
   public func deleteZone(_ zone: WatchZone) async {

--- a/mobile/ios/project.yml
+++ b/mobile/ios/project.yml
@@ -26,7 +26,7 @@ targets:
         DEVELOPMENT_TEAM: 4574VQ7N2X
         TARGETED_DEVICE_FAMILY: "1"
         INFOPLIST_GENERATION_MODE: GeneratedFile
-        MARKETING_VERSION: "1.2.8"
+        MARKETING_VERSION: "1.2.9"
         CURRENT_PROJECT_VERSION: "1"
         GENERATE_INFOPLIST_FILE: "YES"
         INFOPLIST_KEY_UIApplicationSceneManifest_Generation: "YES"

--- a/mobile/ios/town-crier-tests/Sources/Features/WatchZoneListViewModelDeviceLocalZoneRowTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WatchZoneListViewModelDeviceLocalZoneRowTests.swift
@@ -11,8 +11,12 @@ import Testing
 @MainActor
 @Suite("WatchZoneListViewModel -- Device-Local Zone Row")
 struct WatchZoneListViewModelDeviceLocalZoneRowTests {
-  private func makeLocalZone(name: String = "Home") throws -> DeviceLocalZone {
-    try DeviceLocalZone(name: name, centre: .cambridge, radiusMetres: 1000)
+  private func makeLocalZone(
+    name: String = "Home",
+    centre: Coordinate = .cambridge,
+    radiusMetres: Double = 1000
+  ) throws -> DeviceLocalZone {
+    try DeviceLocalZone(name: name, centre: centre, radiusMetres: radiusMetres)
   }
 
   @Test func load_withNoDeviceLocalZoneRepository_neverShowsRow() async {
@@ -122,5 +126,105 @@ struct WatchZoneListViewModelDeviceLocalZoneRowTests {
     sut.convertLocalZones()
 
     #expect(invoked)
+  }
+
+  // MARK: - Explicit delete (tc-luq4u)
+
+  @Test func presentDiscardConfirmation_setsIsDiscardConfirmationPresented() {
+    let sut = WatchZoneListViewModel(
+      repository: SpyWatchZoneRepository(),
+      featureGate: FeatureGate(tier: .free)
+    )
+    #expect(!sut.isDiscardConfirmationPresented)
+
+    sut.presentDiscardConfirmation()
+
+    #expect(sut.isDiscardConfirmationPresented)
+  }
+
+  @Test func discardLocalZones_deletesAllFromRepositoryAndClearsList() async throws {
+    let localRepo = SpyDeviceLocalZoneRepository()
+    let zone = try makeLocalZone()
+    localRepo.loadAllResult = [zone]
+    let sut = WatchZoneListViewModel(
+      repository: SpyWatchZoneRepository(),
+      featureGate: FeatureGate(tier: .free),
+      deviceLocalZoneRepository: localRepo
+    )
+    await sut.load()
+    sut.presentDiscardConfirmation()
+    #expect(sut.showsLocalZoneRow)
+
+    sut.discardLocalZones()
+
+    #expect(localRepo.deleteCalls == [zone.id])
+    #expect(sut.unconvertedLocalZones.isEmpty)
+    #expect(!sut.showsLocalZoneRow)
+    #expect(!sut.isDiscardConfirmationPresented)
+  }
+
+  @Test func discardLocalZones_thenReload_staysHidden() async throws {
+    let localRepo = SpyDeviceLocalZoneRepository()
+    localRepo.loadAllResult = [try makeLocalZone()]
+    let sut = WatchZoneListViewModel(
+      repository: SpyWatchZoneRepository(),
+      featureGate: FeatureGate(tier: .free),
+      deviceLocalZoneRepository: localRepo
+    )
+    await sut.load()
+
+    sut.discardLocalZones()
+    // Mirrors what a real repository would report post-delete — the spy
+    // records calls but does not mutate its own stubbed result.
+    localRepo.loadAllResult = []
+    await sut.load()
+
+    #expect(!sut.showsLocalZoneRow)
+    #expect(sut.unconvertedLocalZones.isEmpty)
+  }
+
+  @Test func load_deduplicatesLocalZoneMatchingServerZone() async throws {
+    let localRepo = SpyDeviceLocalZoneRepository()
+    let serverZone = try WatchZone(
+      name: "Home", centre: .cambridge, radiusMetres: 1000, authorityId: 1)
+    let duplicateCentre = try Coordinate(
+      latitude: Coordinate.cambridge.latitude + 0.00005,
+      longitude: Coordinate.cambridge.longitude - 0.00005
+    )
+    let duplicate = try makeLocalZone(
+      name: "Home", centre: duplicateCentre, radiusMetres: 1000)
+    let distinct = try makeLocalZone(
+      name: "Allotment", centre: .cambridge, radiusMetres: 2000)
+    localRepo.loadAllResult = [duplicate, distinct]
+    let watchRepo = SpyWatchZoneRepository()
+    watchRepo.loadAllResult = .success([serverZone])
+    let sut = WatchZoneListViewModel(
+      repository: watchRepo,
+      featureGate: FeatureGate(tier: .free),
+      deviceLocalZoneRepository: localRepo
+    )
+
+    await sut.load()
+
+    #expect(localRepo.deleteCalls == [duplicate.id])
+    #expect(sut.unconvertedLocalZones == [distinct])
+  }
+
+  @Test func load_withServerLoadFailure_doesNotDeduplicate() async throws {
+    let localRepo = SpyDeviceLocalZoneRepository()
+    let duplicate = try makeLocalZone(name: "Home", centre: .cambridge, radiusMetres: 1000)
+    localRepo.loadAllResult = [duplicate]
+    let watchRepo = SpyWatchZoneRepository()
+    watchRepo.loadAllResult = .failure(DomainError.networkUnavailable)
+    let sut = WatchZoneListViewModel(
+      repository: watchRepo,
+      featureGate: FeatureGate(tier: .free),
+      deviceLocalZoneRepository: localRepo
+    )
+
+    await sut.load()
+
+    #expect(localRepo.deleteCalls.isEmpty)
+    #expect(sut.unconvertedLocalZones == [duplicate])
   }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/WatchZoneListViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WatchZoneListViewTests.swift
@@ -104,4 +104,26 @@ struct WatchZoneListViewTests {
     let sut = WatchZoneListView(viewModel: vm)
     _ = sut.body
   }
+
+  // tc-luq4u: the row's "x" opens a delete-confirmation dialog rather than
+  // dismissing directly.
+  @Test func body_renders_whenDiscardConfirmationPresented() async throws {
+    let spy = SpyWatchZoneRepository()
+    let localRepo = SpyDeviceLocalZoneRepository()
+    localRepo.loadAllResult = [
+      try DeviceLocalZone(name: "Home", centre: .cambridge, radiusMetres: 1000)
+    ]
+    let vm = WatchZoneListViewModel(
+      repository: spy,
+      featureGate: FeatureGate(tier: .free),
+      deviceLocalZoneRepository: localRepo
+    )
+    await vm.load()
+    vm.presentDiscardConfirmation()
+
+    #expect(vm.isDiscardConfirmationPresented)
+
+    let sut = WatchZoneListView(viewModel: vm)
+    _ = sut.body
+  }
 }


### PR DESCRIPTION
## Changes

The "N areas from before you signed up" row on the authed Zones tab had no permanent decline: its x dismissed for the session only, so the banner returned on every launch for anyone whose device-local zone was never converted (e.g. signed in to an existing account, so the onboarding wizard never ran).

- The row's x now opens an alert: **Delete** (destructive, permanently removes the device-local zones) or **Keep for later** (session-only hide, exactly the old behaviour).
- `WatchZoneListViewModel.discardLocalZones()` deletes every unconverted zone from the repository, so the row stays gone across launches.
- On load, device-local zones that exactly duplicate an existing server zone (same radius, centre within 1e-4°) are cleaned up automatically; cleanup never runs when the server zone load failed.
- Uses `.alert` rather than `confirmationDialog`: on iOS 26 the dialog renders as an anchored popover which silently drops `.cancel`-role buttons, leaving "Keep for later" invisible and unreachable by VoiceOver (found in live sim verification).

## Verification

- 1841/1841 unit tests pass; swiftlint --strict clean on changed files.
- Live simulator verification (iPhone 17 Pro, iOS 26.2): banner → alert (both buttons render, copy exact) → Keep for later returns after relaunch → Delete stays gone after relaunch; dedupe-on-load confirmed against a matching server zone; no crashes.

Bead: tc-luq4u

Release-Note: You can now delete saved areas from before you signed up, so the reminder stops coming back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CfTspvWFhrqdq7PoNzbbC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a confirmation prompt before permanently deleting unconverted local zones.
  * Users can delete zones immediately or keep them for later.
  * Confirmation messaging adapts for one or multiple zones.

* **Bug Fixes**
  * Prevented duplicate local zones from appearing after successful server loading.
  * Preserved local zones when server loading fails.
  * Ensured deleted zones remain cleared after reloading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->