### PR TITLE
feat(infra): poll HWM grid covers full pollable set, hides dead PlanIt feeds (tc-f2c4m)

### DIFF
--- a/infra/shared.go
+++ b/infra/shared.go
@@ -1069,20 +1069,30 @@ expected
 	// `auth=<authority id>` and `different_start=<HWM date>` query params, from which this
 	// derives each authority's current high-water mark and how long ago it was last polled — one
 	// row per authority (arg_max de-dupes to the latest url.full seen per AuthorityID within the
-	// last 7 days), oldest HWM first.
+	// last 30 days), oldest HWM first.
 	//
-	// Only Watched-cycle polls count (tc-28k74): the grid is operational, so it lists just the
-	// authorities users actually watch, not the full 485-authority Seed backfill sweep — Seed
-	// rows are dominated by defunct/quiet authorities whose months-old HWMs are noise, never
-	// action items. A poll's cycle type isn't stamped on any span, so the `watched` prefix
-	// classifies each cycle by its ROOT span's start minute — minute%30 < 15 → Watched —
-	// mirroring polling.MinuteCycleSelector (api-go/internal/polling/authorities.go); child
-	// PlanIt spans join to their root on operation_Id, so classification is exact per cycle
-	// with no boundary bleed from cycles that straddle the 15-minute switch. If the selector's
-	// schedule ever changes, this filter must change with it. Validated live against
-	// appi-town-crier-shared on 2026-07-13: 17 watched authorities, vs 39 rows unfiltered with
-	// five ~2000h-old defunct-authority rows (Bromsgrove, Eden, Wellingborough, ...) on top.
-	const dashboardPollHWMByAuthorityQueryBody = `let watched = dependencies | where timestamp > ago(7d) | where customDimensions['deployment.environment'] == 'prod' | where name == 'Polling Cycle (SB)' | where datetime_part('minute', timestamp) % 30 < 15 | project operation_Id; dependencies | where timestamp > ago(7d) | where customDimensions['deployment.environment'] == 'prod' | where target == 'PlanIt search' | join kind=inner watched on operation_Id | extend url = tostring(customDimensions['url.full']) | extend AuthorityID = toint(extract('auth=([0-9]+)', 1, url)) | where isnotnull(AuthorityID) | summarize arg_max(timestamp, url) by AuthorityID | extend HWM = todatetime(extract('different_start=([0-9-]+)', 1, url)) | lookup kind=leftouter names on AuthorityID | project Authority = coalesce(Authority, tostring(AuthorityID)), ['HWM Date'] = format_datetime(HWM, 'yyyy-MM-dd'), ['HWM Age (h)'] = round((now() - HWM) / 1h, 1), ['Last Polled (h ago)'] = round((now() - timestamp) / 1h, 1) | order by ['HWM Age (h)'] desc`
+	// The grid covers the FULL pollable set — both Watched-cycle and Seed-backfill polls
+	// (tc-f2c4m; Seed keeps the whole dataset current so new users see a populated map, and its
+	// lag matters operationally) — minus dead PlanIt feeds: an authority whose HWM is >60 days
+	// old DESPITE being polled within the last 7 days is one PlanIt itself reports nothing new
+	// for (abolished districts like Eden/Wellingborough pinned at the April backfill start, and
+	// long-broken upstream scrapers). Both conditions must hold before a row is hidden: an
+	// ancient HWM with NO recent poll is our own starvation and must stay visible. The filter is
+	// behavioural, not a curated list — areaType can't express it (Broadland/Bromsgrove are
+	// live 'English District' entries with dead feeds) — and self-heals: a revived feed's first
+	// changed application advances its HWM and the row reappears.
+	//
+	// The Watched column marks authorities polled by a Watched cycle in the last 48h (~the
+	// current watch-zone set; a wider window would accumulate zone churn). Cycle type isn't
+	// stamped on any span, so the `watched` prefix classifies each cycle by its ROOT span's
+	// start minute — minute%30 < 15 → Watched — mirroring polling.MinuteCycleSelector
+	// (api-go/internal/polling/authorities.go); child PlanIt spans join to their root on
+	// operation_Id, so classification is exact per cycle with no boundary bleed. If the
+	// selector's schedule ever changes, this filter must change with it. Validated live against
+	// appi-town-crier-shared on 2026-07-13 (with --offset 30d — the az CLI default offset of 1h
+	// silently clips results regardless of the query's own ago() filter): 416 rows of the 461
+	// pollable authorities, 45 dead feeds hidden, 17 flagged Watched.
+	const dashboardPollHWMByAuthorityQueryBody = `let watched = dependencies | where timestamp > ago(48h) | where customDimensions['deployment.environment'] == 'prod' | where name == 'Polling Cycle (SB)' | where datetime_part('minute', timestamp) % 30 < 15 | distinct operation_Id; dependencies | where timestamp > ago(30d) | where customDimensions['deployment.environment'] == 'prod' | where target == 'PlanIt search' | extend url = tostring(customDimensions['url.full']) | extend AuthorityID = toint(extract('auth=([0-9]+)', 1, url)) | where isnotnull(AuthorityID) | join kind=leftouter watched on operation_Id | extend w = iff(isnotempty(operation_Id1), 1, 0) | summarize arg_max(timestamp, url), WatchedN=max(w) by AuthorityID | extend HWM = todatetime(extract('different_start=([0-9-]+)', 1, url)) | extend HWMAgeD = round((now() - HWM) / 1d, 1), LastPolledH = round((now() - timestamp) / 1h, 1) | where not(HWMAgeD > 60 and LastPolledH < 168) | lookup kind=leftouter names on AuthorityID | project Authority = coalesce(Authority, tostring(AuthorityID)), Watched = iff(WatchedN == 1, '✓', ''), ['HWM Date'] = format_datetime(HWM, 'yyyy-MM-dd'), ['HWM Age (d)'] = HWMAgeD, ['Last Polled (h)'] = LastPolledH | order by ['HWM Age (d)'] desc`
 
 	// The names lookup is generated from api-go/internal/authorities/resources/authorities.json
 	// rather than hand-maintained, so it never drifts from the authority dataset the API itself


