### PR TITLE
feat: ingest every non-DP-restricted PlanIt field as silent updates (tc-x24nx)

### DIFF
--- a/api-go/internal/applications/application.go
+++ b/api-go/internal/applications/application.go
@@ -9,6 +9,8 @@
 package applications
 
 import (
+	"bytes"
+	"encoding/json"
 	"strconv"
 	"time"
 )
@@ -35,6 +37,19 @@ type PlanningApplication struct {
 	URL           *string
 	Link          *string
 	LastDifferent time.Time
+
+	// The fields below are the PlanIt full-field widening (GH#935): every
+	// remaining top-level core field plus other_fields, minus the three
+	// DP-restricted keys. All are silent — see HasSameSilentFieldsAs — so a
+	// change in only these fields updates the stored row without triggering
+	// notification fan-out (ADR 0021, the reindex-flood guard).
+	Reference    *string    // PlanIt's own "reference" field (distinct from Name/UID)
+	Altid        []byte     // raw JSON: PlanIt's altid may be a string OR an array depending on scraper
+	AssociatedID []byte     // raw JSON: same string-or-array shape as Altid
+	LastChanged  *time.Time // PlanIt bookkeeping timestamp; excluded from both comparison methods
+	LastScraped  *time.Time // PlanIt bookkeeping timestamp; excluded from both comparison methods
+	ScraperName  *string
+	OtherFields  map[string]any // PlanIt's other_fields map, verbatim minus applicant_name/agent_name/case_officer
 }
 
 // TownCentroid is a validated WGS84 point plus its OWN safety radius: one
@@ -84,6 +99,45 @@ func (a PlanningApplication) HasSameBusinessFieldsAs(other PlanningApplication) 
 		eqFloatPtr(a.Latitude, other.Latitude) &&
 		eqStrPtr(a.URL, other.URL) &&
 		eqStrPtr(a.Link, other.Link)
+}
+
+// HasSameSilentFieldsAs reports whether every silent field (the PlanIt
+// full-field widening, GH#935) matches other: Reference, Altid, AssociatedID,
+// ScraperName, and OtherFields. LastChanged and LastScraped are deliberately
+// EXCLUDED — they are bookkeeping, alongside LastDifferent, and bump on
+// effectively every PlanIt re-emission; including them here would make every
+// PlanIt bulk re-index a row write, defeating the reindex-flood guard the
+// ingester relies on. The poll cycle uses this method, alongside
+// HasSameBusinessFieldsAs, to classify a change as silent (upsert, no
+// notification fan-out) vs bookkeeping-only (no write at all).
+func (a PlanningApplication) HasSameSilentFieldsAs(other PlanningApplication) bool {
+	return eqStrPtr(a.Reference, other.Reference) &&
+		eqRawJSON(a.Altid, other.Altid) &&
+		eqRawJSON(a.AssociatedID, other.AssociatedID) &&
+		eqStrPtr(a.ScraperName, other.ScraperName) &&
+		eqOtherFields(a.OtherFields, other.OtherFields)
+}
+
+// eqRawJSON reports whether two raw-JSON byte slices are equal, treating nil
+// and empty as equal (an absent Altid/AssociatedID either way).
+func eqRawJSON(a, b []byte) bool {
+	if len(a) == 0 && len(b) == 0 {
+		return true
+	}
+	return bytes.Equal(a, b)
+}
+
+// eqOtherFields reports whether two other_fields maps are equal, treating nil
+// and empty as equal. Comparison is via canonical json.Marshal bytes: Go
+// marshals map keys in sorted order, so two maps with the same entries in a
+// different insertion order produce identical bytes.
+func eqOtherFields(a, b map[string]any) bool {
+	if len(a) == 0 && len(b) == 0 {
+		return true
+	}
+	aBytes, _ := json.Marshal(a)
+	bBytes, _ := json.Marshal(b)
+	return bytes.Equal(aBytes, bBytes)
 }
 
 // eqStrPtr reports whether two optional strings are equal (both nil, or both

--- a/api-go/internal/applications/application.go
+++ b/api-go/internal/applications/application.go
@@ -118,13 +118,42 @@ func (a PlanningApplication) HasSameSilentFieldsAs(other PlanningApplication) bo
 		eqOtherFields(a.OtherFields, other.OtherFields)
 }
 
-// eqRawJSON reports whether two raw-JSON byte slices are equal, treating nil
-// and empty as equal (an absent Altid/AssociatedID either way).
+// eqRawJSON reports whether two raw-JSON byte slices represent the same JSON
+// value, treating nil and empty as equal (an absent Altid/AssociatedID either
+// way). This MUST be a semantic comparison, not bytes.Equal: PlanIt's API
+// returns pretty-printed JSON, which json.RawMessage preserves verbatim, while
+// Postgres jsonb canonicalises text on storage (e.g. reformatting
+// ["a","b"] to ["a", "b"]). A byte comparison between a freshly-parsed
+// incoming value and the same value read back from Postgres would therefore
+// find them unequal on every re-fetch for any record with an array-valued
+// altid/associated_id — permanently defeating the silent-change
+// write-suppression guard for that subset of records, which is exactly the
+// reindex-storm write amplification the three-bucket ingester design exists
+// to prevent. Do not "simplify" this back to bytes.Equal.
+//
+// Comparison unmarshals both sides then re-marshals: encoding/json's output
+// is deterministic (sorted map keys, canonical number formatting), so two
+// byte slices are compared after passing through the same normalisation on
+// both sides. Unparseable JSON on either side (never expected in practice —
+// both sides always originate from a prior successful json.Unmarshal) is
+// treated as not-equal, the safe direction — mirrors eqOtherFields.
 func eqRawJSON(a, b []byte) bool {
 	if len(a) == 0 && len(b) == 0 {
 		return true
 	}
-	return bytes.Equal(a, b)
+	var aVal, bVal any
+	if err := json.Unmarshal(a, &aVal); err != nil {
+		return false
+	}
+	if err := json.Unmarshal(b, &bVal); err != nil {
+		return false
+	}
+	aBytes, aErr := json.Marshal(aVal)
+	bBytes, bErr := json.Marshal(bVal)
+	if aErr != nil || bErr != nil {
+		return false
+	}
+	return bytes.Equal(aBytes, bBytes)
 }
 
 // eqOtherFields reports whether two other_fields maps are equal, treating nil

--- a/api-go/internal/applications/application.go
+++ b/api-go/internal/applications/application.go
@@ -130,13 +130,20 @@ func eqRawJSON(a, b []byte) bool {
 // eqOtherFields reports whether two other_fields maps are equal, treating nil
 // and empty as equal. Comparison is via canonical json.Marshal bytes: Go
 // marshals map keys in sorted order, so two maps with the same entries in a
-// different insertion order produce identical bytes.
+// different insertion order produce identical bytes. A marshal failure (never
+// expected: these maps are always sourced from a prior JSON unmarshal, whose
+// output types always re-marshal cleanly) is treated as not-equal — the safe
+// direction, since it only ever causes one extra harmless silent-field upsert
+// rather than masking a real change.
 func eqOtherFields(a, b map[string]any) bool {
 	if len(a) == 0 && len(b) == 0 {
 		return true
 	}
-	aBytes, _ := json.Marshal(a)
-	bBytes, _ := json.Marshal(b)
+	aBytes, aErr := json.Marshal(a)
+	bBytes, bErr := json.Marshal(b)
+	if aErr != nil || bErr != nil {
+		return false
+	}
 	return bytes.Equal(aBytes, bBytes)
 }
 

--- a/api-go/internal/applications/application_test.go
+++ b/api-go/internal/applications/application_test.go
@@ -58,6 +58,120 @@ func TestPlanningApplication_CanonicalUID_PreservesNameWithSlashes(t *testing.T)
 	}
 }
 
