### PR TITLE
feat(infra): poll HWM grid shows only watched authorities (tc-28k74)

### DIFF
--- a/infra/shared.go
+++ b/infra/shared.go
@@ -1069,9 +1069,20 @@ expected
 	// `auth=<authority id>` and `different_start=<HWM date>` query params, from which this
 	// derives each authority's current high-water mark and how long ago it was last polled — one
 	// row per authority (arg_max de-dupes to the latest url.full seen per AuthorityID within the
-	// last 7 days), oldest HWM first. Validated live against appi-town-crier-shared on
-	// 2026-07-13 (returned 23 authorities with correct names/ages).
-	const dashboardPollHWMByAuthorityQueryBody = `dependencies | where timestamp > ago(7d) | where customDimensions['deployment.environment'] == 'prod' | where target == 'PlanIt search' | extend url = tostring(customDimensions['url.full']) | extend AuthorityID = toint(extract('auth=([0-9]+)', 1, url)) | where isnotnull(AuthorityID) | summarize arg_max(timestamp, url) by AuthorityID | extend HWM = todatetime(extract('different_start=([0-9-]+)', 1, url)) | lookup kind=leftouter names on AuthorityID | project Authority = coalesce(Authority, tostring(AuthorityID)), ['HWM Date'] = format_datetime(HWM, 'yyyy-MM-dd'), ['HWM Age (h)'] = round((now() - HWM) / 1h, 1), ['Last Polled (h ago)'] = round((now() - timestamp) / 1h, 1) | order by ['HWM Age (h)'] desc`
+	// last 7 days), oldest HWM first.
+	//
+	// Only Watched-cycle polls count (tc-28k74): the grid is operational, so it lists just the
+	// authorities users actually watch, not the full 485-authority Seed backfill sweep — Seed
+	// rows are dominated by defunct/quiet authorities whose months-old HWMs are noise, never
+	// action items. A poll's cycle type isn't stamped on any span, so the `watched` prefix
+	// classifies each cycle by its ROOT span's start minute — minute%30 < 15 → Watched —
+	// mirroring polling.MinuteCycleSelector (api-go/internal/polling/authorities.go); child
+	// PlanIt spans join to their root on operation_Id, so classification is exact per cycle
+	// with no boundary bleed from cycles that straddle the 15-minute switch. If the selector's
+	// schedule ever changes, this filter must change with it. Validated live against
+	// appi-town-crier-shared on 2026-07-13: 17 watched authorities, vs 39 rows unfiltered with
+	// five ~2000h-old defunct-authority rows (Bromsgrove, Eden, Wellingborough, ...) on top.
+	const dashboardPollHWMByAuthorityQueryBody = `let watched = dependencies | where timestamp > ago(7d) | where customDimensions['deployment.environment'] == 'prod' | where name == 'Polling Cycle (SB)' | where datetime_part('minute', timestamp) % 30 < 15 | project operation_Id; dependencies | where timestamp > ago(7d) | where customDimensions['deployment.environment'] == 'prod' | where target == 'PlanIt search' | join kind=inner watched on operation_Id | extend url = tostring(customDimensions['url.full']) | extend AuthorityID = toint(extract('auth=([0-9]+)', 1, url)) | where isnotnull(AuthorityID) | summarize arg_max(timestamp, url) by AuthorityID | extend HWM = todatetime(extract('different_start=([0-9-]+)', 1, url)) | lookup kind=leftouter names on AuthorityID | project Authority = coalesce(Authority, tostring(AuthorityID)), ['HWM Date'] = format_datetime(HWM, 'yyyy-MM-dd'), ['HWM Age (h)'] = round((now() - HWM) / 1h, 1), ['Last Polled (h ago)'] = round((now() - timestamp) / 1h, 1) | order by ['HWM Age (h)'] desc`
 
 	// The names lookup is generated from api-go/internal/authorities/resources/authorities.json
 	// rather than hand-maintained, so it never drifts from the authority dataset the API itself


### PR DESCRIPTION
## What

The Poll HWM by Authority grid (#952) listed every authority polled in the last 7 days — including the **Seed** backfill sweep over all 485 authorities, whose defunct/quiet entries (HWMs from April, ~2000h) sat at the top of an operational dashboard despite never being action items. Now only **Watched**-cycle polls (authorities with at least one user watch zone) appear.

## How

Cycle type isn't stamped on any span, so the query classifies each cycle by its **root span's start minute** — `minute % 30 < 15` → Watched, mirroring `polling.MinuteCycleSelector` — and inner-joins the PlanIt search child spans to their root on `operation_Id`. Classification is per cycle start, so cycles that straddle the 15-minute boundary don't bleed. The coupling to the selector's schedule is called out in the query's doc comment.

Validated live against `appi-town-crier-shared` (2026-07-13): 17 watched authorities (oldest HWM 61h), vs 39 rows unfiltered with five ~2000h defunct-authority rows on top.

## Testing

- `go build ./...`, `go vet ./...`, `gofmt -l .` clean, `go test ./...` 12 passed, `golangci-lint run ./infra/...` clean.

Bead: tc-28k74 (discovered-from tc-yxrjs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011m6RwSgoj2TKz1J5Cfxykg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the “Poll HWM by Authority” dashboard tile to calculate high-water marks using only watched-cycle polling activity.
  * Updated polling dates, ages, and last-polled times to reflect the relevant watched-cycle data more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->