### PR TITLE
feat(polling): bootstrap reconciler enforces one in-flight trigger + DLQ drain (tc-9wouj)

### DIFF
--- a/api-go/internal/servicebus/client.go
+++ b/api-go/internal/servicebus/client.go
@@ -1,10 +1,12 @@
 // Package servicebus is a thin, consumer-facing wrapper over the official
 // azservicebus SDK for the Town Crier poll-trigger queue. It exposes only the
-// two operations the worker's poll modes need — probe the queue depth and
-// publish a single scheduled trigger — and never leaks SDK types past its
-// methods. Authentication is the pinned user-assigned managed identity
-// (AZURE_CLIENT_ID); there is no SAS / connection-string path, mirroring the
-// Cosmos identity model (see internal/platform/cosmos.go).
+// operations the worker's poll modes need — probe the queue depth, publish a
+// single scheduled trigger, receive-and-delete one trigger, and (for the
+// bootstrap reconciler, GH#938 PR2) peek the queue, cancel a scheduled
+// message, and drain the dead-letter sub-queue — and never leaks SDK types
+// past its methods. Authentication is the pinned user-assigned managed
+// identity (AZURE_CLIENT_ID); there is no SAS / connection-string path,
+// mirroring the Cosmos identity model (see internal/platform/cosmos.go).
 package servicebus
 
 import (
@@ -201,6 +203,159 @@ func (c *Client) ReceiveTrigger(ctx context.Context) (received bool, err error) 
 		return false, fmt.Errorf("receive poll trigger: %w", err)
 	}
 	return len(msgs) > 0, nil
+}
+
+// MessageState mirrors the subset of azservicebus.MessageState the bootstrap
+// reconciler needs to distinguish, without leaking the SDK type past this
+// package boundary.
+type MessageState int
+
+const (
+	// MessageStateActive indicates the message is available for receipt now.
+	MessageStateActive MessageState = iota
+	// MessageStateScheduled indicates the message is not yet visible; it will
+	// enqueue at ScheduledEnqueueTime.
+	MessageStateScheduled
+	// MessageStateDeferred indicates the message was explicitly deferred. The
+	// trigger queue never defers messages, so the reconciler treats this the
+	// same as active (a stray message to discard) rather than as a case worth
+	// distinguishing.
+	MessageStateDeferred
+)
+
+// PeekedMessage is a snapshot of one message's state on the trigger queue, as
+// seen by PeekMessages — never locked or removed. SequenceNumber is the handle
+// CancelScheduled needs to cancel it. ScheduledEnqueueTime is only meaningful
+// when State is MessageStateScheduled.
+type PeekedMessage struct {
+	SequenceNumber       int64
+	State                MessageState
+	ScheduledEnqueueTime time.Time
+}
+
+// peekBatchSize bounds one PeekMessages call. The trigger queue is designed to
+// carry exactly one live message (ADR 0024); this ceiling is generous headroom
+// for a fork, not a hard limit a healthy queue could ever approach.
+const peekBatchSize = 100
+
+// PeekMessages returns a snapshot of up to peekBatchSize messages currently on
+// the trigger queue — active or scheduled, with sequence numbers and (for
+// scheduled messages) their activation time — without locking or removing
+// them. The bootstrap reconciler uses it to decide which trigger to keep when
+// the queue has forked (GH#938 PR2).
+func (c *Client) PeekMessages(ctx context.Context) (_ []PeekedMessage, err error) {
+	receiver, err := c.sbClient.NewReceiverForQueue(c.queueName, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build peek receiver: %w", err)
+	}
+	defer func() {
+		if closeErr := receiver.Close(ctx); closeErr != nil && err == nil {
+			err = fmt.Errorf("close peek receiver: %w", closeErr)
+		}
+	}()
+
+	msgs, err := receiver.PeekMessages(ctx, peekBatchSize, nil)
+	if err != nil {
+		return nil, fmt.Errorf("peek trigger queue: %w", err)
+	}
+
+	peeked := make([]PeekedMessage, 0, len(msgs))
+	for _, m := range msgs {
+		pm := PeekedMessage{}
+		if m.SequenceNumber != nil {
+			pm.SequenceNumber = *m.SequenceNumber
+		}
+		switch m.State {
+		case azservicebus.MessageStateScheduled:
+			pm.State = MessageStateScheduled
+			if m.ScheduledEnqueueTime != nil {
+				pm.ScheduledEnqueueTime = *m.ScheduledEnqueueTime
+			}
+		case azservicebus.MessageStateDeferred:
+			pm.State = MessageStateDeferred
+		default:
+			pm.State = MessageStateActive
+		}
+		peeked = append(peeked, pm)
+	}
+	return peeked, nil
+}
+
+// CancelScheduled cancels one or more scheduled messages on the trigger queue
+// by sequence number, as identified via PeekMessages. The bootstrap reconciler
+// uses it to collapse a forked chain down to the single scheduled trigger it
+// decided to keep (GH#938 PR2). A nil-error no-op when sequenceNumbers is empty.
+func (c *Client) CancelScheduled(ctx context.Context, sequenceNumbers []int64) (err error) {
+	if len(sequenceNumbers) == 0 {
+		return nil
+	}
+
+	sender, err := c.sbClient.NewSender(c.queueName, nil)
+	if err != nil {
+		return fmt.Errorf("build cancel sender: %w", err)
+	}
+	defer func() {
+		if closeErr := sender.Close(ctx); closeErr != nil && err == nil {
+			err = fmt.Errorf("close cancel sender: %w", closeErr)
+		}
+	}()
+
+	if err := sender.CancelScheduledMessages(ctx, sequenceNumbers, nil); err != nil {
+		return fmt.Errorf("cancel scheduled triggers: %w", err)
+	}
+	return nil
+}
+
+// deadLetterDrainBatch bounds one dead-letter ReceiveMessages call. A handful
+// of dead-lettered corpses is the expected case (GH#938's 2026-07-12 incident
+// left 4); this is generous headroom, not a hard ceiling — DrainDeadLetters
+// loops until the sub-queue reports empty regardless of how many batches that
+// takes.
+const deadLetterDrainBatch = 32
+
+// DrainDeadLetters receives and completes every message on the trigger
+// queue's dead-letter sub-queue, returning the number drained. It loops until a
+// receive attempt within receiveWaitTimeout returns no messages (an empty
+// DLQ), so a healthy queue with no dead letters returns (0, nil) promptly. The
+// bootstrap reconciler drains the DLQ on every cycle it runs, regardless of the
+// active/scheduled trigger count — dead-lettered corpses never self-clear
+// (GH#938 PR2).
+func (c *Client) DrainDeadLetters(ctx context.Context) (drained int, err error) {
+	receiver, err := c.sbClient.NewReceiverForQueue(c.queueName, &azservicebus.ReceiverOptions{
+		SubQueue: azservicebus.SubQueueDeadLetter,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("build dead-letter receiver: %w", err)
+	}
+	defer func() {
+		if closeErr := receiver.Close(ctx); closeErr != nil && err == nil {
+			err = fmt.Errorf("close dead-letter receiver: %w", closeErr)
+		}
+	}()
+
+	for {
+		waitCtx, cancel := context.WithTimeout(ctx, receiveWaitTimeout)
+		msgs, recvErr := receiver.ReceiveMessages(waitCtx, deadLetterDrainBatch, nil)
+		cancel()
+		if recvErr != nil {
+			if ctx.Err() != nil {
+				return drained, ctx.Err()
+			}
+			if errors.Is(recvErr, context.DeadlineExceeded) {
+				return drained, nil
+			}
+			return drained, fmt.Errorf("receive dead letters: %w", recvErr)
+		}
+		if len(msgs) == 0 {
+			return drained, nil
+		}
+		for _, msg := range msgs {
+			if completeErr := receiver.CompleteMessage(ctx, msg, nil); completeErr != nil {
+				return drained, fmt.Errorf("complete dead letter: %w", completeErr)
+			}
+			drained++
+		}
+	}
 }
 
 // Close releases the underlying SDK clients.

--- a/api-go/internal/servicebus/client.go
+++ b/api-go/internal/servicebus/client.go
@@ -32,18 +32,30 @@ var (
 	ErrMissingQueue     = errors.New("service bus queue name is required")
 )
 
-// QueueDepth is a snapshot of the trigger queue's active and scheduled message
-// counts. The bootstrapper seeds a new trigger only when both counts are zero
-// (IsEmpty).
+// QueueDepth is a snapshot of the trigger queue's active, scheduled and
+// dead-lettered message counts. The bootstrapper's fork-guard (GH#938 PR2)
+// thresholds on TriggerCount (active+scheduled): 0 seeds, 1 is a healthy
+// single chain, >1 is a fork that must be collapsed. DeadLetterMessageCount is
+// tracked separately — dead letters are corpses, not live triggers, and are
+// handled by an unconditional drain rather than folded into the fork count.
 type QueueDepth struct {
-	ActiveMessageCount    int64
-	ScheduledMessageCount int64
+	ActiveMessageCount     int64
+	ScheduledMessageCount  int64
+	DeadLetterMessageCount int64
 }
 
-// IsEmpty reports whether the queue has no active and no scheduled messages —
-// the signal the bootstrapper uses to decide a reseed is needed.
+// TriggerCount returns the number of live (active+scheduled) trigger
+// messages, excluding dead letters — the count the bootstrap reconciler
+// thresholds on (GH#938 PR2).
+func (d QueueDepth) TriggerCount() int64 {
+	return d.ActiveMessageCount + d.ScheduledMessageCount
+}
+
+// IsEmpty reports whether the queue has no live (active+scheduled) trigger —
+// the signal the bootstrapper uses to decide a reseed is needed. A queue
+// holding only dead letters still counts as empty of live triggers.
 func (d QueueDepth) IsEmpty() bool {
-	return d.ActiveMessageCount == 0 && d.ScheduledMessageCount == 0
+	return d.TriggerCount() == 0
 }
 
 // Client wraps the azservicebus data-plane and management clients for one
@@ -110,8 +122,9 @@ func (c *Client) QueueDepth(ctx context.Context) (QueueDepth, error) {
 		return QueueDepth{}, fmt.Errorf("queue %q not found", c.queueName)
 	}
 	return QueueDepth{
-		ActiveMessageCount:    int64(resp.ActiveMessageCount),
-		ScheduledMessageCount: int64(resp.ScheduledMessageCount),
+		ActiveMessageCount:     int64(resp.ActiveMessageCount),
+		ScheduledMessageCount:  int64(resp.ScheduledMessageCount),
+		DeadLetterMessageCount: int64(resp.DeadLetterMessageCount),
 	}, nil
 }
 

