### PR TITLE
fix(polling): preserve poll cursor on mid-drain fetch error (tc-ryf11)

### DIFF
--- a/api-go/internal/polling/handler.go
+++ b/api-go/internal/polling/handler.go
@@ -533,10 +533,15 @@ func (h *PollPlanItHandler) pollAuthority(ctx context.Context, authorityID int, 
 	return result
 }
 
-// finishAuthority persists the authority's advanced poll state. On a cap-hit or
-// mid-pagination 429 it freezes the HWM and saves a resumable cursor at the
-// next unfetched record index; on a natural end it advances the HWM to the max
-// LastDifferent observed and clears any cursor. State is only written when the
+// finishAuthority persists the authority's advanced poll state. Any early stop —
+// a cap-hit, or a mid-pagination 429 / fetch error after records were ingested —
+// freezes the HWM and saves a resumable cursor at the next unfetched record
+// index. Only a window that genuinely ran to its end (out.completed, no cap-hit)
+// advances the HWM to the max LastDifferent observed and clears the cursor:
+// clearing it on a fetch error would discard the drain progress of every prior
+// visit and, since the freshness probe only runs off an active cursor, silently
+// disable the newest-first ingest too (GH#958). LastPollTime advances on every
+// path so the scheduler rotates off the authority. State is only written when the
 // authority produced work (completed or saw applications).
 func (h *PollPlanItHandler) finishAuthority(
 	ctx context.Context,
@@ -555,10 +560,13 @@ func (h *PollPlanItHandler) finishAuthority(
 
 	rec := h.recorder()
 
-	if capHit || (out.rateLimited && out.appCount > 0) {
-		// Freeze HWM, save a resumable cursor at the next unfetched record index
-		// so the following cycle resumes there. LastPollTime still advances so
-		// the scheduler rotates off this authority.
+	if capHit || (out.appCount > 0 && (out.rateLimited || out.err != nil)) {
+		// Early stop (cap, 429 or fetch error): freeze HWM and save a resumable
+		// cursor at the next unfetched record index so the following cycle resumes
+		// there. nextIndex is from+len of the last SUCCESSFUL fetch, so a failing
+		// fetch contributes nothing and is simply re-read next visit (the resume
+		// overlap plus idempotent upserts make that harmless). LastPollTime still
+		// advances so the scheduler rotates off this authority.
 		cursor := &PollCursor{
 			DifferentStart: truncateToDate(existingHWM),
 			NextIndex:      nextIndex,
@@ -572,8 +580,11 @@ func (h *PollPlanItHandler) finishAuthority(
 		return out
 	}
 
-	// Natural end: advance HWM to the max LastDifferent observed, falling back to
-	// the existing HWM when the authority was quiet. Clear any active cursor.
+	// Natural end. Only a clean completion reaches here: out.completed is exactly
+	// (out.err == nil && !out.rateLimited), and the early return above has already
+	// dropped the completed-nothing case, so every early stop was caught by the
+	// cursor branch. Advance the HWM to the max LastDifferent observed, falling
+	// back to the existing HWM when the authority was quiet, and clear any cursor.
 	advancedHWM := existingHWM
 	if !highWaterMark.IsZero() {
 		advancedHWM = highWaterMark

--- a/api-go/internal/polling/handler_test.go
+++ b/api-go/internal/polling/handler_test.go
@@ -16,12 +16,24 @@ import (
 // --- hand-written fakes for the handler's dependencies ---
 
 // fakePlanIt serves pre-canned pages keyed by (authorityID, page) and can be
-// primed with a rate-limit or transient error per authority.
+// primed with a rate-limit or transient error per authority — either on every
+// fetch (errs) or on one specific fetch ordinal (nthErrs, via failNthFetch).
 type fakePlanIt struct {
 	pages   map[pageKey]planit.FetchPageResult
-	errs    map[int]error // authorityID -> error returned on every page fetch
+	errs    map[int]error      // authorityID -> error returned on every page fetch
+	nthErrs map[int]nthFailure // authorityID -> error returned on one fetch only
+	calls   map[int]int        // authorityID -> fetches served so far
 	fetched []pageKey
 	mu      sync.Mutex
+}
+
+// nthFailure primes a single failing fetch: err is returned on the nth fetch
+// (1-based, counting every fetch for that authority including the freshness
+// probe) and every other fetch is served normally. Models a PlanIt transport
+// timeout part-way through a drain.
+type nthFailure struct {
+	n   int
+	err error
 }
 
 // pageKey identifies one fake fetch: the authority, the requested 0-based
@@ -35,16 +47,32 @@ type pageKey struct {
 }
 
 func newFakePlanIt() *fakePlanIt {
-	return &fakePlanIt{pages: map[pageKey]planit.FetchPageResult{}, errs: map[int]error{}}
+	return &fakePlanIt{
+		pages:   map[pageKey]planit.FetchPageResult{},
+		errs:    map[int]error{},
+		nthErrs: map[int]nthFailure{},
+		calls:   map[int]int{},
+	}
+}
+
+// failNthFetch primes the fake to return err on the nth fetch for authorityID
+// (1-based, counting the freshness probe), serving every other fetch normally.
+func (f *fakePlanIt) failNthFetch(authorityID, n int, err error) {
+	f.nthErrs[authorityID] = nthFailure{n: n, err: err}
 }
 
 func (f *fakePlanIt) FetchApplicationsPage(_ context.Context, authorityID int, _ *time.Time, startIndex int, descending bool) (planit.FetchPageResult, error) {
 	key := pageKey{authority: authorityID, index: startIndex, descending: descending}
 	f.mu.Lock()
 	f.fetched = append(f.fetched, key)
+	f.calls[authorityID]++
+	nth := f.calls[authorityID]
 	f.mu.Unlock()
 	if err := f.errs[authorityID]; err != nil {
 		return planit.FetchPageResult{}, err
+	}
+	if fail, ok := f.nthErrs[authorityID]; ok && fail.n == nth {
+		return planit.FetchPageResult{}, fail.err
 	}
 	res, ok := f.pages[key]
 	if !ok {
@@ -532,6 +560,159 @@ func TestHandler_OmitsOldestHWMWhenNoActiveAuthorities(t *testing.T) {
 	}
 	if res.OldestHWMAgeSeconds != nil {
 		t.Errorf("OldestHWMAgeSeconds: got %v, want nil for an empty candidate set", *res.OldestHWMAgeSeconds)
+	}
+}
+
+// fullPage builds a 100-record page starting at index from, every record
+// carrying lastDifferent, with more pages behind it — the shape of a mid-drain
+// PlanIt page.
+func fullPage(from int, lastDifferent time.Time, total int) planit.FetchPageResult {
+	apps := make([]applications.PlanningApplication, 100)
+	for i := range apps {
+		apps[i] = testApp("app", 99, lastDifferent)
+	}
+	return planit.FetchPageResult{From: from, Applications: apps, HasMorePages: true, Total: platform.Ptr(total)}
+}
+
+// TestHandler_MidDrainFetchErrorFreezesHWMAndSavesCursor pins the GH#958 fix: a
+// PlanIt fetch error part-way through the drain must be treated as an early stop
+// (like a cap hit or a 429), not as a natural end of window. The HWM stays frozen
+// at the existing value and a resumable cursor is persisted at the next unfetched
+// record index, so the next visit resumes the drain instead of restarting the same
+// window from index 0 (which also silently disabled the freshness probe).
+func TestHandler_MidDrainFetchErrorFreezesHWMAndSavesCursor(t *testing.T) {
+	t.Parallel()
+	pi := newFakePlanIt()
+	hwm := time.Date(2026, 6, 13, 0, 0, 0, 0, time.UTC)
+	// Drain records sit inside the HWM's own churn day, exactly as on a large
+	// backlog: advancing the HWM to them would not move the date on at all.
+	ld := hwm.Add(9 * time.Hour)
+	pi.pages[pageKey{authority: 99, index: 0}] = fullPage(0, ld, 500)
+	pi.pages[pageKey{authority: 99, index: 100}] = fullPage(100, ld, 500)
+	// The third drain fetch times out after the first two ingested their records.
+	pi.failNthFetch(99, 3, errors.New("planit timeout after retries"))
+
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	state.states[99] = PollState{LastPollTime: hwm, HighWaterMark: hwm}
+	h := newHandler(t, pi, apps, state, fakeAuthorities{ids: []int{99}}, CycleSeed, defaultHandlerOpts())
+
+	res, err := h.Handle(context.Background())
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if res.AuthorityErrors != 1 {
+		t.Errorf("AuthorityErrors: got %d, want 1", res.AuthorityErrors)
+	}
+	if res.ApplicationCount != 200 {
+		t.Errorf("ApplicationCount: got %d, want 200 (two ingested fetches)", res.ApplicationCount)
+	}
+	if len(state.saves) != 1 {
+		t.Fatalf("state saves: got %d, want 1", len(state.saves))
+	}
+	save := state.saves[0]
+	if !save.highWaterMark.Equal(hwm) {
+		t.Errorf("HWM: got %v, want %v (frozen — a fetch error is not a completed window)", save.highWaterMark, hwm)
+	}
+	if !save.lastPollTime.Equal(time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)) {
+		t.Errorf("LastPollTime: got %v, want the pinned now (the scheduler must still rotate off)", save.lastPollTime)
+	}
+	cur := save.cursor
+	if cur == nil {
+		t.Fatal("cursor: got nil, want a resumable cursor at the next unfetched index")
+	}
+	if cur.NextIndex != 200 {
+		t.Errorf("cursor NextIndex: got %d, want 200 (from=100 + records=100 of the last SUCCESSFUL fetch)", cur.NextIndex)
+	}
+	if cur.KnownTotal == nil || *cur.KnownTotal != 500 {
+		t.Errorf("cursor KnownTotal: got %v, want 500 (preserved)", cur.KnownTotal)
+	}
+	if !cur.DifferentStart.Equal(hwm) {
+		t.Errorf("cursor DifferentStart: got %v, want %v", cur.DifferentStart, hwm)
+	}
+}
+
+// TestHandler_DrainErrorAfterProbeSavesCursorAtResumeIndex covers the probe-then-
+// error path: the probe ingested records (so the authority is past finishAuthority's
+// nothing-to-write early return) and the first drain fetch then failed. No drain
+// fetch succeeded, so the cursor must be persisted at the resume index it started
+// from — never cleared, which would destroy the drain progress of every prior visit.
+func TestHandler_DrainErrorAfterProbeSavesCursorAtResumeIndex(t *testing.T) {
+	t.Parallel()
+	pi := newFakePlanIt()
+	hwm := time.Date(2026, 6, 13, 0, 0, 0, 0, time.UTC)
+	probeLD := time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC)
+	pi.pages[pageKey{authority: 99, index: 0, descending: true}] = planit.FetchPageResult{
+		From: 0, Applications: []applications.PlanningApplication{testApp("newest", 99, probeLD)}, HasMorePages: false,
+	}
+	// Fetch 1 is the probe; fetch 2 is the first drain fetch (resume index 300).
+	pi.failNthFetch(99, 2, errors.New("planit timeout after retries"))
+
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	state.states[99] = PollState{
+		LastPollTime: hwm, HighWaterMark: hwm,
+		Cursor: &PollCursor{DifferentStart: hwm, NextIndex: 400, KnownTotal: platform.Ptr(500)},
+	}
+	h := newHandler(t, pi, apps, state, fakeAuthorities{ids: []int{99}}, CycleSeed, defaultHandlerOpts())
+
+	res, err := h.Handle(context.Background())
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if res.AuthorityErrors != 1 {
+		t.Errorf("AuthorityErrors: got %d, want 1", res.AuthorityErrors)
+	}
+	if len(state.saves) != 1 {
+		t.Fatalf("state saves: got %d, want 1", len(state.saves))
+	}
+	save := state.saves[0]
+	if !save.highWaterMark.Equal(hwm) {
+		t.Errorf("HWM: got %v, want %v (frozen)", save.highWaterMark, hwm)
+	}
+	if save.cursor == nil {
+		t.Fatal("cursor: got nil (cleared), want it preserved at the resume index")
+	}
+	if save.cursor.NextIndex != 300 {
+		t.Errorf("cursor NextIndex: got %d, want 300 (the resume index; the failing fetch contributed nothing)", save.cursor.NextIndex)
+	}
+}
+
+// TestHandler_ErroredVisitSpanReportsHWMNotAdvanced pins the telemetry half of
+// GH#958: the visit that stopped on a fetch error must report
+// polling.hwm_advanced=false, so a starving authority is visible on the poll
+// dashboard instead of masquerading as a cleanly drained window.
+// Deliberately not t.Parallel(): recordSpans mutates the global TracerProvider.
+func TestHandler_ErroredVisitSpanReportsHWMNotAdvanced(t *testing.T) {
+	pi := newFakePlanIt()
+	hwm := time.Date(2026, 6, 13, 0, 0, 0, 0, time.UTC)
+	ld := hwm.Add(9 * time.Hour)
+	pi.pages[pageKey{authority: 99, index: 0}] = fullPage(0, ld, 500)
+	pi.pages[pageKey{authority: 99, index: 100}] = fullPage(100, ld, 500)
+	pi.failNthFetch(99, 3, errors.New("planit timeout after retries"))
+
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	state.states[99] = PollState{LastPollTime: hwm, HighWaterMark: hwm}
+	h := newHandler(t, pi, apps, state, fakeAuthorities{ids: []int{99}}, CycleSeed, defaultHandlerOpts())
+
+	spans := recordSpans(t, func() {
+		if _, err := h.Handle(context.Background()); err != nil {
+			t.Fatalf("Handle: %v", err)
+		}
+	})
+	span, ok := spanNamed(spans, "PlanIt authority poll")
+	if !ok {
+		t.Fatalf("expected a %q span among %d recorded spans", "PlanIt authority poll", len(spans))
+	}
+	if v, ok := attrValue(span, "polling.hwm_advanced"); !ok || v.AsBool() {
+		t.Errorf("polling.hwm_advanced: got %v (ok=%v), want false (a fetch error freezes the HWM)", v, ok)
+	}
+	if v, ok := attrValue(span, "polling.cap_hit"); !ok || v.AsBool() {
+		t.Errorf("polling.cap_hit: got %v (ok=%v), want false (the drain stopped on an error, not the cap)", v, ok)
+	}
+	if v, ok := attrValue(span, "polling.next_index"); !ok || v.AsInt64() != 200 {
+		t.Errorf("polling.next_index: got %v (ok=%v), want 200", v, ok)
 	}
 }
 

--- a/api-go/internal/polling/handler_test.go
+++ b/api-go/internal/polling/handler_test.go
@@ -678,6 +678,75 @@ func TestHandler_DrainErrorAfterProbeSavesCursorAtResumeIndex(t *testing.T) {
 	}
 }
 
+// TestHandler_FirstDrainFetchErrorWithNoRecordsWritesNoState pins the boundary of
+// the GH#958 fix: an authority that errored on its first fetch, ingested nothing
+// and had no prior cursor has no progress to record, so finishAuthority's
+// nothing-to-write early return must still hold — no phantom cursor at index 0,
+// no LastPollTime bump.
+func TestHandler_FirstDrainFetchErrorWithNoRecordsWritesNoState(t *testing.T) {
+	t.Parallel()
+	pi := newFakePlanIt()
+	pi.failNthFetch(99, 1, errors.New("planit timeout after retries"))
+	apps := newFakeApps()
+	state := newFakeStateStore() // no PollState -> no cursor
+	h := newHandler(t, pi, apps, state, fakeAuthorities{ids: []int{99}}, CycleSeed, defaultHandlerOpts())
+
+	res, err := h.Handle(context.Background())
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if res.AuthorityErrors != 1 {
+		t.Errorf("AuthorityErrors: got %d, want 1", res.AuthorityErrors)
+	}
+	if res.ApplicationCount != 0 {
+		t.Errorf("ApplicationCount: got %d, want 0", res.ApplicationCount)
+	}
+	if len(state.saves) != 0 {
+		t.Errorf("state saves: got %+v, want none (nothing was ingested and there was no cursor)", state.saves)
+	}
+}
+
+// TestHandler_CleanNaturalEndAdvancesHWMAndClearsCursor asserts the behaviour the
+// GH#958 fix must preserve: a window that genuinely ran to its end (HasMorePages
+// false, no error) still advances the HWM to the max LastDifferent observed and
+// still clears the active cursor, so the next visit starts a fresh window.
+func TestHandler_CleanNaturalEndAdvancesHWMAndClearsCursor(t *testing.T) {
+	t.Parallel()
+	pi := newFakePlanIt()
+	hwm := time.Date(2026, 6, 13, 0, 0, 0, 0, time.UTC)
+	pi.pages[pageKey{authority: 99, index: 0, descending: true}] = planit.FetchPageResult{From: 0, HasMorePages: false}
+	// The drain resumes at max(0, 100-100)=0 and ends naturally on this last page.
+	drainLD := time.Date(2026, 6, 13, 18, 0, 0, 0, time.UTC)
+	pi.pages[pageKey{authority: 99, index: 0}] = planit.FetchPageResult{
+		From: 0, Applications: []applications.PlanningApplication{testApp("last", 99, drainLD)}, HasMorePages: false,
+	}
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	state.states[99] = PollState{
+		LastPollTime: hwm, HighWaterMark: hwm,
+		Cursor: &PollCursor{DifferentStart: hwm, NextIndex: 100, KnownTotal: platform.Ptr(500)},
+	}
+	h := newHandler(t, pi, apps, state, fakeAuthorities{ids: []int{99}}, CycleSeed, defaultHandlerOpts())
+
+	res, err := h.Handle(context.Background())
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if res.AuthorityErrors != 0 {
+		t.Errorf("AuthorityErrors: got %d, want 0", res.AuthorityErrors)
+	}
+	if len(state.saves) != 1 {
+		t.Fatalf("state saves: got %d, want 1", len(state.saves))
+	}
+	save := state.saves[0]
+	if !save.highWaterMark.Equal(drainLD) {
+		t.Errorf("HWM: got %v, want %v (a completed window advances the HWM)", save.highWaterMark, drainLD)
+	}
+	if save.cursor != nil {
+		t.Errorf("cursor: got %+v, want nil (a completed window clears the cursor)", save.cursor)
+	}
+}
+
 // TestHandler_ErroredVisitSpanReportsHWMNotAdvanced pins the telemetry half of
 // GH#958: the visit that stopped on a fetch error must report
 // polling.hwm_advanced=false, so a starving authority is visible on the poll

--- a/api-go/internal/polling/handler_test.go
+++ b/api-go/internal/polling/handler_test.go
@@ -55,12 +55,6 @@ func newFakePlanIt() *fakePlanIt {
 	}
 }
 
-// failNthFetch primes the fake to return err on the nth fetch for authorityID
-// (1-based, counting the freshness probe), serving every other fetch normally.
-func (f *fakePlanIt) failNthFetch(authorityID, n int, err error) {
-	f.nthErrs[authorityID] = nthFailure{n: n, err: err}
-}
-
 func (f *fakePlanIt) FetchApplicationsPage(_ context.Context, authorityID int, _ *time.Time, startIndex int, descending bool) (planit.FetchPageResult, error) {
 	key := pageKey{authority: authorityID, index: startIndex, descending: descending}
 	f.mu.Lock()
@@ -563,15 +557,20 @@ func TestHandler_OmitsOldestHWMWhenNoActiveAuthorities(t *testing.T) {
 	}
 }
 
+// fakeKnownTotal is the record count PlanIt reports on every paged fetch the
+// fullPage helper serves — the value the persisted cursor's KnownTotal must
+// carry through an interrupted drain.
+const fakeKnownTotal = 500
+
 // fullPage builds a 100-record page starting at index from, every record
 // carrying lastDifferent, with more pages behind it — the shape of a mid-drain
 // PlanIt page.
-func fullPage(from int, lastDifferent time.Time, total int) planit.FetchPageResult {
+func fullPage(from int, lastDifferent time.Time) planit.FetchPageResult {
 	apps := make([]applications.PlanningApplication, 100)
 	for i := range apps {
 		apps[i] = testApp("app", 99, lastDifferent)
 	}
-	return planit.FetchPageResult{From: from, Applications: apps, HasMorePages: true, Total: platform.Ptr(total)}
+	return planit.FetchPageResult{From: from, Applications: apps, HasMorePages: true, Total: platform.Ptr(fakeKnownTotal)}
 }
 
 // TestHandler_MidDrainFetchErrorFreezesHWMAndSavesCursor pins the GH#958 fix: a
@@ -587,10 +586,10 @@ func TestHandler_MidDrainFetchErrorFreezesHWMAndSavesCursor(t *testing.T) {
 	// Drain records sit inside the HWM's own churn day, exactly as on a large
 	// backlog: advancing the HWM to them would not move the date on at all.
 	ld := hwm.Add(9 * time.Hour)
-	pi.pages[pageKey{authority: 99, index: 0}] = fullPage(0, ld, 500)
-	pi.pages[pageKey{authority: 99, index: 100}] = fullPage(100, ld, 500)
+	pi.pages[pageKey{authority: 99, index: 0}] = fullPage(0, ld)
+	pi.pages[pageKey{authority: 99, index: 100}] = fullPage(100, ld)
 	// The third drain fetch times out after the first two ingested their records.
-	pi.failNthFetch(99, 3, errors.New("planit timeout after retries"))
+	pi.nthErrs[99] = nthFailure{n: 3, err: errors.New("planit timeout after retries")}
 
 	apps := newFakeApps()
 	state := newFakeStateStore()
@@ -624,8 +623,8 @@ func TestHandler_MidDrainFetchErrorFreezesHWMAndSavesCursor(t *testing.T) {
 	if cur.NextIndex != 200 {
 		t.Errorf("cursor NextIndex: got %d, want 200 (from=100 + records=100 of the last SUCCESSFUL fetch)", cur.NextIndex)
 	}
-	if cur.KnownTotal == nil || *cur.KnownTotal != 500 {
-		t.Errorf("cursor KnownTotal: got %v, want 500 (preserved)", cur.KnownTotal)
+	if cur.KnownTotal == nil || *cur.KnownTotal != fakeKnownTotal {
+		t.Errorf("cursor KnownTotal: got %v, want %d (preserved)", cur.KnownTotal, fakeKnownTotal)
 	}
 	if !cur.DifferentStart.Equal(hwm) {
 		t.Errorf("cursor DifferentStart: got %v, want %v", cur.DifferentStart, hwm)
@@ -646,7 +645,7 @@ func TestHandler_DrainErrorAfterProbeSavesCursorAtResumeIndex(t *testing.T) {
 		From: 0, Applications: []applications.PlanningApplication{testApp("newest", 99, probeLD)}, HasMorePages: false,
 	}
 	// Fetch 1 is the probe; fetch 2 is the first drain fetch (resume index 300).
-	pi.failNthFetch(99, 2, errors.New("planit timeout after retries"))
+	pi.nthErrs[99] = nthFailure{n: 2, err: errors.New("planit timeout after retries")}
 
 	apps := newFakeApps()
 	state := newFakeStateStore()
@@ -686,7 +685,7 @@ func TestHandler_DrainErrorAfterProbeSavesCursorAtResumeIndex(t *testing.T) {
 func TestHandler_FirstDrainFetchErrorWithNoRecordsWritesNoState(t *testing.T) {
 	t.Parallel()
 	pi := newFakePlanIt()
-	pi.failNthFetch(99, 1, errors.New("planit timeout after retries"))
+	pi.nthErrs[99] = nthFailure{n: 1, err: errors.New("planit timeout after retries")}
 	apps := newFakeApps()
 	state := newFakeStateStore() // no PollState -> no cursor
 	h := newHandler(t, pi, apps, state, fakeAuthorities{ids: []int{99}}, CycleSeed, defaultHandlerOpts())
@@ -756,9 +755,9 @@ func TestHandler_ErroredVisitSpanReportsHWMNotAdvanced(t *testing.T) {
 	pi := newFakePlanIt()
 	hwm := time.Date(2026, 6, 13, 0, 0, 0, 0, time.UTC)
 	ld := hwm.Add(9 * time.Hour)
-	pi.pages[pageKey{authority: 99, index: 0}] = fullPage(0, ld, 500)
-	pi.pages[pageKey{authority: 99, index: 100}] = fullPage(100, ld, 500)
-	pi.failNthFetch(99, 3, errors.New("planit timeout after retries"))
+	pi.pages[pageKey{authority: 99, index: 0}] = fullPage(0, ld)
+	pi.pages[pageKey{authority: 99, index: 100}] = fullPage(100, ld)
+	pi.nthErrs[99] = nthFailure{n: 3, err: errors.New("planit timeout after retries")}
 
 	apps := newFakeApps()
 	state := newFakeStateStore()
@@ -770,9 +769,13 @@ func TestHandler_ErroredVisitSpanReportsHWMNotAdvanced(t *testing.T) {
 			t.Fatalf("Handle: %v", err)
 		}
 	})
-	span, ok := spanNamed(spans, "PlanIt authority poll")
-	if !ok {
-		t.Fatalf("expected a %q span among %d recorded spans", "PlanIt authority poll", len(spans))
+	// One authority, so exactly one "PlanIt authority poll" span.
+	if len(spans) != 1 {
+		t.Fatalf("recorded spans: got %d, want 1", len(spans))
+	}
+	span := spans[0]
+	if span.Name() != "PlanIt authority poll" {
+		t.Fatalf("span name: got %q, want %q", span.Name(), "PlanIt authority poll")
 	}
 	if v, ok := attrValue(span, "polling.hwm_advanced"); !ok || v.AsBool() {
 		t.Errorf("polling.hwm_advanced: got %v (ok=%v), want false (a fetch error freezes the HWM)", v, ok)


### PR DESCRIPTION
Closes #958. Blocks-lifted for #955 PR B.

## What was broken

A PlanIt fetch error part-way through an authority's drain was treated as a natural end of window: `finishAuthority` advanced the high-water mark and **cleared the poll cursor**, discarding every record of drain progress. On a large backlog the HWM does not actually move (the ascending drain is still inside one churn day), so the authority restarted the same window from index 0 next visit, forever. It also silently disabled the freshness probe, which only runs off an active cursor, so that authority got no newest-first ingest either.

Pre-existing since before #955 PR A; PR A's new span is what made it visible.

## Prod evidence (2026-07-14)

Camden (auth=300, `different_start=2026-05-24`, `known_total=18150`) drained cleanly for 13 hours after v0.20.1, cursor climbing 2,600 → 7,000. At 11:09Z the fetch at `index=7000` timed out four times (30s each — the only PlanIt timeout across the whole fleet in 12 hours). The visit emitted `cap_hit=false`, `hwm_advanced=true`, and the cursor was cleared: 4,400 records of progress binned, HWM still 51.5 days stale.

## The fix

`finishAuthority`: the cursor-save branch now covers any early stop — cap-hit, 429, or fetch error after records were ingested — freezing the HWM and persisting the cursor at `nextIndex`. Only a clean completion advances the HWM and clears the cursor. `nextIndex` maths, `LastPollTime` advancement, and natural-end semantics are unchanged.

## Tests

Five new tests in `handler_test.go` (three were red before the fix): mid-drain error freezes HWM and saves the cursor at `from+len` of the last successful fetch with `KnownTotal` preserved; probe-then-drain-error saves the cursor at the resume index; an errored visit reports `polling.hwm_advanced=false`; plus characterisation tests pinning no-state-write and clean-natural-end. The `planItFetcher` fake gained Nth-fetch failure injection (hand-written, no mocking library). Existing cap-hit/429/probe/resume tests pass unchanged.

Gates: `gofmt -l` empty, `go build`, `go vet`, `golangci-lint run` 0 issues, `go test -race ./...` 1847 passed across 49 packages.

Follow-up filed as tc-m7ck7 (P3): on the probe-then-drain-error path the persisted cursor loses `KnownTotal`, so the dashboard Backlog column blanks for that authority until the next successful drain fetch. Cosmetic and self-healing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved polling recovery when errors occur after some applications have been processed.
  * Preserved resumable progress so interrupted polling can continue from the correct position.
  * Prevented incomplete polling runs from incorrectly advancing progress markers.
  * Ensured cleanly completed polling runs continue to advance progress and clear outdated resume information.
  * Improved handling of failures before any records are written, avoiding unnecessary state changes.

* **Monitoring**
  * Improved status reporting for polling runs that stop because of errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->