+func TestPlanningApplication_HasSameSilentFieldsAs(t *testing.T) {
+	t.Parallel()
+	base := testApplication(t)
+	base.Reference = ptr("REF-1")
+	base.Altid = []byte(`["A","B"]`)
+	base.AssociatedID = []byte(`"single"`)
+	base.ScraperName = ptr("scraper-1")
+	base.OtherFields = map[string]any{"comment_url": "https://example.test/comment", "n_comments": float64(3)}
+	base.LastChanged = timePtr(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	base.LastScraped = timePtr(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+
+	t.Run("identical silent fields compare equal", func(t *testing.T) {
+		t.Parallel()
+		other := base
+		if !base.HasSameSilentFieldsAs(other) {
+			t.Error("identical silent fields must compare equal")
+		}
+	})
+
+	t.Run("differing other_fields compares not-equal", func(t *testing.T) {
+		t.Parallel()
+		other := base
+		other.OtherFields = map[string]any{"comment_url": "https://example.test/different", "n_comments": float64(3)}
+		if base.HasSameSilentFieldsAs(other) {
+			t.Error("a changed other_fields entry must compare not-equal")
+		}
+	})
+
+	t.Run("equal maps built in different insertion order compare equal", func(t *testing.T) {
+		t.Parallel()
+		a := PlanningApplication{OtherFields: map[string]any{"a": 1.0, "b": 2.0, "c": 3.0}}
+		b := PlanningApplication{OtherFields: map[string]any{"c": 3.0, "a": 1.0, "b": 2.0}}
+		if !a.HasSameSilentFieldsAs(b) {
+			t.Error("maps with the same entries in different insertion order must compare equal")
+		}
+	})
+
+	t.Run("nil vs empty other_fields map compares equal", func(t *testing.T) {
+		t.Parallel()
+		a := PlanningApplication{OtherFields: nil}
+		b := PlanningApplication{OtherFields: map[string]any{}}
+		if !a.HasSameSilentFieldsAs(b) {
+			t.Error("nil vs empty other_fields must compare equal")
+		}
+	})
+
+	t.Run("differing reference compares not-equal", func(t *testing.T) {
+		t.Parallel()
+		other := base
+		other.Reference = ptr("REF-2")
+		if base.HasSameSilentFieldsAs(other) {
+			t.Error("a changed reference must compare not-equal")
+		}
+	})
+
+	t.Run("differing altid compares not-equal", func(t *testing.T) {
+		t.Parallel()
+		other := base
+		other.Altid = []byte(`["A","C"]`)
+		if base.HasSameSilentFieldsAs(other) {
+			t.Error("a changed altid must compare not-equal")
+		}
+	})
+
+	t.Run("differing associated_id compares not-equal", func(t *testing.T) {
+		t.Parallel()
+		other := base
+		other.AssociatedID = []byte(`"other"`)
+		if base.HasSameSilentFieldsAs(other) {
+			t.Error("a changed associated_id must compare not-equal")
+		}
+	})
+
+	t.Run("differing scraper_name compares not-equal", func(t *testing.T) {
+		t.Parallel()
+		other := base
+		other.ScraperName = ptr("scraper-2")
+		if base.HasSameSilentFieldsAs(other) {
+			t.Error("a changed scraper_name must compare not-equal")
+		}
+	})
+
+	t.Run("differing LastScraped alone compares equal (bookkeeping is ignored)", func(t *testing.T) {
+		t.Parallel()
+		other := base
+		other.LastScraped = timePtr(base.LastScraped.Add(48 * time.Hour))
+		if !base.HasSameSilentFieldsAs(other) {
+			t.Error("a changed LastScraped alone must compare equal: it is bookkeeping, not silent")
+		}
+	})
+
+	t.Run("differing LastChanged alone compares equal (bookkeeping is ignored)", func(t *testing.T) {
+		t.Parallel()
+		other := base
+		other.LastChanged = timePtr(base.LastChanged.Add(48 * time.Hour))
+		if !base.HasSameSilentFieldsAs(other) {
+			t.Error("a changed LastChanged alone must compare equal: it is bookkeeping, not silent")
+		}
+	})
+
+	t.Run("nil vs set altid compares not-equal", func(t *testing.T) {
+		t.Parallel()
+		other := base
+		other.Altid = nil
+		if base.HasSameSilentFieldsAs(other) {
+			t.Error("nil vs set altid must compare not-equal")
+		}
+	})
+}
+
+func ptr(s string) *string { return &s }
+
+func timePtr(t time.Time) *time.Time { return &t }
+
 func TestPlanningApplication_HasSameBusinessFieldsAs(t *testing.T) {
 	t.Parallel()
 	base := testApplication(t)

--- a/api-go/internal/applications/application_test.go
+++ b/api-go/internal/applications/application_test.go
@@ -168,6 +168,64 @@ func TestPlanningApplication_HasSameSilentFieldsAs(t *testing.T) {
 	})
 }
 
+// TestEqRawJSON_SemanticComparison proves eqRawJSON compares by decoded JSON
+// value, not raw bytes: PlanIt's API returns pretty-printed JSON (preserved
+// verbatim in json.RawMessage), while Postgres jsonb canonicalises text on
+// storage (reformats spacing) — so for any record with an array-valued altid
+// or associated_id, a bytes.Equal comparison would find the freshly-parsed
+// incoming bytes and the read-back-from-Postgres bytes ALWAYS unequal, even
+// when semantically identical. That permanently defeats the silent-change
+// write-suppression guard for that subset of records, on every re-fetch —
+// exactly the reindex-storm write amplification the three-bucket ingester
+// design exists to prevent.
+func TestEqRawJSON_SemanticComparison(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		a, b []byte
+		want bool
+	}{
+		{
+			name: "pretty-printed vs Postgres-canonical form of the same array compares equal",
+			a:    []byte("[\"a\",\n  \"b\"]"),
+			b:    []byte(`["a", "b"]`),
+			want: true,
+		},
+		{
+			name: "a string value vs a single-element array compares not-equal",
+			a:    []byte(`"x"`),
+			b:    []byte(`["x"]`),
+			want: false,
+		},
+		{
+			name: "nil vs nil compares equal",
+			a:    nil,
+			b:    nil,
+			want: true,
+		},
+		{
+			name: "genuinely different arrays compare not-equal",
+			a:    []byte(`["a","b"]`),
+			b:    []byte(`["a","c"]`),
+			want: false,
+		},
+		{
+			name: "unparseable bytes on either side compare not-equal (safe direction)",
+			a:    []byte(`not-json`),
+			b:    []byte(`["a"]`),
+			want: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := eqRawJSON(tc.a, tc.b); got != tc.want {
+				t.Errorf("eqRawJSON(%s, %s): got %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
 func ptr(s string) *string { return &s }
 
 func timePtr(t time.Time) *time.Time { return &t }

--- a/api-go/internal/applications/store_postgres.go
+++ b/api-go/internal/applications/store_postgres.go
@@ -111,15 +111,21 @@ func scanAppRow(row pgx.CollectableRow) (PlanningApplication, error) {
 // planit_name). location is built from longitude ($15) and latitude ($16): when
 // either is NULL, ST_MakePoint yields NULL, so a coordinate-less application stores
 // a NULL location — matching the Cosmos newGeoPoint both-or-nothing rule.
+// $20-$26 are the PlanIt full-field widening's seven silent columns (GH#935):
+// other_fields ($26) binds a map[string]any natively as jsonb via pgx; a nil
+// map binds as SQL NULL. altid/associated_id ($21/$22) bind raw JSON bytes the
+// same way; a nil slice binds as SQL NULL.
 const upsertQuery = `
 INSERT INTO applications (
 	planit_name, authority_code, uid, area_name, area_id, address, postcode,
 	description, app_type, app_state, app_size, start_date, decided_date,
-	consulted_date, location, url, link, last_different
+	consulted_date, location, url, link, last_different,
+	reference, altid, associated_id, last_changed, last_scraped, scraper_name, other_fields
 ) VALUES (
 	$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14,
 	ST_SetSRID(ST_MakePoint($15::double precision, $16::double precision), 4326)::geography,
-	$17, $18, $19
+	$17, $18, $19,
+	$20, $21, $22, $23, $24, $25, $26
 )
 ON CONFLICT (authority_code, planit_name) DO UPDATE SET
 	uid = EXCLUDED.uid,
@@ -137,7 +143,14 @@ ON CONFLICT (authority_code, planit_name) DO UPDATE SET
 	location = EXCLUDED.location,
 	url = EXCLUDED.url,
 	link = EXCLUDED.link,
-	last_different = EXCLUDED.last_different`
+	last_different = EXCLUDED.last_different,
+	reference = EXCLUDED.reference,
+	altid = EXCLUDED.altid,
+	associated_id = EXCLUDED.associated_id,
+	last_changed = EXCLUDED.last_changed,
+	last_scraped = EXCLUDED.last_scraped,
+	scraper_name = EXCLUDED.scraper_name,
+	other_fields = EXCLUDED.other_fields`
 
 // Upsert inserts or updates the application. authority_code is the stringified
 // AreaID, matching the Cosmos partition key.
@@ -147,11 +160,32 @@ func (s *PostgresStore) Upsert(ctx context.Context, a PlanningApplication) error
 		a.Postcode, a.Description, a.AppType, a.AppState, a.AppSize,
 		a.StartDate, a.DecidedDate, a.ConsultedDate,
 		a.Longitude, a.Latitude, a.URL, a.Link, a.LastDifferent,
+		a.Reference, nilIfEmptyBytes(a.Altid), nilIfEmptyBytes(a.AssociatedID),
+		a.LastChanged, a.LastScraped, a.ScraperName, nilIfEmptyOtherFields(a.OtherFields),
 	)
 	if err != nil {
 		return fmt.Errorf("upsert application %q: %w", a.Name, err)
 	}
 	return nil
+}
+
+// nilIfEmptyBytes returns b, or an explicit nil when b is empty, so pgx binds
+// SQL NULL rather than an empty jsonb value for an absent Altid/AssociatedID.
+func nilIfEmptyBytes(b []byte) []byte {
+	if len(b) == 0 {
+		return nil
+	}
+	return b
+}
+
+// nilIfEmptyOtherFields returns fields, or an explicit nil when fields is
+// empty, so pgx binds SQL NULL rather than jsonb "{}" for an absent
+// other_fields map.
+func nilIfEmptyOtherFields(fields map[string]any) map[string]any {
+	if len(fields) == 0 {
+		return nil
+	}
+	return fields
 }
 
 const getByAuthorityAndNameQuery = "SELECT " + appColumns +
@@ -170,13 +204,43 @@ func (s *PostgresStore) GetByAuthorityAndName(ctx context.Context, authorityCode
 	return a, true, nil
 }
 
-const getByUIDQuery = "SELECT " + appColumns +
+// fullAppColumns is appColumns plus the seven silent-field columns (GH#935,
+// the PlanIt full-field widening). It is used ONLY by getByUIDQuery: the
+// ingester's read-back needs the silent-field snapshot to evaluate
+// HasSameSilentFieldsAs. Every other read keeps appColumns unchanged, so
+// list/search payloads and every HTTP response DTO are byte-for-byte
+// unaffected — no query path outside GetByUID ever selects these columns.
+const fullAppColumns = appColumns +
+	", reference, altid, associated_id, last_changed, last_scraped, scraper_name, other_fields"
+
+const getByUIDQuery = "SELECT " + fullAppColumns +
 	" FROM applications WHERE authority_code = $1 AND uid = $2 ORDER BY planit_name LIMIT 1"
 
+// scanFullApp hydrates one application from a fullAppColumns single-row read:
+// appScanDest's destinations plus the seven silent fields. other_fields scans
+// into an intermediate []byte (the jsonb wire form) and is then unmarshalled,
+// matching the savedapplications snapshot-column pattern.
+func scanFullApp(row pgx.Row) (PlanningApplication, error) {
+	var a PlanningApplication
+	var otherFieldsJSON []byte
+	dest := append(appScanDest(&a),
+		&a.Reference, &a.Altid, &a.AssociatedID, &a.LastChanged, &a.LastScraped, &a.ScraperName, &otherFieldsJSON)
+	if err := row.Scan(dest...); err != nil {
+		return PlanningApplication{}, err
+	}
+	if len(otherFieldsJSON) > 0 {
+		if err := json.Unmarshal(otherFieldsJSON, &a.OtherFields); err != nil {
+			return PlanningApplication{}, fmt.Errorf("decode other_fields: %w", err)
+		}
+	}
+	return a, nil
+}
+
 // GetByUID looks up an application by its raw PlanIt uid within an authority,
-// for the saved-application lazy snapshot backfill. The boolean reports presence.
+// for the saved-application lazy snapshot backfill and the ingester's
+// silent-field read-back. The boolean reports presence.
 func (s *PostgresStore) GetByUID(ctx context.Context, uid, authorityCode string) (PlanningApplication, bool, error) {
-	a, err := scanApp(s.db.QueryRow(ctx, getByUIDQuery, authorityCode, uid))
+	a, err := scanFullApp(s.db.QueryRow(ctx, getByUIDQuery, authorityCode, uid))
 	if errors.Is(err, pgx.ErrNoRows) {
 		return PlanningApplication{}, false, nil
 	}

--- a/api-go/internal/applications/store_postgres_test.go
+++ b/api-go/internal/applications/store_postgres_test.go
@@ -363,6 +363,14 @@ func TestPostgresStore_Upsert_GetByUID_RoundTripsFullFields(t *testing.T) {
 	if !reflect.DeepEqual(got.OtherFields, a.OtherFields) {
 		t.Errorf("OtherFields: got %+v, want %+v", got.OtherFields, a.OtherFields)
 	}
+	// The domain-level regression proof: a semantically-unchanged Altid must
+	// compare equal even after a round trip through Postgres's jsonb
+	// canonicalisation, or the ingester's silent-change write-suppression
+	// guard is defeated on every re-fetch for any record with an array-valued
+	// altid/associated_id (see eqRawJSON's doc comment).
+	if !a.HasSameSilentFieldsAs(got) {
+		t.Errorf("a jsonb-reformatted-but-semantically-unchanged round trip must still compare equal via HasSameSilentFieldsAs")
+	}
 }
 
 // TestPostgresStore_Upsert_OverwritesOtherFieldsOnSecondUpsert proves a second

--- a/api-go/internal/applications/store_postgres_test.go
+++ b/api-go/internal/applications/store_postgres_test.go
@@ -294,6 +294,156 @@ func TestPostgresStore_GetByUID(t *testing.T) {
 	}
 }
 
+// TestPostgresStore_Upsert_GetByUID_RoundTripsFullFields is the GH#935
+// pgtest acceptance criterion: Upsert -> GetByUID round-trips all seven new
+// silent fields — the jsonb other_fields map, altid in its raw-JSON array
+// form, and the two bookkeeping timestamps.
+func TestPostgresStore_Upsert_GetByUID_RoundTripsFullFields(t *testing.T) {
+	ctx := context.Background()
+	store := newAppPGStore(t)
+
+	lastChanged := time.Date(2026, 7, 11, 21, 4, 14, 856483000, time.UTC)
+	lastScraped := time.Date(2026, 7, 11, 20, 0, 0, 123456000, time.UTC)
+	a := pgApp("24/0005/FUL", 100)
+	a.UID = "full-fields-uid"
+	a.Reference = pgPtr("REF-100")
+	a.Altid = []byte(`["A","B"]`)
+	a.AssociatedID = []byte(`"single-id"`)
+	a.LastChanged = &lastChanged
+	a.LastScraped = &lastScraped
+	a.ScraperName = pgPtr("Richmondshire")
+	a.OtherFields = map[string]any{"comment_url": "https://example.test/comment", "n_comments": float64(3)}
+
+	if err := store.Upsert(ctx, a); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	got, found, err := store.GetByUID(ctx, "full-fields-uid", "100")
+	if err != nil || !found {
+		t.Fatalf("GetByUID: found=%v err=%v", found, err)
+	}
+	if got.Reference == nil || *got.Reference != "REF-100" {
+		t.Errorf("Reference: got %v, want REF-100", got.Reference)
+	}
+	if string(got.Altid) != `["A","B"]` {
+		t.Errorf("Altid: got %s, want [\"A\",\"B\"]", got.Altid)
+	}
+	if string(got.AssociatedID) != `"single-id"` {
+		t.Errorf("AssociatedID: got %s, want \"single-id\"", got.AssociatedID)
+	}
+	if got.LastChanged == nil || !got.LastChanged.Equal(lastChanged) {
+		t.Errorf("LastChanged: got %v, want %v", got.LastChanged, lastChanged)
+	}
+	if got.LastScraped == nil || !got.LastScraped.Equal(lastScraped) {
+		t.Errorf("LastScraped: got %v, want %v", got.LastScraped, lastScraped)
+	}
+	if got.ScraperName == nil || *got.ScraperName != "Richmondshire" {
+		t.Errorf("ScraperName: got %v, want Richmondshire", got.ScraperName)
+	}
+	if !a.HasSameSilentFieldsAs(got) {
+		t.Errorf("round-tripped other_fields differ: got %+v, want %+v", got.OtherFields, a.OtherFields)
+	}
+}
+
+// TestPostgresStore_Upsert_OverwritesOtherFieldsOnSecondUpsert proves a second
+// Upsert with a changed other_fields map replaces the stored jsonb rather than
+// merging with the first.
+func TestPostgresStore_Upsert_OverwritesOtherFieldsOnSecondUpsert(t *testing.T) {
+	ctx := context.Background()
+	store := newAppPGStore(t)
+
+	first := pgApp("24/0006/FUL", 100)
+	first.UID = "overwrite-uid"
+	first.OtherFields = map[string]any{"comment_url": "https://old", "n_comments": float64(1)}
+	if err := store.Upsert(ctx, first); err != nil {
+		t.Fatalf("Upsert first: %v", err)
+	}
+
+	second := first
+	second.OtherFields = map[string]any{"comment_url": "https://new"}
+	if err := store.Upsert(ctx, second); err != nil {
+		t.Fatalf("Upsert second: %v", err)
+	}
+
+	got, found, err := store.GetByUID(ctx, "overwrite-uid", "100")
+	if err != nil || !found {
+		t.Fatalf("GetByUID: found=%v err=%v", found, err)
+	}
+	if _, stale := got.OtherFields["n_comments"]; stale {
+		t.Errorf("stale key n_comments must not survive an overwriting Upsert: %+v", got.OtherFields)
+	}
+	if got.OtherFields["comment_url"] != "https://new" {
+		t.Errorf("comment_url: got %v, want https://new", got.OtherFields["comment_url"])
+	}
+}
+
+// TestPostgresStore_Upsert_FullFieldsNullRoundTripAsNil proves an application
+// with none of the seven new fields set stores and reads back all of them as
+// nil/empty, not the JSON literal "null" or an empty (non-nil) map.
+func TestPostgresStore_Upsert_FullFieldsNullRoundTripAsNil(t *testing.T) {
+	ctx := context.Background()
+	store := newAppPGStore(t)
+
+	a := pgApp("24/0007/FUL", 100)
+	a.UID = "null-fields-uid"
+	if err := store.Upsert(ctx, a); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	got, found, err := store.GetByUID(ctx, "null-fields-uid", "100")
+	if err != nil || !found {
+		t.Fatalf("GetByUID: found=%v err=%v", found, err)
+	}
+	if got.Reference != nil {
+		t.Errorf("Reference: got %v, want nil", *got.Reference)
+	}
+	if got.Altid != nil {
+		t.Errorf("Altid: got %s, want nil", got.Altid)
+	}
+	if got.AssociatedID != nil {
+		t.Errorf("AssociatedID: got %s, want nil", got.AssociatedID)
+	}
+	if got.LastChanged != nil {
+		t.Errorf("LastChanged: got %v, want nil", got.LastChanged)
+	}
+	if got.LastScraped != nil {
+		t.Errorf("LastScraped: got %v, want nil", got.LastScraped)
+	}
+	if got.ScraperName != nil {
+		t.Errorf("ScraperName: got %v, want nil", *got.ScraperName)
+	}
+	if got.OtherFields != nil {
+		t.Errorf("OtherFields: got %v, want nil", got.OtherFields)
+	}
+}
+
+// TestPostgresStore_GetByAuthorityAndName_DoesNotSurfaceFullFields proves
+// appColumns (used by every read path except GetByUID) is unchanged: even
+// though the row carries populated silent fields, GetByAuthorityAndName's
+// projection never selects them, so its result carries the zero value for
+// every one of the seven new fields — no payload growth, no API leak.
+func TestPostgresStore_GetByAuthorityAndName_DoesNotSurfaceFullFields(t *testing.T) {
+	ctx := context.Background()
+	store := newAppPGStore(t)
+
+	a := pgApp("24/0008/FUL", 100)
+	a.UID = "not-surfaced-uid"
+	a.Reference = pgPtr("REF-999")
+	a.OtherFields = map[string]any{"comment_url": "https://example.test/comment"}
+	if err := store.Upsert(ctx, a); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	got, found, err := store.GetByAuthorityAndName(ctx, "100", "24/0008/FUL")
+	if err != nil || !found {
+		t.Fatalf("GetByAuthorityAndName: found=%v err=%v", found, err)
+	}
+	if got.Reference != nil || got.OtherFields != nil {
+		t.Errorf("GetByAuthorityAndName must not surface full fields, got Reference=%v OtherFields=%v",
+			got.Reference, got.OtherFields)
+	}
+}
+
 // TestPostgresStore_RecentByAuthority orders by last_different DESC, bounds by
 // cap, and scopes to the authority.
 // TestPostgresStore_RecentByAuthority_OrdersByRealDateDescNullsLast proves the

--- a/api-go/internal/applications/store_postgres_test.go
+++ b/api-go/internal/applications/store_postgres_test.go
@@ -4,6 +4,7 @@ package applications
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"reflect"
 	"testing"
@@ -91,6 +92,25 @@ func assertAppEqual(t *testing.T, got, want PlanningApplication) {
 	g.ConsultedDate, w.ConsultedDate = nil, nil
 	if !reflect.DeepEqual(g, w) {
 		t.Errorf("application mismatch:\n got = %+v\nwant = %+v", g, w)
+	}
+}
+
+// assertJSONSemanticallyEqual compares two raw-JSON byte slices by decoded
+// value rather than by exact bytes. jsonb is a canonical, reparsed storage
+// format (Postgres reformats the text it stores, e.g. inserting a space after
+// each comma), so a round-tripped Altid/AssociatedID is not byte-identical to
+// what was written even when it is the same JSON value.
+func assertJSONSemanticallyEqual(t *testing.T, field string, got, want []byte) {
+	t.Helper()
+	var gotVal, wantVal any
+	if err := json.Unmarshal(got, &gotVal); err != nil {
+		t.Fatalf("%s: unmarshal got %s: %v", field, got, err)
+	}
+	if err := json.Unmarshal(want, &wantVal); err != nil {
+		t.Fatalf("%s: unmarshal want %s: %v", field, want, err)
+	}
+	if !reflect.DeepEqual(gotVal, wantVal) {
+		t.Errorf("%s: got %s, want %s", field, got, want)
 	}
 }
 
@@ -325,12 +345,12 @@ func TestPostgresStore_Upsert_GetByUID_RoundTripsFullFields(t *testing.T) {
 	if got.Reference == nil || *got.Reference != "REF-100" {
 		t.Errorf("Reference: got %v, want REF-100", got.Reference)
 	}
-	if string(got.Altid) != `["A","B"]` {
-		t.Errorf("Altid: got %s, want [\"A\",\"B\"]", got.Altid)
-	}
-	if string(got.AssociatedID) != `"single-id"` {
-		t.Errorf("AssociatedID: got %s, want \"single-id\"", got.AssociatedID)
-	}
+	// jsonb is a canonical, reparsed storage format: Postgres reformats the
+	// text it stores (e.g. inserts a space after each comma), so the bytes
+	// read back are not byte-identical to what was written even though they
+	// are the same JSON value. Compare semantically, not byte-for-byte.
+	assertJSONSemanticallyEqual(t, "Altid", got.Altid, []byte(`["A","B"]`))
+	assertJSONSemanticallyEqual(t, "AssociatedID", got.AssociatedID, []byte(`"single-id"`))
 	if got.LastChanged == nil || !got.LastChanged.Equal(lastChanged) {
 		t.Errorf("LastChanged: got %v, want %v", got.LastChanged, lastChanged)
 	}
@@ -340,8 +360,8 @@ func TestPostgresStore_Upsert_GetByUID_RoundTripsFullFields(t *testing.T) {
 	if got.ScraperName == nil || *got.ScraperName != "Richmondshire" {
 		t.Errorf("ScraperName: got %v, want Richmondshire", got.ScraperName)
 	}
-	if !a.HasSameSilentFieldsAs(got) {
-		t.Errorf("round-tripped other_fields differ: got %+v, want %+v", got.OtherFields, a.OtherFields)
+	if !reflect.DeepEqual(got.OtherFields, a.OtherFields) {
+		t.Errorf("OtherFields: got %+v, want %+v", got.OtherFields, a.OtherFields)
 	}
 }
 

--- a/api-go/internal/planit/response.go
+++ b/api-go/internal/planit/response.go
@@ -1,6 +1,8 @@
 package planit
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -38,6 +40,77 @@ type planItRecord struct {
 	URL           *string  `json:"url"`
 	Link          *string  `json:"link"`
 	LastDifferent string   `json:"last_different"`
+
+	// The fields below are the PlanIt full-field widening (GH#935). All are
+	// carried into applications.PlanningApplication's silent fields verbatim
+	// (minus the three DP-restricted OtherFields keys); the top-level
+	// "location" GeoJSON object PlanIt also returns is deliberately absent
+	// here (no json tag) so it is ignored — location_x/location_y already
+	// build the geography point, so it is redundant.
+	Reference    *string         `json:"reference"`
+	Altid        json.RawMessage `json:"altid"`         // may be a JSON string OR array depending on scraper
+	AssociatedID json.RawMessage `json:"associated_id"` // same string-or-array shape as Altid
+	LastChanged  *string         `json:"last_changed"`  // same naive-UTC format as LastDifferent; bookkeeping
+	LastScraped  *string         `json:"last_scraped"`  // same naive-UTC format as LastDifferent; bookkeeping
+	ScraperName  *string         `json:"scraper_name"`
+	OtherFields  map[string]any  `json:"other_fields"`
+}
+
+// restrictedOtherFieldsKeys are the three PlanIt other_fields keys carrying
+// Data-Protection-restricted values (PlanIt itself returns the literal
+// placeholder "See source" for each). Owner decision 2026-07-12: strip
+// exactly these three keys — nothing else — verbatim-minus-three has zero
+// ambiguity, and every other other_fields key (including applicant_address,
+// agent company/address/tel fields, and coordinate duplicates) is kept.
+var restrictedOtherFieldsKeys = [...]string{"applicant_name", "agent_name", "case_officer"}
+
+// stripRestrictedOtherFields returns a copy of fields with
+// restrictedOtherFieldsKeys removed. An absent or empty (post-strip) map maps
+// to nil, matching PlanningApplication.OtherFields' "absent means nil" contract.
+func stripRestrictedOtherFields(fields map[string]any) map[string]any {
+	if len(fields) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(fields))
+	for k, v := range fields {
+		out[k] = v
+	}
+	for _, restricted := range restrictedOtherFieldsKeys {
+		delete(out, restricted)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// rawJSONOrNil returns raw's bytes, or nil when raw is absent or its value is
+// the JSON literal null — so an explicit "altid": null (PlanIt's real shape
+// when the field is unset) maps to a nil domain pointer rather than the
+// 4-byte literal "null". json.RawMessage always captures a JSON value's exact
+// matched token with no surrounding whitespace, so a plain byte comparison is
+// sufficient here.
+func rawJSONOrNil(raw json.RawMessage) []byte {
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return nil
+	}
+	return append([]byte(nil), raw...)
+}
+
+// parsePlanItInstantLenient parses an optional PlanIt bookkeeping timestamp
+// (LastChanged/LastScraped), tolerating an absent, empty, or unparseable
+// value by mapping it to nil rather than failing the whole record — unlike
+// LastDifferent, these fields are pure PlanIt bookkeeping (GH#935) and must
+// never cause a real application to be dropped.
+func parsePlanItInstantLenient(value *string) *time.Time {
+	if value == nil || *value == "" {
+		return nil
+	}
+	t, err := parsePlanItInstant(*value)
+	if err != nil {
+		return nil
+	}
+	return &t
 }
 
 // toDomain maps a PlanIt record to the applications.PlanningApplication snapshot:
@@ -85,6 +158,14 @@ func (r planItRecord) toDomain() (applications.PlanningApplication, error) {
 		URL:           r.URL,
 		Link:          r.Link,
 		LastDifferent: lastDifferent,
+
+		Reference:    r.Reference,
+		Altid:        rawJSONOrNil(r.Altid),
+		AssociatedID: rawJSONOrNil(r.AssociatedID),
+		LastChanged:  parsePlanItInstantLenient(r.LastChanged),
+		LastScraped:  parsePlanItInstantLenient(r.LastScraped),
+		ScraperName:  r.ScraperName,
+		OtherFields:  stripRestrictedOtherFields(r.OtherFields),
 	}, nil
 }
 

--- a/api-go/internal/planit/response_test.go
+++ b/api-go/internal/planit/response_test.go
@@ -1,6 +1,7 @@
 package planit
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 )
@@ -97,3 +98,215 @@ func TestToDomain_ParsesNoTimezoneFractionalLastDifferent(t *testing.T) {
 		t.Errorf("LastDifferent location = %v, want UTC", app.LastDifferent.Location())
 	}
 }
+
+// richmondshireFixture mirrors the real 2026-07-12 Richmondshire record
+// (GH#935): the 18 existing core fields, the six new top-level fields (altid
+// and associated_id null in the real sample; reference also null), a 24-key
+// other_fields map including the three DP-restricted keys (their real value is
+// the literal placeholder "See source"), a redundant top-level GeoJSON
+// location object (must be ignored — location_x/location_y already build the
+// geography point), and the secs_taken/to envelope fields (also ignored).
+const richmondshireFixture = `{
+	"name": "24/0001",
+	"uid": "24/0001/FUL",
+	"area_name": "Richmondshire",
+	"area_id": 350,
+	"address": "1 High St",
+	"postcode": "DL10 4AA",
+	"description": "Erection of a shed",
+	"app_type": "Full",
+	"app_state": "Undecided",
+	"app_size": "Small",
+	"start_date": "2026-06-01",
+	"location_x": -1.7297,
+	"location_y": 54.4021,
+	"url": "https://planit.example/app/1",
+	"link": "https://council.example/app/1",
+	"last_different": "2026-07-11T21:04:14.856483",
+	"altid": null,
+	"associated_id": null,
+	"reference": null,
+	"last_changed": "2026-07-11T21:04:14.856483",
+	"last_scraped": "2026-07-11T20:00:00.123456",
+	"scraper_name": "Richmondshire",
+	"location": {"type": "Point", "coordinates": [-1.7297, 54.4021]},
+	"secs_taken": 0.12,
+	"to": 1,
+	"other_fields": {
+		"applicant_address": "1 High St, Richmond",
+		"applicant_name": "See source",
+		"agent_name": "See source",
+		"application_type": "Full Planning Permission",
+		"case_officer": "See source",
+		"comment_date": "2026-07-25",
+		"comment_url": "https://planit.example/comment/1",
+		"date_received": "2026-06-01",
+		"date_validated": "2026-06-05",
+		"decided_by": "Delegated",
+		"docs_url": "https://planit.example/docs/1",
+		"easting": 417000,
+		"lat": 54.4021,
+		"lng": -1.7297,
+		"map_url": "https://planit.example/map/1",
+		"n_comments": 2,
+		"n_constraints": 1,
+		"n_documents": 5,
+		"n_statutory_days": 56,
+		"northing": 501000,
+		"parish": "Richmond",
+		"source_url": "https://richmondshire.example/app/1",
+		"status": "Undecided",
+		"target_decision_date": "2026-07-27",
+		"ward_name": "Richmond Central"
+	}
+}`
+
+func TestToDomain_FullFieldFixture_StripsRestrictedKeysAndKeepsTheRest(t *testing.T) {
+	t.Parallel()
+	var rec planItRecord
+	if err := json.Unmarshal([]byte(richmondshireFixture), &rec); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+	app, err := rec.toDomain()
+	if err != nil {
+		t.Fatalf("toDomain: %v", err)
+	}
+
+	for _, restricted := range []string{"applicant_name", "agent_name", "case_officer"} {
+		if _, ok := app.OtherFields[restricted]; ok {
+			t.Errorf("OtherFields must not contain restricted key %q", restricted)
+		}
+	}
+	kept := []string{"comment_url", "comment_date", "docs_url", "n_dwellings", "ward_name", "applicant_address"}
+	for _, key := range kept {
+		if key == "n_dwellings" {
+			continue // not present in this fixture; listed for reviewer clarity only
+		}
+		if _, ok := app.OtherFields[key]; !ok {
+			t.Errorf("OtherFields must keep non-restricted key %q, got %+v", key, app.OtherFields)
+		}
+	}
+	if got, want := app.OtherFields["comment_url"], "https://planit.example/comment/1"; got != want {
+		t.Errorf("OtherFields[comment_url]: got %v, want %v", got, want)
+	}
+
+	if app.Reference != nil {
+		t.Errorf("Reference: got %v, want nil", *app.Reference)
+	}
+	if app.Altid != nil {
+		t.Errorf("Altid: got %s, want nil", app.Altid)
+	}
+	if app.AssociatedID != nil {
+		t.Errorf("AssociatedID: got %s, want nil", app.AssociatedID)
+	}
+	if app.ScraperName == nil || *app.ScraperName != "Richmondshire" {
+		t.Errorf("ScraperName: got %v, want Richmondshire", app.ScraperName)
+	}
+	wantChanged := time.Date(2026, 7, 11, 21, 4, 14, 856483000, time.UTC)
+	if app.LastChanged == nil || !app.LastChanged.Equal(wantChanged) {
+		t.Errorf("LastChanged: got %v, want %v", app.LastChanged, wantChanged)
+	}
+	wantScraped := time.Date(2026, 7, 11, 20, 0, 0, 123456000, time.UTC)
+	if app.LastScraped == nil || !app.LastScraped.Equal(wantScraped) {
+		t.Errorf("LastScraped: got %v, want %v", app.LastScraped, wantScraped)
+	}
+}
+
+func TestToDomain_OtherFields_AbsentMapsToNil(t *testing.T) {
+	t.Parallel()
+	rec := planItRecord{
+		Name: "24/0002", UID: "u", AreaName: "a", AreaID: 1, Address: "x",
+		Description: "d", AppType: "t", AppState: "s", LastDifferent: "2026-06-13T00:06:34.112581",
+	}
+	app, err := rec.toDomain()
+	if err != nil {
+		t.Fatalf("toDomain: %v", err)
+	}
+	if app.OtherFields != nil {
+		t.Errorf("OtherFields: got %v, want nil", app.OtherFields)
+	}
+}
+
+func TestToDomain_OtherFields_EmptyAfterStrippingMapsToNil(t *testing.T) {
+	t.Parallel()
+	rec := planItRecord{
+		Name: "24/0003", UID: "u", AreaName: "a", AreaID: 1, Address: "x",
+		Description: "d", AppType: "t", AppState: "s", LastDifferent: "2026-06-13T00:06:34.112581",
+		OtherFields: map[string]any{"applicant_name": "See source", "agent_name": "See source", "case_officer": "See source"},
+	}
+	app, err := rec.toDomain()
+	if err != nil {
+		t.Fatalf("toDomain: %v", err)
+	}
+	if app.OtherFields != nil {
+		t.Errorf("OtherFields: got %v, want nil once only restricted keys remain", app.OtherFields)
+	}
+}
+
+func TestToDomain_LastChangedLastScraped_LenientParsing(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		value *string
+	}{
+		{"nil", nil},
+		{"empty", ptrStr("")},
+		{"malformed", ptrStr("not-a-timestamp")},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rec := planItRecord{
+				Name: "24/0004", UID: "u", AreaName: "a", AreaID: 1, Address: "x",
+				Description: "d", AppType: "t", AppState: "s", LastDifferent: "2026-06-13T00:06:34.112581",
+				LastChanged: tc.value, LastScraped: tc.value,
+			}
+			app, err := rec.toDomain()
+			if err != nil {
+				t.Fatalf("toDomain must never fail on a bookkeeping timestamp, got: %v", err)
+			}
+			if app.LastChanged != nil {
+				t.Errorf("LastChanged: got %v, want nil", app.LastChanged)
+			}
+			if app.LastScraped != nil {
+				t.Errorf("LastScraped: got %v, want nil", app.LastScraped)
+			}
+		})
+	}
+}
+
+func TestToDomain_AltidAssociatedID_StringOrArrayShapeTolerance(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"string form", `"single-id"`, `"single-id"`},
+		{"array form", `["a","b"]`, `["a","b"]`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			body := `{"name":"n","uid":"u","area_name":"a","area_id":1,"address":"x","description":"d",` +
+				`"app_type":"t","app_state":"s","last_different":"2026-06-13T00:06:34.112581",` +
+				`"altid":` + tc.raw + `,"associated_id":` + tc.raw + `}`
+			var rec planItRecord
+			if err := json.Unmarshal([]byte(body), &rec); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			app, err := rec.toDomain()
+			if err != nil {
+				t.Fatalf("toDomain: %v", err)
+			}
+			if string(app.Altid) != tc.want {
+				t.Errorf("Altid: got %s, want %s", app.Altid, tc.want)
+			}
+			if string(app.AssociatedID) != tc.want {
+				t.Errorf("AssociatedID: got %s, want %s", app.AssociatedID, tc.want)
+			}
+		})
+	}
+}
+
+func ptrStr(s string) *string { return &s }

--- a/api-go/internal/platform/postgres/migrations/0020_application_planit_full_fields.sql
+++ b/api-go/internal/platform/postgres/migrations/0020_application_planit_full_fields.sql
@@ -1,0 +1,33 @@
+-- +goose Up
+
+-- PlanIt full-field widening (GH#935): persist every non-DP-restricted field
+-- PlanIt publishes for a planning application, not just the 18 core fields
+-- ingested today. All seven columns are additive, nullable, and unindexed —
+-- no query path reads them yet (they back the ingester's silent-field
+-- comparison and future product features, not any live read today). altid and
+-- associated_id are jsonb rather than text because PlanIt's dictionary
+-- describes both as plural "identifiers": the wire shape may be a JSON string
+-- OR an array depending on the scraper, and jsonb tolerates either without
+-- ever failing a record. other_fields holds PlanIt's entire other_fields map
+-- verbatim, minus the three DP-restricted keys (applicant_name, agent_name,
+-- case_officer) stripped at the application layer before it ever reaches this
+-- column.
+ALTER TABLE applications
+    ADD COLUMN reference      text,
+    ADD COLUMN altid          jsonb,
+    ADD COLUMN associated_id  jsonb,
+    ADD COLUMN last_changed   timestamptz,
+    ADD COLUMN last_scraped   timestamptz,
+    ADD COLUMN scraper_name   text,
+    ADD COLUMN other_fields   jsonb;
+
+-- +goose Down
+
+ALTER TABLE applications
+    DROP COLUMN IF EXISTS other_fields,
+    DROP COLUMN IF EXISTS scraper_name,
+    DROP COLUMN IF EXISTS last_scraped,
+    DROP COLUMN IF EXISTS last_changed,
+    DROP COLUMN IF EXISTS associated_id,
+    DROP COLUMN IF EXISTS altid,
+    DROP COLUMN IF EXISTS reference;

--- a/api-go/internal/polling/ingester.go
+++ b/api-go/internal/polling/ingester.go
@@ -28,10 +28,21 @@ func NewIngester(apps applicationStore, decision DecisionDispatcher, enqueuer No
 }
 
 // Ingest point-reads the persisted application by uid within its authority
-// partition, and — when a business field changed (the reindex-flood guard; a
-// first-time insert always counts as changed) — upserts it, then runs the
-// notification fan-out: a decision-event dispatch when the app has just
-// transitioned into a decision state, and the watch-zone notification fan-out.
+// partition, then classifies the incoming record into one of three buckets
+// (GH#935, the PlanIt full-field widening):
+//
+//   - bookkeeping-only (neither the notifiable nor the silent field set
+//     changed — e.g. only last_different/last_changed/last_scraped bumped, the
+//     load-bearing reindex-flood guard): no upsert, no fan-out at all.
+//   - silent-only (the silent field set — other_fields, reference, altid,
+//     associated_id, scraper_name — changed but the notifiable set did not):
+//     upsert, but NO decision dispatch and NO watch-zone enqueue.
+//   - notifiable (the existing 17-field business set changed, or this is a
+//     first-time insert): upsert, plus the full fan-out below.
+//
+// The fan-out itself is unchanged: a decision-event dispatch when the app has
+// just transitioned into a decision state, and the watch-zone notification
+// fan-out for any notifiable change.
 //
 // The new-decision check is computed BEFORE the upsert so it compares the
 // PERSISTED state, not the incoming one: a non-decision -> decision transition
@@ -46,7 +57,10 @@ func (i *Ingester) Ingest(ctx context.Context, app applications.PlanningApplicat
 	if err != nil {
 		return err
 	}
-	if found && existing.HasSameBusinessFieldsAs(app) {
+
+	notifiableChanged := !found || !existing.HasSameBusinessFieldsAs(app)
+	silentChanged := !found || !existing.HasSameSilentFieldsAs(app)
+	if !notifiableChanged && !silentChanged {
 		return nil
 	}
 
@@ -65,7 +79,7 @@ func (i *Ingester) Ingest(ctx context.Context, app applications.PlanningApplicat
 			return err
 		}
 	}
-	if i.enqueuer != nil {
+	if notifiableChanged && i.enqueuer != nil {
 		if err := i.enqueuer.EnqueueForApplication(ctx, app); err != nil {
 			return err
 		}

--- a/api-go/internal/polling/ingester_test.go
+++ b/api-go/internal/polling/ingester_test.go
@@ -24,6 +24,30 @@ func TestIngester_UpsertsNewApplication(t *testing.T) {
 	}
 }
 
+// TestIngester_NewApplication_UpsertsAndEnqueues is bucket-matrix case (a): a
+// first-time insert (existing absent) always counts as a notifiable change,
+// so it upserts and enqueues for zone fan-out — with real (non-nil) fan-out
+// collaborators, unlike TestIngester_UpsertsNewApplication above.
+func TestIngester_NewApplication_UpsertsAndEnqueues(t *testing.T) {
+	t.Parallel()
+	apps := newFakeApps()
+	ld := time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC)
+	app := testApp("24/0001", 99, ld)
+	disp := &fakeDecisionDispatcher{}
+	enq := &fakeEnqueuer{}
+	ing := NewIngester(apps, disp, enq)
+
+	if err := ing.Ingest(context.Background(), app); err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	if len(apps.upserts) != 1 {
+		t.Errorf("upserts: got %d, want 1", len(apps.upserts))
+	}
+	if enq.count() != 1 {
+		t.Errorf("a first-time insert must be enqueued for zone fan-out, got %d, want 1", enq.count())
+	}
+}
+
 func TestIngester_SkipsUpsertWhenBusinessFieldsUnchanged(t *testing.T) {
 	t.Parallel()
 	apps := newFakeApps()

--- a/api-go/internal/polling/ingester_test.go
+++ b/api-go/internal/polling/ingester_test.go
@@ -109,6 +109,94 @@ func TestIngester_PropagatesGetByUIDError(t *testing.T) {
 	}
 }
 
+// --- tests: the three-bucket change classification (GH#935) ---
+
+func TestIngester_SilentOnlyChange_UpsertsWithoutFanOut(t *testing.T) {
+	t.Parallel()
+	apps := newFakeApps()
+	ld := time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC)
+	existing := testApp("24/0001", 99, ld)
+	existing.OtherFields = map[string]any{"comment_url": "https://old"}
+	apps.existing[existing.UID] = existing
+
+	incoming := existing
+	incoming.OtherFields = map[string]any{"comment_url": "https://new"}
+
+	disp := &fakeDecisionDispatcher{}
+	enq := &fakeEnqueuer{}
+	ing := NewIngester(apps, disp, enq)
+
+	if err := ing.Ingest(context.Background(), incoming); err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	if len(apps.upserts) != 1 {
+		t.Errorf("silent-only change must still upsert, got %d, want 1", len(apps.upserts))
+	}
+	if enq.count() != 0 {
+		t.Errorf("silent-only change must NOT enqueue, got %d, want 0", enq.count())
+	}
+	if disp.count() != 0 {
+		t.Errorf("silent-only change must NOT dispatch a decision, got %d, want 0", disp.count())
+	}
+}
+
+func TestIngester_BookkeepingOnlyChange_SkipsUpsertEntirely(t *testing.T) {
+	t.Parallel()
+	apps := newFakeApps()
+	ld := time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC)
+	existing := testApp("24/0001", 99, ld)
+	existing.LastChanged = timePtr(ld)
+	existing.LastScraped = timePtr(ld)
+	apps.existing[existing.UID] = existing
+
+	incoming := existing
+	incoming.LastDifferent = ld.Add(48 * time.Hour) // PlanIt re-index bump
+	incoming.LastChanged = timePtr(ld.Add(time.Hour))
+	incoming.LastScraped = timePtr(ld.Add(2 * time.Hour))
+
+	disp := &fakeDecisionDispatcher{}
+	enq := &fakeEnqueuer{}
+	ing := NewIngester(apps, disp, enq)
+
+	if err := ing.Ingest(context.Background(), incoming); err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	if len(apps.upserts) != 0 {
+		t.Errorf("bookkeeping-only change must skip the upsert entirely, got %d, want 0", len(apps.upserts))
+	}
+	if enq.count() != 0 || disp.count() != 0 {
+		t.Errorf("bookkeeping-only change must not fan out: enqueue=%d dispatch=%d", enq.count(), disp.count())
+	}
+}
+
+func TestIngester_SilentOnlyChangeOnAlreadyDecidedApp_DoesNotRedispatchDecision(t *testing.T) {
+	t.Parallel()
+	apps := newFakeApps()
+	ld := time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC)
+	existing := decisionApp("Permitted", ld)
+	existing.OtherFields = map[string]any{"comment_url": "https://old"}
+	apps.existing[existing.UID] = existing
+
+	incoming := existing
+	incoming.OtherFields = map[string]any{"comment_url": "https://new"}
+
+	disp := &fakeDecisionDispatcher{}
+	enq := &fakeEnqueuer{}
+	ing := NewIngester(apps, disp, enq)
+
+	if err := ing.Ingest(context.Background(), incoming); err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	if disp.count() != 0 {
+		t.Errorf("silent-only change on an already-decided app must not re-dispatch, got %d, want 0", disp.count())
+	}
+	if len(apps.upserts) != 1 {
+		t.Errorf("silent-only change must still upsert, got %d, want 1", len(apps.upserts))
+	}
+}
+
+func timePtr(t time.Time) *time.Time { return &t }
+
 func TestIngester_PropagatesUpsertError(t *testing.T) {
 	t.Parallel()
 	apps := newFakeApps()


### PR DESCRIPTION
Implements #935 (closes #935).

## What

- Migration 0020: seven additive nullable columns on `applications` — `reference`, `altid` (jsonb), `associated_id` (jsonb), `last_changed`, `last_scraped`, `scraper_name`, `other_fields` (jsonb).
- `planit` client parses the full record: six new top-level fields plus `other_fields` verbatim, stripping exactly the three DP-restricted keys (`applicant_name`, `agent_name`, `case_officer` — PlanIt redacts them to "See source" anyway). Lenient parsing for the two new bookkeeping timestamps; string-or-array tolerance for `altid`/`associated_id`.
- Ingester moves to three-bucket change classification: **notifiable** (the unchanged 17-field set → upsert + fan-out), **silent** (new fields → upsert, NO fan-out), **bookkeeping** (`last_different`/`last_changed`/`last_scraped` alone → no write at all, preserving the ADR 0021 reindex-flood guard).
- `GetByUID` (the ingester read-back) gets a full-projection variant; every other read keeps `appColumns` — zero change to any API response.
- Spec amendment applied per the #935 comment thread: `eqRawJSON` compares semantically (Postgres jsonb canonicalises stored text, so raw-byte equality would defeat write suppression for array-valued altid/associated_id).

## Testing

- 1772 unit tests green (`go test -race ./...`), incl. the ingester three-bucket matrix and eqRawJSON formatting-variant cases.
- 1947+ integration tests green (`make test-integration`), incl. five new pgtest round-trips (full round-trip, overwrite, NULL→nil, jsonb-canonicalisation regression proof, and proof list reads do NOT surface the new fields).
- `go vet`, `gofmt -l`, `golangci-lint run` all clean.

Backend-only: no iOS/web changes, no new indexes, no PlanIt query-param changes, no backfill (on hold per #935).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H7b48itEnVYhTVeKehkFuM