### PR DESCRIPTION
## What

Revises the Poll HWM by Authority grid (#953) per updated requirements: Seed-cycle visibility is operationally valuable (it keeps the full dataset current for new users), so the grid now covers the **full pollable set** (461 authorities, 30-day window) rather than watched-only — and instead hides the **dead PlanIt feeds** that were the actual noise.

## How

- **Dead-feed filter (behavioural, self-healing):** a row is hidden only when its HWM is **>60 days** old **and** the authority was polled within the last **7 days** — i.e. PlanIt itself confirms nothing new. Both conditions must hold: ancient HWM without a recent poll is our own starvation and stays visible. A curated list or `areaType` filter can't express this — the abolished districts are `Council District`, but Broadland/Bromsgrove are live `English District` entries with dead feeds. If PlanIt revives a feed, its HWM advances and the row reappears.
- **Watched column:** ✓ marks authorities polled by a Watched cycle in the last 48h (≈ the current watch-zone set — a wider window accumulates zone churn; 30d flagged 170 authorities vs 17 current). Same minute%30 root-span classification as #953, now a leftouter join.
- Window widened 7d → 30d so lagged Seed coverage stays visible (daily authority coverage has been degraded since the PlanIt upstream issues began mid-June).

Validated live against `appi-town-crier-shared` (2026-07-13, `--offset 30d`): 416 rows, 45 dead feeds hidden (the ~2000h abolished-district cluster plus long-dead scrapers), 17 Watched. HWM-age distribution is cleanly bimodal: 415 authorities ≤30d, dead cluster at 80d+, six in between (PlanIt scraper decay: St Albans 63d, Portsmouth 77d, etc.).

## Testing

- `go build ./...`, `go vet ./...`, `gofmt -l .` clean, `go test ./...` 12 passed, `golangci-lint run ./infra/...` clean.

Bead: tc-f2c4m (discovered-from tc-28k74)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011m6RwSgoj2TKz1J5Cfxykg