### PR TITLE
fix(polling): lease-guard bootstrap reseed, lease-confirmed publish, honest TTL (tc-ejjbl)

### DIFF
--- a/api-go/cmd/worker/main.go
+++ b/api-go/cmd/worker/main.go
@@ -166,7 +166,13 @@ func run() int {
 				logger.Error("service bus client close", "error", err)
 			}
 		}()
-		bootstrapper = worker.NewBootstrapper(sbClient, logger, time.Now)
+		// The bootstrapper shares the same Postgres polling lease the poll-sb
+		// orchestrator uses (built into st.lease below) — this is what closes the
+		// unleased-bootstrap fork mechanism (GH#938 PR1): only the current lease
+		// holder may mutate the trigger queue. WithLeaseMetrics records
+		// towncrier.polling.lease.acquired with caller "bootstrap" (registry.go:264,
+		// designed for but never wired until now).
+		bootstrapper = worker.NewBootstrapper(sbClient, st.lease, logger, time.Now).WithLeaseMetrics(registry)
 	}
 
 	// The digest, dormant-cleanup, subscription-sweep and pg-purge handlers build
@@ -285,9 +291,15 @@ func buildPollOrchestrator(cfg platform.Config, sbClient *servicebus.Client, reg
 	scheduler := polling.NewNextRunScheduler(polling.DefaultSchedulerOptions(), polling.NewRandomJitter())
 
 	// Lease TTL must exceed the handler's worst-case runtime so the lease cannot
-	// expire mid-handler (which would let a peer start a duplicate cycle). Size it
-	// at the handler budget plus a 30s margin.
-	leaseTTL := secondsToDuration(float64(cfg.PollingHandlerBudgetSeconds)) + 30*time.Second
+	// expire mid-handler (which would let a peer start a duplicate cycle, forking
+	// the trigger chain). leaseTTLFor's +5m margin (GH#938 PR1) replaces a +30s
+	// margin that was observed too tight: the 4-minute handler budget is soft
+	// (checked between authorities, not preemptive), and an in-flight timeout plus
+	// container startup (acquire happens before receive) overran the old slack —
+	// a cycle ran ~4.9m against a 4.5m TTL during the 2026-07-12 PlanIt outage.
+	// RunOnce's Confirm-before-publish CAS is the second, TOCTOU-safe layer that
+	// still catches any residual overrun.
+	leaseTTL := leaseTTLFor(secondsToDuration(float64(cfg.PollingHandlerBudgetSeconds)))
 
 	orchestrator := polling.NewOrchestrator(
 		handler,
@@ -475,6 +487,14 @@ func (a *pollOrchestratorAdapter) RunOnce(ctx context.Context) (worker.PollRunRe
 // secondsToDuration converts a fractional-seconds config value to a Duration.
 func secondsToDuration(s float64) time.Duration {
 	return time.Duration(s * float64(time.Second))
+}
+
+// leaseTTLFor derives the polling lease TTL from the handler budget: budget
+// plus a 5-minute margin, covering soft-budget overshoot (the budget is checked
+// between authorities, not preemptive) plus container cold-start before the
+// lease is even acquired (GH#938 PR1's "honest TTL").
+func leaseTTLFor(handlerBudget time.Duration) time.Duration {
+	return handlerBudget + 5*time.Minute
 }
 
 // maxInt returns the larger of a and b.

--- a/api-go/cmd/worker/wiring_test.go
+++ b/api-go/cmd/worker/wiring_test.go
@@ -100,3 +100,19 @@ func TestEnqueuer_FindZonesContainingFlowsThroughInterface(t *testing.T) {
 			spy.lastFindLat, spy.lastFindLng, lat, lng)
 	}
 }
+
+// TestLeaseTTLFor_AddsFiveMinuteMargin pins the honest-TTL derivation (GH#938
+// PR1): the polling lease TTL is the handler budget plus a 5-minute margin,
+// covering soft-budget overshoot (the budget is checked between authorities, not
+// preemptive) plus container cold-start before the lease is even acquired. The
+// previous +30s margin was observed to be too tight: a cycle overran to ~4.9m
+// against a 4.5m TTL, letting a peer take over mid-cycle and fork the trigger
+// chain.
+func TestLeaseTTLFor_AddsFiveMinuteMargin(t *testing.T) {
+	t.Parallel()
+	got := leaseTTLFor(240 * time.Second) // PollingHandlerBudgetSeconds default
+	want := 240*time.Second + 5*time.Minute
+	if got != want {
+		t.Errorf("leaseTTLFor(240s): got %v, want %v", got, want)
+	}
+}

--- a/api-go/internal/polling/orchestrator.go
+++ b/api-go/internal/polling/orchestrator.go
@@ -25,6 +25,7 @@ type triggerPublisher interface {
 type leaseStore interface {
 	TryAcquire(ctx context.Context, ttl time.Duration) (LeaseAcquireResult, error)
 	Release(ctx context.Context, handle LeaseHandle) LeaseReleaseOutcome
+	Confirm(ctx context.Context, handle LeaseHandle, extend time.Duration) bool
 }
 
 // cycleHandler runs one ingestion cycle. *PollPlanItHandler satisfies it.

--- a/api-go/internal/polling/orchestrator.go
+++ b/api-go/internal/polling/orchestrator.go
@@ -190,6 +190,18 @@ func (o *Orchestrator) RunOnce(ctx context.Context) (OrchestratorRunResult, erro
 		// malformed trigger.
 		return OrchestratorRunResult{MessageReceived: true, PollResult: &result}, err
 	}
+
+	// Confirm-and-extend immediately before publish closes the TOCTOU window
+	// between the acquire at the top of RunOnce and this point: if the lease
+	// expired mid-cycle and a peer took it over, publishing here would fork the
+	// trigger chain (two live chains double-poll PlanIt). Skipping the publish
+	// instead is safe — the safety-net bootstrap reseeds within its window
+	// (Pre-Resolved Design Decision, GH#938).
+	if !o.lease.Confirm(ctx, acquire.Handle, o.opts.LeaseTTL) {
+		o.logger.WarnContext(ctx, "polling lease lost before publish; skipping next-trigger publish (bootstrap will reseed)")
+		return OrchestratorRunResult{MessageReceived: true, PollResult: &result}, nil
+	}
+
 	if err := o.publisher.PublishAt(ctx, nextRun, body); err != nil {
 		return OrchestratorRunResult{MessageReceived: true, PollResult: &result}, err
 	}

--- a/api-go/internal/polling/orchestrator_test.go
+++ b/api-go/internal/polling/orchestrator_test.go
@@ -20,6 +20,11 @@ type fakeLease struct {
 	acquireCt int
 	releaseCt int
 	released  bool
+
+	// confirmDenied makes Confirm report false (lease lost before publish); the
+	// zero value confirms, matching held/transient's "zero value = success" style.
+	confirmDenied bool
+	confirmCt     int
 }
 
 func (f *fakeLease) TryAcquire(_ context.Context, _ time.Duration) (LeaseAcquireResult, error) {
@@ -39,6 +44,15 @@ func (f *fakeLease) Release(_ context.Context, _ LeaseHandle) LeaseReleaseOutcom
 	f.released = true
 	f.log.add("release")
 	return LeaseReleased
+}
+
+func (f *fakeLease) Confirm(_ context.Context, _ LeaseHandle, _ time.Duration) bool {
+	f.confirmCt++
+	if f.confirmDenied {
+		return false
+	}
+	f.log.add("confirm")
+	return true
 }
 
 // fakeReceiver hands out one trigger (or none) in receive-and-delete mode. There
@@ -128,8 +142,8 @@ func TestOrchestrator_HappyPath_AcquireReceiveHandlePublishRelease(t *testing.T)
 	if !res.MessageReceived || !res.PublishedNext {
 		t.Errorf("result: %+v", res)
 	}
-	// Ordering MUST be acquire -> receive -> handle -> publish -> release.
-	want := []string{"acquire", "receive", "handle", "publish", "release"}
+	// Ordering MUST be acquire -> receive -> handle -> confirm -> publish -> release.
+	want := []string{"acquire", "receive", "handle", "confirm", "publish", "release"}
 	if got := log.events; !equalStrings(got, want) {
 		t.Errorf("call order: got %v, want %v", got, want)
 	}
@@ -252,6 +266,65 @@ func TestOrchestrator_ReleasesLeaseEvenWhenHandlerFails(t *testing.T) {
 	// a failed cycle) — the bootstrap recovers the chain.
 	if pub.publishCt != 0 {
 		t.Errorf("must not publish after a handler failure: publish=%d", pub.publishCt)
+	}
+}
+
+// TestRunOnce_SkipsPublishWhenLeaseLost proves the fork-guard (GH#938 PR1): when
+// Confirm reports the lease is no longer held (expired mid-cycle and taken by a
+// peer), RunOnce must never call PublishAt — publishing here would fork the
+// trigger chain. Losing the chain instead is safe (the bootstrap reseeds).
+func TestRunOnce_SkipsPublishWhenLeaseLost(t *testing.T) {
+	t.Parallel()
+	log, lease, recv, pub, handler := newWiredFakes()
+	lease.confirmDenied = true
+	o := newOrchestrator(t, lease, recv, pub, handler)
+
+	res, err := o.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("RunOnce must not error when the lease is lost before publish: %v", err)
+	}
+	if res.PublishedNext {
+		t.Error("PublishedNext: got true, want false (lease lost; must not publish)")
+	}
+	if !res.MessageReceived {
+		t.Error("MessageReceived: got false, want true (the trigger was still consumed)")
+	}
+	if pub.publishCt != 0 {
+		t.Errorf("publish calls: got %d, want 0 (a lost lease must skip publish entirely)", pub.publishCt)
+	}
+	if lease.confirmCt != 1 {
+		t.Errorf("confirm calls: got %d, want 1", lease.confirmCt)
+	}
+	if idx := indexOf(log.events, "publish"); idx != -1 {
+		t.Errorf("publish must not appear in the call log: %v", log.events)
+	}
+	// The lease is still released even though publish was skipped — TTL is a
+	// backstop, not the only release path.
+	if !lease.released {
+		t.Error("lease must still be released after a skipped publish")
+	}
+}
+
+// TestRunOnce_PublishesWhenLeaseConfirmed proves the companion happy path: when
+// Confirm reports the lease is still held (and extends it), RunOnce publishes
+// the next trigger exactly once.
+func TestRunOnce_PublishesWhenLeaseConfirmed(t *testing.T) {
+	t.Parallel()
+	_, lease, recv, pub, handler := newWiredFakes()
+	o := newOrchestrator(t, lease, recv, pub, handler)
+
+	res, err := o.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if !res.PublishedNext {
+		t.Error("PublishedNext: got false, want true (lease confirmed)")
+	}
+	if pub.publishCt != 1 {
+		t.Errorf("publish calls: got %d, want exactly 1", pub.publishCt)
+	}
+	if lease.confirmCt != 1 {
+		t.Errorf("confirm calls: got %d, want 1", lease.confirmCt)
 	}
 }
 

--- a/api-go/internal/polling/store_postgres_integration_test.go
+++ b/api-go/internal/polling/store_postgres_integration_test.go
@@ -293,6 +293,77 @@ func TestPostgresLeaseStore_ReleaseOutcomes(t *testing.T) {
 	})
 }
 
