### PR TITLE
feat(api): stamp HWM age, ASSN type, and email kind on spans (tc-3jx8d)

### DIFF
--- a/api-go/cmd/worker/main.go
+++ b/api-go/cmd/worker/main.go
@@ -518,7 +518,10 @@ func buildDigester(cfg platform.Config, st *stores, logger *slog.Logger) *digest
 		point: st.profile,
 	}
 
-	emailSender := buildEmailSender(cfg, logger)
+	// Wrapped in InstrumentedSender so every digest email gets exactly one
+	// "Email send" span (tagged email.kind) distinct from the underlying "ACS
+	// email send" HTTP client spans (tc-3jx8d).
+	emailSender := acsemail.NewInstrumentedSender(buildEmailSender(cfg, logger))
 	dispatcher := buildPlatformDispatcher(cfg, logger)
 
 	return digest.NewHandler(

--- a/api-go/cmd/worker/main.go
+++ b/api-go/cmd/worker/main.go
@@ -480,6 +480,8 @@ func (a *pollOrchestratorAdapter) RunOnce(ctx context.Context) (worker.PollRunRe
 		out.AuthoritiesPolled = res.PollResult.AuthoritiesPolled
 		out.AuthorityErrors = res.PollResult.AuthorityErrors
 		out.Termination = res.PollResult.TerminationReason.TelemetryValue()
+		out.OldestHWMAgeSeconds = res.PollResult.OldestHWMAgeSeconds
+		out.OldestHWMNeverPolled = res.PollResult.OldestHWMNeverPolled
 	}
 	return out, nil
 }

--- a/api-go/internal/acsemail/instrumented.go
+++ b/api-go/internal/acsemail/instrumented.go
@@ -1,0 +1,47 @@
+package acsemail
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+)
+
+// tracerName labels the "Email send" wrapper span this package emits.
+const tracerName = "github.com/AmyDe/town-crier/api-go/internal/acsemail"
+
+// InstrumentedSender wraps an EmailSender in exactly one "Email send" span per
+// call, tagged email.kind, so a per-email dependency is visible in App
+// Insights distinct from the transport-level "ACS email send" HTTP client
+// spans a single logical send can emit (one POST plus, when the operation
+// doesn't complete synchronously, one or more status polls — inflating the
+// raw per-email span count). It never renames or alters those wrapped spans;
+// it only adds a span around the call.
+type InstrumentedSender struct {
+	next EmailSender
+}
+
+// NewInstrumentedSender wraps next. *Client and NoOpSender both satisfy
+// EmailSender.
+func NewInstrumentedSender(next EmailSender) *InstrumentedSender {
+	return &InstrumentedSender{next: next}
+}
+
+// Send starts the "Email send" wrapper span tagged with kind, delegates to
+// the wrapped sender, and — on failure — records the error and Error status
+// on the span before returning it, so the dependency's success flag reflects
+// the outcome.
+func (s *InstrumentedSender) Send(ctx context.Context, kind string, msg Message) error {
+	tracer := otel.Tracer(tracerName)
+	ctx, span := tracer.Start(ctx, "Email send")
+	defer span.End()
+	span.SetAttributes(attribute.String("email.kind", kind))
+
+	if err := s.next.Send(ctx, msg); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	return nil
+}

