### PR TITLE
fix(infra): pin poll-queue metric alert location to global (tc-bube6)

### DIFF
--- a/infra/environment.go
+++ b/infra/environment.go
@@ -856,8 +856,13 @@ func createServiceBusPollingInfra(ctx *pulumi.Context, env string, resourceGroup
 func createPollQueueDepthAlert(ctx *pulumi.Context, env string, resourceGroupName pulumi.StringOutput, pollingBus *serviceBusPollingInfra, actionGroupID pulumi.StringOutput, tags pulumi.StringMap) error {
 	name := fmt.Sprintf("alert-poll-queue-depth-%s", env)
 	_, err := monitor.NewMetricAlert(ctx, name, &monitor.MetricAlertArgs{
-		RuleName:            pulumi.String(name),
-		ResourceGroupName:   resourceGroupName,
+		RuleName:          pulumi.String(name),
+		ResourceGroupName: resourceGroupName,
+		// Platform-metric alert rules must be "global" — Azure rejects a regional
+		// location on anything but a custom metric ("A Regional alert rule can only
+		// be created on a custom metric", broke the v0.19.3 deploy). Without this
+		// the provider defaults to the resource group's region.
+		Location:            pulumi.String("global"),
 		Description:         pulumi.String("Poll Service Bus queue holds more than 1 message (active + scheduled + dead-lettered); steady state is exactly 1. Indicates a forked trigger chain or dead-letter accumulation. See GH #938."),
 		Severity:            pulumi.Int(2),
 		Enabled:             pulumi.Bool(true),


### PR DESCRIPTION
Follow-up to #939 / #938. The v0.19.3 CD Production run failed in `Pulumi up (prod)`: `alert-poll-queue-depth-prod` was created without an explicit `Location`, the provider defaulted it to the resource group's region, and Azure rejects regional alert rules on platform metrics ("A Regional alert rule can only be created on a custom metric"). All app-deploy jobs were skipped as a result, so v0.19.3 never reached prod.

One-line fix: `Location: pulumi.String("global")` on the MetricAlert. Gates: `gofmt -l .` empty, `go vet ./...` clean, `go build ./...` clean.

After merge this ships via v0.19.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrShbsvV3RiC4iFuZ1R6h1