--- a/api-go/internal/servicebus/client_test.go
+++ b/api-go/internal/servicebus/client_test.go
@@ -42,6 +42,44 @@ func TestNewClient_RequiresNamespaceAndQueue(t *testing.T) {
 	}
 }
 
+// TestQueueDepth_IsEmpty proves the fork-guard's emptiness/threshold semantics
+// (GH#938 PR2): a queue is "empty" only when it has no live (active+scheduled)
+// trigger. Dead-lettered messages are corpses, not live triggers, so a queue
+// holding only dead letters still counts as empty of live triggers.
+func TestQueueDepth_IsEmpty(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		depth QueueDepth
+		want  bool
+	}{
+		{"all zero", QueueDepth{}, true},
+		{"active present", QueueDepth{ActiveMessageCount: 1}, false},
+		{"scheduled present", QueueDepth{ScheduledMessageCount: 1}, false},
+		{"dead letters only", QueueDepth{DeadLetterMessageCount: 4}, true},
+		{"active and dead letters", QueueDepth{ActiveMessageCount: 1, DeadLetterMessageCount: 4}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.depth.IsEmpty(); got != tc.want {
+				t.Errorf("IsEmpty(): got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestQueueDepth_TriggerCount proves TriggerCount sums only the live
+// (active+scheduled) counts, excluding dead letters — the threshold the
+// bootstrap reconciler uses to detect a fork (>1).
+func TestQueueDepth_TriggerCount(t *testing.T) {
+	t.Parallel()
+	depth := QueueDepth{ActiveMessageCount: 2, ScheduledMessageCount: 3, DeadLetterMessageCount: 10}
+	if got, want := depth.TriggerCount(), int64(5); got != want {
+		t.Errorf("TriggerCount(): got %d, want %d (dead letters must not count)", got, want)
+	}
+}
+
 func TestNormalizeFQDN(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/api-go/internal/worker/bootstrap.go
+++ b/api-go/internal/worker/bootstrap.go
@@ -101,10 +101,12 @@ type BootstrapResult struct {
 	DeadLettered int
 }
 
-// Bootstrapper is the poll-trigger safety net. Under the shared Postgres polling
-// lease, it probes the trigger queue and, only when the queue is completely
-// empty, publishes one jittered seed trigger scheduled for the future. It never
-// invokes the poll handler — that is the orchestrator's job (poll-sb mode).
+// Bootstrapper is the poll-trigger safety net and reconciler. Under the shared
+// Postgres polling lease, it probes the trigger queue and either publishes one
+// jittered seed trigger (queue empty), leaves a healthy single trigger alone,
+// or collapses a fork back to exactly one trigger (GH#938 PR2) — then drains
+// the dead-letter sub-queue. It never invokes the poll handler — that is the
+// orchestrator's job (poll-sb mode).
 type Bootstrapper struct {
 	queue   triggerQueue
 	lease   leaseAccess

--- a/api-go/internal/worker/bootstrap.go
+++ b/api-go/internal/worker/bootstrap.go
@@ -1,11 +1,14 @@
 // Package worker holds the Town Crier background-worker modes that run as
 // short-lived Container Apps Jobs. The poll-bootstrap mode is the tracer-bullet
 // slice: a safety net that reseeds the poll-trigger queue when the adaptive
-// polling chain has gone silent. It shares the Postgres polling lease with the
-// orchestrator (poll-sb mode): only the current lease holder may mutate the
-// trigger queue, so a bootstrap tick landing mid-cycle cannot fork the chain
-// (GH#938 PR1). The heavier poll-sb / digest / dormant-cleanup modes land in
-// later beads (see epic tc-wad3).
+// polling chain has gone silent, and a reconciler that collapses a forked
+// chain back to exactly one live trigger and drains dead letters. It shares
+// the Postgres polling lease with the orchestrator (poll-sb mode): only the
+// current lease holder may mutate the trigger queue, so a bootstrap tick
+// landing mid-cycle cannot fork the chain (GH#938 PR1), and any fork that
+// appears anyway is race-free to reconcile under the same lease (GH#938 PR2).
+// The heavier poll-sb / digest / dormant-cleanup modes land in later beads
+// (see epic tc-wad3).
 package worker
 
 import (
@@ -34,12 +37,18 @@ const (
 	bootstrapLeaseTTL = 1 * time.Minute
 )
 
-// triggerQueue is the consumer-side interface the bootstrapper depends on. It is
-// satisfied by *servicebus.Client in production and by a hand-written fake in
-// tests. Only the two methods the bootstrapper uses are declared here.
+// triggerQueue is the consumer-side interface the bootstrapper depends on. It
+// is satisfied by *servicebus.Client in production and by a hand-written fake
+// in tests. Only the methods the bootstrapper uses are declared here: probe
+// and seed (original safety net), plus peek, cancel and receive-and-discard
+// (the GH#938 PR2 reconciler) and dead-letter drain.
 type triggerQueue interface {
 	QueueDepth(ctx context.Context) (servicebus.QueueDepth, error)
 	PublishAt(ctx context.Context, scheduledEnqueueTime time.Time, body []byte) error
+	PeekMessages(ctx context.Context) ([]servicebus.PeekedMessage, error)
+	CancelScheduled(ctx context.Context, sequenceNumbers []int64) error
+	ReceiveTrigger(ctx context.Context) (bool, error)
+	DrainDeadLetters(ctx context.Context) (int, error)
 }
 
 // leaseAccess is the consumer-side slice of the Postgres polling lease the
@@ -63,18 +72,33 @@ type leaseMetricsRecorder interface {
 
 // BootstrapResult is the outcome of TryBootstrap. The field names match the
 // App Insights telemetry tags (polling.safety_net.bootstrap_published /
-// bootstrap_probe_failed).
+// bootstrap_probe_failed / lease_unavailable / reconciled / …).
 type BootstrapResult struct {
 	// Published reports whether a seed trigger was successfully published.
 	Published bool
-	// ProbeFailed reports whether the depth probe OR the publish failed. Both are
-	// absorbed (a failed reseed retries on the next cron tick); the flag exists
-	// purely for telemetry.
+	// ProbeFailed reports whether the depth probe, the reconciliation peek, or a
+	// publish failed. All are absorbed (a failed cycle retries on the next cron
+	// tick); the flag exists purely for telemetry.
 	ProbeFailed bool
 	// LeaseUnavailable reports that the polling lease was held by a peer (the
 	// chain owner is alive), so TryBootstrap skipped cleanly without probing or
 	// publishing. Mirrors OrchestratorRunResult.LeaseUnavailable.
 	LeaseUnavailable bool
+	// Reconciled reports whether the queue held more than one live
+	// (active+scheduled) trigger and TryBootstrap collapsed it back to one
+	// (GH#938 PR2).
+	Reconciled bool
+	// ScheduledCancelled is the number of surplus scheduled messages cancelled
+	// while reconciling a fork. Zero on every cycle that did not reconcile.
+	ScheduledCancelled int
+	// ActiveDiscarded is the number of surplus active messages destructively
+	// received and discarded while reconciling a fork. Zero on every cycle that
+	// did not reconcile.
+	ActiveDiscarded int
+	// DeadLettered is the number of dead-lettered messages drained from the
+	// trigger queue's DLQ this cycle. The DLQ is drained on every cycle
+	// TryBootstrap runs (lease held), independent of Published/Reconciled.
+	DeadLettered int
 }
 
 // Bootstrapper is the poll-trigger safety net. Under the shared Postgres polling
@@ -111,15 +135,18 @@ type triggerPayload struct {
 	PublishedAtUtc string `json:"publishedAtUtc"`
 }
 
-// TryBootstrap acquires the polling lease, then probes the queue and reseeds it
-// if and only if it is empty, releasing the lease afterwards. When the lease is
-// held by a peer, TryBootstrap is a clean no-op: the chain owner is alive, and if
-// it had instead crashed, the lease's own TTL expiry lets the next cron tick
+// TryBootstrap acquires the polling lease, then probes the queue, reconciles
+// it to exactly one live trigger (GH#938 PR2 — seeding an empty queue,
+// leaving a healthy single trigger untouched, or collapsing a fork), drains
+// the dead-letter sub-queue, and releases the lease. When the lease is held by
+// a peer, TryBootstrap is a clean no-op: the chain owner is alive, and if it
+// had instead crashed, the lease's own TTL expiry lets the next cron tick
 // reseed (Pre-Resolved Design Decision, GH#938 — bootstrap skips rather than
-// waits/retries). All lease-acquire, probe and publish failures are absorbed
-// into the returned result (never returned as an error) so a transient failure
-// does not fail the job — the next cron tick retries. The returned error is
-// reserved for caller-side concerns; today it is always nil.
+// waits/retries). All lease-acquire, probe, reconciliation and publish
+// failures are absorbed into the returned result (never returned as an error)
+// so a transient failure does not fail the job — the next cron tick retries.
+// The returned error is reserved for caller-side concerns; today it is always
+// nil.
 func (b *Bootstrapper) TryBootstrap(ctx context.Context) (BootstrapResult, error) {
 	acquire, err := b.lease.TryAcquire(ctx, bootstrapLeaseTTL)
 	if err != nil {
@@ -153,13 +180,49 @@ func (b *Bootstrapper) TryBootstrap(ctx context.Context) (BootstrapResult, error
 		return BootstrapResult{ProbeFailed: true}, nil
 	}
 
-	if !depth.IsEmpty() {
+	result := b.reconcileToSingleTrigger(ctx, depth)
+
+	// The DLQ is drained on every cycle that holds the lease, independent of the
+	// active/scheduled outcome above — dead-lettered corpses never self-clear
+	// (GH#938 PR2 Proposed Approach: "always drain the DLQ").
+	drained, drainErr := b.queue.DrainDeadLetters(ctx)
+	if drainErr != nil {
+		b.logger.WarnContext(ctx, "poll-bootstrap dead-letter drain failed; next cron tick will retry", "error", drainErr)
+	} else if drained > 0 {
+		b.logger.InfoContext(ctx, "poll-bootstrap drained dead-letter queue", "drained", drained)
+	}
+	result.DeadLettered = drained
+
+	return result, nil
+}
+
+// reconcileToSingleTrigger enforces the GH#938 PR2 invariant: after this call
+// (barring an absorbed failure), the trigger queue carries at most one live
+// (active+scheduled) trigger. An empty queue is reseeded exactly as before
+// PR2; a queue already carrying exactly one trigger is left untouched; a
+// forked queue (TriggerCount > 1) is collapsed to one via reconcileFork.
+func (b *Bootstrapper) reconcileToSingleTrigger(ctx context.Context, depth servicebus.QueueDepth) BootstrapResult {
+	switch triggerCount := depth.TriggerCount(); {
+	case triggerCount == 0:
+		return b.seed(ctx)
+	case triggerCount == 1:
 		b.logger.InfoContext(ctx, "poll-bootstrap skipped; trigger queue already seeded",
 			"active", depth.ActiveMessageCount,
-			"scheduled", depth.ScheduledMessageCount)
-		return BootstrapResult{}, nil
+			"scheduled", depth.ScheduledMessageCount,
+			"deadLettered", depth.DeadLetterMessageCount)
+		return BootstrapResult{}
+	default:
+		b.logger.WarnContext(ctx, "poll-bootstrap detected forked trigger chain; reconciling to one",
+			"active", depth.ActiveMessageCount,
+			"scheduled", depth.ScheduledMessageCount,
+			"deadLettered", depth.DeadLetterMessageCount)
+		return b.reconcileFork(ctx)
 	}
+}
 
+// seed publishes one jittered seed trigger for a queue found completely empty.
+// Behaviour is unchanged from the pre-PR2 bootstrap.
+func (b *Bootstrapper) seed(ctx context.Context) BootstrapResult {
 	now := b.now()
 	scheduledAt := now.Add(nextSeedDelay())
 
@@ -168,16 +231,121 @@ func (b *Bootstrapper) TryBootstrap(ctx context.Context) (BootstrapResult, error
 		// json.Marshal of a fixed struct cannot realistically fail; treat any
 		// failure as a probe failure for telemetry parity rather than panicking.
 		b.logger.WarnContext(ctx, "poll-bootstrap payload marshal failed; skipping reseed", "error", err)
-		return BootstrapResult{ProbeFailed: true}, nil
+		return BootstrapResult{ProbeFailed: true}
 	}
 
 	if err := b.queue.PublishAt(ctx, scheduledAt, body); err != nil {
 		b.logger.WarnContext(ctx, "poll-bootstrap publish failed; next cron tick will retry", "error", err)
-		return BootstrapResult{ProbeFailed: true}, nil
+		return BootstrapResult{ProbeFailed: true}
 	}
 
 	b.logger.InfoContext(ctx, "poll-bootstrap published seed trigger", "scheduledAt", scheduledAt.UTC())
-	return BootstrapResult{Published: true}, nil
+	return BootstrapResult{Published: true}
+}
+
+// reconcileFork collapses a queue holding more than one live trigger back down
+// to exactly one, preferring the latest-activating scheduled message
+// (Pre-Resolved Design Decision, GH#938 — it carries the most recent
+// Retry-After knowledge, the safest choice for PlanIt). Every other scheduled
+// message is cancelled by sequence number; every surplus active message is
+// destructively received and discarded. A peek failure is absorbed exactly
+// like a depth-probe failure — the next cron tick retries. A cancel or discard
+// failure is logged and the count reflects only what actually succeeded; it
+// never escalates to a caller-visible error, so a partially-reconciled fork is
+// simply retried (and re-peeked) on the next tick.
+func (b *Bootstrapper) reconcileFork(ctx context.Context) BootstrapResult {
+	peeked, err := b.queue.PeekMessages(ctx)
+	if err != nil {
+		b.logger.WarnContext(ctx, "poll-bootstrap reconciliation peek failed; skipping this cycle", "error", err)
+		return BootstrapResult{ProbeFailed: true}
+	}
+	if len(peeked) == 0 {
+		// The depth probe reported a fork but peek found nothing concrete to act
+		// on (e.g. the fork resolved itself between the two calls). Nothing to do
+		// this cycle; the next tick re-probes.
+		b.logger.WarnContext(ctx, "poll-bootstrap fork detected by depth but peek returned no messages; skipping reconciliation this cycle")
+		return BootstrapResult{}
+	}
+
+	keep, cancelSeqs, discardCount := pickKeeper(peeked)
+
+	cancelled := 0
+	if len(cancelSeqs) > 0 {
+		if err := b.queue.CancelScheduled(ctx, cancelSeqs); err != nil {
+			b.logger.WarnContext(ctx, "poll-bootstrap cancel of surplus scheduled triggers failed",
+				"error", err, "attempted", len(cancelSeqs))
+		} else {
+			cancelled = len(cancelSeqs)
+		}
+	}
+
+	discarded := 0
+	for range discardCount {
+		received, err := b.queue.ReceiveTrigger(ctx)
+		if err != nil {
+			b.logger.WarnContext(ctx, "poll-bootstrap discard of surplus active trigger failed",
+				"error", err, "discardedSoFar", discarded)
+			break
+		}
+		if !received {
+			break
+		}
+		discarded++
+	}
+
+	b.logger.InfoContext(ctx, "poll-bootstrap reconciled forked trigger chain",
+		"scheduledCancelled", cancelled,
+		"activeDiscarded", discarded,
+		"keptSequenceNumber", keep.SequenceNumber,
+		"keptState", keep.State,
+		"keptActivatesAt", keep.ScheduledEnqueueTime.UTC())
+
+	return BootstrapResult{
+		Reconciled:         true,
+		ScheduledCancelled: cancelled,
+		ActiveDiscarded:    discarded,
+	}
+}
+
+// pickKeeper decides which peeked message survives reconciliation. When any
+// scheduled message exists it keeps the latest-activating one (Pre-Resolved
+// Design Decision, GH#938) and reports every other scheduled message's
+// sequence number for cancellation, plus the count of active messages to
+// discard (all of them — a scheduled survivor always wins over an active one).
+// When no scheduled message exists it keeps the lowest-sequence-numbered
+// active message (the oldest) and reports the rest for discard.
+func pickKeeper(peeked []servicebus.PeekedMessage) (keep servicebus.PeekedMessage, cancelScheduled []int64, discardActive int) {
+	var scheduled, active []servicebus.PeekedMessage
+	for _, m := range peeked {
+		if m.State == servicebus.MessageStateScheduled {
+			scheduled = append(scheduled, m)
+		} else {
+			active = append(active, m)
+		}
+	}
+
+	if len(scheduled) > 0 {
+		keepIdx := 0
+		for i, m := range scheduled {
+			if m.ScheduledEnqueueTime.After(scheduled[keepIdx].ScheduledEnqueueTime) {
+				keepIdx = i
+			}
+		}
+		for i, m := range scheduled {
+			if i != keepIdx {
+				cancelScheduled = append(cancelScheduled, m.SequenceNumber)
+			}
+		}
+		return scheduled[keepIdx], cancelScheduled, len(active)
+	}
+
+	keepIdx := 0
+	for i, m := range active {
+		if m.SequenceNumber < active[keepIdx].SequenceNumber {
+			keepIdx = i
+		}
+	}
+	return active[keepIdx], nil, len(active) - 1
 }
 
 // nextSeedDelay returns the natural cadence plus a symmetric jitter in

--- a/api-go/internal/worker/bootstrap.go
+++ b/api-go/internal/worker/bootstrap.go
@@ -202,10 +202,10 @@ func (b *Bootstrapper) TryBootstrap(ctx context.Context) (BootstrapResult, error
 // PR2; a queue already carrying exactly one trigger is left untouched; a
 // forked queue (TriggerCount > 1) is collapsed to one via reconcileFork.
 func (b *Bootstrapper) reconcileToSingleTrigger(ctx context.Context, depth servicebus.QueueDepth) BootstrapResult {
-	switch triggerCount := depth.TriggerCount(); {
-	case triggerCount == 0:
+	switch triggerCount := depth.TriggerCount(); triggerCount {
+	case 0:
 		return b.seed(ctx)
-	case triggerCount == 1:
+	case 1:
 		b.logger.InfoContext(ctx, "poll-bootstrap skipped; trigger queue already seeded",
 			"active", depth.ActiveMessageCount,
 			"scheduled", depth.ScheduledMessageCount,

--- a/api-go/internal/worker/bootstrap_test.go
+++ b/api-go/internal/worker/bootstrap_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"slices"
 	"testing"
 	"time"
 
@@ -22,6 +23,31 @@ type fakeTriggerQueue struct {
 	publishCalls int
 	publishedAt  time.Time
 	publishedBig []byte
+
+	// peeked/peekErr prime PeekMessages, used by the reconciler to decide which
+	// trigger to keep when the queue has forked (GH#938 PR2).
+	peeked    []servicebus.PeekedMessage
+	peekErr   error
+	peekCalls int
+
+	// cancelErr primes CancelScheduled; cancelledSeqs records every sequence
+	// number the reconciler asked to cancel, across all calls.
+	cancelErr     error
+	cancelCalls   int
+	cancelledSeqs []int64
+
+	// receiveResult/receiveErr prime ReceiveTrigger for the reconciler's
+	// discard-surplus-active loop. The loop's iteration count is bounded by the
+	// peeked snapshot, not by this fake counting down, so a fixed result per
+	// call is enough to drive the tests.
+	receiveResult bool
+	receiveErr    error
+	receiveCalls  int
+
+	// dlqDrained/dlqErr prime DrainDeadLetters.
+	dlqDrained int
+	dlqErr     error
+	dlqCalls   int
 }
 
 func (f *fakeTriggerQueue) QueueDepth(context.Context) (servicebus.QueueDepth, error) {
@@ -36,6 +62,33 @@ func (f *fakeTriggerQueue) PublishAt(_ context.Context, at time.Time, body []byt
 	f.publishedAt = at
 	f.publishedBig = body
 	return f.publishErr
+}
+
+func (f *fakeTriggerQueue) PeekMessages(context.Context) ([]servicebus.PeekedMessage, error) {
+	f.peekCalls++
+	if f.peekErr != nil {
+		return nil, f.peekErr
+	}
+	return f.peeked, nil
+}
+
+func (f *fakeTriggerQueue) CancelScheduled(_ context.Context, sequenceNumbers []int64) error {
+	f.cancelCalls++
+	f.cancelledSeqs = append(f.cancelledSeqs, sequenceNumbers...)
+	return f.cancelErr
+}
+
+func (f *fakeTriggerQueue) ReceiveTrigger(context.Context) (bool, error) {
+	f.receiveCalls++
+	if f.receiveErr != nil {
+		return false, f.receiveErr
+	}
+	return f.receiveResult, nil
+}
+
+func (f *fakeTriggerQueue) DrainDeadLetters(context.Context) (int, error) {
+	f.dlqCalls++
+	return f.dlqDrained, f.dlqErr
 }
 
 // fakeLeaseAccess is a hand-written double for the bootstrapper's consumer-side
@@ -253,6 +306,165 @@ func TestBootstrapper_PublishFailureIsAbsorbed(t *testing.T) {
 	}
 	if !res.ProbeFailed {
 		t.Error("ProbeFailed: got false, want true (a failed publish is recorded as a probe failure for telemetry parity)")
+	}
+}
+
+// TestTryBootstrap_ReconcilesForkToSingleTrigger proves the GH#938 PR2
+// reconciler: when the queue holds more than one live (active+scheduled)
+// trigger, TryBootstrap collapses it back to exactly one, preferring the
+// latest-activating scheduled message (Pre-Resolved Design Decision — it
+// carries the most recent Retry-After knowledge), cancelling every other
+// scheduled message and destructively discarding every surplus active one. It
+// must never publish a new seed while reconciling a live fork.
+func TestTryBootstrap_ReconcilesForkToSingleTrigger(t *testing.T) {
+	t.Parallel()
+	earlier := time.Date(2026, 7, 12, 9, 0, 0, 0, time.UTC)
+	latest := time.Date(2026, 7, 12, 9, 5, 0, 0, time.UTC)
+	q := &fakeTriggerQueue{
+		depth: servicebus.QueueDepth{ActiveMessageCount: 1, ScheduledMessageCount: 2},
+		peeked: []servicebus.PeekedMessage{
+			{SequenceNumber: 10, State: servicebus.MessageStateActive},
+			{SequenceNumber: 20, State: servicebus.MessageStateScheduled, ScheduledEnqueueTime: earlier},
+			{SequenceNumber: 21, State: servicebus.MessageStateScheduled, ScheduledEnqueueTime: latest},
+		},
+		receiveResult: true,
+	}
+	b := newTestBootstrapper(t, q)
+
+	res, err := b.TryBootstrap(context.Background())
+	if err != nil {
+		t.Fatalf("TryBootstrap: %v", err)
+	}
+	if !res.Reconciled {
+		t.Error("Reconciled: got false, want true (queue held 3 live triggers)")
+	}
+	if res.Published {
+		t.Error("Published: got true, want false (must never seed while reconciling a live fork)")
+	}
+	if q.publishCalls != 0 {
+		t.Errorf("publish calls: got %d, want 0", q.publishCalls)
+	}
+	if res.ScheduledCancelled != 1 {
+		t.Errorf("ScheduledCancelled: got %d, want 1 (the earlier of the two scheduled triggers)", res.ScheduledCancelled)
+	}
+	if len(q.cancelledSeqs) != 1 || q.cancelledSeqs[0] != 20 {
+		t.Errorf("cancelledSeqs: got %v, want [20] (the earlier-activating scheduled message)", q.cancelledSeqs)
+	}
+	if res.ActiveDiscarded != 1 {
+		t.Errorf("ActiveDiscarded: got %d, want 1 (the sole active message)", res.ActiveDiscarded)
+	}
+	if q.receiveCalls != 1 {
+		t.Errorf("ReceiveTrigger calls: got %d, want 1", q.receiveCalls)
+	}
+}
+
+// TestTryBootstrap_DrainsDeadLetterQueue proves TryBootstrap drains the
+// trigger queue's dead-letter sub-queue on every cycle it runs (lease held),
+// regardless of the active/scheduled outcome — dead-lettered corpses never
+// self-clear (GH#938 PR2).
+func TestTryBootstrap_DrainsDeadLetterQueue(t *testing.T) {
+	t.Parallel()
+	q := &fakeTriggerQueue{
+		depth:      servicebus.QueueDepth{ActiveMessageCount: 1}, // healthy single trigger: no reseed, no reconcile
+		dlqDrained: 4,
+	}
+	b := newTestBootstrapper(t, q)
+
+	res, err := b.TryBootstrap(context.Background())
+	if err != nil {
+		t.Fatalf("TryBootstrap: %v", err)
+	}
+	if res.DeadLettered != 4 {
+		t.Errorf("DeadLettered: got %d, want 4", res.DeadLettered)
+	}
+	if q.dlqCalls != 1 {
+		t.Errorf("DrainDeadLetters calls: got %d, want 1", q.dlqCalls)
+	}
+	if res.Published || res.Reconciled {
+		t.Errorf("a healthy single-trigger queue must not seed or reconcile, got %+v", res)
+	}
+}
+
+// TestTryBootstrap_DeadLetterDrainFailureIsAbsorbed proves a DLQ drain failure
+// never escalates to a caller-visible error — the next cron tick retries, same
+// as every other absorbed failure in TryBootstrap.
+func TestTryBootstrap_DeadLetterDrainFailureIsAbsorbed(t *testing.T) {
+	t.Parallel()
+	q := &fakeTriggerQueue{
+		depth:  servicebus.QueueDepth{ActiveMessageCount: 1},
+		dlqErr: errors.New("dlq receive failed"),
+	}
+	b := newTestBootstrapper(t, q)
+
+	res, err := b.TryBootstrap(context.Background())
+	if err != nil {
+		t.Fatalf("TryBootstrap should absorb dead-letter drain failures, got err=%v", err)
+	}
+	if res.DeadLettered != 0 {
+		t.Errorf("DeadLettered: got %d, want 0 (drain failed)", res.DeadLettered)
+	}
+}
+
+// TestPickKeeper covers the pure reconciliation decision — which trigger
+// survives a fork — in isolation from the queue and lease plumbing.
+func TestPickKeeper(t *testing.T) {
+	t.Parallel()
+	earlier := time.Date(2026, 7, 12, 9, 0, 0, 0, time.UTC)
+	latest := time.Date(2026, 7, 12, 9, 5, 0, 0, time.UTC)
+
+	tests := []struct {
+		name             string
+		peeked           []servicebus.PeekedMessage
+		wantKeepSeq      int64
+		wantCancelSeqs   []int64
+		wantDiscardCount int
+	}{
+		{
+			name: "two scheduled plus one active: keeps latest-activating scheduled",
+			peeked: []servicebus.PeekedMessage{
+				{SequenceNumber: 10, State: servicebus.MessageStateActive},
+				{SequenceNumber: 20, State: servicebus.MessageStateScheduled, ScheduledEnqueueTime: earlier},
+				{SequenceNumber: 21, State: servicebus.MessageStateScheduled, ScheduledEnqueueTime: latest},
+			},
+			wantKeepSeq:      21,
+			wantCancelSeqs:   []int64{20},
+			wantDiscardCount: 1,
+		},
+		{
+			name: "no scheduled: keeps the lowest-sequence active, discards the rest",
+			peeked: []servicebus.PeekedMessage{
+				{SequenceNumber: 30, State: servicebus.MessageStateActive},
+				{SequenceNumber: 15, State: servicebus.MessageStateActive},
+				{SequenceNumber: 22, State: servicebus.MessageStateActive},
+			},
+			wantKeepSeq:      15,
+			wantCancelSeqs:   nil,
+			wantDiscardCount: 2,
+		},
+		{
+			name: "single scheduled: kept outright, nothing to cancel or discard",
+			peeked: []servicebus.PeekedMessage{
+				{SequenceNumber: 5, State: servicebus.MessageStateScheduled, ScheduledEnqueueTime: earlier},
+			},
+			wantKeepSeq:      5,
+			wantCancelSeqs:   nil,
+			wantDiscardCount: 0,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			keep, cancelSeqs, discardCount := pickKeeper(tc.peeked)
+			if keep.SequenceNumber != tc.wantKeepSeq {
+				t.Errorf("keep.SequenceNumber: got %d, want %d", keep.SequenceNumber, tc.wantKeepSeq)
+			}
+			if !slices.Equal(cancelSeqs, tc.wantCancelSeqs) {
+				t.Errorf("cancelSeqs: got %v, want %v", cancelSeqs, tc.wantCancelSeqs)
+			}
+			if discardCount != tc.wantDiscardCount {
+				t.Errorf("discardCount: got %d, want %d", discardCount, tc.wantDiscardCount)
+			}
+		})
 	}
 }
 

--- a/api-go/internal/worker/dispatch.go
+++ b/api-go/internal/worker/dispatch.go
@@ -415,10 +415,17 @@ func runPollBootstrap(ctx context.Context, bootstrapper *Bootstrapper, logger *s
 	}
 
 	// Tag names match the App Insights telemetry schema so existing queries
-	// and dashboards keep working.
+	// and dashboards keep working. lease_unavailable (PR1) and the
+	// reconciliation counts (PR2) are additive: they let an alert fire on a
+	// forked chain or a stuck DLQ without a human happening to look (GH#938).
 	span.SetAttributes(
 		attribute.Bool("polling.safety_net.bootstrap_published", res.Published),
 		attribute.Bool("polling.safety_net.bootstrap_probe_failed", res.ProbeFailed),
+		attribute.Bool("polling.safety_net.lease_unavailable", res.LeaseUnavailable),
+		attribute.Bool("polling.safety_net.reconciled", res.Reconciled),
+		attribute.Int("polling.safety_net.scheduled_cancelled", res.ScheduledCancelled),
+		attribute.Int("polling.safety_net.active_discarded", res.ActiveDiscarded),
+		attribute.Int("polling.safety_net.dead_lettered", res.DeadLettered),
 	)
 	return 0
 }

--- a/api-go/internal/worker/dispatch_test.go
+++ b/api-go/internal/worker/dispatch_test.go
@@ -8,8 +8,62 @@ import (
 	"strings"
 	"testing"
 
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/AmyDe/town-crier/api-go/internal/polling"
 	"github.com/AmyDe/town-crier/api-go/internal/servicebus"
 )
+
+// recordBootstrapSpan swaps in an in-memory SDK TracerProvider for the
+// duration of one poll-bootstrap Run call, restoring the previous global
+// provider on cleanup, and returns the single "Polling Bootstrap" span
+// recorded. Deliberately not t.Parallel(): mutating the global TracerProvider
+// is safe only while no sibling test's body is concurrently executing (the
+// existing middleware span tests use the same non-parallel convention).
+func recordBootstrapSpan(t *testing.T, run func()) sdktrace.ReadOnlySpan {
+	t.Helper()
+
+	prev := otel.GetTracerProvider()
+	rec := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+		otel.SetTracerProvider(prev)
+	})
+
+	run()
+
+	spans := rec.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 recorded span, got %d", len(spans))
+	}
+	return spans[0]
+}
+
+// attrBool returns the bool value of the named attribute on the span and
+// whether it was present.
+func attrBool(span sdktrace.ReadOnlySpan, key string) (bool, bool) {
+	for _, kv := range span.Attributes() {
+		if string(kv.Key) == key {
+			return kv.Value.AsBool(), true
+		}
+	}
+	return false, false
+}
+
+// attrInt returns the int64 value of the named attribute on the span and
+// whether it was present.
+func attrInt(span sdktrace.ReadOnlySpan, key string) (int64, bool) {
+	for _, kv := range span.Attributes() {
+		if string(kv.Key) == key {
+			return kv.Value.AsInt64(), true
+		}
+	}
+	return 0, false
+}
 
 // fakeDigester is a hand-written double for the digestRunner the dispatcher
 // invokes. It records which cycle ran and can be primed with an error.
@@ -436,6 +490,80 @@ func TestRun_PollBootstrapProbeFailureStillExitsZero(t *testing.T) {
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0 (absorbed probe failure is not a job failure)", code)
+	}
+}
+
+// TestRunPollBootstrap_TagsReconciliationAttributes proves the "Polling
+// Bootstrap" span surfaces the GH#938 PR1/PR2 BootstrapResult fields as
+// attributes, so App Insights can alert on a fork without a human happening to
+// look: a forked queue (2 scheduled + 1 active) reconciled down to one trigger
+// tags polling.safety_net.reconciled/scheduled_cancelled/active_discarded, and
+// a non-empty DLQ drain tags dead_lettered — additive telemetry only, no
+// dispatch behaviour change.
+func TestRunPollBootstrap_TagsReconciliationAttributes(t *testing.T) {
+	q := &fakeTriggerQueue{
+		depth: servicebus.QueueDepth{ActiveMessageCount: 1, ScheduledMessageCount: 2},
+		peeked: []servicebus.PeekedMessage{
+			{SequenceNumber: 10, State: servicebus.MessageStateActive},
+			{SequenceNumber: 20, State: servicebus.MessageStateScheduled},
+			{SequenceNumber: 21, State: servicebus.MessageStateScheduled},
+		},
+		receiveResult: true,
+		dlqDrained:    3,
+	}
+	b := newTestBootstrapper(t, q)
+	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
+
+	span := recordBootstrapSpan(t, func() {
+		code := Run(context.Background(), "poll-bootstrap", b, nil, nil, nil, nil, nil, nil, logger)
+		if code != 0 {
+			t.Errorf("exit code: got %d, want 0", code)
+		}
+	})
+
+	if got, ok := attrBool(span, "polling.safety_net.reconciled"); !ok || !got {
+		t.Errorf("polling.safety_net.reconciled: got %v (ok=%v), want true", got, ok)
+	}
+	if got, ok := attrInt(span, "polling.safety_net.scheduled_cancelled"); !ok || got != 1 {
+		t.Errorf("polling.safety_net.scheduled_cancelled: got %d (ok=%v), want 1", got, ok)
+	}
+	if got, ok := attrInt(span, "polling.safety_net.active_discarded"); !ok || got != 1 {
+		t.Errorf("polling.safety_net.active_discarded: got %d (ok=%v), want 1", got, ok)
+	}
+	if got, ok := attrInt(span, "polling.safety_net.dead_lettered"); !ok || got != 3 {
+		t.Errorf("polling.safety_net.dead_lettered: got %d (ok=%v), want 3", got, ok)
+	}
+	if got, ok := attrBool(span, "polling.safety_net.lease_unavailable"); !ok || got {
+		t.Errorf("polling.safety_net.lease_unavailable: got %v (ok=%v), want false", got, ok)
+	}
+}
+
+// TestRunPollBootstrap_TagsLeaseUnavailableAttribute proves the PR1
+// LeaseUnavailable field (never previously surfaced) is now tagged on the
+// span: when a peer holds the polling lease, the span must report
+// lease_unavailable=true and every reconciliation count at its zero value
+// (nothing was probed or touched).
+func TestRunPollBootstrap_TagsLeaseUnavailableAttribute(t *testing.T) {
+	q := &fakeTriggerQueue{depth: servicebus.QueueDepth{}}
+	lease := &fakeLeaseAccess{acquireResult: polling.LeaseAcquireResult{Held: true}}
+	b := newTestBootstrapperWithLease(t, q, lease)
+	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
+
+	span := recordBootstrapSpan(t, func() {
+		code := Run(context.Background(), "poll-bootstrap", b, nil, nil, nil, nil, nil, nil, logger)
+		if code != 0 {
+			t.Errorf("exit code: got %d, want 0", code)
+		}
+	})
+
+	if got, ok := attrBool(span, "polling.safety_net.lease_unavailable"); !ok || !got {
+		t.Errorf("polling.safety_net.lease_unavailable: got %v (ok=%v), want true", got, ok)
+	}
+	if got, ok := attrBool(span, "polling.safety_net.reconciled"); !ok || got {
+		t.Errorf("polling.safety_net.reconciled: got %v (ok=%v), want false", got, ok)
+	}
+	if got, ok := attrInt(span, "polling.safety_net.dead_lettered"); !ok || got != 0 {
+		t.Errorf("polling.safety_net.dead_lettered: got %d (ok=%v), want 0 (lease held; never probed)", got, ok)
 	}
 }
 


### PR DESCRIPTION
Part of #938 (PR2 section) — the self-healing layer on top of #940's fork prevention.

## What

Running under the polling lease (from #940), `TryBootstrap` now enforces the queue invariant instead of only reseeding:

- **Empty queue** → seed (unchanged behaviour).
- **Exactly one live trigger** → skip (unchanged).
- **Fork (active+scheduled > 1)** → collapse to one: keep the latest-activating scheduled message (it carries the freshest Retry-After knowledge), cancel the other scheduled messages by sequence number, destructively receive-and-discard surplus actives.
- **Always** drain the dead-letter sub-queue (corpses never self-clear), logging the count.

Any future fork, whatever the cause, now lasts at most one bootstrap interval (30 min). `servicebus.Client` gains thin `PeekMessages` / `CancelScheduled` / `DrainDeadLetters` methods and `QueueDepth.DeadLetterMessageCount` + `TriggerCount()`. The bootstrap span now tags `polling.safety_net.lease_unavailable` (a #940 field never surfaced) plus reconciliation counts.

## Notes

- SDK-touching client methods follow this file's existing convention of no dedicated unit tests (no Service Bus emulator); all decision logic is unit-tested against the hand-written fake, including a table-driven `TestPickKeeper`.
- Known nit, deliberate: in the rare active-only fork (a transient state — actives are consumed within seconds), the discard loop receives from the queue head, so the surviving active may not be the one `pickKeeper` nominated. All trigger messages are interchangeable run-once ticks, so the ≤1 invariant is enforced identically; only the "kept" log line can mislabel in that edge case.

## Gates (from api-go/ in the worktree)

- `gofmt -l .` empty; `go vet ./...` clean; `golangci-lint run` 0 issues
- `go test -race ./...` — 1799 passed
- `go vet -tags=integration ./...` clean

Backend-only: no Release-Note trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrShbsvV3RiC4iFuZ1R6h1