+// TestPostgresLeaseStore_Confirm covers the three CAS outcomes the orchestrator's
+// lease-confirmed publish (GH#938 PR1) depends on against a real database: still
+// held by us and live -> true with the expiry extended; expired -> false; held by
+// a different holder -> false. This is additive real-DB coverage (ADR 0032) for
+// SQL behaviour the fake querier in TestPostgresLeaseStore_ConfirmCAS cannot
+// honestly prove — that the UPDATE ... WHERE ... RETURNING actually extends
+// expires_at in Postgres.
+func TestPostgresLeaseStore_Confirm(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("held by us and live: confirms and extends expiry", func(t *testing.T) {
+		store := newPGLeaseStore2(t)
+		res, err := store.TryAcquire(ctx, 1*time.Minute)
+		if err != nil || !res.Acquired {
+			t.Fatalf("TryAcquire: acquired=%v err=%v", res.Acquired, err)
+		}
+
+		if ok := store.Confirm(ctx, res.Handle, 10*time.Minute); !ok {
+			t.Fatal("Confirm: got false, want true (live lease held by us)")
+		}
+
+		// The extend must have taken effect: a peer's TryAcquire, evaluated against
+		// a clock only 1 minute in the future (the original TTL would already have
+		// expired by then absent the extend), must still see it as live.
+		peer := NewPostgresLeaseStore(store.db, func() time.Time { return time.Now().UTC().Add(1 * time.Minute) })
+		peerRes, err := peer.TryAcquire(ctx, 1*time.Minute)
+		if err != nil {
+			t.Fatalf("peer TryAcquire: %v", err)
+		}
+		if peerRes.Acquired {
+			t.Error("peer acquired the lease; Confirm's extend did not take effect")
+		}
+		if !peerRes.Held {
+			t.Error("expected peer to see the lease as still held (extended)")
+		}
+	})
+
+	t.Run("expired: does not confirm", func(t *testing.T) {
+		past := time.Now().UTC().Add(-10 * time.Minute)
+		expiredClock := func() time.Time { return past }
+		pool := pgtest.New(t)
+		pgtest.Truncate(t, pool, "poll_state", "leases")
+
+		store := NewPostgresLeaseStore(pool, expiredClock)
+		res, err := store.TryAcquire(ctx, 1*time.Second) // TTL already in the past
+		if err != nil || !res.Acquired {
+			t.Fatalf("TryAcquire: acquired=%v err=%v", res.Acquired, err)
+		}
+
+		// Confirm from the real clock: the row's expires_at is long past, so the
+		// liveness predicate (expires_at > now) is false regardless of holder_id.
+		realClockStore := NewPostgresLeaseStore(pool, time.Now)
+		if ok := realClockStore.Confirm(ctx, res.Handle, 10*time.Minute); ok {
+			t.Error("Confirm: got true, want false (lease already expired)")
+		}
+	})
+
+	t.Run("held by a different holder: does not confirm", func(t *testing.T) {
+		store := newPGLeaseStore2(t)
+		res, err := store.TryAcquire(ctx, 4*time.Minute)
+		if err != nil || !res.Acquired {
+			t.Fatalf("TryAcquire: acquired=%v err=%v", res.Acquired, err)
+		}
+
+		peer := NewPostgresLeaseStore(store.db, time.Now)
+		if ok := peer.Confirm(ctx, LeaseHandle{ETag: peer.holderID}, 10*time.Minute); ok {
+			t.Error("Confirm: got true, want false (handle belongs to a different holder)")
+		}
+	})
+}
+
 // TestPostgresLeaseStore_RaceProof is the required acceptance-criterion test:
 // two concurrent goroutines both call TryAcquire; exactly one must win
 // (Acquired=true) and the other must be told the lease is unavailable