--- a/api-go/internal/acsemail/instrumented_test.go
+++ b/api-go/internal/acsemail/instrumented_test.go
@@ -1,0 +1,128 @@
+package acsemail
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// fakeSender is a hand-written double for the EmailSender InstrumentedSender
+// wraps.
+type fakeSender struct {
+	calls int
+	sent  []Message
+	err   error
+}
+
+func (f *fakeSender) Send(_ context.Context, msg Message) error {
+	f.calls++
+	f.sent = append(f.sent, msg)
+	return f.err
+}
+
+// recordEmailSpan swaps in an in-memory SDK TracerProvider for the duration of
+// run, restoring the previous global provider on cleanup, and returns the
+// single recorded span. Deliberately not t.Parallel(): mutating the global
+// TracerProvider is safe only while no sibling test's body is concurrently
+// executing (matches the convention already used in
+// internal/middleware/*_span_test.go and internal/worker/dispatch_test.go).
+func recordEmailSpan(t *testing.T, run func()) sdktrace.ReadOnlySpan {
+	t.Helper()
+
+	prev := otel.GetTracerProvider()
+	rec := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+		otel.SetTracerProvider(prev)
+	})
+
+	run()
+
+	spans := rec.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 recorded span, got %d", len(spans))
+	}
+	return spans[0]
+}
+
+func attrString(span sdktrace.ReadOnlySpan, key string) (string, bool) {
+	for _, kv := range span.Attributes() {
+		if string(kv.Key) == key {
+			return kv.Value.AsString(), true
+		}
+	}
+	return "", false
+}
+
+// TestInstrumentedSender_EmitsEmailSendSpanWithKind pins tc-3jx8d: exactly one
+// "Email send" wrapper span per Send call, tagged with the caller's kind, so
+// per-email delivery is visible as a dependency distinct from the low-level
+// "ACS email send" HTTP client spans (unaffected by this wrapper).
+func TestInstrumentedSender_EmitsEmailSendSpanWithKind(t *testing.T) {
+	next := &fakeSender{}
+	s := NewInstrumentedSender(next)
+	msg := testMessage()
+
+	span := recordEmailSpan(t, func() {
+		if err := s.Send(context.Background(), "digest-weekly", msg); err != nil {
+			t.Fatalf("Send: %v", err)
+		}
+	})
+
+	if span.Name() != "Email send" {
+		t.Errorf("span name: got %q, want %q", span.Name(), "Email send")
+	}
+	if got, ok := attrString(span, "email.kind"); !ok || got != "digest-weekly" {
+		t.Errorf("email.kind: got %q (present=%v), want %q", got, ok, "digest-weekly")
+	}
+	if span.Status().Code == codes.Error {
+		t.Error("span status: got Error, want unset for a successful send")
+	}
+	if next.calls != 1 || len(next.sent) != 1 || next.sent[0] != msg {
+		t.Errorf("wrapped sender: calls=%d sent=%v, want exactly 1 call with the original message", next.calls, next.sent)
+	}
+}
+
+// TestInstrumentedSender_RecordsErrorAndStatusOnFailure asserts a failed send
+// is recorded on the wrapper span (RecordError + Error status) so the
+// dependency's success flag reflects the outcome, and that the underlying
+// error still propagates to the caller.
+func TestInstrumentedSender_RecordsErrorAndStatusOnFailure(t *testing.T) {
+	sendErr := errors.New("acs rejected")
+	next := &fakeSender{err: sendErr}
+	s := NewInstrumentedSender(next)
+
+	var gotErr error
+	span := recordEmailSpan(t, func() {
+		gotErr = s.Send(context.Background(), "digest-hourly", testMessage())
+	})
+
+	if !errors.Is(gotErr, sendErr) {
+		t.Errorf("Send error: got %v, want %v", gotErr, sendErr)
+	}
+	if span.Status().Code != codes.Error {
+		t.Errorf("span status: got %v, want Error", span.Status().Code)
+	}
+	if span.Status().Description != sendErr.Error() {
+		t.Errorf("span status description: got %q, want %q", span.Status().Description, sendErr.Error())
+	}
+	var foundException bool
+	for _, ev := range span.Events() {
+		if ev.Name == "exception" {
+			foundException = true
+		}
+	}
+	if !foundException {
+		t.Error("expected an exception event recorded on the span")
+	}
+	if got, ok := attrString(span, "email.kind"); !ok || got != "digest-hourly" {
+		t.Errorf("email.kind: got %q (present=%v), want %q", got, ok, "digest-hourly")
+	}
+}

