### PR TITLE
feat(infra): poll-queue fork/DLQ metric alert + PlanIt failure-rate log alert (tc-ttjor)

### DIFF
--- a/infra/environment.go
+++ b/infra/environment.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pulumi/pulumi-azure-native-sdk/app/v3"
 	"github.com/pulumi/pulumi-azure-native-sdk/authorization/v3"
 	"github.com/pulumi/pulumi-azure-native-sdk/dbforpostgresql/v3"
+	"github.com/pulumi/pulumi-azure-native-sdk/monitor/v3"
 	"github.com/pulumi/pulumi-azure-native-sdk/resources/v3"
 	"github.com/pulumi/pulumi-azure-native-sdk/servicebus/v3"
 	"github.com/pulumi/pulumi-azure-native-sdk/storage/v3"
@@ -81,6 +82,8 @@ func cloudflareIngressIPRestrictions() app.IpSecurityRestrictionRuleArray {
 // serviceBusPollingInfra captures the Service Bus resources used by the adaptive polling
 // trigger: namespace (short name + FQDN) and queue name.
 type serviceBusPollingInfra struct {
+	// namespaceID scopes the poll-queue-depth metric alert (tc-ttjor / GH #938 PR3).
+	namespaceID        pulumi.IDOutput
 	namespaceShortName pulumi.StringOutput
 	namespaceFqdn      pulumi.StringOutput
 	queueName          pulumi.StringOutput
@@ -441,6 +444,14 @@ func runEnvironmentStack(ctx *pulumi.Context, conf *config.Config, env string, t
 		pollingBus, err = createServiceBusPollingInfra(ctx, env, resourceGroup.Name,
 			shared.GetStringOutput(pulumi.String("cosmosDataIdentityPrincipalId")), tags)
 		if err != nil {
+			return err
+		}
+
+		// Poll-queue-depth metric alert (tc-ttjor / GH #938 PR3). actionGroupId is exported
+		// by the shared stack (see shared.go) — this is the same shared -> env read direction
+		// every other cross-stack value in this function already uses.
+		if err = createPollQueueDepthAlert(ctx, env, resourceGroup.Name, pollingBus,
+			shared.GetStringOutput(pulumi.String("actionGroupId")), tags); err != nil {
 			return err
 		}
 	}
@@ -829,10 +840,57 @@ func createServiceBusPollingInfra(ctx *pulumi.Context, env string, resourceGroup
 	}).(pulumi.StringOutput)
 
 	return &serviceBusPollingInfra{
+		namespaceID:        namespaceResource.ID(),
 		namespaceShortName: namespaceResource.Name,
 		namespaceFqdn:      fqdn,
 		queueName:          queue.Name,
 	}, nil
+}
+
+// createPollQueueDepthAlert creates the metric alert (prod only) that fires when the poll
+// queue's total Messages (active + scheduled + dead-lettered) exceeds 1 for a sustained 15
+// minutes. Steady state holds exactly one in-flight trigger, so this single threshold catches
+// both a forked trigger chain and dead-letter accumulation without needing separate rules per
+// sub-count (tc-ttjor / GH #938 PR3). Wired to the action group created in the shared stack —
+// see the rationale comment on its creation in shared.go.
+func createPollQueueDepthAlert(ctx *pulumi.Context, env string, resourceGroupName pulumi.StringOutput, pollingBus *serviceBusPollingInfra, actionGroupID pulumi.StringOutput, tags pulumi.StringMap) error {
+	name := fmt.Sprintf("alert-poll-queue-depth-%s", env)
+	_, err := monitor.NewMetricAlert(ctx, name, &monitor.MetricAlertArgs{
+		RuleName:            pulumi.String(name),
+		ResourceGroupName:   resourceGroupName,
+		Description:         pulumi.String("Poll Service Bus queue holds more than 1 message (active + scheduled + dead-lettered); steady state is exactly 1. Indicates a forked trigger chain or dead-letter accumulation. See GH #938."),
+		Severity:            pulumi.Int(2),
+		Enabled:             pulumi.Bool(true),
+		EvaluationFrequency: pulumi.String("PT5M"),
+		WindowSize:          pulumi.String("PT15M"),
+		Scopes:              pulumi.StringArray{pollingBus.namespaceID},
+		Criteria: monitor.MetricAlertSingleResourceMultipleMetricCriteriaArgs{
+			OdataType: pulumi.String("Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria"),
+			AllOf: monitor.MetricCriteriaArray{
+				monitor.MetricCriteriaArgs{
+					CriterionType:   pulumi.String("StaticThresholdCriterion"),
+					Name:            pulumi.String("PollQueueMessagesTotal"),
+					MetricName:      pulumi.String("Messages"),
+					MetricNamespace: pulumi.String("Microsoft.ServiceBus/namespaces"),
+					Dimensions: monitor.MetricDimensionArray{
+						monitor.MetricDimensionArgs{
+							Name:     pulumi.String("EntityName"),
+							Operator: pulumi.String("Include"),
+							Values:   pulumi.StringArray{pulumi.String("poll")},
+						},
+					},
+					Operator:        pulumi.String("GreaterThan"),
+					Threshold:       pulumi.Float64(1),
+					TimeAggregation: pulumi.String("Maximum"),
+				},
+			},
+		},
+		Actions: monitor.MetricAlertActionArray{
+			monitor.MetricAlertActionArgs{ActionGroupId: actionGroupID},
+		},
+		Tags: tags,
+	})
+	return err
 }
 
 // createSeoSnapshotStorage provisions the per-environment Storage Account + seo-snapshot blob