--- a/api-go/internal/polling/store_postgres_lease.go
+++ b/api-go/internal/polling/store_postgres_lease.go
@@ -114,6 +114,39 @@ func (s *PostgresLeaseStore) TryAcquire(ctx context.Context, ttl time.Duration) 
 	return LeaseAcquireResult{Acquired: true, Handle: LeaseHandle{ETag: holderID}}, nil
 }
 
+// confirmLeaseQuery atomically confirms this holder still owns a live lease AND
+// extends its expiry in one statement, eliminating the TOCTOU window between a
+// check and a subsequent publish. Same conditional-holder pattern as
+// releaseLeaseQuery, plus the same liveness check tryAcquireLeaseQuery's ON
+// CONFLICT WHERE clause performs: the row must belong to this holder ($2) and
+// not yet be expired ($3) for the UPDATE to affect it.
+//
+// Parameters: $1=id, $2=holder_id, $3=now (liveness check), $4=new expires_at.
+const confirmLeaseQuery = `
+UPDATE leases SET expires_at = $4
+WHERE id = $1 AND holder_id = $2 AND expires_at > $3
+RETURNING holder_id`
+
+// Confirm reports whether handle's holder still owns a live polling lease, and
+// if so atomically extends its expiry by extend from now. It never returns a
+// hard error — a lost lease (expired, held by a peer, or a database failure) all
+// report false, so a caller's next-trigger publish gate degrades to "skip
+// publish" rather than panicking or exit-coding on a routine race.
+func (s *PostgresLeaseStore) Confirm(ctx context.Context, handle LeaseHandle, extend time.Duration) bool {
+	now := s.now().UTC()
+	newExpiresAt := now.Add(extend)
+
+	var holderID string
+	err := s.db.QueryRow(ctx, confirmLeaseQuery,
+		leaseDocumentID, // $1 = id ("polling")
+		handle.ETag,     // $2 = holder_id
+		now,             // $3 = liveness check (WHERE leases.expires_at > now)
+		newExpiresAt,    // $4 = new expires_at
+	).Scan(&holderID)
+
+	return err == nil
+}
+
 // Release performs a conditional delete using the handle's holder id. It never
 // returns a hard error — failures surface as an outcome, and the lease TTL is
 // the backstop for any non-Released outcome.

