### PR TITLE
fix(api): exempt valid build-key requests from anonymous rate limiter (tc-zod82)

### DIFF
--- a/api-go/cmd/api/anonratelimit_wiring_test.go
+++ b/api-go/cmd/api/anonratelimit_wiring_test.go
@@ -109,3 +109,75 @@ func TestRouter_AnonRateLimitDoesNotThrottleAuthenticatedTraffic(t *testing.T) {
 		t.Fatalf("authenticated request throttled by the anonymous limiter: got %d", rec.Code)
 	}
 }
+
+// TestRouter_AnonRateLimitExemptsValidBuildKeyRequests is the wiring-level
+// acceptance test for the SEO-refresh 429 fix (GH#872 collateral, tc-zod82):
+// wired end to end (not just unit tested against middleware.AnonRateLimit in
+// isolation), a request bearing the correct X-Build-Key on a real
+// build-key-gated route passes even after the tiny anonymous budget has been
+// exhausted by other (keyless) callers sharing its IP.
+func TestRouter_AnonRateLimitExemptsValidBuildKeyRequests(t *testing.T) {
+	t.Parallel()
+
+	const buildKey = "s3cret-build-key"
+	logger := slog.New(slog.DiscardHandler)
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, fakeAppStore{}, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", buildKey, nil, nil, "", nil, nil, nil, 1, 60, logger)
+
+	const sameIP = "203.0.113.93:1"
+
+	// Exhaust the tiny anonymous budget with a keyless request on the same IP.
+	exhaust := anonRateLimitRequest(t, h, "/v1/version-config", sameIP)
+	if exhaust.Code != http.StatusOK {
+		t.Fatalf("setup: budget-consuming request got %d, want 200", exhaust.Code)
+	}
+	exhausted := anonRateLimitRequest(t, h, "/v1/version-config", sameIP)
+	if exhausted.Code != http.StatusTooManyRequests {
+		t.Fatalf("setup: expected budget exhausted, got %d", exhausted.Code)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/v1/authorities/471/applications", nil)
+	req.RemoteAddr = sameIP
+	req.Header.Set("X-Build-Key", buildKey)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("valid build-key request: got %d, want 200 (exempt from the exhausted anonymous budget)", rec.Code)
+	}
+}
+
+// TestRouter_AnonRateLimitDoesNotExemptWrongOrMissingBuildKey confirms the
+// exemption above is narrowly scoped: wired end to end, a request to the same
+// build-key-gated route with a wrong (or absent) key is metered exactly like
+// any other anonymous request, not just rejected by requireBuildKey after
+// already burning budget for free.
+func TestRouter_AnonRateLimitDoesNotExemptWrongOrMissingBuildKey(t *testing.T) {
+	t.Parallel()
+
+	const buildKey = "s3cret-build-key"
+	logger := slog.New(slog.DiscardHandler)
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, fakeAppStore{}, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", buildKey, nil, nil, "", nil, nil, nil, 1, 60, logger)
+
+	const sameIP = "203.0.113.94:1"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	firstReq := httptest.NewRequestWithContext(ctx, http.MethodGet, "/v1/authorities/471/applications", nil)
+	firstReq.RemoteAddr = sameIP
+	firstReq.Header.Set("X-Build-Key", "wrong-key")
+	first := httptest.NewRecorder()
+	h.ServeHTTP(first, firstReq)
+	if first.Code != http.StatusUnauthorized {
+		t.Fatalf("first (wrong-key) request: got %d, want 401", first.Code)
+	}
+
+	// The wrong-key request above still consumed the size-1 anonymous budget,
+	// so a second request from the same IP — even to an unrelated anonymous
+	// route — is throttled.
+	second := anonRateLimitRequest(t, h, "/v1/version-config", sameIP)
+	if second.Code != http.StatusTooManyRequests {
+		t.Fatalf("second request (unrelated route, same IP): got %d, want 429 (wrong key consumed budget)", second.Code)
+	}
+}