--- a/api-go/internal/digest/handler.go
+++ b/api-go/internal/digest/handler.go
@@ -27,6 +27,22 @@ import (
 // digestWindow is the 7-day look-back the weekly digest gathers notifications over.
 const digestWindow = 7 * 24 * time.Hour
 
+// email.kind values stamped on the "Email send" wrapper span (tc-3jx8d),
+// distinguishing the two digest cycles that share sendDigestEmail.
+const (
+	emailKindWeekly = "digest-weekly"
+	emailKindHourly = "digest-hourly"
+)
+
+// emailSender is the consumer-side slice of the instrumented email transport
+// the digest handler needs: Send wraps exactly one "Email send" span (tagged
+// email.kind) around the underlying ACS transport, leaving the low-level "ACS
+// email send" HTTP client spans untouched. *acsemail.InstrumentedSender
+// satisfies it.
+type emailSender interface {
+	Send(ctx context.Context, kind string, msg acsemail.Message) error
+}
+
 // profileReader is the consumer-side slice of the profile stores the digest
 // worker needs: the weekly cycle selects by digest day (cross-partition) and the
 // hourly cycle point-reads each candidate user. profiles.AdminStore satisfies
@@ -81,7 +97,7 @@ type Handler struct {
 	zones         zoneReader
 	state         stateReader
 	devices       deviceReader
-	email         acsemail.EmailSender
+	email         emailSender
 	dispatcher    pushDispatcher
 	logger        *slog.Logger
 	now           func() time.Time
@@ -96,7 +112,7 @@ func NewHandler(
 	zones zoneReader,
 	state stateReader,
 	devices deviceReader,
-	email acsemail.EmailSender,
+	email emailSender,
 	dispatcher pushDispatcher,
 	logger *slog.Logger,
 	now func() time.Time,
@@ -156,7 +172,7 @@ func (h *Handler) RunWeekly(ctx context.Context) error {
 			// The weekly cycle does not track emailSent (it re-derives the digest from
 			// the look-back window each run), so a failed send is already logged inside
 			// sendDigestEmail; we just move on to the next user.
-			if err := h.sendDigestEmail(ctx, profile.UserID, *profile.Email, notifs); err != nil {
+			if err := h.sendDigestEmail(ctx, emailKindWeekly, profile.UserID, *profile.Email, notifs); err != nil {
 				continue
 			}
 		}
@@ -282,7 +298,7 @@ func (h *Handler) RunHourly(ctx context.Context) error {
 		// batches every included notification for this user, so a failed send must
 		// leave the whole batch unmarked for the next cycle to retry. Marking on a
 		// swallowed send error is silent data loss (tc-qvds).
-		if err := h.sendDigestEmail(ctx, userID, *profile.Email, included); err != nil {
+		if err := h.sendDigestEmail(ctx, emailKindHourly, userID, *profile.Email, included); err != nil {
 			continue
 		}
 
@@ -337,8 +353,10 @@ func markSent(n notifications.DigestNotification) notifications.DigestNotificati
 // caller can decide whether to proceed: the hourly cycle must NOT flip
 // emailSent when the send fails (otherwise the email is silently lost and
 // never retried — tc-qvds), while the weekly cycle simply moves on to the next
-// user. A failed email never aborts the rest of the cycle either way.
-func (h *Handler) sendDigestEmail(ctx context.Context, userID, email string, notifs []notifications.DigestNotification) error {
+// user. A failed email never aborts the rest of the cycle either way. kind is
+// the "Email send" span's email.kind tag (emailKindWeekly / emailKindHourly),
+// distinguishing the two cycles that share this method.
+func (h *Handler) sendDigestEmail(ctx context.Context, kind, userID, email string, notifs []notifications.DigestNotification) error {
 	zones, err := h.zones.GetByUserID(ctx, userID)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "digest email: load zones failed", "user", userID, "error", err)
@@ -358,7 +376,7 @@ func (h *Handler) sendDigestEmail(ctx context.Context, userID, email string, not
 		Subject:   buildDigestSubject(total),
 		HTMLBody:  buildDigestHTML(sections, saved, total),
 	}
-	if err := h.email.Send(ctx, msg); err != nil {
+	if err := h.email.Send(ctx, kind, msg); err != nil {
 		h.logger.ErrorContext(ctx, "digest email: send failed", "user", userID, "error", err)
 		return fmt.Errorf("send digest email to %s: %w", userID, err)
 	}

--- a/api-go/internal/digest/handler_test.go
+++ b/api-go/internal/digest/handler_test.go
@@ -101,11 +101,13 @@ func (f *fakeDevices) Delete(_ context.Context, _ string, token string) error {
 
 type spyEmail struct {
 	sent    []acsemail.Message
-	sendErr error // returned (after recording the attempt) when set
+	kinds   []string // email.kind passed on each Send call, in order
+	sendErr error    // returned (after recording the attempt) when set
 }
 
-func (s *spyEmail) Send(_ context.Context, msg acsemail.Message) error {
+func (s *spyEmail) Send(_ context.Context, kind string, msg acsemail.Message) error {
 	s.sent = append(s.sent, msg)
+	s.kinds = append(s.kinds, kind)
 	return s.sendErr
 }
 
@@ -192,11 +194,11 @@ func zoneNotif(uid, zoneID string) notifications.DigestNotification {
 // spy (the platform the pre-existing weekly tests exercise). The Android sender
 // is a throwaway spy those tests never reach; tests needing the FCM path build
 // their own fakeDispatcher via newHandlerWithDispatcher.
-func newHandler(p *fakeProfiles, n *fakeNotifications, z *fakeZones, st *fakeState, d *fakeDevices, email acsemail.EmailSender, push *spyPush) *Handler {
+func newHandler(p *fakeProfiles, n *fakeNotifications, z *fakeZones, st *fakeState, d *fakeDevices, email emailSender, push *spyPush) *Handler {
 	return newHandlerWithDispatcher(p, n, z, st, d, email, &fakeDispatcher{ios: push, android: &spyPush{}})
 }
 
-func newHandlerWithDispatcher(p *fakeProfiles, n *fakeNotifications, z *fakeZones, st *fakeState, d *fakeDevices, email acsemail.EmailSender, dispatcher pushDispatcher) *Handler {
+func newHandlerWithDispatcher(p *fakeProfiles, n *fakeNotifications, z *fakeZones, st *fakeState, d *fakeDevices, email emailSender, dispatcher pushDispatcher) *Handler {
 	return NewHandler(p, n, z, st, d, email, dispatcher, testLogger(), func() time.Time {
 		// Pin "now" to a Wednesday so weekly tests select the Wednesday digest day.
 		return time.Date(2026, 2, 4, 9, 0, 0, 0, time.UTC) // 2026-02-04 is a Wednesday
@@ -243,6 +245,10 @@ func TestRunWeekly_EmailGroupsByZoneAndSavedSection(t *testing.T) {
 	}
 	if !contains(msg.HTMLBody, "addr uid-A") || !contains(msg.HTMLBody, "addr uid-B") {
 		t.Errorf("body missing notification addresses:\n%s", msg.HTMLBody)
+	}
+	// The weekly cycle must tag its "Email send" span digest-weekly (tc-3jx8d).
+	if len(email.kinds) != 1 || email.kinds[0] != "digest-weekly" {
+		t.Errorf("email kinds: got %v, want [digest-weekly]", email.kinds)
 	}
 	// Email-only profile: no push.
 	if push.calls != 0 {
@@ -418,6 +424,10 @@ func TestRunHourly_PaidTierSendsAndMarksEmailSent(t *testing.T) {
 	}
 	if len(email.sent) != 1 {
 		t.Fatalf("emails sent: got %d, want 1", len(email.sent))
+	}
+	// The hourly cycle must tag its "Email send" span digest-hourly (tc-3jx8d).
+	if len(email.kinds) != 1 || email.kinds[0] != "digest-hourly" {
+		t.Errorf("email kinds: got %v, want [digest-hourly]", email.kinds)
 	}
 	// Both included notifications marked email-sent for dedup.
 	if len(fn.marked) != 2 {

--- a/api-go/internal/digest/handler_test.go
+++ b/api-go/internal/digest/handler_test.go
@@ -617,7 +617,7 @@ func TestRunHourly_NoOpSenderDropsEmailButStillMarksSent(t *testing.T) {
 	fz := &fakeZones{byUser: map[string][]watchzones.WatchZone{
 		"user-1": {mkZone(t, "zone-1", "Home", true)},
 	}}
-	h := newHandler(fp, fn, fz, &fakeState{}, &fakeDevices{}, acsemail.NewNoOpSender(), &spyPush{})
+	h := newHandler(fp, fn, fz, &fakeState{}, &fakeDevices{}, acsemail.NewInstrumentedSender(acsemail.NewNoOpSender()), &spyPush{})
 
 	if err := h.RunHourly(context.Background()); err != nil {
 		t.Fatalf("RunHourly: %v", err)

--- a/api-go/internal/polling/handler.go
+++ b/api-go/internal/polling/handler.go
@@ -117,6 +117,16 @@ type PollPlanItResult struct {
 	// RetryAfter is the Retry-After hint bubbled up from a 429, consumed by the
 	// scheduler to time the next trigger. nil when not rate-limited or absent.
 	RetryAfter *time.Duration
+	// OldestHWMAgeSeconds is the staleness (in seconds) of the least-recently-
+	// polled candidate authority's high-water mark at cycle start, mirroring the
+	// value fed to metricsRecorder.OldestHighWaterMarkAge. nil when the
+	// candidate set was empty (nothing to report). Carried on the result (not
+	// just the metrics registry, which never reaches App Insights) so
+	// runPollSB can stamp it on the "Polling Cycle (SB)" telemetry span.
+	OldestHWMAgeSeconds *float64
+	// OldestHWMNeverPolled reports whether that oldest candidate has never been
+	// polled (no PollState). Meaningless when OldestHWMAgeSeconds is nil.
+	OldestHWMNeverPolled bool
 }
 
 // PollPlanItHandler runs one adaptive PlanIt poll cycle: select the active
@@ -258,7 +268,7 @@ func (h *PollPlanItHandler) Handle(ctx context.Context) (PollPlanItResult, error
 	// Cycle-start gauges: the never-polled backlog and the staleness of the
 	// oldest authority's LastPollTime, so the lag dashboards keep working.
 	rec.NeverPolledCount(ctx, lru.NeverPolledCount, cycleType)
-	h.recordOldestHWMAge(ctx, rec, lru, now, cycleType)
+	oldestHWMAgeSeconds, oldestHWMNeverPolled, hasOldestHWM := h.recordOldestHWMAge(ctx, rec, lru, now, cycleType)
 
 	var (
 		count           int
@@ -333,14 +343,19 @@ func (h *PollPlanItHandler) Handle(ctx context.Context) (PollPlanItResult, error
 
 	rec.CycleCompleted(ctx, cycleType, reason.TelemetryValue())
 
-	return PollPlanItResult{
+	result := PollPlanItResult{
 		ApplicationCount:  count,
 		AuthoritiesPolled: authoritiesPoll,
 		RateLimited:       rateLimited,
 		TerminationReason: reason,
 		AuthorityErrors:   authorityErrors,
 		RetryAfter:        retryAfter,
-	}, nil
+	}
+	if hasOldestHWM {
+		result.OldestHWMAgeSeconds = &oldestHWMAgeSeconds
+		result.OldestHWMNeverPolled = oldestHWMNeverPolled
+	}
+	return result, nil
 }
 
 // authorityOutcome captures one authority's processing result.
@@ -500,26 +515,28 @@ func (h *PollPlanItHandler) finishAuthority(
 }
 
 // recordOldestHWMAge records the staleness of the oldest candidate authority's
-// LastPollTime at the start of a cycle. The LRU result orders never-polled-first
-// then ascending LastPollTime, so AuthorityIDs[0] is the stalest authority. A
-// never-polled authority (no PollState) reports its age from the Unix epoch and
-// is tagged never_polled=true so dashboards distinguish it from a genuinely stale
-// HWM. An empty candidate set records nothing.
-func (h *PollPlanItHandler) recordOldestHWMAge(ctx context.Context, rec metricsRecorder, lru LeastRecentlyPolledResult, now time.Time, cycleType string) {
+// LastPollTime at the start of a cycle, and returns the same values (ok=false
+// when there was no candidate) so the caller can also carry them on the
+// result. The LRU result orders never-polled-first then ascending
+// LastPollTime, so AuthorityIDs[0] is the stalest authority. A never-polled
+// authority (no PollState) reports its age from the Unix epoch and is tagged
+// neverPolled=true so dashboards distinguish it from a genuinely stale HWM. An
+// empty candidate set records and returns nothing.
+func (h *PollPlanItHandler) recordOldestHWMAge(ctx context.Context, rec metricsRecorder, lru LeastRecentlyPolledResult, now time.Time, cycleType string) (ageSeconds float64, neverPolled bool, ok bool) {
 	if len(lru.AuthorityIDs) == 0 {
-		return
+		return 0, false, false
 	}
 	oldestID := lru.AuthorityIDs[0]
 	state, found, err := h.state.Get(ctx, oldestID)
-	neverPolled := err != nil || !found || state.LastPollTime.IsZero()
+	neverPolled = err != nil || !found || state.LastPollTime.IsZero()
 
-	var ageSeconds float64
 	if neverPolled {
 		ageSeconds = now.Sub(time.Unix(0, 0).UTC()).Seconds()
 	} else {
 		ageSeconds = now.Sub(state.LastPollTime).Seconds()
 	}
 	rec.OldestHighWaterMarkAge(ctx, ageSeconds, cycleType, oldestID, neverPolled)
+	return ageSeconds, neverPolled, true
 }
 
 // recordRetryAfter records the parsed Retry-After value (seconds) for a 429,

--- a/api-go/internal/polling/handler_test.go
+++ b/api-go/internal/polling/handler_test.go
@@ -378,6 +378,77 @@ func TestHandler_NoActiveAuthoritiesIsCleanEmptyCycle(t *testing.T) {
 	}
 }
 
+// TestHandler_RecordsOldestHWMAgeOnResult pins tc-3jx8d: the staleness of the
+// oldest candidate authority's high-water mark must land on the returned
+// result (not just the OTel metrics registry, which never reaches App
+// Insights) so runPollSB can stamp it on the "Polling Cycle (SB)" span.
+func TestHandler_RecordsOldestHWMAgeOnResult(t *testing.T) {
+	t.Parallel()
+	pi := newFakePlanIt()
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	// newHandler pins the clock to 2026-06-14T12:00:00Z; four days earlier.
+	lastPoll := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	state.states[99] = PollState{LastPollTime: lastPoll}
+	h := newHandler(t, pi, apps, state, fakeAuthorities{ids: []int{99}}, CycleSeed, defaultHandlerOpts())
+
+	res, err := h.Handle(context.Background())
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+
+	if res.OldestHWMAgeSeconds == nil {
+		t.Fatal("expected OldestHWMAgeSeconds to be set")
+	}
+	wantAge := 4 * 24 * time.Hour
+	if *res.OldestHWMAgeSeconds != wantAge.Seconds() {
+		t.Errorf("OldestHWMAgeSeconds: got %v, want %v", *res.OldestHWMAgeSeconds, wantAge.Seconds())
+	}
+	if res.OldestHWMNeverPolled {
+		t.Error("OldestHWMNeverPolled: got true, want false (authority has a PollState)")
+	}
+}
+
+// TestHandler_RecordsOldestHWMNeverPolledOnResult covers the never-polled
+// candidate: no PollState means the age is measured from the Unix epoch and
+// the result must flag never_polled so dashboards can distinguish it from a
+// genuinely stale high-water mark.
+func TestHandler_RecordsOldestHWMNeverPolledOnResult(t *testing.T) {
+	t.Parallel()
+	pi := newFakePlanIt()
+	apps := newFakeApps()
+	state := newFakeStateStore() // no PollState for authority 99
+	h := newHandler(t, pi, apps, state, fakeAuthorities{ids: []int{99}}, CycleSeed, defaultHandlerOpts())
+
+	res, err := h.Handle(context.Background())
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+
+	if res.OldestHWMAgeSeconds == nil {
+		t.Fatal("expected OldestHWMAgeSeconds to be set even when never polled")
+	}
+	if !res.OldestHWMNeverPolled {
+		t.Error("OldestHWMNeverPolled: got false, want true (no PollState)")
+	}
+}
+
+// TestHandler_OmitsOldestHWMWhenNoActiveAuthorities covers the empty
+// candidate set: nothing to report, so the field stays nil rather than
+// reporting a misleading zero.
+func TestHandler_OmitsOldestHWMWhenNoActiveAuthorities(t *testing.T) {
+	t.Parallel()
+	h := newHandler(t, newFakePlanIt(), newFakeApps(), newFakeStateStore(), fakeAuthorities{ids: []int{}}, CycleWatched, defaultHandlerOpts())
+
+	res, err := h.Handle(context.Background())
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if res.OldestHWMAgeSeconds != nil {
+		t.Errorf("OldestHWMAgeSeconds: got %v, want nil for an empty candidate set", *res.OldestHWMAgeSeconds)
+	}
+}
+
 func TestHandler_CancelledContextTerminatesTimeBounded(t *testing.T) {
 	t.Parallel()
 	pi := newFakePlanIt()

--- a/api-go/internal/subscriptions/handler.go
+++ b/api-go/internal/subscriptions/handler.go
@@ -10,6 +10,9 @@ import (
 	"strings"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/AmyDe/town-crier/api-go/internal/auth"
 	"github.com/AmyDe/town-crier/api-go/internal/httputil"
 	"github.com/AmyDe/town-crier/api-go/internal/platform"
@@ -343,6 +346,17 @@ func (h *handler) runWebhook(ctx context.Context, signedPayload string) error {
 	notification, err := DecodeNotification(outerJSON)
 	if err != nil {
 		return err
+	}
+
+	// Stamp the notification type on the live request span as soon as it's
+	// decoded, before any idempotency/ignore logic runs — visibility into what
+	// Apple actually sent is the point, including for notifications this
+	// handler goes on to ignore (unknown subscriber, environment mismatch).
+	// These are enum strings, no PII.
+	span := trace.SpanFromContext(ctx)
+	span.SetAttributes(attribute.String("assn.notification_type", notification.NotificationType))
+	if notification.Subtype != "" {
+		span.SetAttributes(attribute.String("assn.subtype", notification.Subtype))
 	}
 
 	processed, err := h.idempotency.IsProcessed(ctx, notification.NotificationUUID)

--- a/api-go/internal/subscriptions/handler_test.go
+++ b/api-go/internal/subscriptions/handler_test.go
@@ -11,6 +11,10 @@ import (
 	"testing"
 	"time"
 
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
 	"github.com/AmyDe/town-crier/api-go/internal/auth"
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
 )
@@ -336,6 +340,11 @@ func notificationJSON(notifType, uuid, signedTxn string) string {
 		notifType, uuid, signedTxn)
 }
 
+func notificationJSONWithSubtype(notifType, subtype, uuid, signedTxn string) string {
+	return fmt.Sprintf(`{"notificationType":%q,"subtype":%q,"notificationUUID":%q,"data":{"signedTransactionInfo":%q}}`,
+		notifType, subtype, uuid, signedTxn)
+}
+
 func TestWebhook_SubscribedActivatesProfile(t *testing.T) {
 	t.Parallel()
 	d := newTestDeps()
@@ -445,6 +454,117 @@ func TestWebhook_ErrorContract(t *testing.T) {
 				t.Errorf("error = %q, want %q", got, tc.wantError)
 			}
 		})
+	}
+}
+
+// --- ASSN notification-type span tests (tc-3jx8d) ---
+
+// spanStarter mimics otelhttp: it begins a server span on the request ctx so
+// the webhook handler (further in) has a live span to stamp, matching the
+// convention already used in internal/middleware/*_span_test.go.
+func spanStarter(next http.Handler) http.Handler {
+	tracer := otel.Tracer("test")
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx, span := tracer.Start(r.Context(), "request")
+		defer span.End()
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// serveWithSpan wraps d.mux in spanStarter, swaps in an in-memory SDK
+// TracerProvider for the duration of the call, restores the previous global
+// provider on cleanup, and returns both the recorded response and the single
+// recorded request span. Deliberately not t.Parallel(): mutating the global
+// TracerProvider is safe only while no sibling test's body is concurrently
+// executing (the existing middleware span tests use the same convention).
+func (d *testDeps) serveWithSpan(t *testing.T, path, body string) (*httptest.ResponseRecorder, sdktrace.ReadOnlySpan) {
+	t.Helper()
+
+	prev := otel.GetTracerProvider()
+	spanRec := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRec))
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+		otel.SetTracerProvider(prev)
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, path, strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	spanStarter(d.mux).ServeHTTP(rec, req)
+
+	spans := spanRec.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 recorded span, got %d", len(spans))
+	}
+	return rec, spans[0]
+}
+
+func spanAttrString(span sdktrace.ReadOnlySpan, key string) (string, bool) {
+	for _, kv := range span.Attributes() {
+		if string(kv.Key) == key {
+			return kv.Value.AsString(), true
+		}
+	}
+	return "", false
+}
+
+func TestWebhook_StampsNotificationTypeOnRequestSpan(t *testing.T) {
+	d := newTestDeps()
+	d.byTxn.profile = freshProfile(t)
+	d.verifier.results["hdr.OUTER.sig"] = notificationJSON("SUBSCRIBED", "uuid-1", "INNER")
+	d.verifier.results["INNER"] = txnJSON(ProductProMonthly, testBundleID, "orig-1", futureExpiryMs())
+
+	rec, span := d.serveWithSpan(t, "/v1/webhooks/appstore", `{"signedPayload":"hdr.OUTER.sig"}`)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	got, ok := spanAttrString(span, "assn.notification_type")
+	if !ok || got != "SUBSCRIBED" {
+		t.Errorf("assn.notification_type: got %q (present=%v), want %q", got, ok, "SUBSCRIBED")
+	}
+	if _, ok := spanAttrString(span, "assn.subtype"); ok {
+		t.Error("assn.subtype: present, want absent when the notification carries no subtype")
+	}
+}
+
+func TestWebhook_StampsSubtypeOnRequestSpanWhenPresent(t *testing.T) {
+	d := newTestDeps()
+	d.byTxn.profile = freshProfile(t)
+	d.verifier.results["hdr.OUTER.sig"] = notificationJSONWithSubtype("DID_CHANGE_RENEWAL_PREF", "UPGRADE", "uuid-2", "INNER")
+	d.verifier.results["INNER"] = txnJSON(ProductProMonthly, testBundleID, "orig-1", futureExpiryMs())
+
+	rec, span := d.serveWithSpan(t, "/v1/webhooks/appstore", `{"signedPayload":"hdr.OUTER.sig"}`)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if got, ok := spanAttrString(span, "assn.notification_type"); !ok || got != "DID_CHANGE_RENEWAL_PREF" {
+		t.Errorf("assn.notification_type: got %q (present=%v), want %q", got, ok, "DID_CHANGE_RENEWAL_PREF")
+	}
+	if got, ok := spanAttrString(span, "assn.subtype"); !ok || got != "UPGRADE" {
+		t.Errorf("assn.subtype: got %q (present=%v), want %q", got, ok, "UPGRADE")
+	}
+}
+
+// TestWebhook_StampsNotificationTypeEvenWhenIgnored pins the "including for
+// notifications the handler ignores" requirement: an unknown subscriber is
+// silently marked processed with no profile mutation, but the span must still
+// carry the notification type — visibility into what Apple sent is the point.
+func TestWebhook_StampsNotificationTypeEvenWhenIgnored(t *testing.T) {
+	d := newTestDeps()
+	d.byTxn.profile = nil // no matching subscriber
+	d.verifier.results["hdr.OUTER.sig"] = notificationJSON("DID_RENEW", "uuid-3", "INNER")
+	d.verifier.results["INNER"] = txnJSON(ProductProMonthly, testBundleID, "orig-x", futureExpiryMs())
+
+	rec, span := d.serveWithSpan(t, "/v1/webhooks/appstore", `{"signedPayload":"hdr.OUTER.sig"}`)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if got, ok := spanAttrString(span, "assn.notification_type"); !ok || got != "DID_RENEW" {
+		t.Errorf("assn.notification_type: got %q (present=%v), want %q", got, ok, "DID_RENEW")
 	}
 }
 

--- a/api-go/internal/worker/dispatch.go
+++ b/api-go/internal/worker/dispatch.go
@@ -107,6 +107,14 @@ type PollRunResult struct {
 	AuthoritiesPolled int
 	AuthorityErrors   int
 	Termination       string
+	// OldestHWMAgeSeconds mirrors polling.PollPlanItResult.OldestHWMAgeSeconds:
+	// the staleness (seconds) of the least-recently-polled candidate
+	// authority's high-water mark at cycle start, nil when the cycle had no
+	// candidates.
+	OldestHWMAgeSeconds *float64
+	// OldestHWMNeverPolled mirrors polling.PollPlanItResult.OldestHWMNeverPolled.
+	// Meaningless when OldestHWMAgeSeconds is nil.
+	OldestHWMNeverPolled bool
 }
 
 // PollOrchestrator is the consumer-side slice of the poll-sb orchestrator the
@@ -218,6 +226,14 @@ func runPollSB(ctx context.Context, poller PollOrchestrator, logger *slog.Logger
 		attribute.Int("polling.authority_errors", res.AuthorityErrors),
 		attribute.String("polling.termination", res.Termination),
 	)
+	// Absent (not zero) when the cycle had no candidate authorities to report —
+	// see PollRunResult.OldestHWMAgeSeconds.
+	if res.OldestHWMAgeSeconds != nil {
+		span.SetAttributes(
+			attribute.Float64("polling.oldest_hwm_age_seconds", *res.OldestHWMAgeSeconds),
+			attribute.Bool("polling.oldest_hwm_never_polled", res.OldestHWMNeverPolled),
+		)
+	}
 
 	logger.InfoContext(ctx, "poll-sb cycle completed",
 		"applicationsIngested", res.ApplicationCount,

--- a/api-go/internal/worker/dispatch_test.go
+++ b/api-go/internal/worker/dispatch_test.go
@@ -16,13 +16,13 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/servicebus"
 )
 
-// recordBootstrapSpan swaps in an in-memory SDK TracerProvider for the
-// duration of one poll-bootstrap Run call, restoring the previous global
-// provider on cleanup, and returns the single "Polling Bootstrap" span
-// recorded. Deliberately not t.Parallel(): mutating the global TracerProvider
-// is safe only while no sibling test's body is concurrently executing (the
-// existing middleware span tests use the same non-parallel convention).
-func recordBootstrapSpan(t *testing.T, run func()) sdktrace.ReadOnlySpan {
+// recordSingleSpan swaps in an in-memory SDK TracerProvider for the duration
+// of run, restoring the previous global provider on cleanup, and returns the
+// single span recorded. Deliberately not t.Parallel(): mutating the global
+// TracerProvider is safe only while no sibling test's body is concurrently
+// executing (the existing middleware span tests use the same non-parallel
+// convention).
+func recordSingleSpan(t *testing.T, run func()) sdktrace.ReadOnlySpan {
 	t.Helper()
 
 	prev := otel.GetTracerProvider()
@@ -43,6 +43,14 @@ func recordBootstrapSpan(t *testing.T, run func()) sdktrace.ReadOnlySpan {
 	return spans[0]
 }
 
+// recordBootstrapSpan is recordSingleSpan under the name the poll-bootstrap
+// span tests were written against; kept as a thin alias so those tests read
+// the same as before.
+func recordBootstrapSpan(t *testing.T, run func()) sdktrace.ReadOnlySpan {
+	t.Helper()
+	return recordSingleSpan(t, run)
+}
+
 // attrBool returns the bool value of the named attribute on the span and
 // whether it was present.
 func attrBool(span sdktrace.ReadOnlySpan, key string) (bool, bool) {
@@ -60,6 +68,17 @@ func attrInt(span sdktrace.ReadOnlySpan, key string) (int64, bool) {
 	for _, kv := range span.Attributes() {
 		if string(kv.Key) == key {
 			return kv.Value.AsInt64(), true
+		}
+	}
+	return 0, false
+}
+
+// attrFloat64 returns the float64 value of the named attribute on the span
+// and whether it was present.
+func attrFloat64(span sdktrace.ReadOnlySpan, key string) (float64, bool) {
+	for _, kv := range span.Attributes() {
+		if string(kv.Key) == key {
+			return kv.Value.AsFloat64(), true
 		}
 	}
 	return 0, false
@@ -295,6 +314,61 @@ func TestRun_PollSBExitsOneOnlyWhenNoAppsAndAuthorityErrors(t *testing.T) {
 				t.Errorf("exit code: got %d, want %d", code, tc.wantExit)
 			}
 		})
+	}
+}
+
+// TestRun_PollSBStampsOldestHWMAttributesOnSpan pins tc-3jx8d: the oldest-HWM
+// staleness the polling handler already computes must land on the "Polling
+// Cycle (SB)" span so it's queryable in App Insights (the OTel metrics
+// registry alone never reaches it).
+func TestRun_PollSBStampsOldestHWMAttributesOnSpan(t *testing.T) {
+	age := 345600.0 // 4 days, seconds
+	o := &fakePollOrchestrator{result: PollRunResult{
+		MessageReceived:      true,
+		OldestHWMAgeSeconds:  &age,
+		OldestHWMNeverPolled: false,
+	}}
+	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
+
+	span := recordSingleSpan(t, func() {
+		Run(context.Background(), "poll-sb", nil, nil, nil, o, nil, nil, nil, logger)
+	})
+
+	if span.Name() != "Polling Cycle (SB)" {
+		t.Fatalf("span name: got %q, want %q", span.Name(), "Polling Cycle (SB)")
+	}
+	got, ok := attrFloat64(span, "polling.oldest_hwm_age_seconds")
+	if !ok {
+		t.Fatalf("missing polling.oldest_hwm_age_seconds; attrs=%v", span.Attributes())
+	}
+	if got != age {
+		t.Errorf("polling.oldest_hwm_age_seconds: got %v, want %v", got, age)
+	}
+	neverPolled, ok := attrBool(span, "polling.oldest_hwm_never_polled")
+	if !ok {
+		t.Fatalf("missing polling.oldest_hwm_never_polled; attrs=%v", span.Attributes())
+	}
+	if neverPolled {
+		t.Errorf("polling.oldest_hwm_never_polled: got true, want false")
+	}
+}
+
+// TestRun_PollSBOmitsOldestHWMAttributesWhenAbsent covers the empty
+// candidate-set case: the handler records nothing, so the span must not carry
+// a misleading zero value for either attribute.
+func TestRun_PollSBOmitsOldestHWMAttributesWhenAbsent(t *testing.T) {
+	o := &fakePollOrchestrator{result: PollRunResult{MessageReceived: true}}
+	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
+
+	span := recordSingleSpan(t, func() {
+		Run(context.Background(), "poll-sb", nil, nil, nil, o, nil, nil, nil, logger)
+	})
+
+	if _, ok := attrFloat64(span, "polling.oldest_hwm_age_seconds"); ok {
+		t.Error("polling.oldest_hwm_age_seconds: present, want absent when no candidate was recorded")
+	}
+	if _, ok := attrBool(span, "polling.oldest_hwm_never_polled"); ok {
+		t.Error("polling.oldest_hwm_never_polled: present, want absent when no candidate was recorded")
 	}
 }
 


### PR DESCRIPTION
Three additive telemetry changes feeding the new operational dashboard tiles (PR #950, bead tc-gha6l). No behaviour changes, no new env vars.

1. **Polling ingestion freshness**: `polling.oldest_hwm_age_seconds` (float64) + `polling.oldest_hwm_never_polled` (bool) now land on the `Polling Cycle (SB)` span, plumbed through the orchestrator result so the canonical `polling.*` keys stay in one place (`runPollSB`). The values were already computed each cycle but only fed the OTel metrics registry, which never reaches App Insights. Attributes are absent (not zero) when a cycle has no candidate authorities.
2. **App Store Server Notifications visibility**: `assn.notification_type` (+ `assn.subtype` when non-empty) stamped on the request span as soon as the webhook payload decodes — including notifications the handler then ignores (unknown subscriber / env mismatch), which were previously invisible.
3. **Per-email telemetry**: new `acsemail.InstrumentedSender` decorator emits exactly one `Email send` span per send, tagged `email.kind` (`digest-weekly` | `digest-hourly`), error + status recorded on failure. The transport-level `ACS email send` HTTP spans (which alert rules query) are untouched.

TDD red/green pairs per feature; SpanRecorder span assertions throughout. 1821 tests pass incl. `-race`; vet/gofmt/golangci-lint clean.

Bead: tc-3jx8d. Backend-only, no Release-Note trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rcQAescUGrAUjpT8bVz2T