--- a/api-go/internal/polling/store_postgres_lease.go
+++ b/api-go/internal/polling/store_postgres_lease.go
@@ -14,6 +14,7 @@ import (
 type LeaseAccess interface {
 	TryAcquire(ctx context.Context, ttl time.Duration) (LeaseAcquireResult, error)
 	Release(ctx context.Context, handle LeaseHandle) LeaseReleaseOutcome
+	Confirm(ctx context.Context, handle LeaseHandle, extend time.Duration) bool
 }
 
 // Compile-time check: the store satisfies the consumer-side interface.

--- a/api-go/internal/polling/store_postgres_lease_test.go
+++ b/api-go/internal/polling/store_postgres_lease_test.go
@@ -108,6 +108,54 @@ func newPGLeaseStore(q querier) *PostgresLeaseStore {
 	return NewPostgresLeaseStore(q, clock)
 }
 
+// fakeConfirmQuerier is a hand-written double isolated to the Confirm CAS's
+// single QueryRow round-trip. Confirm never calls Exec or Query, so those panic
+// to catch a wiring mistake rather than silently doing the wrong thing; this
+// keeps Confirm's test isolated from fakeLeaseQuerier's TryAcquire/Release
+// call-count routing.
+type fakeConfirmQuerier struct {
+	row pgx.Row
+}
+
+func (f *fakeConfirmQuerier) Exec(context.Context, string, ...any) (pgconn.CommandTag, error) {
+	panic("Confirm must not call Exec")
+}
+
+func (f *fakeConfirmQuerier) Query(context.Context, string, ...any) (pgx.Rows, error) {
+	panic("Confirm must not call Query")
+}
+
+func (f *fakeConfirmQuerier) QueryRow(context.Context, string, ...any) pgx.Row {
+	return f.row
+}
+
+// TestPostgresLeaseStore_ConfirmCAS covers Confirm's two SQL outcomes at the
+// querier level: a returned row (still ours, live) confirms; ErrNoRows (expired,
+// held by a peer, or already gone) and any other query error both report false —
+// Confirm never hard-errors, mirroring TryAcquire/Release's absorption contract.
+func TestPostgresLeaseStore_ConfirmCAS(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		row  pgx.Row
+		want bool
+	}{
+		{"row returned: still held by us and live", &fakeLeaseRow{holderID: "h1"}, true},
+		{"no rows: expired or held by a peer", &fakeLeaseRow{err: pgx.ErrNoRows}, false},
+		{"query error: transient failure absorbed as not confirmed", &fakeLeaseRow{err: errors.New("connection refused")}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			store := newPGLeaseStore(&fakeConfirmQuerier{row: tc.row})
+			got := store.Confirm(context.Background(), LeaseHandle{ETag: "h1"}, 4*time.Minute)
+			if got != tc.want {
+				t.Errorf("Confirm: got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestPostgresLeaseStore_TryAcquireHeldWhenNoRow confirms that when the atomic
 // INSERT/UPDATE does not return a row (live lease held by a peer), TryAcquire
 // reports Held=true and does not set Acquired.

--- a/api-go/internal/worker/bootstrap.go
+++ b/api-go/internal/worker/bootstrap.go
@@ -1,8 +1,11 @@
 // Package worker holds the Town Crier background-worker modes that run as
 // short-lived Container Apps Jobs. The poll-bootstrap mode is the tracer-bullet
-// slice: a Service-Bus-only safety net that reseeds the poll-trigger queue when
-// the adaptive polling chain has gone silent. The heavier poll-sb / digest /
-// dormant-cleanup modes land in later beads (see epic tc-wad3).
+// slice: a safety net that reseeds the poll-trigger queue when the adaptive
+// polling chain has gone silent. It shares the Postgres polling lease with the
+// orchestrator (poll-sb mode): only the current lease holder may mutate the
+// trigger queue, so a bootstrap tick landing mid-cycle cannot fork the chain
+// (GH#938 PR1). The heavier poll-sb / digest / dormant-cleanup modes land in
+// later beads (see epic tc-wad3).
 package worker
 
 import (
@@ -12,6 +15,7 @@ import (
 	mathrand "math/rand/v2"
 	"time"
 
+	"github.com/AmyDe/town-crier/api-go/internal/polling"
 	"github.com/AmyDe/town-crier/api-go/internal/servicebus"
 )
 
@@ -22,6 +26,12 @@ import (
 const (
 	naturalCadence = 5 * time.Minute
 	jitterBound    = 10 * time.Second
+
+	// bootstrapLeaseTTL is the polling-lease TTL the bootstrap requests. A probe
+	// + publish is a sub-second operation, so a short TTL suffices; it never
+	// holds the lease anywhere near the natural-cadence gap between reseeds
+	// (GH#938 PR1).
+	bootstrapLeaseTTL = 1 * time.Minute
 )
 
 // triggerQueue is the consumer-side interface the bootstrapper depends on. It is
@@ -30,6 +40,25 @@ const (
 type triggerQueue interface {
 	QueueDepth(ctx context.Context) (servicebus.QueueDepth, error)
 	PublishAt(ctx context.Context, scheduledEnqueueTime time.Time, body []byte) error
+}
+
+// leaseAccess is the consumer-side slice of the Postgres polling lease the
+// bootstrapper needs. *polling.PostgresLeaseStore satisfies it. Sharing the same
+// lease the orchestrator acquires (poll-sb mode) is what closes the unleased-
+// bootstrap fork mechanism: no actor other than the current holder can mutate
+// the trigger queue (GH#938 PR1).
+type leaseAccess interface {
+	TryAcquire(ctx context.Context, ttl time.Duration) (polling.LeaseAcquireResult, error)
+	Release(ctx context.Context, handle polling.LeaseHandle) polling.LeaseReleaseOutcome
+}
+
+// leaseMetricsRecorder is the consumer-side slice of the metrics registry the
+// bootstrapper records the lease-acquired counter on. *metrics.Registry
+// satisfies it; nil no-ops, so the counter stays dark until WithLeaseMetrics
+// wires a recorder. caller is always "bootstrap" here (the orchestrator records
+// its own acquisitions with caller "orchestrator").
+type leaseMetricsRecorder interface {
+	LeaseAcquired(ctx context.Context, caller string)
 }
 
 // BootstrapResult is the outcome of TryBootstrap. The field names match the
@@ -42,22 +71,38 @@ type BootstrapResult struct {
 	// absorbed (a failed reseed retries on the next cron tick); the flag exists
 	// purely for telemetry.
 	ProbeFailed bool
+	// LeaseUnavailable reports that the polling lease was held by a peer (the
+	// chain owner is alive), so TryBootstrap skipped cleanly without probing or
+	// publishing. Mirrors OrchestratorRunResult.LeaseUnavailable.
+	LeaseUnavailable bool
 }
 
-// Bootstrapper is the Service-Bus-only poll-trigger safety net. It probes the
-// trigger queue and, only when the queue is completely empty, publishes one
-// jittered seed trigger scheduled for the future. It never invokes the poll
-// handler — that is the orchestrator's job (poll-sb mode).
+// Bootstrapper is the poll-trigger safety net. Under the shared Postgres polling
+// lease, it probes the trigger queue and, only when the queue is completely
+// empty, publishes one jittered seed trigger scheduled for the future. It never
+// invokes the poll handler — that is the orchestrator's job (poll-sb mode).
 type Bootstrapper struct {
-	queue  triggerQueue
-	logger *slog.Logger
-	now    func() time.Time
+	queue   triggerQueue
+	lease   leaseAccess
+	logger  *slog.Logger
+	now     func() time.Time
+	metrics leaseMetricsRecorder
 }
 
 // NewBootstrapper wires the bootstrapper. now is injected so tests can pin time;
 // production passes time.Now.
-func NewBootstrapper(queue triggerQueue, logger *slog.Logger, now func() time.Time) *Bootstrapper {
-	return &Bootstrapper{queue: queue, logger: logger, now: now}
+func NewBootstrapper(queue triggerQueue, lease leaseAccess, logger *slog.Logger, now func() time.Time) *Bootstrapper {
+	return &Bootstrapper{queue: queue, lease: lease, logger: logger, now: now}
+}
+
+// WithLeaseMetrics wires the recorder the bootstrapper records the
+// lease-acquired counter on. A post-construction setter (mirroring the
+// orchestrator's WithLeaseMetrics) so the existing lease-guard tests are
+// unaffected by a missing registry; cmd/worker calls it once after building the
+// bootstrapper. Returns the bootstrapper for chaining.
+func (b *Bootstrapper) WithLeaseMetrics(rec leaseMetricsRecorder) *Bootstrapper {
+	b.metrics = rec
+	return b
 }
 
 // triggerPayload is the seed message body. It carries only a diagnostic
@@ -66,12 +111,42 @@ type triggerPayload struct {
 	PublishedAtUtc string `json:"publishedAtUtc"`
 }
 
-// TryBootstrap probes the queue and reseeds it if and only if it is empty. All
-// probe and publish failures are absorbed into the returned result (never
-// returned as an error) so a transient Service Bus blip does not fail the job —
-// the next cron tick retries. The returned error is reserved for caller-side
-// concerns; today it is always nil.
+// TryBootstrap acquires the polling lease, then probes the queue and reseeds it
+// if and only if it is empty, releasing the lease afterwards. When the lease is
+// held by a peer, TryBootstrap is a clean no-op: the chain owner is alive, and if
+// it had instead crashed, the lease's own TTL expiry lets the next cron tick
+// reseed (Pre-Resolved Design Decision, GH#938 — bootstrap skips rather than
+// waits/retries). All lease-acquire, probe and publish failures are absorbed
+// into the returned result (never returned as an error) so a transient failure
+// does not fail the job — the next cron tick retries. The returned error is
+// reserved for caller-side concerns; today it is always nil.
 func (b *Bootstrapper) TryBootstrap(ctx context.Context) (BootstrapResult, error) {
+	acquire, err := b.lease.TryAcquire(ctx, bootstrapLeaseTTL)
+	if err != nil {
+		b.logger.WarnContext(ctx, "poll-bootstrap lease acquire failed; skipping reseed", "error", err)
+		return BootstrapResult{ProbeFailed: true}, nil
+	}
+	if acquire.TransientErr != nil {
+		b.logger.WarnContext(ctx, "poll-bootstrap lease acquire failed; skipping reseed", "error", acquire.TransientErr)
+		return BootstrapResult{ProbeFailed: true}, nil
+	}
+	if !acquire.Acquired {
+		// Held by a peer: the chain owner is alive, so this is a clean no-op, not a
+		// probe failure.
+		b.logger.InfoContext(ctx, "poll-bootstrap skipped; polling lease held")
+		return BootstrapResult{LeaseUnavailable: true}, nil
+	}
+
+	if b.metrics != nil {
+		b.metrics.LeaseAcquired(ctx, "bootstrap")
+	}
+
+	defer func() {
+		if outcome := b.lease.Release(ctx, acquire.Handle); outcome == polling.LeasePreconditionFailed {
+			b.logger.WarnContext(ctx, "poll-bootstrap lease release returned precondition-failed; TTL is the backstop")
+		}
+	}()
+
 	depth, err := b.queue.QueueDepth(ctx)
 	if err != nil {
 		b.logger.WarnContext(ctx, "poll-bootstrap probe failed; skipping reseed", "error", err)

--- a/api-go/internal/worker/bootstrap_test.go
+++ b/api-go/internal/worker/bootstrap_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/AmyDe/town-crier/api-go/internal/polling"
 	"github.com/AmyDe/town-crier/api-go/internal/servicebus"
 )
 
@@ -37,11 +38,52 @@ func (f *fakeTriggerQueue) PublishAt(_ context.Context, at time.Time, body []byt
 	return f.publishErr
 }
 
+// fakeLeaseAccess is a hand-written double for the bootstrapper's consumer-side
+// leaseAccess interface. It records acquire/release calls so tests can prove the
+// lease-guard ordering (acquire before probe, release after publish) and the
+// TTL requested on acquire.
+type fakeLeaseAccess struct {
+	acquireResult polling.LeaseAcquireResult
+	acquireErr    error
+	acquireCalls  int
+	lastTTL       time.Duration
+
+	releaseCalls   int
+	releaseHandle  polling.LeaseHandle
+	releaseOutcome polling.LeaseReleaseOutcome
+}
+
+func (f *fakeLeaseAccess) TryAcquire(_ context.Context, ttl time.Duration) (polling.LeaseAcquireResult, error) {
+	f.acquireCalls++
+	f.lastTTL = ttl
+	return f.acquireResult, f.acquireErr
+}
+
+func (f *fakeLeaseAccess) Release(_ context.Context, handle polling.LeaseHandle) polling.LeaseReleaseOutcome {
+	f.releaseCalls++
+	f.releaseHandle = handle
+	return f.releaseOutcome
+}
+
+// newAcquiredLeaseFake returns a fakeLeaseAccess primed to win the acquire
+// immediately, the default every queue-behaviour test (predating the lease
+// guard) implicitly relies on.
+func newAcquiredLeaseFake() *fakeLeaseAccess {
+	return &fakeLeaseAccess{
+		acquireResult: polling.LeaseAcquireResult{Acquired: true, Handle: polling.LeaseHandle{ETag: "test-holder"}},
+	}
+}
+
 func newTestBootstrapper(t *testing.T, q *fakeTriggerQueue) *Bootstrapper {
+	t.Helper()
+	return newTestBootstrapperWithLease(t, q, newAcquiredLeaseFake())
+}
+
+func newTestBootstrapperWithLease(t *testing.T, q *fakeTriggerQueue, lease *fakeLeaseAccess) *Bootstrapper {
 	t.Helper()
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
-	return NewBootstrapper(q, logger, func() time.Time { return now })
+	return NewBootstrapper(q, lease, logger, func() time.Time { return now })
 }
 
 func TestBootstrapper_PublishesSeedWhenQueueEmpty(t *testing.T) {
@@ -98,6 +140,80 @@ func TestBootstrapper_SkipsWhenQueueNotEmpty(t *testing.T) {
 			}
 			if q.publishCalls != 0 {
 				t.Errorf("publish calls: got %d, want 0 (must not reseed a live chain)", q.publishCalls)
+			}
+		})
+	}
+}
+
+// TestTryBootstrap_SkipsWhenLeaseHeld proves the fork-guard (GH#938 PR1): when
+// the polling lease is held by a peer (the chain owner is alive), TryBootstrap
+// must not probe the queue depth or publish a seed trigger — a bootstrap tick
+// landing mid-cycle must never reseed a live chain. The result reports the skip
+// via LeaseUnavailable.
+func TestTryBootstrap_SkipsWhenLeaseHeld(t *testing.T) {
+	t.Parallel()
+	q := &fakeTriggerQueue{depth: servicebus.QueueDepth{}} // would otherwise seed: queue looks empty
+	lease := &fakeLeaseAccess{acquireResult: polling.LeaseAcquireResult{Held: true}}
+	b := newTestBootstrapperWithLease(t, q, lease)
+
+	res, err := b.TryBootstrap(context.Background())
+	if err != nil {
+		t.Fatalf("TryBootstrap: %v", err)
+	}
+	if !res.LeaseUnavailable {
+		t.Error("LeaseUnavailable: got false, want true (lease held by a peer)")
+	}
+	if res.Published || res.ProbeFailed {
+		t.Errorf("result must report a clean skip, got %+v", res)
+	}
+	if q.publishCalls != 0 {
+		t.Errorf("publish calls: got %d, want 0 (must not touch the queue while the lease is held)", q.publishCalls)
+	}
+	if lease.releaseCalls != 0 {
+		t.Errorf("release calls: got %d, want 0 (never acquired, nothing to release)", lease.releaseCalls)
+	}
+}
+
+// TestTryBootstrap_AcquiresAndReleasesLease proves the happy path: the lease is
+// acquired before the depth probe runs at all (a fake that returns Held would
+// otherwise make QueueDepth/PublishAt calls meaningless), the queue is only
+// seeded when genuinely empty, and the lease is released exactly once
+// afterwards regardless of whether a publish happened.
+func TestTryBootstrap_AcquiresAndReleasesLease(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		depth       servicebus.QueueDepth
+		wantPublish bool
+	}{
+		{"empty queue: acquires, publishes, releases", servicebus.QueueDepth{}, true},
+		{"live chain: acquires, skips publish, still releases", servicebus.QueueDepth{ActiveMessageCount: 1}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			q := &fakeTriggerQueue{depth: tc.depth}
+			lease := newAcquiredLeaseFake()
+			b := newTestBootstrapperWithLease(t, q, lease)
+
+			res, err := b.TryBootstrap(context.Background())
+			if err != nil {
+				t.Fatalf("TryBootstrap: %v", err)
+			}
+			if res.Published != tc.wantPublish {
+				t.Errorf("Published: got %v, want %v", res.Published, tc.wantPublish)
+			}
+			if lease.acquireCalls != 1 {
+				t.Errorf("acquire calls: got %d, want 1", lease.acquireCalls)
+			}
+			if lease.lastTTL != bootstrapLeaseTTL {
+				t.Errorf("acquire TTL: got %v, want %v (short TTL suffices for probe+publish)", lease.lastTTL, bootstrapLeaseTTL)
+			}
+			if lease.releaseCalls != 1 {
+				t.Errorf("release calls: got %d, want 1 (must always release after acquiring)", lease.releaseCalls)
+			}
+			if lease.releaseHandle != lease.acquireResult.Handle {
+				t.Errorf("release handle: got %+v, want the acquired handle %+v", lease.releaseHandle, lease.acquireResult.Handle)
 			}
 		})
 	}


### PR DESCRIPTION
Part of #938 (PR1 section). Closes both fork mechanisms behind the 2026-07-12 trigger-chain fork.

## What

1. **Lease-guarded bootstrap** — `Bootstrapper` now acquires the Postgres polling lease (1-min TTL) before its depth probe and releases after publish; when a peer holds it, it no-ops cleanly (`BootstrapResult.LeaseUnavailable`, info log). Lease acquisitions recorded with the `caller="bootstrap"` label the metrics registry always anticipated. This removes the unleased probe-then-publish race that seeded duplicate chains whenever a 30-min bootstrap tick landed mid-cycle.
2. **Lease-confirmed publish** — new `Confirm(ctx, handle, extend)` CAS on the lease store (single conditional `UPDATE … RETURNING`, same holder-gated pattern as release). `Orchestrator.RunOnce` calls it immediately before `PublishAt`; if the lease was lost, it skips the publish and lets the bootstrap reseed. Chain death is self-healing; a fork is not.
3. **Honest TTL** — `leaseTTLFor(budget) = budget + 5m` (was +30s). The 4-min handler budget is soft; an in-flight 30s timeout plus container cold-start overran the old margin during the outage (observed 4.9-min cycle vs 4.5-min TTL).

## Deviations from the issue (all additive)

- `BootstrapResult.LeaseUnavailable` is a new field rather than overloading `ProbeFailed` (a held lease is healthy, not a failure). Not yet surfaced as a span attribute — that's a one-line dispatch.go follow-up planned for PR2.
- Lease store is a required `NewBootstrapper` constructor arg, mirroring the orchestrator's shape.
- Bootstrap absorbs lease-store hard errors as `ProbeFailed` per its existing "always absorb" contract (unlike the orchestrator, which bubbles them).

## Gates (from api-go/ in the worktree)

- `gofmt -l .` empty; `go vet ./...` clean; `golangci-lint run` no issues
- `go test -race ./...` — 1783 passed
- `go test -tags=integration ./...` against local Docker Postgres+PostGIS — 1968 passed (includes new real-DB `TestPostgresLeaseStore_Confirm` CAS coverage)

Backend-only: no Release-Note trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrShbsvV3RiC4iFuZ1R6h1