--- a/infra/shared.go
+++ b/infra/shared.go
@@ -442,6 +442,88 @@ func runSharedStack(ctx *pulumi.Context, conf *config.Config, tags pulumi.String
 		return err
 	}
 
+	// Action Group (tc-ttjor / GH #938 PR3) — single email receiver, reused by both alerts
+	// below and by the poll-queue-depth metric alert in the prod env stack (infra/environment.go).
+	// Deliberately created HERE rather than in the prod env stack (as the bead literally asked):
+	// the PlanIt failure-rate log alert below must live in this file (it queries the shared Log
+	// Analytics workspace), and wiring it to an action group owned by the prod stack would need a
+	// StackReference running shared -> prod, inverting the foundational shared -> env dependency
+	// direction every other cross-stack read in this codebase uses. The env stack already reads
+	// shared outputs the normal way round, so the prod metric alert consumes actionGroupId
+	// (exported below) instead.
+	actionGroup, err := monitor.NewActionGroup(ctx, "ag-town-crier-shared", &monitor.ActionGroupArgs{
+		ActionGroupName:   pulumi.String("ag-town-crier-shared"),
+		ResourceGroupName: resourceGroup.Name,
+		Location:          pulumi.String("Global"),
+		GroupShortName:    pulumi.String("tcalerts"),
+		Enabled:           pulumi.Bool(true),
+		EmailReceivers: monitor.EmailReceiverArray{
+			monitor.EmailReceiverArgs{
+				Name:                 pulumi.String("owner"),
+				EmailAddress:         pulumi.String(alertEmail),
+				UseCommonAlertSchema: pulumi.Bool(true),
+			},
+		},
+		Tags: tags,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Scheduled query (log) alert — PlanIt non-429 dependency failure ratio over the last hour,
+	// computed from AppDependencies on this shared Log Analytics workspace (tc-ttjor / GH #938
+	// PR3). Go emits no AppMetrics by design (no Go Azure Monitor metrics exporter), so a
+	// log-based alert is the only option here. The query requires >=20 calls in the window so a
+	// quiet hour with one stray failure can't read as 100%. ResultCode on these dependency spans
+	// is the OTel span status ('0'/'2'), NOT the HTTP status — hence filtering on
+	// Properties['http.response.status_code'] instead, per the issue.
+	//
+	// Location is pinned to uksouth (rather than left to the provider default the way the
+	// workspace above is) because, unlike the Global action group, Log Analytics-based scheduled
+	// query rules are regional and must be explicit — mirrors the same rationale documented on
+	// the Service Bus namespace in environment.go (tc-ds1e).
+	const planitFailureRatioQuery = `AppDependencies
+| where Target has "planit"
+| summarize Total = count(), NonRetryableFailures = countif(Success == false and tostring(Properties["http.response.status_code"]) != "429")
+| where Total >= 20
+| extend FailureRatioPercent = round(100.0 * NonRetryableFailures / Total, 1)
+| where FailureRatioPercent > 30`
+
+	_, err = monitor.NewScheduledQueryRule(ctx, "alert-planit-failure-rate-shared", &monitor.ScheduledQueryRuleArgs{
+		RuleName:            pulumi.String("alert-planit-failure-rate-shared"),
+		ResourceGroupName:   resourceGroup.Name,
+		Location:            pulumi.String("uksouth"),
+		Kind:                pulumi.String("LogAlert"),
+		Description:         pulumi.String("PlanIt non-429 dependency failure ratio exceeded 30% over the last hour (>=20 calls). See GH #938."),
+		DisplayName:         pulumi.String("PlanIt non-429 failure rate"),
+		Severity:            pulumi.Float64(2), // Warning
+		Enabled:             pulumi.Bool(true),
+		EvaluationFrequency: pulumi.String("PT15M"),
+		WindowSize:          pulumi.String("PT1H"),
+		Scopes:              pulumi.StringArray{logAnalytics.ID()},
+		Criteria: monitor.ScheduledQueryRuleCriteriaArgs{
+			AllOf: monitor.ConditionArray{
+				monitor.ConditionArgs{
+					Query: pulumi.String(planitFailureRatioQuery),
+					// The query already filters down to failing windows (FailureRatioPercent >
+					// 30 with >=20 calls); "count of rows produced > 0" is the standard
+					// scheduled-query-rule pattern for "fire when the filtered query returns
+					// anything", so no MetricMeasureColumn is needed.
+					TimeAggregation: pulumi.String("Count"),
+					Operator:        pulumi.String("GreaterThan"),
+					Threshold:       pulumi.Float64(0),
+				},
+			},
+		},
+		Actions: monitor.ActionsArgs{
+			ActionGroups: pulumi.StringArray{actionGroup.ID()},
+		},
+		Tags: tags,
+	})
+	if err != nil {
+		return err
+	}
+
 	// Azure Communication Services (Email) — UK data location.
 	emailServiceUk, err := communication.NewEmailService(ctx, "email-town-crier-uk", &communication.EmailServiceArgs{
 		EmailServiceName:  pulumi.String("email-town-crier-uk"),
@@ -566,6 +648,9 @@ func runSharedStack(ctx *pulumi.Context, conf *config.Config, tags pulumi.String
 	ctx.Export("postgresAdminPassword", postgresAdminPassword.Result)
 	ctx.Export("appInsightsId", appInsights.ID())
 	ctx.Export("appInsightsConnectionString", appInsights.ConnectionString)
+	// Action group (tc-ttjor / GH #938 PR3): consumed by the prod env stack's poll-queue-depth
+	// metric alert (infra/environment.go) so both alerts notify the same email receiver.
+	ctx.Export("actionGroupId", actionGroup.ID())
 	ctx.Export("acsConnectionString", communication.ListCommunicationServiceKeysOutput(ctx, communication.ListCommunicationServiceKeysOutputArgs{
 		ResourceGroupName:        resourceGroup.Name,
 		CommunicationServiceName: communicationServiceUk.Name,


### PR DESCRIPTION
Part of #938 (PR3 section).

## What

- **Action group** `ag-town-crier-shared` (shared stack) — single email receiver reusing the existing `alertEmail` config. Exported as `actionGroupId`.
- **Metric alert** `alert-poll-queue-depth-prod` (prod stack) — Service Bus `Messages` (EntityName=`poll`) max > 1 over 15 min, evaluated every 5 min. Steady state is exactly 1 in-flight trigger, so one rule catches both a forked trigger chain and DLQ accumulation.
- **Scheduled query alert** `alert-planit-failure-rate-shared` (shared stack) — PlanIt non-429 dependency failure ratio > 30% over 1h with ≥20 calls, from `AppDependencies` (Go emits no AppMetrics; `ResultCode` is OTel span status, so the query filters on `Properties['http.response.status_code']`).

## Deviation from the issue text

The action group lives in `shared.go`, not `environment.go`: the log alert must scope to the shared Log Analytics workspace, and wiring a shared-stack alert to a prod-stack action group would invert the codebase's `shared -> env` StackReference direction (and bootstrap-order). The prod metric alert consumes `actionGroupId` via the same `shared.GetStringOutput` pattern as every other cross-stack read. This deviation was pre-authorised in the issue dispatch.

Deploy ordering is safe: cd-dev deploys shared before dev on merge; cd-prod (tag-triggered) reads the export after shared already carries it.

## Gates

- `gofmt -l .` clean, `go vet ./...` clean, `go build ./...` clean, `go test ./...` 10 passed (from `infra/`).
- No `pulumi up` from local — CI owns deploys. Reminder: pr-gate's infra preview can mask pulumi crashes; watch cd-dev's shared+dev `pulumi up` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrShbsvV3RiC4iFuZ1R6h1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added monitoring alerts for Service Bus poll queue depth, notifying the configured alert recipients when messages remain queued.
  * Added an alert for elevated non-429 dependency failure rates, based on recent activity and minimum request volume.
  * Added a shared notification channel for coordinating infrastructure alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->