--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -199,7 +199,12 @@ type adminUserStore interface {
 //	    RecordActivity below, it always wraps dispatch regardless of whether the
 //	    profile store is wired — a store-less boot must not leave anonymous
 //	    routes completely unmetered. GET /health and GET /v1/health are exempt
-//	    (ACA probes; see middleware.AnonRateLimit's doc for the convention).
+//	    (ACA probes; see middleware.AnonRateLimit's doc for the convention), as
+//	    is any request bearing a valid X-Build-Key (GH#872 collateral,
+//	    tc-zod82): the build-key SEO endpoints authenticate inside the handler
+//	    rather than via Auth0, so without this exemption they are wrongly
+//	    metered as anonymous and the CI seo-refresh job's sequential requests
+//	    from one runner IP 429.
 //	  - RateLimit/RecordActivity are no-ops for anonymous routes (no subject),
 //	    the mirror image of AnonRateLimit's no-op for authenticated ones.
 //
@@ -275,8 +280,17 @@ func newRouter(
 	// load that ultimately lands on PlanIt) completely unmetered. It is a no-op
 	// for authenticated requests, so it never interferes with the per-subject
 	// RateLimit it wraps.
+	//
+	// The exemption predicate recognises a valid X-Build-Key via
+	// applications.BuildKeyMatches (GH#872 collateral, tc-zod82): the build-key
+	// SEO endpoints (RecentRoutes/NearRoutes below) authenticate inside the
+	// handler rather than via Auth0, so without this exemption their traffic —
+	// including the CI seo-refresh job's ~418 sequential requests from one
+	// runner IP — is wrongly metered as anonymous. A missing or wrong key still
+	// exempts nothing, preserving the anti-scraping posture for everyone else.
 	anonWindow := time.Duration(anonRateLimitWindowSeconds) * time.Second
-	dispatch = middleware.AnonRateLimit(middleware.NewAnonRateLimitStore(anonWindow), anonRateLimitRequests, logger)(dispatch)
+	buildKeyExempt := func(r *http.Request) bool { return applications.BuildKeyMatches(r, siteBuildKey) }
+	dispatch = middleware.AnonRateLimit(middleware.NewAnonRateLimitStore(anonWindow), anonRateLimitRequests, buildKeyExempt, logger)(dispatch)
 	if deviceStore != nil {
 		devicetokens.Routes(mux, deviceStore, time.Now, logger)
 	}

--- a/api-go/internal/applications/buildkey.go
+++ b/api-go/internal/applications/buildkey.go
@@ -8,20 +8,41 @@ import (
 // buildKeyHeader is the header carrying the dedicated site-build key.
 const buildKeyHeader = "X-Build-Key"
 
+// BuildKeyMatches reports whether r carries an X-Build-Key header that
+// constant-time-matches expectedKey. An empty expectedKey NEVER matches, even
+// against an empty or absent header: crypto/subtle.ConstantTimeCompare
+// returns 1 for two empty byte slices, so without this guard an unconfigured
+// deployment (SITE_BUILD_KEY unset) would treat a keyless caller as a match
+// instead of rejecting every request.
+//
+// Exported so a caller outside this package can recognise build-key-
+// authenticated traffic without duplicating the header name or the
+// constant-time compare — specifically the anonymous-rate-limit exemption
+// predicate wired in cmd/api/wiring.go (GH#872 collateral, tc-zod82): the
+// build-key SEO endpoints authenticate inside the handler rather than via
+// Auth0, so without this exemption their traffic is wrongly metered as
+// anonymous.
+func BuildKeyMatches(r *http.Request, expectedKey string) bool {
+	if expectedKey == "" {
+		return false
+	}
+	provided := []byte(r.Header.Get(buildKeyHeader))
+	expected := []byte(expectedKey)
+	return subtle.ConstantTimeCompare(provided, expected) == 1
+}
+
 // requireBuildKey wraps next with the build-key gate for the build-time SEO
 // endpoint: a request lacking a matching X-Build-Key gets a bodyless 401 (the
 // PascalCase envelope is backfilled by middleware.ErrorBody). An empty configured
 // key rejects every request, so an unconfigured deployment cannot be reached. The
-// compare is constant-time to avoid leaking the key by timing.
+// compare is constant-time to avoid leaking the key by timing (BuildKeyMatches).
 //
 // This is a separate gate from admin.requireAdminKey by design (least privilege):
 // the SEO endpoint reads only public planning data, so it must not share the
 // high-blast-radius admin key.
 func requireBuildKey(expectedKey string, next http.HandlerFunc) http.HandlerFunc {
-	expected := []byte(expectedKey)
 	return func(w http.ResponseWriter, r *http.Request) {
-		provided := []byte(r.Header.Get(buildKeyHeader))
-		if len(expected) == 0 || subtle.ConstantTimeCompare(provided, expected) != 1 {
+		if !BuildKeyMatches(r, expectedKey) {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}

--- a/api-go/internal/applications/buildkey_test.go
+++ b/api-go/internal/applications/buildkey_test.go
@@ -7,6 +7,44 @@ import (
 	"testing"
 )
 
+// TestBuildKeyMatches covers the exported matcher directly (GH#872 collateral,
+// tc-zod82): it backs both requireBuildKey and the anonymous-rate-limit
+// exemption predicate wired in cmd/api/wiring.go, so its empty-key behaviour
+// must hold independent of either caller.
+func TestBuildKeyMatches(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		expected  string
+		provided  string
+		setHeader bool
+		want      bool
+	}{
+		{"matching key matches", "s3cret", "s3cret", true, true},
+		{"wrong key does not match", "s3cret", "nope", true, false},
+		{"absent header does not match", "s3cret", "", false, false},
+		{"key prefix does not match (length-sensitive)", "s3cret", "s3cre", true, false},
+		{"empty expected key never matches, even an empty header", "", "", true, false},
+		{"empty expected key never matches a non-empty header", "", "anything", true, false},
+		{"empty expected key never matches an absent header", "", "", false, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/authorities/471/applications", nil)
+			if tc.setHeader {
+				req.Header.Set("X-Build-Key", tc.provided)
+			}
+
+			if got := BuildKeyMatches(req, tc.expected); got != tc.want {
+				t.Errorf("BuildKeyMatches() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestRequireBuildKey(t *testing.T) {
 	t.Parallel()
 

--- a/api-go/internal/middleware/anonratelimit.go
+++ b/api-go/internal/middleware/anonratelimit.go
@@ -44,11 +44,25 @@ var healthCheckPaths = map[string]struct{}{
 // on a throttled one it returns 429 with those headers (Remaining 0) plus
 // Retry-After — the same response contract as the per-subject RateLimit.
 //
+// exempt is an additional per-request bypass alongside the health-check paths
+// above, evaluated only for otherwise-anonymous requests: when it returns
+// true the request passes straight through untouched, exactly like
+// authenticated traffic. nil means no additional exemption. The motivating
+// case (GH#872 collateral, tc-zod82) is the build-time SEO endpoints
+// (GET /v1/authorities/{id}/applications, GET /v1/applications/near): they
+// authenticate via the X-Build-Key header checked inside the handler
+// (applications.requireBuildKey), not via Auth0, so auth.Subject is always
+// empty for them and the CI seo-refresh job's ~418 sequential requests from
+// one runner IP were being metered as anonymous and 429ing. Callers build the
+// predicate from applications.BuildKeyMatches (cmd/api/wiring.go) rather than
+// this package importing internal/applications directly, keeping middleware
+// dependency-free.
+//
 // The client IP itself is never logged, stored, or exported anywhere beyond
 // this in-memory accounting: only the numeric limit/retry values are recorded
 // on a throttle, honouring the clientip package's "in-memory, non-persisted
 // purpose only" constraint.
-func AnonRateLimit(store *anonRateLimitStore, limit int, logger *slog.Logger) func(http.Handler) http.Handler {
+func AnonRateLimit(store *anonRateLimitStore, limit int, exempt func(*http.Request) bool, logger *slog.Logger) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if auth.Subject(r.Context()) != "" {
@@ -56,6 +70,10 @@ func AnonRateLimit(store *anonRateLimitStore, limit int, logger *slog.Logger) fu
 				return
 			}
 			if _, ok := healthCheckPaths[r.URL.Path]; ok {
+				next.ServeHTTP(w, r)
+				return
+			}
+			if exempt != nil && exempt(r) {
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/api-go/internal/middleware/anonratelimit_test.go
+++ b/api-go/internal/middleware/anonratelimit_test.go
@@ -36,7 +36,7 @@ func TestAnonRateLimit_AllowedRequestSetsHeaders(t *testing.T) {
 
 	clock := &fixedClock{t: time.Unix(2000, 0)}
 	store := newAnonRateLimitStore(clock.now, time.Minute)
-	mw := AnonRateLimit(store, 60, slogDiscard())
+	mw := AnonRateLimit(store, 60, nil, slogDiscard())
 
 	rec := httptest.NewRecorder()
 	mw(okHandler()).ServeHTTP(rec, anonRequest("203.0.113.10:51000"))
@@ -57,7 +57,7 @@ func TestAnonRateLimit_RequestsBelowLimitAreUnaffected(t *testing.T) {
 
 	clock := &fixedClock{t: time.Unix(2000, 0)}
 	store := newAnonRateLimitStore(clock.now, time.Minute)
-	mw := AnonRateLimit(store, 5, slogDiscard())
+	mw := AnonRateLimit(store, 5, nil, slogDiscard())
 	h := mw(okHandler())
 
 	for i := range 5 {
@@ -74,7 +74,7 @@ func TestAnonRateLimit_ExceededReturns429WithHeaders(t *testing.T) {
 
 	clock := &fixedClock{t: time.Unix(2000, 0)}
 	store := newAnonRateLimitStore(clock.now, time.Minute)
-	mw := AnonRateLimit(store, 60, slogDiscard())
+	mw := AnonRateLimit(store, 60, nil, slogDiscard())
 	h := mw(okHandler())
 
 	for i := range 60 {
@@ -110,7 +110,7 @@ func TestAnonRateLimit_AuthenticatedRequestPassesThrough(t *testing.T) {
 
 	clock := &fixedClock{t: time.Unix(2000, 0)}
 	store := newAnonRateLimitStore(clock.now, time.Minute)
-	mw := AnonRateLimit(store, 1, slogDiscard())
+	mw := AnonRateLimit(store, 1, nil, slogDiscard())
 	h := mw(okHandler())
 
 	for i := range 5 {
@@ -136,12 +136,88 @@ func TestAnonRateLimit_AuthenticatedRequestPassesThrough(t *testing.T) {
 	}
 }
 
+// TestAnonRateLimit_ExemptPredicatePassesThroughUnmetered is the acceptance
+// test for the build-key exemption (GH#872 collateral, tc-zod82): a request
+// the exempt predicate recognises must pass straight through even when the
+// per-IP budget is exhausted, with no X-RateLimit headers set and no budget
+// consumed — exactly like authenticated (Auth0-subject) traffic above.
+func TestAnonRateLimit_ExemptPredicatePassesThroughUnmetered(t *testing.T) {
+	t.Parallel()
+
+	clock := &fixedClock{t: time.Unix(2000, 0)}
+	store := newAnonRateLimitStore(clock.now, time.Minute)
+	exempt := func(r *http.Request) bool { return r.Header.Get("X-Build-Key") == "s3cret" }
+	mw := AnonRateLimit(store, 1, exempt, slogDiscard())
+	h := mw(okHandler())
+
+	exemptRequest := func() *http.Request {
+		r := anonRequest("203.0.113.70:51000")
+		r.Header.Set("X-Build-Key", "s3cret")
+		return r
+	}
+
+	for i := range 5 {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, exemptRequest())
+		if rec.Code != http.StatusOK {
+			t.Fatalf("exempt request %d: got %d, want 200", i, rec.Code)
+		}
+		if got := rec.Header().Get("X-RateLimit-Limit"); got != "" {
+			t.Errorf("exempt request %d: got rate-limit header %q, want none", i, got)
+		}
+	}
+
+	// The same IP, now making its first genuinely anonymous (keyless) request,
+	// still has its full budget — proving the exempt loop above never touched
+	// the IP's counter.
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, anonRequest("203.0.113.70:51000"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("first anonymous (keyless) request on the IP: got %d, want 200", rec.Code)
+	}
+}
+
+// TestAnonRateLimit_ExemptPredicateFalseIsMeteredNormally confirms the
+// exemption is opt-in per request: traffic the predicate does not recognise
+// (wrong or absent build key) is metered exactly as it was before the
+// predicate existed.
+func TestAnonRateLimit_ExemptPredicateFalseIsMeteredNormally(t *testing.T) {
+	t.Parallel()
+
+	clock := &fixedClock{t: time.Unix(2000, 0)}
+	store := newAnonRateLimitStore(clock.now, time.Minute)
+	exempt := func(r *http.Request) bool { return r.Header.Get("X-Build-Key") == "s3cret" }
+	mw := AnonRateLimit(store, 1, exempt, slogDiscard())
+	h := mw(okHandler())
+
+	first := httptest.NewRecorder()
+	h.ServeHTTP(first, anonRequest("203.0.113.71:51000"))
+	if first.Code != http.StatusOK {
+		t.Fatalf("first (keyless) request: got %d, want 200", first.Code)
+	}
+
+	second := httptest.NewRecorder()
+	h.ServeHTTP(second, anonRequest("203.0.113.71:51000"))
+	if second.Code != http.StatusTooManyRequests {
+		t.Fatalf("second (keyless) request: got %d, want 429 (metered normally)", second.Code)
+	}
+
+	// A wrong key does not exempt either.
+	wrongKey := anonRequest("203.0.113.71:51000")
+	wrongKey.Header.Set("X-Build-Key", "wrong")
+	third := httptest.NewRecorder()
+	h.ServeHTTP(third, wrongKey)
+	if third.Code != http.StatusTooManyRequests {
+		t.Fatalf("wrong-key request: got %d, want 429 (metered normally)", third.Code)
+	}
+}
+
 func TestAnonRateLimit_DifferentIPsHaveIndependentBudgets(t *testing.T) {
 	t.Parallel()
 
 	clock := &fixedClock{t: time.Unix(2000, 0)}
 	store := newAnonRateLimitStore(clock.now, time.Minute)
-	mw := AnonRateLimit(store, 1, slogDiscard())
+	mw := AnonRateLimit(store, 1, nil, slogDiscard())
 	h := mw(okHandler())
 
 	rec1 := httptest.NewRecorder()
@@ -175,7 +251,7 @@ func TestAnonRateLimit_UnresolvableIPsShareOneConservativeBucket(t *testing.T) {
 
 	clock := &fixedClock{t: time.Unix(2000, 0)}
 	store := newAnonRateLimitStore(clock.now, time.Minute)
-	mw := AnonRateLimit(store, 1, slogDiscard())
+	mw := AnonRateLimit(store, 1, nil, slogDiscard())
 	h := mw(okHandler())
 
 	rec1 := httptest.NewRecorder()
@@ -206,7 +282,7 @@ func TestAnonRateLimit_HealthCheckPathsExempt(t *testing.T) {
 
 	clock := &fixedClock{t: time.Unix(2000, 0)}
 	store := newAnonRateLimitStore(clock.now, time.Minute)
-	mw := AnonRateLimit(store, 1, slogDiscard())
+	mw := AnonRateLimit(store, 1, nil, slogDiscard())
 	h := mw(okHandler())
 
 	for _, path := range []string{"/health", "/v1/health"} {
@@ -228,7 +304,7 @@ func TestAnonRateLimit_WindowResets(t *testing.T) {
 
 	clock := &fixedClock{t: time.Unix(2000, 0)}
 	store := newAnonRateLimitStore(clock.now, time.Minute)
-	mw := AnonRateLimit(store, 2, slogDiscard())
+	mw := AnonRateLimit(store, 2, nil, slogDiscard())
 	h := mw(okHandler())
 
 	for range 2 {
@@ -261,7 +337,7 @@ func TestAnonRateLimit_NoClientIPInLogs(t *testing.T) {
 	spy := &logSpy{}
 	clock := &fixedClock{t: time.Unix(2000, 0)}
 	store := newAnonRateLimitStore(clock.now, time.Minute)
-	mw := AnonRateLimit(store, 1, slog.New(spy))
+	mw := AnonRateLimit(store, 1, nil, slog.New(spy))
 	h := mw(okHandler())
 
 	h.ServeHTTP(httptest.NewRecorder(), anonRequest(distinctiveIP+":51000"))


### PR DESCRIPTION
## Problem

The scheduled SEO Refresh workflow has failed every run since 2026-07-08 (last success 2026-07-07). Both dev and prod jobs die in the snapshot fetch with `HTTP 429` from our own API.

Root cause: #872 added per-IP anonymous rate limiting (`AnonRateLimit`, default 60 req/60s sliding window) to every request with no Auth0 subject. The build-time SEO endpoints (`GET /v1/authorities/{id}/applications`, `GET /v1/applications/near`) authenticate via the `X-Build-Key` header checked *inside* the handler (`requireBuildKey`), which never sets `auth.Subject` — so the seo-refresh snapshot fetch (~418 sequential authority requests plus town requests, all from one GitHub runner IP) is metered as anonymous. It 429s at request #61, exactly the limit (prod died on request #61, dev on #62).

## Fix

Treat valid build-key traffic as what it is — authenticated, just not via Auth0:

- `applications.BuildKeyMatches` (new, exported): constant-time `X-Build-Key` compare; an empty configured key never matches (guards the `ConstantTimeCompare` empty-vs-empty == 1 trap, same as the existing handler gate). `requireBuildKey` now delegates to it, keeping header name + compare in one place.
- `middleware.AnonRateLimit` gains an exemption predicate (`nil` = no exemption); an exempt request passes through unmetered with no `X-RateLimit-*` headers, exactly like authenticated traffic. Middleware stays dependency-free — the predicate is built in wiring.
- `cmd/api/wiring.go` wires the predicate from `SiteBuildKey`.

A missing or wrong key still exempts nothing, so the anti-scraping posture from #872 is unchanged for everyone else.

## Tests

- `TestBuildKeyMatches` — match/mismatch/absent header/empty-expected-key variants incl. empty-vs-empty.
- `TestAnonRateLimit_ExemptPredicatePassesThroughUnmetered` — exempt request passes beyond the limit, gets no rate headers, consumes no budget.
- `TestAnonRateLimit_ExemptPredicateFalseIsMeteredNormally` — plus all 9 existing limiter tests updated to `nil` predicate, proving parity.
- End-to-end through the real router: `TestRouter_AnonRateLimitExemptsValidBuildKeyRequests` (verified load-bearing by forcing the predicate false and watching it fail), `TestRouter_AnonRateLimitDoesNotExemptWrongOrMissingBuildKey`.

Gates: `gofmt` clean, `go vet` clean, `golangci-lint run` clean, `go test -race ./...` 1811 passed.

Closes tc-zod82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XoywhnYS6u4FgfKsqvPmCz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Valid build-key requests are no longer incorrectly blocked by anonymous rate limits.
  - Requests with missing or invalid build keys continue to be rate-limited as expected.
  - Protected authority application requests now reliably succeed when properly authenticated.
  - Rate-limit behavior remains unchanged for unrelated anonymous routes and invalid authentication attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->