### PR TITLE
feat(polling): ADR 0041 churn-masked national delta poll — committed cutover (tc-5m3tw)

### DIFF
--- a/api-go/cmd/worker/main.go
+++ b/api-go/cmd/worker/main.go
@@ -222,12 +222,23 @@ func run() int {
 }
 
 // buildPollOrchestrator wires the poll-sb orchestrator: the PlanIt client, the
-// Postgres poll-state and lease stores, the cycle-alternating authority provider,
-// the ingestion handler, and the next-run scheduler — bridged to the
-// receive/publish operations of the shared Service Bus client. It returns
-// (nil, nil) when Service Bus config is absent, so poll-sb refuses to run rather
-// than nil-panicking. The cycle budget (replicaTimeout − grace) and the
+// Postgres poll-state and lease stores, ADR 0041's three national delta lanes
+// (A/B/C), and the next-run scheduler — bridged to the receive/publish
+// operations of the shared Service Bus client. It returns (nil, nil) when
+// Service Bus config is absent, so poll-sb refuses to run rather than
+// nil-panicking. The cycle budget (replicaTimeout − grace) and the
 // handler/lease budgets all come from config.
+//
+// ADR 0041 / GH#962 (bead tc-5m3tw) replaced the per-authority drain this
+// function used to build — the LRU authority selection, the watched/seed
+// cycle alternation, and the per-authority cursor/high-water-mark handler —
+// with a single national query per lane and one global watermark per lane.
+// That old wiring (polling.NewMinuteCycleSelector, NewCycleAlternatingProvider,
+// NewWatchZoneAuthorityProvider, NewPollPlanItHandler) is left compiling but
+// unwired (the ADR's explicit migration posture: rollback is a config change,
+// not a revert). NewAllAuthorityProvider is the one exception — it is
+// REWIRED below as Lane C's per-authority sweep target, the same pollable-
+// authority list the old Seed cycle drained.
 func buildPollOrchestrator(cfg platform.Config, sbClient *servicebus.Client, registry *metrics.Registry, st *stores, logger *slog.Logger) (*pollOrchestratorAdapter, error) {
 	if sbClient == nil {
 		return nil, nil //nolint:nilnil // absent Service Bus config is a valid "no poller" state, not an error
@@ -243,51 +254,73 @@ func buildPollOrchestrator(cfg platform.Config, sbClient *servicebus.Client, reg
 			InitialBackoff:   secondsToDuration(cfg.PlanItInitialBackoffSeconds),
 			RateLimitBackoff: secondsToDuration(cfg.PlanItRateLimitBackoffSeconds),
 		},
-		Metrics:  registry,
+		Metrics: registry,
+		// PageSize governs only the legacy per-authority FetchApplicationsPage
+		// path (unwired below); the national lanes hardcode pg_sz=300
+		// (planit.nationalPageSize) — a fixed safety rule, not a config dial.
 		PageSize: cfg.PollingPlanItPageSize,
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	// appStore and zoneStore are the Postgres stores the poll handler (Upsert +
-	// change dedup) and the watch-zone notify fan-out (FindZonesContaining) consume.
+	// appStore and zoneStore are the Postgres stores every lane's ingester
+	// (Upsert + change dedup) and the watch-zone notify fan-out
+	// (FindZonesContaining) consume.
 	appStore := st.app
 	zoneStore := st.zone
 
 	var stateStore polling.PollStateAccess = st.pollState
 	var leaseStore polling.LeaseAccess = st.lease
 
-	cycleSelector := polling.NewMinuteCycleSelector(time.Now)
-	authorityProvider := polling.NewCycleAlternatingProvider(
-		polling.NewWatchZoneAuthorityProvider(zoneStore),
-		polling.NewAllAuthorityProvider(authorities.NewLookup()),
-		cycleSelector,
-	)
-
-	maxPages := cfg.PollingMaxPagesPerAuthorityPerCycle
-	handler := polling.NewPollPlanItHandler(
-		planItClient,
-		appStore,
-		stateStore,
-		authorityProvider,
-		cycleSelector,
-		polling.HandlerOptions{
-			MaxPagesPerAuthorityPerCycle: &maxPages,
-			HandlerBudget:                secondsToDuration(float64(cfg.PollingHandlerBudgetSeconds)),
+	// Lane A (new applications) and Lane B (decisions): the national
+	// churn-masked delta poll. Each lane owns ONE global watermark (persisted
+	// in the existing poll_state table via a reserved sentinel authority_id —
+	// no schema migration) instead of the retired per-authority cursors.
+	laneA := polling.NewNationalLaneHandler(
+		planItClient, stateStore, appStore,
+		polling.NationalLaneOptions{
+			Lane:       polling.LaneA,
+			Mask:       planit.MaskStartDate,
+			MaskWindow: time.Duration(cfg.PollingLaneAMaskDays) * 24 * time.Hour,
+			MaxPages:   nil, // unbounded: the national delta is measured at ~6 pages/day (ADR 0041)
 		},
-		time.Now,
-		logger,
+		time.Now, logger,
 	)
-	// Record the towncrier.polling.* per-cycle / per-authority KPIs (tc-21np).
-	handler.WithMetrics(registry)
+	laneBMaxPages := cfg.PollingLaneBMaxPages
+	laneB := polling.NewNationalLaneHandler(
+		planItClient, stateStore, appStore,
+		polling.NationalLaneOptions{
+			Lane:       polling.LaneB,
+			Mask:       planit.MaskDecidedStart,
+			MaskWindow: time.Duration(cfg.PollingLaneBMaskDays) * 24 * time.Hour,
+			MaxPages:   &laneBMaxPages, // decision volume is unmeasured pre-cutover; do not remove this cap
+		},
+		time.Now, logger,
+	)
 
-	// Wire the poll-path notification fan-out: each upserted application drives a
-	// decision-event dispatch (on a non-decision -> decision transition) and a
-	// watch-zone notification fan-out.
-	// This is the CUTOVER-BLOCKER fan-out (bead tc-uc2p) — without it the
-	// Notifications table stays empty and every alert/digest breaks.
-	wirePollFanOut(cfg, handler, zoneStore, registry, st, logger)
+	// Lane C (reconciliation): a weekly (config-dialable) per-authority
+	// completeness backstop, not on the cutover's critical path. Reuses the
+	// static pollable-authority list the old Seed cycle drained.
+	laneC := polling.NewReconciliationHandler(
+		planItClient, stateStore, appStore,
+		polling.NewAllAuthorityProvider(authorities.NewLookup()),
+		polling.ReconciliationOptions{
+			Interval:                  time.Duration(cfg.PollingLaneCIntervalHours) * time.Hour,
+			MaxStragglersPerAuthority: cfg.PollingLaneCMaxStragglersPerAuthority,
+		},
+		time.Now, logger,
+	)
+
+	handler := polling.NewNationalPollHandler(laneA, laneB, laneC, time.Now, logger)
+
+	// Wire the poll-path notification fan-out onto all three lanes: each
+	// upserted/hydrated application drives a decision-event dispatch (on a
+	// non-decision -> decision transition) and a watch-zone notification
+	// fan-out, unchanged from the old drain (GH#784, tc-uc2p — the
+	// CUTOVER-BLOCKER fan-out; without it the Notifications table stays
+	// empty and every alert/digest breaks).
+	wirePollFanOut(cfg, laneA, laneB, laneC, handler, zoneStore, registry, st, logger)
 
 	scheduler := polling.NewNextRunScheduler(polling.DefaultSchedulerOptions(), polling.NewRandomJitter())
 
@@ -329,20 +362,23 @@ func buildPollOrchestrator(cfg platform.Config, sbClient *servicebus.Client, reg
 // wirePollFanOut builds the poll-path notification fan-out collaborators — the
 // decision-event dispatcher, the watch-zone enqueuer, and the push coalescer
 // that batches the cycle's queued pushes into at most one per (user, watch
-// zone) — and attaches them to the ingestion handler (GH#784). They share the
-// WatchZones store with the poll's authority provider (the same watchzones.Store
-// satisfies the zone-containment lookup and the coalescer's zone-name
-// resolution) and the Postgres Notifications / Users / NotificationState /
-// DeviceRegistrations / SavedApplications stores. zoneStore is the same Postgres
-// watchzones.Store from buildPollOrchestrator so FindZonesContaining already runs
-// against the right backend. The APNs push sender is real when its credentials
-// are present, NoOp otherwise so the poll job boots even without APNs config (the
-// record is still written, so the digest pipeline keeps working).
+// zone) — and attaches them to all three ADR 0041 lanes (GH#784). They share
+// the WatchZones store with Lane C's authority provider (the same
+// watchzones.Store satisfies the zone-containment lookup and the coalescer's
+// zone-name resolution) and the Postgres Notifications / Users /
+// NotificationState / DeviceRegistrations / SavedApplications stores.
+// zoneStore is the same Postgres watchzones.Store from buildPollOrchestrator
+// so FindZonesContaining already runs against the right backend. The APNs
+// push sender is real when its credentials are present, NoOp otherwise so the
+// poll job boots even without APNs config (the record is still written, so
+// the digest pipeline keeps working). The push coalescer is wired onto the
+// top-level handler, not the individual lanes: one Reset/Flush per cycle
+// covers every lane's pushes, mirroring the old drain's single flush point.
 //
 // st may be nil in tests that only exercise the zone-containment path; the store
 // fields are extracted under a nil guard so the fan-out wires with no other
 // store dependency.
-func wirePollFanOut(cfg platform.Config, handler *polling.PollPlanItHandler, zoneStore watchzones.Store, registry *metrics.Registry, st *stores, logger *slog.Logger) {
+func wirePollFanOut(cfg platform.Config, laneA, laneB *polling.NationalLaneHandler, laneC *polling.ReconciliationHandler, handler *polling.NationalPollHandler, zoneStore watchzones.Store, registry *metrics.Registry, st *stores, logger *slog.Logger) {
 	dispatcher, enqueuer, coalescer := buildNotifyFanOut(cfg, zoneStore, st, logger)
 
 	// Record towncrier.notifications.created on each dispatcher (tc-21np). Only
@@ -351,7 +387,9 @@ func wirePollFanOut(cfg platform.Config, handler *polling.PollPlanItHandler, zon
 	enqueuer = enqueuer.WithMetrics(registry)
 	dispatcher = dispatcher.WithMetrics(registry)
 
-	handler.WithFanOut(dispatcher, enqueuer)
+	laneA.WithFanOut(dispatcher, enqueuer)
+	laneB.WithFanOut(dispatcher, enqueuer)
+	laneC.WithFanOut(dispatcher, enqueuer)
 	handler.WithPushFlusher(coalescer)
 }
 

--- a/api-go/cmd/worker/wiring_test.go
+++ b/api-go/cmd/worker/wiring_test.go
@@ -18,9 +18,10 @@ import (
 
 // pollAppConsumer mirrors polling's unexported applicationStore: the exact slice
 // of applications.Store the poll handler consumes — the change-dedup read and the
-// Upsert write the poll cycle performs. The worker hands NewPollPlanItHandler the
-// applications.Store interface, so that interface must satisfy this contract for
-// the poll Upsert to reach the store.
+// Upsert write the poll cycle performs. The worker hands each ADR 0041 lane
+// (NewNationalLaneHandler / NewReconciliationHandler) the applications.Store
+// interface, so that interface must satisfy this contract for the poll Upsert
+// to reach the store.
 type pollAppConsumer interface {
 	GetByUID(ctx context.Context, uid, authorityCode string) (applications.PlanningApplication, bool, error)
 	Upsert(ctx context.Context, a applications.PlanningApplication) error
@@ -60,12 +61,15 @@ func testRegistry() *metrics.Registry {
 func TestWirePollFanOut_AcceptsZoneStoreInterface(t *testing.T) {
 	t.Parallel()
 
-	handler := &polling.PollPlanItHandler{}
+	laneA := &polling.NationalLaneHandler{}
+	laneB := &polling.NationalLaneHandler{}
+	laneC := &polling.ReconciliationHandler{}
+	handler := &polling.NationalPollHandler{}
 	spy := newSpyZoneStore()
 
 	// wirePollFanOut must accept the watchzones.Store interface (the spy) and wire
-	// the fan-out onto the handler without panicking on a nil stores pointer.
-	wirePollFanOut(platform.Config{}, handler, spy, testRegistry(), nil, discardLogger())
+	// the fan-out onto all three lanes without panicking on a nil stores pointer.
+	wirePollFanOut(platform.Config{}, laneA, laneB, laneC, handler, spy, testRegistry(), nil, discardLogger())
 }
 
 // TestEnqueuer_FindZonesContainingFlowsThroughInterface proves the notify fan-out

--- a/api-go/internal/planit/client.go
+++ b/api-go/internal/planit/client.go
@@ -196,8 +196,22 @@ func NewClient(opts Options) (*Client, error) {
 // retries transient failures, and surfaces 429 as *RateLimitError.
 func (c *Client) FetchApplicationsPage(ctx context.Context, authorityID int, differentStart *time.Time, startIndex int, descending bool) (FetchPageResult, error) {
 	target := c.baseURL + buildPath(authorityID, differentStart, startIndex, descending, c.pageSize)
+	return c.fetchPage(ctx, target, authorityID, startIndex, c.pageSize)
+}
 
-	resp, err := c.sendWithThrottle(ctx, target, authorityID)
+// fetchPage sends target, classifies the response, decodes the PlanIt
+// envelope, and maps its records to the domain snapshot. It is the shared tail
+// end of every fetch method — the per-authority drain (FetchApplicationsPage),
+// the ADR 0041 national delta lanes (FetchNationalDeltaPage), Lane C's light
+// per-authority sweep (FetchReconciliationPage), and its single-uid hydration
+// lookup (FetchByUID) — so the classify/decode/zero-progress logic lives in
+// exactly one place. authorityIDForMetrics tags the http-error counter only; a
+// national or uid-scoped request has no single owning authority, so callers
+// pass 0. pageSize drives both the zero-progress guard's "from < total"
+// comparison context and the length-heuristic HasMorePages fallback for a
+// response that omits total.
+func (c *Client) fetchPage(ctx context.Context, target string, authorityIDForMetrics, startIndex, pageSize int) (FetchPageResult, error) {
+	resp, err := c.sendWithThrottle(ctx, target, authorityIDForMetrics)
 	if err != nil {
 		return FetchPageResult{}, err
 	}
@@ -233,14 +247,14 @@ func (c *Client) FetchApplicationsPage(ctx context.Context, authorityID int, dif
 
 	// Zero-progress guard: PlanIt reporting more records remain (from < total)
 	// while returning none this fetch would livelock a caller that blindly
-	// resumes at the same index forever. Treat it as a hard authority error
-	// instead — the poll handler's existing per-authority error path skips to
-	// the next authority and retries this one next cycle.
+	// resumes at the same index forever. Treat it as a hard fetch error
+	// instead — every caller's existing per-unit (authority/lane) error path
+	// skips to the next unit and retries this one next cycle.
 	if len(apps) == 0 && parsed.Total != nil && from < *parsed.Total {
-		return FetchPageResult{}, fmt.Errorf("planit authority %d at index %d: %w", authorityID, startIndex, ErrZeroProgress)
+		return FetchPageResult{}, fmt.Errorf("planit fetch (authority %d) at index %d: %w", authorityIDForMetrics, startIndex, ErrZeroProgress)
 	}
 
-	hasMorePages := len(apps) >= c.pageSize
+	hasMorePages := len(apps) >= pageSize
 	if parsed.Total != nil {
 		hasMorePages = from+len(apps) < *parsed.Total
 	}

--- a/api-go/internal/planit/national.go
+++ b/api-go/internal/planit/national.go
@@ -1,0 +1,149 @@
+// ADR 0041 / GH#962: the churn-masked national delta poll. This file adds the
+// query shapes the old per-authority drain (client.go) never needed: a
+// national (no-auth) query masked by start_date or decided_start so the
+// re-index churn that dominates the raw last_different axis is filtered out
+// upstream, a select projection (mandatory on every one of these requests —
+// PlanIt's other_fields is ~60% of a record's bytes and nothing here reads it
+// back), and compress=on. FetchApplicationsPage (client.go) is unchanged and
+// untouched by this file.
+package planit
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// nationalPageSize is the pg_sz sent on every Lane A/B/C request (ADR 0041):
+// PlanIt's own documented default, which its docs explicitly ask callers not
+// to raise ("please don't try to get all the data in one request by setting
+// this as your default page size"). Deliberately NOT Options.PageSize (which
+// still governs the legacy per-authority FetchApplicationsPage drain,
+// unwired but left compiling) — pg_sz=300 is a fixed safety rule for the new
+// lanes, not an operator-tunable dial that could be raised by accident.
+const nationalPageSize = 300
+
+// uidPageSize is the pg_sz sent on a single-uid hydration lookup (Lane C):
+// exactly one record is ever expected back.
+const uidPageSize = 1
+
+// ingestSelectFields lists every field the ingest pipeline consumes (ADR 0041
+// / GH#962), in the exact order the build spec gives. last_different — the
+// field every lane sorts on — MUST be present here: PlanIt 400s if a sort
+// field is absent from select.
+var ingestSelectFields = []string{
+	"name", "uid", "area_name", "area_id", "address", "postcode", "description",
+	"app_type", "app_state", "app_size", "start_date", "decided_date", "consulted_date",
+	"location_x", "location_y", "url", "link", "last_different", "reference", "altid",
+	"associated_id", "last_changed", "last_scraped", "scraper_name",
+}
+
+// reconciliationSelectFields is Lane C's light projection (ADR 0041): just
+// enough to detect a straggler — a row whose PlanIt state has drifted from
+// what Postgres holds — without paying for the full ~778 bytes/record ingest
+// set.
+var reconciliationSelectFields = []string{"uid", "app_state", "decided_date", "last_different"}
+
+// MaskParam names the churn-mask query parameter ADR 0041 defines: Lane A
+// masks on start_date (the council's own date, which a PlanIt re-index cannot
+// move); Lane B masks on decided_start for the same reason, scoped to
+// decisions.
+type MaskParam string
+
+// MaskStartDate and MaskDecidedStart are the only two valid MaskParam values.
+const (
+	MaskStartDate    MaskParam = "start_date"
+	MaskDecidedStart MaskParam = "decided_start"
+)
+
+// NationalDeltaQuery configures one Lane A/B national delta-poll fetch: no
+// auth param (national, no per-authority scope), a coarse date-granular
+// different_start prefilter, a churn mask (field + cutoff), and the page's
+// 0-based record offset. FetchNationalDeltaPage always sorts descending
+// (-last_different), pages at pg_sz=300, and requests the ingest select
+// projection with compress=on.
+type NationalDeltaQuery struct {
+	// DifferentStart is the coarse, date-granular different_start prefilter —
+	// the calling lane's in-memory watermark's calendar date (or, on a lane's
+	// first-ever run, the mask cutoff date itself, since there is no prior
+	// watermark to prefilter on). This alone does NOT give exact delta
+	// semantics (different_start is date-granular); the descending sort plus
+	// the caller's in-memory timestamp watermark does that.
+	DifferentStart time.Time
+	// Mask is which date field narrows the query to genuinely new/changed
+	// records: MaskStartDate (Lane A) or MaskDecidedStart (Lane B).
+	Mask MaskParam
+	// MaskCutoff is the mask's cutoff date (today minus the configured mask
+	// window).
+	MaskCutoff time.Time
+	// StartIndex is this page's 0-based record offset (index=).
+	StartIndex int
+}
+
+// FetchNationalDeltaPage fetches one page of PlanIt's national churn-masked
+// delta query (ADR 0041 Lane A/B): no auth param, sort=-last_different,
+// pg_sz=300, the full ingest select projection, and compress=on. Throttling,
+// retry, and 429 handling are identical to FetchApplicationsPage.
+func (c *Client) FetchNationalDeltaPage(ctx context.Context, q NationalDeltaQuery) (FetchPageResult, error) {
+	target := c.baseURL + buildNationalDeltaPath(q)
+	return c.fetchPage(ctx, target, 0, q.StartIndex, nationalPageSize)
+}
+
+// FetchReconciliationPage fetches one page of Lane C's light per-authority
+// projection (ADR 0041): select=uid,app_state,decided_date,last_different,
+// sorted newest-touched-first, pg_sz=300, scoped to authorityID.
+func (c *Client) FetchReconciliationPage(ctx context.Context, authorityID, startIndex int) (FetchPageResult, error) {
+	target := c.baseURL + buildReconciliationPath(authorityID, startIndex)
+	return c.fetchPage(ctx, target, authorityID, startIndex, nationalPageSize)
+}
+
+// FetchByUID hydrates one straggler Lane C flagged: a single-record fetch via
+// PlanIt's id_match filter, with the full ingest select projection. Whether
+// id_match accepts a comma-separated uid list is unproven (ADR 0041), so this
+// deliberately fetches one uid at a time — the ADR's explicitly sanctioned
+// fallback.
+func (c *Client) FetchByUID(ctx context.Context, uid string) (FetchPageResult, error) {
+	target := c.baseURL + buildUIDPath(uid)
+	return c.fetchPage(ctx, target, 0, 0, uidPageSize)
+}
+
+// selectParam joins a select-field list into PlanIt's comma-separated query
+// value.
+func selectParam(fields []string) string {
+	return strings.Join(fields, ",")
+}
+
+// buildNationalDeltaPath builds the Lane A/B national query path: no auth,
+// different_start (the coarse prefilter), the mask param, sort=-last_different,
+// pg_sz=300, index, the ingest select projection (which contains
+// last_different, satisfying PlanIt's "sort field must be selected" rule), and
+// compress=on.
+func buildNationalDeltaPath(q NationalDeltaQuery) string {
+	return fmt.Sprintf(
+		"/api/applics/json?different_start=%s&%s=%s&sort=-last_different&pg_sz=%d&index=%d&select=%s&compress=on",
+		q.DifferentStart.UTC().Format("2006-01-02"),
+		q.Mask,
+		q.MaskCutoff.UTC().Format("2006-01-02"),
+		nationalPageSize,
+		q.StartIndex,
+		selectParam(ingestSelectFields),
+	)
+}
+
+// buildReconciliationPath builds Lane C's light per-authority projection path.
+func buildReconciliationPath(authorityID, startIndex int) string {
+	return fmt.Sprintf(
+		"/api/applics/json?auth=%d&sort=-last_different&pg_sz=%d&index=%d&select=%s&compress=on",
+		authorityID, nationalPageSize, startIndex, selectParam(reconciliationSelectFields),
+	)
+}
+
+// buildUIDPath builds Lane C's single-record hydration path.
+func buildUIDPath(uid string) string {
+	return fmt.Sprintf(
+		"/api/applics/json?id_match=%s&pg_sz=%d&select=%s&compress=on",
+		url.QueryEscape(uid), uidPageSize, selectParam(ingestSelectFields),
+	)
+}

--- a/api-go/internal/planit/national_test.go
+++ b/api-go/internal/planit/national_test.go
@@ -1,0 +1,240 @@
+package planit
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestBuildNationalDeltaPath pins the Lane A/B query shape (ADR 0041 / GH#962):
+// the mask, the coarse different_start prefilter, the descending sort, a
+// select projection containing the sort field, no auth param, pg_sz=300, and
+// compress=on.
+func TestBuildNationalDeltaPath(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		mask          MaskParam
+		wantMaskParam string
+	}{
+		{name: "lane A masks on start_date", mask: MaskStartDate, wantMaskParam: "start_date"},
+		{name: "lane B masks on decided_start", mask: MaskDecidedStart, wantMaskParam: "decided_start"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			q := NationalDeltaQuery{
+				DifferentStart: time.Date(2026, 7, 14, 0, 0, 0, 0, time.UTC),
+				Mask:           tc.mask,
+				MaskCutoff:     time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC),
+				StartIndex:     300,
+			}
+			path := buildNationalDeltaPath(q)
+
+			u, err := url.Parse(path)
+			if err != nil {
+				t.Fatalf("parse built path %q: %v", path, err)
+			}
+			got := u.Query()
+
+			if got.Get("different_start") != "2026-07-14" {
+				t.Errorf("different_start prefilter: got %q, want 2026-07-14", got.Get("different_start"))
+			}
+			if got.Get(tc.wantMaskParam) != "2026-04-15" {
+				t.Errorf("mask %s: got %q, want 2026-04-15", tc.wantMaskParam, got.Get(tc.wantMaskParam))
+			}
+			if got.Get("sort") != "-last_different" {
+				t.Errorf("sort: got %q, want -last_different", got.Get("sort"))
+			}
+			if got.Get("pg_sz") != "300" {
+				t.Errorf("pg_sz: got %q, want 300", got.Get("pg_sz"))
+			}
+			if got.Get("compress") != "on" {
+				t.Errorf("compress: got %q, want on", got.Get("compress"))
+			}
+			if got.Get("index") != "300" {
+				t.Errorf("index: got %q, want 300", got.Get("index"))
+			}
+			if got.Has("auth") {
+				t.Error("national query must not carry an auth param")
+			}
+			fields := strings.Split(got.Get("select"), ",")
+			if !containsString(fields, "last_different") {
+				t.Errorf("select must contain the sort field last_different: got %v", fields)
+			}
+		})
+	}
+}
+
+// TestBuildReconciliationPath pins Lane C's light per-authority projection
+// shape: scoped by auth, the light select set (containing the sort field),
+// pg_sz=300, compress=on.
+func TestBuildReconciliationPath(t *testing.T) {
+	t.Parallel()
+	path := buildReconciliationPath(99, 0)
+	u, err := url.Parse(path)
+	if err != nil {
+		t.Fatalf("parse built path %q: %v", path, err)
+	}
+	got := u.Query()
+
+	if got.Get("auth") != "99" {
+		t.Errorf("auth: got %q, want 99", got.Get("auth"))
+	}
+	if got.Get("pg_sz") != "300" {
+		t.Errorf("pg_sz: got %q, want 300", got.Get("pg_sz"))
+	}
+	if got.Get("compress") != "on" {
+		t.Errorf("compress: got %q, want on", got.Get("compress"))
+	}
+	fields := strings.Split(got.Get("select"), ",")
+	if !containsString(fields, "last_different") {
+		t.Errorf("select must contain the sort field last_different: got %v", fields)
+	}
+	if containsString(fields, "name") {
+		t.Errorf("reconciliation select must stay a light projection, not the full ingest set: got %v", fields)
+	}
+}
+
+// TestBuildUIDPath pins Lane C's single-record hydration shape: id_match, the
+// full ingest select set, a minimal page size.
+func TestBuildUIDPath(t *testing.T) {
+	t.Parallel()
+	path := buildUIDPath("24/0001/FUL")
+	u, err := url.Parse(path)
+	if err != nil {
+		t.Fatalf("parse built path %q: %v", path, err)
+	}
+	got := u.Query()
+
+	if got.Get("id_match") != "24/0001/FUL" {
+		t.Errorf("id_match: got %q, want 24/0001/FUL", got.Get("id_match"))
+	}
+	if got.Get("pg_sz") != "1" {
+		t.Errorf("pg_sz: got %q, want 1", got.Get("pg_sz"))
+	}
+	fields := strings.Split(got.Get("select"), ",")
+	if !containsString(fields, "area_id") {
+		t.Errorf("uid hydration must request the full ingest set (area_id needed for authority partitioning): got %v", fields)
+	}
+}
+
+// TestFetchNationalDeltaPage_SendsExpectedQueryAndParsesResponse drives the
+// client end-to-end against an httptest server on localhost (never
+// planit.org.uk): the request the client actually sends carries every
+// mandatory query param, and the response maps back into the domain snapshot.
+func TestFetchNationalDeltaPage_SendsExpectedQueryAndParsesResponse(t *testing.T) {
+	t.Parallel()
+	body := `{"total":1717,"pg_sz":300,"from":0,"records":[
+		{"name":"26/0001","uid":"26/0001/FUL","area_name":"Camden","area_id":300,"address":"1 High St","description":"A shed","app_type":"Full","app_state":"Undecided","start_date":"2026-07-01","location_x":-0.1,"location_y":51.5,"last_different":"2026-07-14T09:00:00.123456"}
+	]}`
+	var gotQuery url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	clock := &fakeClock{}
+	c := newTestClient(t, srv.URL, clock)
+
+	q := NationalDeltaQuery{
+		DifferentStart: time.Date(2026, 7, 14, 0, 0, 0, 0, time.UTC),
+		Mask:           MaskStartDate,
+		MaskCutoff:     time.Date(2026, 4, 16, 0, 0, 0, 0, time.UTC),
+		StartIndex:     0,
+	}
+	res, err := c.FetchNationalDeltaPage(context.Background(), q)
+	if err != nil {
+		t.Fatalf("FetchNationalDeltaPage: %v", err)
+	}
+
+	if gotQuery.Get("different_start") != "2026-07-14" ||
+		gotQuery.Get("start_date") != "2026-04-16" ||
+		gotQuery.Get("sort") != "-last_different" ||
+		gotQuery.Get("pg_sz") != "300" ||
+		gotQuery.Get("compress") != "on" ||
+		gotQuery.Has("auth") {
+		t.Errorf("unexpected request query: %s", gotQuery.Encode())
+	}
+
+	if res.Total == nil || *res.Total != 1717 {
+		t.Errorf("Total: got %v, want 1717", res.Total)
+	}
+	if len(res.Applications) != 1 || res.Applications[0].UID != "26/0001/FUL" {
+		t.Fatalf("Applications: got %+v", res.Applications)
+	}
+	wantLastDifferent := time.Date(2026, 7, 14, 9, 0, 0, 123456000, time.UTC)
+	if !res.Applications[0].LastDifferent.Equal(wantLastDifferent) {
+		t.Errorf("LastDifferent: got %v, want %v", res.Applications[0].LastDifferent, wantLastDifferent)
+	}
+}
+
+// TestFetchNationalDeltaPage_RateLimited proves a 429 surfaces as
+// *RateLimitError, identically to FetchApplicationsPage.
+func TestFetchNationalDeltaPage_RateLimited(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "30")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	t.Cleanup(srv.Close)
+
+	clock := &fakeClock{}
+	c := newTestClient(t, srv.URL, clock)
+
+	_, err := c.FetchNationalDeltaPage(context.Background(), NationalDeltaQuery{
+		DifferentStart: time.Now(),
+		Mask:           MaskStartDate,
+		MaskCutoff:     time.Now(),
+	})
+	var rl *RateLimitError
+	if !errors.As(err, &rl) {
+		t.Fatalf("expected *RateLimitError, got %T: %v", err, err)
+	}
+	if rl.RetryAfter == nil || *rl.RetryAfter != 30*time.Second {
+		t.Errorf("RetryAfter: got %v", rl.RetryAfter)
+	}
+}
+
+// TestFetchByUID_SendsExpectedQuery pins the single-uid hydration lookup.
+func TestFetchByUID_SendsExpectedQuery(t *testing.T) {
+	t.Parallel()
+	body := `{"records":[{"name":"26/0001","uid":"26/0001/FUL","area_id":300,"last_different":"2026-07-14T09:00:00"}]}`
+	var gotQuery url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	clock := &fakeClock{}
+	c := newTestClient(t, srv.URL, clock)
+
+	res, err := c.FetchByUID(context.Background(), "26/0001/FUL")
+	if err != nil {
+		t.Fatalf("FetchByUID: %v", err)
+	}
+	if gotQuery.Get("id_match") != "26/0001/FUL" || gotQuery.Get("pg_sz") != "1" {
+		t.Errorf("unexpected request query: %s", gotQuery.Encode())
+	}
+	if len(res.Applications) != 1 || res.Applications[0].AreaID != 300 {
+		t.Fatalf("Applications: got %+v", res.Applications)
+	}
+}
+
+func containsString(list []string, s string) bool {
+	for _, v := range list {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}

--- a/api-go/internal/platform/config.go
+++ b/api-go/internal/platform/config.go
@@ -184,7 +184,28 @@ type Config struct {
 	// 100, unchanged behaviour). Loaded from POLLING_PLANIT_PAGE_SIZE. This PR
 	// (GH#955 PR A, tc-nlvpz) only adds the capability to configure it via env;
 	// PR B flips the prod value to 300 through infra, not a code default change.
+	// Governs only the legacy per-authority drain (unwired since ADR 0041) —
+	// the national lanes below hardcode pg_sz=300, not this field.
 	PollingPlanItPageSize int
+
+	// PollingLane* configure ADR 0041's churn-masked national delta poll
+	// (GH#962, bead tc-5m3tw), which replaces the per-authority drain above.
+	// PollingLaneAMaskDays / PollingLaneBMaskDays are the start_date /
+	// decided_start churn-mask widths in days (default 90 — "a config dial,
+	// not a correctness boundary": ADR 0041, Lane C is the backstop for
+	// anything a mask misses). PollingLaneBMaxPages hard-caps Lane B's
+	// descending page walk per run (decision volume is unmeasured
+	// pre-cutover) — do not remove this cap. PollingLaneCIntervalHours is the
+	// minimum gap between full Lane C reconciliation sweeps (default 168 =
+	// weekly; dial down to 24 for a daily soak, per the ADR's migration plan).
+	// PollingLaneCMaxStragglersPerAuthority bounds Lane C's per-authority
+	// hydration fan-out so one badly-drifted authority cannot balloon a
+	// single sweep's PlanIt request count.
+	PollingLaneAMaskDays                  int
+	PollingLaneBMaskDays                  int
+	PollingLaneBMaxPages                  int
+	PollingLaneCIntervalHours             int
+	PollingLaneCMaxStragglersPerAuthority int
 
 	// NotificationsRetentionDays is the number of days to keep Notifications rows
 	// when running the pg-purge job. Loaded from NOTIFICATIONS_RETENTION_DAYS;
@@ -318,6 +339,12 @@ func LoadConfig() (Config, error) {
 		PollReplicaTimeoutSeconds:           getenvInt("POLL_REPLICA_TIMEOUT_SECONDS", 600),
 		PollShutdownGraceSeconds:            getenvInt("POLL_SHUTDOWN_GRACE_SECONDS", 30),
 		PollingPlanItPageSize:               getenvInt("POLLING_PLANIT_PAGE_SIZE", 100),
+
+		PollingLaneAMaskDays:                  getenvInt("POLLING_LANE_A_MASK_DAYS", 90),
+		PollingLaneBMaskDays:                  getenvInt("POLLING_LANE_B_MASK_DAYS", 90),
+		PollingLaneBMaxPages:                  getenvInt("POLLING_LANE_B_MAX_PAGES", 20),
+		PollingLaneCIntervalHours:             getenvInt("POLLING_LANE_C_INTERVAL_HOURS", 168),
+		PollingLaneCMaxStragglersPerAuthority: getenvInt("POLLING_LANE_C_MAX_STRAGGLERS_PER_AUTHORITY", 10),
 
 		NotificationsRetentionDays:       getenvInt("NOTIFICATIONS_RETENTION_DAYS", 90),
 		DeviceRegistrationsRetentionDays: getenvInt("DEVICE_REGISTRATIONS_RETENTION_DAYS", 180),

--- a/api-go/internal/platform/config_test.go
+++ b/api-go/internal/platform/config_test.go
@@ -412,6 +412,8 @@ func TestLoadConfig_PollingDefaults(t *testing.T) {
 		"POLLING_MAX_PAGES_PER_AUTHORITY_PER_CYCLE", "POLLING_HANDLER_BUDGET_SECONDS",
 		"POLL_REPLICA_TIMEOUT_SECONDS", "POLL_SHUTDOWN_GRACE_SECONDS",
 		"POLLING_PLANIT_PAGE_SIZE",
+		"POLLING_LANE_A_MASK_DAYS", "POLLING_LANE_B_MASK_DAYS", "POLLING_LANE_B_MAX_PAGES",
+		"POLLING_LANE_C_INTERVAL_HOURS", "POLLING_LANE_C_MAX_STRAGGLERS_PER_AUTHORITY",
 	} {
 		t.Setenv(k, "")
 	}
@@ -442,6 +444,18 @@ func TestLoadConfig_PollingDefaults(t *testing.T) {
 	// (100) is unchanged behaviour — PR B flips it to 300 via infra, not here.
 	if cfg.PollingPlanItPageSize != 100 {
 		t.Errorf("page size default: got %d, want 100", cfg.PollingPlanItPageSize)
+	}
+	if cfg.PollingLaneAMaskDays != 90 || cfg.PollingLaneBMaskDays != 90 {
+		t.Errorf("lane mask day defaults: got %d/%d, want 90/90", cfg.PollingLaneAMaskDays, cfg.PollingLaneBMaskDays)
+	}
+	if cfg.PollingLaneBMaxPages != 20 {
+		t.Errorf("lane B max pages default: got %d, want 20", cfg.PollingLaneBMaxPages)
+	}
+	if cfg.PollingLaneCIntervalHours != 168 {
+		t.Errorf("lane C interval default: got %d, want 168", cfg.PollingLaneCIntervalHours)
+	}
+	if cfg.PollingLaneCMaxStragglersPerAuthority != 10 {
+		t.Errorf("lane C max stragglers default: got %d, want 10", cfg.PollingLaneCMaxStragglersPerAuthority)
 	}
 }
 
@@ -545,6 +559,11 @@ func TestLoadConfig_PollingOverrides(t *testing.T) {
 	t.Setenv("POLL_REPLICA_TIMEOUT_SECONDS", "300")
 	t.Setenv("POLL_SHUTDOWN_GRACE_SECONDS", "15")
 	t.Setenv("POLLING_PLANIT_PAGE_SIZE", "300")
+	t.Setenv("POLLING_LANE_A_MASK_DAYS", "45")
+	t.Setenv("POLLING_LANE_B_MASK_DAYS", "60")
+	t.Setenv("POLLING_LANE_B_MAX_PAGES", "10")
+	t.Setenv("POLLING_LANE_C_INTERVAL_HOURS", "24")
+	t.Setenv("POLLING_LANE_C_MAX_STRAGGLERS_PER_AUTHORITY", "5")
 
 	cfg, err := LoadConfig()
 	if err != nil {
@@ -564,5 +583,17 @@ func TestLoadConfig_PollingOverrides(t *testing.T) {
 	}
 	if cfg.PollingPlanItPageSize != 300 {
 		t.Errorf("page size override: got %d, want 300", cfg.PollingPlanItPageSize)
+	}
+	if cfg.PollingLaneAMaskDays != 45 || cfg.PollingLaneBMaskDays != 60 {
+		t.Errorf("lane mask day overrides: got %d/%d, want 45/60", cfg.PollingLaneAMaskDays, cfg.PollingLaneBMaskDays)
+	}
+	if cfg.PollingLaneBMaxPages != 10 {
+		t.Errorf("lane B max pages override: got %d, want 10", cfg.PollingLaneBMaxPages)
+	}
+	if cfg.PollingLaneCIntervalHours != 24 {
+		t.Errorf("lane C interval override: got %d, want 24", cfg.PollingLaneCIntervalHours)
+	}
+	if cfg.PollingLaneCMaxStragglersPerAuthority != 5 {
+		t.Errorf("lane C max stragglers override: got %d, want 5", cfg.PollingLaneCMaxStragglersPerAuthority)
 	}
 }

--- a/api-go/internal/polling/ingester_integration_test.go
+++ b/api-go/internal/polling/ingester_integration_test.go
@@ -1,0 +1,122 @@
+//go:build integration
+
+package polling
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/platform/postgres/pgtest"
+)
+
+// newPGIngester returns an Ingester wired over a real, truncated Postgres
+// applications store (ADR 0032 / ADR 0041): the reindex-flood guard
+// (HasSameBusinessFieldsAs) is the load-bearing mechanism every ADR 0041 lane
+// depends on to make a re-ingested, unchanged record free (no write, no
+// fan-out) — a fake store can assert the guard's LOGIC, but only a real
+// Postgres round trip proves the guarded write genuinely never reaches the
+// database. Integration tests are NOT run in parallel: pgtest.New holds a
+// process-wide advisory lock for the test's duration.
+func newPGIngester(t *testing.T) (*Ingester, *applications.PostgresStore) {
+	t.Helper()
+	pool := pgtest.New(t)
+	pgtest.Truncate(t, pool, "applications", "watch_zones")
+	store := applications.NewPostgresStore(pool)
+	return NewIngester(store, nil, nil), store
+}
+
+// TestIngester_Integration_NewApplicationPersists proves a first-time Ingest
+// actually writes to Postgres and every field survives the round trip.
+func TestIngester_Integration_NewApplicationPersists(t *testing.T) {
+	ctx := context.Background()
+	ingester, store := newPGIngester(t)
+
+	ld := time.Date(2026, 7, 10, 9, 0, 0, 0, time.UTC)
+	app := testApp("24/0001", 300, ld)
+
+	if err := ingester.Ingest(ctx, app); err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+
+	got, found, err := store.GetByUID(ctx, app.UID, "300")
+	if err != nil {
+		t.Fatalf("GetByUID: %v", err)
+	}
+	if !found {
+		t.Fatal("expected the ingested application to be persisted")
+	}
+	if got.Name != app.Name || !got.LastDifferent.Equal(ld) {
+		t.Errorf("round trip mismatch: got %+v", got)
+	}
+}
+
+// TestIngester_Integration_ReindexTouchAloneNeverReachesPostgres proves the
+// reindex-flood guard against the REAL database, not just the fake: a
+// PlanIt re-emission that bumps only LastDifferent (every ADR 0041 lane's
+// steady-state re-touch case, per the churn ADR 0041 documents) must not
+// write at all — the row's stored last_different must stay at the
+// FIRST-ingested value, proving the guarded Upsert genuinely never reached
+// Postgres a second time.
+func TestIngester_Integration_ReindexTouchAloneNeverReachesPostgres(t *testing.T) {
+	ctx := context.Background()
+	ingester, store := newPGIngester(t)
+
+	original := testApp("24/0002", 300, time.Date(2026, 7, 10, 9, 0, 0, 0, time.UTC))
+	if err := ingester.Ingest(ctx, original); err != nil {
+		t.Fatalf("Ingest (first): %v", err)
+	}
+
+	rebumped := original
+	rebumped.LastDifferent = time.Date(2026, 7, 14, 3, 0, 0, 0, time.UTC) // a re-index touch, business fields unchanged
+	if err := ingester.Ingest(ctx, rebumped); err != nil {
+		t.Fatalf("Ingest (re-touch): %v", err)
+	}
+
+	got, found, err := store.GetByUID(ctx, original.UID, "300")
+	if err != nil {
+		t.Fatalf("GetByUID: %v", err)
+	}
+	if !found {
+		t.Fatal("expected the original row to still exist")
+	}
+	if !got.LastDifferent.Equal(original.LastDifferent) {
+		t.Errorf("last_different: got %v, want unchanged %v (a bookkeeping-only re-touch must never write)", got.LastDifferent, original.LastDifferent)
+	}
+}
+
+// TestIngester_Integration_BusinessFieldChangeUpserts proves the converse: a
+// genuine business-field change (a decision landing) DOES reach Postgres and
+// the new value is what a subsequent read returns.
+func TestIngester_Integration_BusinessFieldChangeUpserts(t *testing.T) {
+	ctx := context.Background()
+	ingester, store := newPGIngester(t)
+
+	original := testApp("24/0003", 300, time.Date(2026, 7, 10, 9, 0, 0, 0, time.UTC))
+	if err := ingester.Ingest(ctx, original); err != nil {
+		t.Fatalf("Ingest (first): %v", err)
+	}
+
+	permitted := "Permitted"
+	decided := original
+	decided.AppState = &permitted
+	decided.LastDifferent = time.Date(2026, 7, 14, 3, 0, 0, 0, time.UTC)
+	if err := ingester.Ingest(ctx, decided); err != nil {
+		t.Fatalf("Ingest (decision): %v", err)
+	}
+
+	got, found, err := store.GetByUID(ctx, original.UID, "300")
+	if err != nil {
+		t.Fatalf("GetByUID: %v", err)
+	}
+	if !found {
+		t.Fatal("expected the row to exist")
+	}
+	if got.AppState == nil || *got.AppState != "Permitted" {
+		t.Errorf("AppState: got %v, want Permitted", got.AppState)
+	}
+	if !got.LastDifferent.Equal(decided.LastDifferent) {
+		t.Errorf("last_different: got %v, want %v (a genuine business change must write through)", got.LastDifferent, decided.LastDifferent)
+	}
+}

--- a/api-go/internal/polling/nationallane.go
+++ b/api-go/internal/polling/nationallane.go
@@ -1,0 +1,437 @@
+// ADR 0041 / GH#962: the churn-masked national delta poll. This file replaces
+// the per-authority drain (handler.go, left compiling but unwired — see
+// cmd/worker/main.go) with a single national query per lane and ONE global
+// watermark per lane, persisted in the EXISTING poll_state table via a
+// reserved sentinel authority_id (no schema migration: rollback stays a pure
+// image redeploy).
+package polling
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/AmyDe/town-crier/api-go/internal/planit"
+)
+
+// Sentinel poll_state.authority_id values reserved for the three ADR 0041
+// lanes' global watermark bookkeeping. Real PlanIt authority ids are always
+// positive (authorities.Lookup never emits <= 0), so a sentinel row can never
+// collide with a real authority's poll state.
+const (
+	sentinelLaneA = -1
+	sentinelLaneB = -2
+	sentinelLaneC = -3
+)
+
+// LaneName tags which ADR 0041 lane produced a span/result: "A" (new
+// applications), "B" (decisions), or "C" (reconciliation).
+type LaneName string
+
+// LaneA, LaneB, and LaneC are the three ADR 0041 lanes.
+const (
+	LaneA LaneName = "A"
+	LaneB LaneName = "B"
+	LaneC LaneName = "C"
+)
+
+// sentinelIDForLane maps a lane to its reserved poll_state.authority_id, so a
+// lane handler's caller never needs to know or pass the sentinel directly —
+// removing a footgun where a lane and its watermark row could be mismatched.
+func sentinelIDForLane(lane LaneName) int {
+	switch lane {
+	case LaneB:
+		return sentinelLaneB
+	case LaneC:
+		return sentinelLaneC
+	case LaneA:
+		return sentinelLaneA
+	default:
+		return sentinelLaneA
+	}
+}
+
+// nationalDeltaFetcher is the consumer-side slice of the PlanIt client a
+// national lane needs: one descending page of the churn-masked delta query.
+// *planit.Client satisfies it.
+type nationalDeltaFetcher interface {
+	FetchNationalDeltaPage(ctx context.Context, q planit.NationalDeltaQuery) (planit.FetchPageResult, error)
+}
+
+// laneWatermarkStore persists ONE lane's global delta watermark in the
+// existing poll_state table via a reserved sentinel authority_id (see the
+// package doc above): HighWaterMark holds the watermark, LastPollTime the
+// lane's last-run time, and the cursor columns are always nil — lanes A/B/C
+// are cursor-less by design (ADR 0041: "a single timestamp, not 485
+// cursors"). It is a thin wrapper over the existing pollStateAccess
+// Get/Save — no new store, no new columns.
+type laneWatermarkStore struct {
+	state      pollStateAccess
+	sentinelID int
+}
+
+func newLaneWatermarkStore(state pollStateAccess, sentinelID int) *laneWatermarkStore {
+	return &laneWatermarkStore{state: state, sentinelID: sentinelID}
+}
+
+// get returns the lane's persisted watermark and last-run time, both zero when
+// the lane has never run (no sentinel row yet).
+func (s *laneWatermarkStore) get(ctx context.Context) (watermark, lastRun time.Time, err error) {
+	st, found, err := s.state.Get(ctx, s.sentinelID)
+	if err != nil {
+		return time.Time{}, time.Time{}, err
+	}
+	if !found {
+		return time.Time{}, time.Time{}, nil
+	}
+	return st.HighWaterMark, st.LastPollTime, nil
+}
+
+// save persists the lane's watermark and this run's timestamp, with no
+// cursor (lanes A/B/C never use one).
+func (s *laneWatermarkStore) save(ctx context.Context, lastRun, watermark time.Time) error {
+	return s.state.Save(ctx, s.sentinelID, lastRun, watermark, nil)
+}
+
+// NationalLaneOptions configure one of ADR 0041's national delta lanes (A or
+// B — Lane C has its own ReconciliationOptions).
+type NationalLaneOptions struct {
+	// Lane tags telemetry and selects the sentinel watermark row ("A" or "B").
+	Lane LaneName
+	// Mask selects the churn-mask query parameter: planit.MaskStartDate (Lane
+	// A) or planit.MaskDecidedStart (Lane B).
+	Mask planit.MaskParam
+	// MaskWindow is how far back the churn mask reaches (today - MaskWindow).
+	// A config dial, not a correctness boundary (ADR 0041): Lane C is the
+	// backstop for anything a mask misses.
+	MaskWindow time.Duration
+	// MaxPages caps the descending page walk. nil = unbounded (Lane A: the
+	// national delta is measured at ~6 pages/day). Non-nil hard-caps the
+	// walk (Lane B: 20 pages/run — decision volume is unmeasured
+	// pre-cutover, and this cap must not be removed).
+	MaxPages *int
+}
+
+// NationalLaneHandler runs one ADR 0041 national delta lane (A or B): a
+// single national PlanIt query (no auth param), masked by start_date or
+// decided_start to filter out re-index churn, paged descending by
+// last_different until a record at or before the lane's watermark is
+// reached. State is ONE global timestamp — no per-authority cursors, no LRU
+// authority selection.
+type NationalLaneHandler struct {
+	fetcher   nationalDeltaFetcher
+	watermark *laneWatermarkStore
+	ingester  *Ingester
+	opts      NationalLaneOptions
+	now       func() time.Time
+	logger    *slog.Logger
+}
+
+// NewNationalLaneHandler wires a national lane. now is injected so tests pin
+// the clock.
+func NewNationalLaneHandler(
+	fetcher nationalDeltaFetcher,
+	state pollStateAccess,
+	apps applicationStore,
+	opts NationalLaneOptions,
+	now func() time.Time,
+	logger *slog.Logger,
+) *NationalLaneHandler {
+	return &NationalLaneHandler{
+		fetcher:   fetcher,
+		watermark: newLaneWatermarkStore(state, sentinelIDForLane(opts.Lane)),
+		ingester:  NewIngester(apps, nil, nil),
+		opts:      opts,
+		now:       now,
+		logger:    logger,
+	}
+}
+
+// WithFanOut wires the notification fan-out collaborators onto this lane's
+// ingests, mirroring PollPlanItHandler.WithFanOut (including its nil-ingester
+// guard, so calling this on a zero-value NationalLaneHandler — as a wiring
+// test does — never panics). Returns the handler for chaining.
+func (h *NationalLaneHandler) WithFanOut(decision DecisionDispatcher, enqueuer NotificationEnqueuer) *NationalLaneHandler {
+	if h.ingester == nil {
+		h.ingester = &Ingester{}
+	}
+	h.ingester.decision = decision
+	h.ingester.enqueuer = enqueuer
+	return h
+}
+
+// laneOutcome is one national lane run's result, carried both into
+// PollPlanItResult (by the caller) and onto the lane's telemetry span.
+type laneOutcome struct {
+	recordsSeen     int
+	recordsIngested int
+	pages           int
+	rateLimited     bool
+	retryAfter      *time.Duration
+	err             error
+	planitTotal     *int
+	watermarkBefore time.Time
+	watermarkAfter  time.Time
+	capHit          bool
+}
+
+// Run walks one national delta lane's descending pages from PlanIt's newest
+// record down to the lane's watermark (ADR 0041): the coarse different_start
+// prefilter narrows PlanIt's scan to roughly the right window, the
+// start_date/decided_start mask filters out re-index churn, and the
+// descending sort plus this in-memory timestamp watermark give exact delta
+// semantics with no cursor to persist.
+//
+// A record whose LastDifferent is at or before the watermark was already
+// ingested by a prior run (the watermark is set to that run's max ingested
+// value) — paging stops there without re-ingesting it. Every record strictly
+// newer that shares its page with the boundary record has already been
+// ingested earlier in the same page's iteration (descending order means it
+// comes first), so nothing between the old watermark and the new one is
+// dropped.
+//
+// The watermark advances ONLY on a completely clean run (no fetch error, no
+// 429, no page-cap or context cut-off): only then is every record between the
+// old watermark and the new one accounted for. Any early stop leaves the
+// watermark untouched — the next run re-walks the same range from scratch,
+// which is wasted request budget, not a silent skip (Ingester's
+// HasSameBusinessFieldsAs gate makes the redundant re-ingests free), and is
+// the safe failure direction the ADR calls out: "never advance a watermark
+// past a page that errored."
+func (h *NationalLaneHandler) Run(ctx context.Context) laneOutcome {
+	ctx, span := otel.Tracer(tracerName).Start(ctx, "PlanIt national lane poll")
+	defer span.End()
+
+	now := h.now().UTC()
+	var out laneOutcome
+
+	watermarkBefore, _, err := h.watermark.get(ctx)
+	if err != nil {
+		out.err = fmt.Errorf("lane %s: read watermark: %w", h.opts.Lane, err)
+		span.SetAttributes(attribute.String("poll.lane", string(h.opts.Lane)))
+		return out
+	}
+	out.watermarkBefore = watermarkBefore
+
+	maskCutoff := truncateToDate(now.Add(-h.opts.MaskWindow))
+	// On a lane's first-ever run there is no watermark to prefilter on; the
+	// mask cutoff itself is the widest sane different_start, so the first run
+	// behaves like a bounded national sweep of the mask window rather than an
+	// unprefiltered query (never sent — ADR 0041's 11.7s-vs-0.2s guardrail).
+	prefilterDate := maskCutoff
+	if !watermarkBefore.IsZero() {
+		prefilterDate = truncateToDate(watermarkBefore)
+	}
+
+	var (
+		index       int
+		maxIngested time.Time
+	)
+
+pageLoop:
+	for {
+		if h.opts.MaxPages != nil && out.pages >= *h.opts.MaxPages {
+			out.capHit = true
+			break
+		}
+		if ctx.Err() != nil {
+			out.capHit = true
+			break
+		}
+
+		res, ferr := h.fetcher.FetchNationalDeltaPage(ctx, planit.NationalDeltaQuery{
+			DifferentStart: prefilterDate,
+			Mask:           h.opts.Mask,
+			MaskCutoff:     maskCutoff,
+			StartIndex:     index,
+		})
+		if ferr != nil {
+			var rl *planit.RateLimitError
+			if errors.As(ferr, &rl) {
+				out.rateLimited = true
+				out.retryAfter = rl.RetryAfter
+			} else {
+				out.err = ferr
+			}
+			break pageLoop
+		}
+
+		out.pages++
+		if out.pages == 1 {
+			out.planitTotal = res.Total
+		}
+		out.recordsSeen += len(res.Applications)
+
+		reachedBoundary := false
+		for _, app := range res.Applications {
+			if !app.LastDifferent.After(watermarkBefore) {
+				reachedBoundary = true
+				break
+			}
+			if ierr := h.ingester.Ingest(ctx, app); ierr != nil {
+				out.err = ierr
+				break pageLoop
+			}
+			out.recordsIngested++
+			if app.LastDifferent.After(maxIngested) {
+				maxIngested = app.LastDifferent
+			}
+		}
+		if reachedBoundary {
+			break
+		}
+
+		index += len(res.Applications)
+		if !res.HasMorePages {
+			break
+		}
+	}
+
+	naturalEnd := out.err == nil && !out.rateLimited && !out.capHit
+	newWatermark := watermarkBefore
+	if naturalEnd && !maxIngested.IsZero() {
+		newWatermark = maxIngested
+	}
+	out.watermarkAfter = newWatermark
+
+	if serr := h.watermark.save(ctx, now, newWatermark); serr != nil && out.err == nil {
+		out.err = serr
+	}
+
+	attrs := []attribute.KeyValue{
+		attribute.String("poll.lane", string(h.opts.Lane)),
+		attribute.Int("poll.records_seen", out.recordsSeen),
+		attribute.Int("poll.records_ingested", out.recordsIngested),
+		attribute.Int("poll.pages", out.pages),
+		attribute.String("poll.watermark_before", formatWatermark(watermarkBefore)),
+		attribute.String("poll.watermark_after", formatWatermark(out.watermarkAfter)),
+		attribute.Bool("poll.rate_limited", out.rateLimited),
+		attribute.Bool("poll.cap_hit", out.capHit),
+	}
+	if out.planitTotal != nil {
+		attrs = append(attrs, attribute.Int("planit.total", *out.planitTotal))
+	}
+	if out.err != nil {
+		attrs = append(attrs, attribute.String("poll.error", out.err.Error()))
+	}
+	span.SetAttributes(attrs...)
+
+	return out
+}
+
+// formatWatermark renders a lane watermark as RFC3339, or "" for a lane that
+// has never ingested anything (the zero time.Time).
+func formatWatermark(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339)
+}
+
+// NationalPollHandler runs ADR 0041's churn-masked national delta poll: Lane A
+// (new applications) and Lane B (decisions) every cycle, plus Lane C
+// (reconciliation) whenever its own, much longer interval has elapsed. It
+// satisfies the Orchestrator's cycleHandler interface, so it plugs into the
+// existing Service-Bus-triggered orchestrator (orchestrator.go, ADR 0024)
+// unchanged — the trigger/lease machinery does not know or care which
+// concrete handler it drives.
+type NationalPollHandler struct {
+	laneA   *NationalLaneHandler
+	laneB   *NationalLaneHandler
+	laneC   *ReconciliationHandler // nil skips Lane C entirely (e.g. a test exercising only the critical path)
+	flusher pushFlusher
+	now     func() time.Time
+	logger  *slog.Logger
+}
+
+// NewNationalPollHandler wires the three lanes. laneC may be nil to skip
+// reconciliation.
+func NewNationalPollHandler(laneA, laneB *NationalLaneHandler, laneC *ReconciliationHandler, now func() time.Time, logger *slog.Logger) *NationalPollHandler {
+	return &NationalPollHandler{laneA: laneA, laneB: laneB, laneC: laneC, now: now, logger: logger}
+}
+
+// WithPushFlusher wires the poll-cycle push coalescer (GH#784), mirroring
+// PollPlanItHandler.WithPushFlusher. Returns the handler for chaining.
+func (h *NationalPollHandler) WithPushFlusher(f pushFlusher) *NationalPollHandler {
+	h.flusher = f
+	return h
+}
+
+// Handle runs one national poll cycle: Lane A, then Lane B, then — only when
+// due — Lane C. A lane error is logged and counted (AuthorityErrors) but
+// never fails the cycle: there is no per-authority state to strand and no
+// cursor to corrupt, so the next hourly run is self-healing. Handle returns a
+// non-nil error only when it cannot even determine what to do (never reached
+// today — kept for interface parity with cycleHandler, mirroring
+// PollPlanItHandler.Handle's contract).
+func (h *NationalPollHandler) Handle(ctx context.Context) (PollPlanItResult, error) {
+	if h.flusher != nil {
+		h.flusher.Reset()
+	}
+
+	outA := h.laneA.Run(ctx)
+	outB := h.laneB.Run(ctx)
+
+	if h.flusher != nil {
+		if err := h.flusher.Flush(ctx); err != nil {
+			h.logger.ErrorContext(ctx, "push flush failed", "error", err)
+		}
+	}
+
+	if outA.err != nil {
+		h.logger.ErrorContext(ctx, "lane A poll error", "error", outA.err)
+	}
+	if outB.err != nil {
+		h.logger.ErrorContext(ctx, "lane B poll error", "error", outB.err)
+	}
+
+	laneErrors := 0
+	if outA.err != nil {
+		laneErrors++
+	}
+	if outB.err != nil {
+		laneErrors++
+	}
+
+	rateLimited := outA.rateLimited || outB.rateLimited
+	var retryAfter *time.Duration
+	switch {
+	case outA.retryAfter != nil:
+		retryAfter = outA.retryAfter
+	case outB.retryAfter != nil:
+		retryAfter = outB.retryAfter
+	}
+
+	reason := TerminationNatural
+	switch {
+	case rateLimited:
+		reason = TerminationRateLimited
+	case outA.capHit || outB.capHit:
+		reason = TerminationTimeBounded
+	}
+
+	if h.laneC != nil {
+		now := h.now().UTC()
+		if h.laneC.Due(ctx, now) {
+			outC := h.laneC.Run(ctx)
+			if outC.err != nil {
+				h.logger.ErrorContext(ctx, "lane C reconciliation error", "error", outC.err)
+			}
+		}
+	}
+
+	return PollPlanItResult{
+		ApplicationCount:  outA.recordsIngested + outB.recordsIngested,
+		AuthoritiesPolled: 0, // no per-authority concept in the national lanes
+		RateLimited:       rateLimited,
+		TerminationReason: reason,
+		AuthorityErrors:   laneErrors,
+		RetryAfter:        retryAfter,
+		CycleType:         "National",
+	}, nil
+}

--- a/api-go/internal/polling/nationallane.go
+++ b/api-go/internal/polling/nationallane.go
@@ -15,6 +15,7 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/AmyDe/town-crier/api-go/internal/planit"
 )
@@ -203,6 +204,9 @@ type laneOutcome struct {
 // HasSameBusinessFieldsAs gate makes the redundant re-ingests free), and is
 // the safe failure direction the ADR calls out: "never advance a watermark
 // past a page that errored."
+//
+// A lane with no prior watermark (never run) does NOT walk this way at all —
+// see seed.
 func (h *NationalLaneHandler) Run(ctx context.Context) laneOutcome {
 	ctx, span := otel.Tracer(tracerName).Start(ctx, "PlanIt national lane poll")
 	defer span.End()
@@ -219,14 +223,24 @@ func (h *NationalLaneHandler) Run(ctx context.Context) laneOutcome {
 	out.watermarkBefore = watermarkBefore
 
 	maskCutoff := truncateToDate(now.Add(-h.opts.MaskWindow))
-	// On a lane's first-ever run there is no watermark to prefilter on; the
-	// mask cutoff itself is the widest sane different_start, so the first run
-	// behaves like a bounded national sweep of the mask window rather than an
-	// unprefiltered query (never sent — ADR 0041's 11.7s-vs-0.2s guardrail).
-	prefilterDate := maskCutoff
-	if !watermarkBefore.IsZero() {
-		prefilterDate = truncateToDate(watermarkBefore)
+
+	// A lane with no prior watermark has never run. Walking the mask window
+	// here — as a normal delta walk would, since "> zero time" is true for
+	// every real record — would be a historical backfill (forbidden: ADR 0041
+	// rule 2) and, for Lane A's unbounded page walk, a red-line request
+	// spike that never even finishes inside the cycle budget: a budget
+	// cut-off is never a "clean run", so the watermark could never be set,
+	// and every subsequent cycle would re-attempt the same full-window walk
+	// forever. Seed instead: read PlanIt's current head from a single page-0
+	// fetch and persist it, ingesting nothing. The old drain already held us
+	// at the head (prod baseline max last_different 2026-07-14 05:14:58Z);
+	// Lane C's reconciliation sweep is the backstop for the small forward-flow
+	// gap a seed (rather than a backfill) leaves.
+	if watermarkBefore.IsZero() {
+		return h.seed(ctx, span, now, maskCutoff)
 	}
+
+	prefilterDate := truncateToDate(watermarkBefore)
 
 	var (
 		index       int
@@ -303,6 +317,73 @@ pageLoop:
 		out.err = serr
 	}
 
+	h.setSpanAttributes(span, out, watermarkBefore, prefilterDate, false)
+	return out
+}
+
+// seed handles a lane's first-ever run (no prior watermark): forward-flow
+// only, never a historical sweep (ADR 0041 rule 2). It fetches PlanIt's
+// current head from a SINGLE page-0 fetch — never paging further — and
+// persists that as the watermark without ingesting anything, so the cutover
+// starts from "now" rather than replaying the whole masked window. An empty
+// page 0 (nothing currently matches the masked window) seeds the watermark to
+// now() instead, so a quiet mask window still leaves the lane seeded rather
+// than permanently stuck re-attempting the seed. A page-0 fetch error or 429
+// seeds NOTHING — the lane stays unseeded and the next cycle retries the seed
+// (bounded to one extra request/cycle, harmless).
+func (h *NationalLaneHandler) seed(ctx context.Context, span trace.Span, now, maskCutoff time.Time) laneOutcome {
+	var out laneOutcome
+
+	res, ferr := h.fetcher.FetchNationalDeltaPage(ctx, planit.NationalDeltaQuery{
+		DifferentStart: maskCutoff,
+		Mask:           h.opts.Mask,
+		MaskCutoff:     maskCutoff,
+		StartIndex:     0,
+	})
+	if ferr != nil {
+		var rl *planit.RateLimitError
+		if errors.As(ferr, &rl) {
+			out.rateLimited = true
+			out.retryAfter = rl.RetryAfter
+		} else {
+			out.err = ferr
+		}
+		h.setSpanAttributes(span, out, time.Time{}, maskCutoff, true)
+		return out
+	}
+
+	out.pages = 1
+	out.planitTotal = res.Total
+	out.recordsSeen = len(res.Applications)
+
+	head := time.Time{}
+	for _, app := range res.Applications {
+		if app.LastDifferent.After(head) {
+			head = app.LastDifferent
+		}
+	}
+	if head.IsZero() {
+		head = now
+	}
+	out.watermarkAfter = head
+
+	if serr := h.watermark.save(ctx, now, head); serr != nil {
+		out.err = serr
+	}
+
+	h.setSpanAttributes(span, out, time.Time{}, maskCutoff, true)
+	return out
+}
+
+// setSpanAttributes stamps the "PlanIt national lane poll" span with the full
+// ADR 0041 telemetry set — the safety mechanism a silent-skip bug would
+// otherwise defeat with no error, no 429, and no alert. differentStart is the
+// different_start prefilter actually sent this run (the mask cutoff on a
+// seeding run, the watermark's calendar date on a normal walk), so spans can
+// be grouped by that day to check the records_seen == planit.total invariant.
+// seeded tags a first-run seed, so a seeding run's recordsIngested==0 is never
+// misread as a stall.
+func (h *NationalLaneHandler) setSpanAttributes(span trace.Span, out laneOutcome, watermarkBefore, differentStart time.Time, seeded bool) {
 	attrs := []attribute.KeyValue{
 		attribute.String("poll.lane", string(h.opts.Lane)),
 		attribute.Int("poll.records_seen", out.recordsSeen),
@@ -312,6 +393,8 @@ pageLoop:
 		attribute.String("poll.watermark_after", formatWatermark(out.watermarkAfter)),
 		attribute.Bool("poll.rate_limited", out.rateLimited),
 		attribute.Bool("poll.cap_hit", out.capHit),
+		attribute.Bool("poll.seeded", seeded),
+		attribute.String("poll.different_start", differentStart.UTC().Format("2006-01-02")),
 	}
 	if out.planitTotal != nil {
 		attrs = append(attrs, attribute.Int("planit.total", *out.planitTotal))
@@ -320,8 +403,6 @@ pageLoop:
 		attrs = append(attrs, attribute.String("poll.error", out.err.Error()))
 	}
 	span.SetAttributes(attrs...)
-
-	return out
 }
 
 // formatWatermark renders a lane watermark as RFC3339, or "" for a lane that

--- a/api-go/internal/polling/nationallane_test.go
+++ b/api-go/internal/polling/nationallane_test.go
@@ -1,0 +1,435 @@
+package polling
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/planit"
+)
+
+// fakeNationalFetcher serves pre-canned national-delta pages keyed by the
+// requested 0-based record offset, and can be primed to fail on a specific
+// call ordinal (1-based, failNth) to model a mid-walk transport error or 429.
+type fakeNationalFetcher struct {
+	pages   map[int]planit.FetchPageResult
+	failNth map[int]error
+	calls   int
+	queries []planit.NationalDeltaQuery
+}
+
+func newFakeNationalFetcher() *fakeNationalFetcher {
+	return &fakeNationalFetcher{pages: map[int]planit.FetchPageResult{}, failNth: map[int]error{}}
+}
+
+func (f *fakeNationalFetcher) FetchNationalDeltaPage(_ context.Context, q planit.NationalDeltaQuery) (planit.FetchPageResult, error) {
+	f.calls++
+	f.queries = append(f.queries, q)
+	if err, ok := f.failNth[f.calls]; ok {
+		return planit.FetchPageResult{}, err
+	}
+	res, ok := f.pages[q.StartIndex]
+	if !ok {
+		return planit.FetchPageResult{From: q.StartIndex, HasMorePages: false}, nil
+	}
+	return res, nil
+}
+
+// newLaneHandler wires a NationalLaneHandler pinned to a fixed clock
+// (2026-07-14T12:00:00Z), for deterministic mask-cutoff math.
+func newLaneHandler(t *testing.T, fetcher *fakeNationalFetcher, apps *fakeApps, state *fakeStateStore, opts NationalLaneOptions) *NationalLaneHandler {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(discard{}, nil))
+	clock := func() time.Time { return time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC) }
+	return NewNationalLaneHandler(fetcher, state, apps, opts, clock, logger)
+}
+
+func laneAOpts() NationalLaneOptions {
+	return NationalLaneOptions{Lane: LaneA, Mask: planit.MaskStartDate, MaskWindow: 90 * 24 * time.Hour}
+}
+
+func laneBOpts(maxPages int) NationalLaneOptions {
+	return NationalLaneOptions{Lane: LaneB, Mask: planit.MaskDecidedStart, MaskWindow: 90 * 24 * time.Hour, MaxPages: &maxPages}
+}
+
+// TestNationalLane_IngestsNewerRecordsAndStopsAtExactBoundary pins the
+// central boundary decision (ADR 0041 / GH#962): a record whose
+// LastDifferent equals the watermark stops the walk without being
+// re-ingested, but a strictly-newer record that shares the SAME page as the
+// boundary record must still be ingested — descending order means it is
+// encountered first.
+func TestNationalLane_IngestsNewerRecordsAndStopsAtExactBoundary(t *testing.T) {
+	t.Parallel()
+	watermark := time.Date(2026, 7, 10, 9, 0, 0, 0, time.UTC)
+	newer := watermark.Add(1 * time.Hour)
+	older := watermark.Add(-1 * time.Hour)
+
+	fetcher := newFakeNationalFetcher()
+	fetcher.pages[0] = planit.FetchPageResult{
+		From: 0,
+		Applications: []applications.PlanningApplication{
+			testApp("newer", 300, newer),        // strictly newer: must be ingested
+			testApp("boundary", 300, watermark), // == watermark: must stop here, not ingested
+			testApp("older", 300, older),        // must never be reached
+		},
+		HasMorePages: false,
+	}
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	state.states[sentinelLaneA] = PollState{HighWaterMark: watermark, LastPollTime: watermark}
+
+	h := newLaneHandler(t, fetcher, apps, state, laneAOpts())
+	out := h.Run(context.Background())
+
+	if out.err != nil {
+		t.Fatalf("Run: %v", out.err)
+	}
+	if out.recordsSeen != 3 {
+		t.Errorf("recordsSeen: got %d, want 3 (every record fetched, including the ones at/after the boundary)", out.recordsSeen)
+	}
+	if out.recordsIngested != 1 {
+		t.Errorf("recordsIngested: got %d, want 1 (only the strictly-newer record)", out.recordsIngested)
+	}
+	if len(apps.upserts) != 1 || apps.upserts[0].Name != "newer" {
+		t.Fatalf("upserts: got %+v, want exactly the 'newer' record", apps.upserts)
+	}
+	if !out.watermarkAfter.Equal(newer) {
+		t.Errorf("watermarkAfter: got %v, want %v (max ingested this run)", out.watermarkAfter, newer)
+	}
+}
+
+// TestNationalLane_HandlesEmptyPage covers a page with zero records: no
+// ingestion, watermark unchanged, no panic on the empty slice.
+func TestNationalLane_HandlesEmptyPage(t *testing.T) {
+	t.Parallel()
+	watermark := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+	fetcher := newFakeNationalFetcher()
+	fetcher.pages[0] = planit.FetchPageResult{From: 0, Applications: nil, HasMorePages: false}
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	state.states[sentinelLaneA] = PollState{HighWaterMark: watermark, LastPollTime: watermark}
+
+	h := newLaneHandler(t, fetcher, apps, state, laneAOpts())
+	out := h.Run(context.Background())
+
+	if out.err != nil {
+		t.Fatalf("Run: %v", out.err)
+	}
+	if out.recordsSeen != 0 || out.recordsIngested != 0 {
+		t.Errorf("expected no records seen/ingested, got seen=%d ingested=%d", out.recordsSeen, out.recordsIngested)
+	}
+	if !out.watermarkAfter.Equal(watermark) {
+		t.Errorf("watermarkAfter: got %v, want unchanged %v", out.watermarkAfter, watermark)
+	}
+}
+
+// TestNationalLane_HandlesTotalAbsent covers a response that omits total: the
+// outcome must not carry a misleading planitTotal, and the caller (span
+// attributes) must be able to distinguish "PlanIt omitted total" from
+// "total is zero".
+func TestNationalLane_HandlesTotalAbsent(t *testing.T) {
+	t.Parallel()
+	fetcher := newFakeNationalFetcher()
+	fetcher.pages[0] = planit.FetchPageResult{From: 0, Applications: nil, HasMorePages: false, Total: nil}
+	apps := newFakeApps()
+	state := newFakeStateStore()
+
+	h := newLaneHandler(t, fetcher, apps, state, laneAOpts())
+	out := h.Run(context.Background())
+
+	if out.planitTotal != nil {
+		t.Errorf("planitTotal: got %v, want nil (PlanIt omitted total)", out.planitTotal)
+	}
+}
+
+// TestNationalLane_NeverAdvancesWatermarkPastAnErroredPage is the safety
+// invariant: a page that ingests successfully, followed by a page that
+// fails, must leave the watermark exactly where it was before the run —
+// never partway advanced to the first page's max — so nothing between the
+// old watermark and the failed page is silently skipped on the next run.
+func TestNationalLane_NeverAdvancesWatermarkPastAnErroredPage(t *testing.T) {
+	t.Parallel()
+	watermark := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	page1LD := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+
+	fetcher := newFakeNationalFetcher()
+	fetcher.pages[0] = planit.FetchPageResult{
+		From:         0,
+		Applications: []applications.PlanningApplication{testApp("page1", 300, page1LD)},
+		HasMorePages: true, // more pages follow -> the loop will fetch index 1
+	}
+	fetcher.failNth[2] = errors.New("planit: transport blew up")
+
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	state.states[sentinelLaneA] = PollState{HighWaterMark: watermark, LastPollTime: watermark}
+
+	h := newLaneHandler(t, fetcher, apps, state, laneAOpts())
+	out := h.Run(context.Background())
+
+	if out.err == nil {
+		t.Fatal("expected the second page's fetch error to surface on the outcome")
+	}
+	if len(apps.upserts) != 1 {
+		t.Errorf("page 1's record should still have been ingested: got %d upserts", len(apps.upserts))
+	}
+	if !out.watermarkAfter.Equal(watermark) {
+		t.Errorf("watermarkAfter: got %v, want unchanged %v (never advance past an errored page)", out.watermarkAfter, watermark)
+	}
+}
+
+// TestNationalLane_NeverAdvancesWatermarkOn429 mirrors the errored-page test
+// for a 429: the watermark must not advance even though the walk stopped for
+// an "expected" reason rather than a hard error.
+func TestNationalLane_NeverAdvancesWatermarkOn429(t *testing.T) {
+	t.Parallel()
+	watermark := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	page1LD := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+	retryAfter := 30 * time.Second
+
+	fetcher := newFakeNationalFetcher()
+	fetcher.pages[0] = planit.FetchPageResult{
+		From:         0,
+		Applications: []applications.PlanningApplication{testApp("page1", 300, page1LD)},
+		HasMorePages: true,
+	}
+	fetcher.failNth[2] = &planit.RateLimitError{RetryAfter: &retryAfter}
+
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	state.states[sentinelLaneA] = PollState{HighWaterMark: watermark, LastPollTime: watermark}
+
+	h := newLaneHandler(t, fetcher, apps, state, laneAOpts())
+	out := h.Run(context.Background())
+
+	if !out.rateLimited {
+		t.Fatal("expected rateLimited=true")
+	}
+	if out.retryAfter == nil || *out.retryAfter != retryAfter {
+		t.Errorf("retryAfter: got %v, want %v", out.retryAfter, retryAfter)
+	}
+	if !out.watermarkAfter.Equal(watermark) {
+		t.Errorf("watermarkAfter: got %v, want unchanged %v (never advance past a 429)", out.watermarkAfter, watermark)
+	}
+}
+
+// TestNationalLane_LaneBPageCapStopsWalkAndFreezesWatermark proves Lane B's
+// hard page cap: the walk stops after MaxPages even though more pages remain,
+// and — because a cap-hit is an incomplete run — the watermark freezes rather
+// than advancing to whatever the capped walk saw.
+func TestNationalLane_LaneBPageCapStopsWalkAndFreezesWatermark(t *testing.T) {
+	t.Parallel()
+	watermark := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	ld := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+
+	fetcher := newFakeNationalFetcher()
+	for i := range 3 {
+		fetcher.pages[i] = planit.FetchPageResult{
+			From:         i,
+			Applications: []applications.PlanningApplication{testApp("d", 300, ld)},
+			HasMorePages: true, // every page claims more follow
+		}
+	}
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	state.states[sentinelLaneB] = PollState{HighWaterMark: watermark, LastPollTime: watermark}
+
+	h := newLaneHandler(t, fetcher, apps, state, laneBOpts(2))
+	out := h.Run(context.Background())
+
+	if out.pages != 2 {
+		t.Errorf("pages: got %d, want 2 (capped)", out.pages)
+	}
+	if !out.capHit {
+		t.Error("capHit: got false, want true")
+	}
+	if !out.watermarkAfter.Equal(watermark) {
+		t.Errorf("watermarkAfter: got %v, want unchanged %v (a cap hit is an incomplete run)", out.watermarkAfter, watermark)
+	}
+}
+
+// TestNationalLane_FirstRunPrefiltersOnMaskCutoff covers a lane that has
+// never run (no sentinel poll_state row): there is no watermark to
+// prefilter on, so different_start must fall back to the mask cutoff date —
+// never an unprefiltered national query (ADR 0041's guardrail).
+func TestNationalLane_FirstRunPrefiltersOnMaskCutoff(t *testing.T) {
+	t.Parallel()
+	fetcher := newFakeNationalFetcher()
+	apps := newFakeApps()
+	state := newFakeStateStore() // no sentinel row: never run
+
+	h := newLaneHandler(t, fetcher, apps, state, laneAOpts())
+	h.Run(context.Background())
+
+	if len(fetcher.queries) != 1 {
+		t.Fatalf("expected exactly one fetch, got %d", len(fetcher.queries))
+	}
+	q := fetcher.queries[0]
+	wantCutoff := time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC) // 2026-07-14 - 90 days
+	if !q.DifferentStart.Equal(wantCutoff) {
+		t.Errorf("DifferentStart prefilter: got %v, want the mask cutoff %v", q.DifferentStart, wantCutoff)
+	}
+	if !q.MaskCutoff.Equal(wantCutoff) {
+		t.Errorf("MaskCutoff: got %v, want %v", q.MaskCutoff, wantCutoff)
+	}
+	if q.Mask != planit.MaskStartDate {
+		t.Errorf("Mask: got %v, want MaskStartDate", q.Mask)
+	}
+}
+
+// TestNationalLane_SubsequentRunPrefiltersOnWatermarkDate covers the normal
+// case: the different_start prefilter tracks the watermark's calendar date,
+// not the mask cutoff.
+func TestNationalLane_SubsequentRunPrefiltersOnWatermarkDate(t *testing.T) {
+	t.Parallel()
+	watermark := time.Date(2026, 7, 10, 15, 30, 0, 0, time.UTC)
+	fetcher := newFakeNationalFetcher()
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	state.states[sentinelLaneB] = PollState{HighWaterMark: watermark, LastPollTime: watermark}
+
+	h := newLaneHandler(t, fetcher, apps, state, laneBOpts(20))
+	h.Run(context.Background())
+
+	q := fetcher.queries[0]
+	wantPrefilter := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+	if !q.DifferentStart.Equal(wantPrefilter) {
+		t.Errorf("DifferentStart prefilter: got %v, want the watermark's calendar date %v", q.DifferentStart, wantPrefilter)
+	}
+	if q.Mask != planit.MaskDecidedStart {
+		t.Errorf("Mask: got %v, want MaskDecidedStart", q.Mask)
+	}
+}
+
+// TestNationalLaneRun_EmitsSpanWithFullAttributeSet pins the "PlanIt national
+// lane poll" span's attribute set — the telemetry that IS the cutover's
+// safety mechanism (ADR 0041): planit.total, poll.records_seen,
+// poll.records_ingested, poll.pages, poll.watermark_before/after, poll.lane.
+func TestNationalLaneRun_EmitsSpanWithFullAttributeSet(t *testing.T) {
+	watermark := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+	ld := watermark.Add(1 * time.Hour)
+	total := 1717
+
+	fetcher := newFakeNationalFetcher()
+	fetcher.pages[0] = planit.FetchPageResult{
+		From:         0,
+		Applications: []applications.PlanningApplication{testApp("a", 300, ld)},
+		HasMorePages: false,
+		Total:        &total,
+	}
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	state.states[sentinelLaneA] = PollState{HighWaterMark: watermark, LastPollTime: watermark}
+
+	h := newLaneHandler(t, fetcher, apps, state, laneAOpts())
+
+	spans := recordSpans(t, func() {
+		h.Run(context.Background())
+	})
+	span, ok := spanNamed(spans, "PlanIt national lane poll")
+	if !ok {
+		t.Fatalf("expected a %q span among %d recorded spans", "PlanIt national lane poll", len(spans))
+	}
+
+	if v, ok := attrValue(span, "poll.lane"); !ok || v.AsString() != "A" {
+		t.Errorf("poll.lane: got %v (ok=%v), want A", v, ok)
+	}
+	if v, ok := attrValue(span, "poll.records_seen"); !ok || v.AsInt64() != 1 {
+		t.Errorf("poll.records_seen: got %v (ok=%v), want 1", v, ok)
+	}
+	if v, ok := attrValue(span, "poll.records_ingested"); !ok || v.AsInt64() != 1 {
+		t.Errorf("poll.records_ingested: got %v (ok=%v), want 1", v, ok)
+	}
+	if v, ok := attrValue(span, "poll.pages"); !ok || v.AsInt64() != 1 {
+		t.Errorf("poll.pages: got %v (ok=%v), want 1", v, ok)
+	}
+	if v, ok := attrValue(span, "planit.total"); !ok || v.AsInt64() != 1717 {
+		t.Errorf("planit.total: got %v (ok=%v), want 1717", v, ok)
+	}
+	if v, ok := attrValue(span, "poll.watermark_before"); !ok || v.AsString() != watermark.Format(time.RFC3339) {
+		t.Errorf("poll.watermark_before: got %v (ok=%v)", v, ok)
+	}
+	if v, ok := attrValue(span, "poll.watermark_after"); !ok || v.AsString() != ld.Format(time.RFC3339) {
+		t.Errorf("poll.watermark_after: got %v (ok=%v), want %v", v, ok, ld.Format(time.RFC3339))
+	}
+	if v, ok := attrValue(span, "poll.rate_limited"); !ok || v.AsBool() {
+		t.Errorf("poll.rate_limited: got %v (ok=%v), want false", v, ok)
+	}
+	if v, ok := attrValue(span, "poll.cap_hit"); !ok || v.AsBool() {
+		t.Errorf("poll.cap_hit: got %v (ok=%v), want false", v, ok)
+	}
+}
+
+// TestNationalPollHandler_Handle_AggregatesBothLanes covers the top-level
+// cycleHandler: both lanes run, their ingested counts sum, and CycleType is
+// stamped "National" so runPollSB's existing polling.cycle_type tag keeps
+// working with a value that reflects the new design.
+func TestNationalPollHandler_Handle_AggregatesBothLanes(t *testing.T) {
+	t.Parallel()
+	ldA := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+	ldB := time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC)
+
+	fetcherA := newFakeNationalFetcher()
+	fetcherA.pages[0] = planit.FetchPageResult{From: 0, Applications: []applications.PlanningApplication{testApp("a", 300, ldA)}}
+	fetcherB := newFakeNationalFetcher()
+	fetcherB.pages[0] = planit.FetchPageResult{From: 0, Applications: []applications.PlanningApplication{testApp("b", 300, ldB)}}
+
+	appsA := newFakeApps()
+	appsB := newFakeApps()
+	state := newFakeStateStore()
+	logger := slog.New(slog.NewTextHandler(discard{}, nil))
+	clock := func() time.Time { return time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC) }
+
+	laneAHandler := NewNationalLaneHandler(fetcherA, state, appsA, laneAOpts(), clock, logger)
+	laneBHandler := NewNationalLaneHandler(fetcherB, state, appsB, laneBOpts(20), clock, logger)
+
+	handler := NewNationalPollHandler(laneAHandler, laneBHandler, nil, clock, logger)
+
+	res, err := handler.Handle(context.Background())
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if res.ApplicationCount != 2 {
+		t.Errorf("ApplicationCount: got %d, want 2", res.ApplicationCount)
+	}
+	if res.CycleType != "National" {
+		t.Errorf("CycleType: got %q, want National", res.CycleType)
+	}
+	if res.TerminationReason != TerminationNatural {
+		t.Errorf("TerminationReason: got %v, want TerminationNatural", res.TerminationReason)
+	}
+	if res.AuthorityErrors != 0 {
+		t.Errorf("AuthorityErrors: got %d, want 0", res.AuthorityErrors)
+	}
+}
+
+// TestNationalPollHandler_Handle_CountsLaneErrorsWithoutFailingTheCycle
+// proves a lane error is counted, not fatal: the cycle still returns a nil
+// error so the orchestrator schedules the next run (self-healing — no
+// per-authority state to strand).
+func TestNationalPollHandler_Handle_CountsLaneErrorsWithoutFailingTheCycle(t *testing.T) {
+	t.Parallel()
+	fetcherA := newFakeNationalFetcher()
+	fetcherA.failNth[1] = errors.New("planit: transport blew up")
+	fetcherB := newFakeNationalFetcher()
+
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	logger := slog.New(slog.NewTextHandler(discard{}, nil))
+	clock := func() time.Time { return time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC) }
+
+	laneAHandler := NewNationalLaneHandler(fetcherA, state, apps, laneAOpts(), clock, logger)
+	laneBHandler := NewNationalLaneHandler(fetcherB, state, apps, laneBOpts(20), clock, logger)
+	handler := NewNationalPollHandler(laneAHandler, laneBHandler, nil, clock, logger)
+
+	res, err := handler.Handle(context.Background())
+	if err != nil {
+		t.Fatalf("Handle must not fail the cycle on a lane error: %v", err)
+	}
+	if res.AuthorityErrors != 1 {
+		t.Errorf("AuthorityErrors: got %d, want 1", res.AuthorityErrors)
+	}
+}

--- a/api-go/internal/polling/nationallane_test.go
+++ b/api-go/internal/polling/nationallane_test.go
@@ -252,9 +252,9 @@ func TestNationalLane_LaneBPageCapStopsWalkAndFreezesWatermark(t *testing.T) {
 }
 
 // TestNationalLane_FirstRunPrefiltersOnMaskCutoff covers a lane that has
-// never run (no sentinel poll_state row): there is no watermark to
-// prefilter on, so different_start must fall back to the mask cutoff date —
-// never an unprefiltered national query (ADR 0041's guardrail).
+// never run (no sentinel poll_state row): the seeding fetch's different_start
+// falls back to the mask cutoff date — never an unprefiltered national query
+// (ADR 0041's guardrail) — and requests only page 0.
 func TestNationalLane_FirstRunPrefiltersOnMaskCutoff(t *testing.T) {
 	t.Parallel()
 	fetcher := newFakeNationalFetcher()
@@ -277,6 +277,173 @@ func TestNationalLane_FirstRunPrefiltersOnMaskCutoff(t *testing.T) {
 	}
 	if q.Mask != planit.MaskStartDate {
 		t.Errorf("Mask: got %v, want MaskStartDate", q.Mask)
+	}
+}
+
+// TestNationalLane_SeedsWatermarkFromHeadOnFirstRun is the fix for the
+// first-run backfill bug: a lane with no prior watermark must fetch page 0
+// ONLY — never walking further pages even when PlanIt reports more follow —
+// ingest nothing, and persist the watermark as the max last_different seen on
+// that single page. Forward-flow only: no historical sweep (ADR 0041 rule 2).
+func TestNationalLane_SeedsWatermarkFromHeadOnFirstRun(t *testing.T) {
+	t.Parallel()
+	head := time.Date(2026, 7, 14, 5, 14, 58, 0, time.UTC)
+	older := head.Add(-2 * time.Hour)
+	total := 1717
+
+	fetcher := newFakeNationalFetcher()
+	fetcher.pages[0] = planit.FetchPageResult{
+		From: 0,
+		Applications: []applications.PlanningApplication{
+			testApp("newest", 300, head),
+			testApp("older", 300, older),
+		},
+		HasMorePages: true, // PlanIt claims more pages follow; seeding must never fetch them
+		Total:        &total,
+	}
+	apps := newFakeApps()
+	state := newFakeStateStore() // no sentinel row: never run
+
+	h := newLaneHandler(t, fetcher, apps, state, laneAOpts())
+	out := h.Run(context.Background())
+
+	if out.err != nil {
+		t.Fatalf("Run: %v", out.err)
+	}
+	if fetcher.calls != 1 {
+		t.Fatalf("expected exactly one fetch (page 0 only, never walking further pages), got %d", fetcher.calls)
+	}
+	if out.recordsIngested != 0 {
+		t.Errorf("recordsIngested: got %d, want 0 (a seed must never ingest — that would be a backfill)", out.recordsIngested)
+	}
+	if len(apps.upserts) != 0 {
+		t.Errorf("expected zero upserts on a seed, got %d", len(apps.upserts))
+	}
+	if !out.watermarkAfter.Equal(head) {
+		t.Errorf("watermarkAfter: got %v, want the page's max last_different %v", out.watermarkAfter, head)
+	}
+	if len(state.saves) != 1 || !state.saves[0].highWaterMark.Equal(head) {
+		t.Fatalf("expected exactly one Save persisting the seeded watermark: got %+v", state.saves)
+	}
+}
+
+// TestNationalLane_SeedsToNowOnEmptyFirstPage proves a lane whose masked
+// window currently matches nothing still seeds (to now()) rather than
+// staying permanently unseeded and re-attempting the seed forever.
+func TestNationalLane_SeedsToNowOnEmptyFirstPage(t *testing.T) {
+	t.Parallel()
+	fetcher := newFakeNationalFetcher()
+	fetcher.pages[0] = planit.FetchPageResult{From: 0, Applications: nil, HasMorePages: false}
+	apps := newFakeApps()
+	state := newFakeStateStore()
+
+	h := newLaneHandler(t, fetcher, apps, state, laneAOpts())
+	out := h.Run(context.Background())
+
+	if out.err != nil {
+		t.Fatalf("Run: %v", out.err)
+	}
+	wantNow := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC) // newLaneHandler's pinned clock
+	if !out.watermarkAfter.Equal(wantNow) {
+		t.Errorf("watermarkAfter: got %v, want now() %v", out.watermarkAfter, wantNow)
+	}
+	if out.recordsIngested != 0 {
+		t.Errorf("recordsIngested: got %d, want 0", out.recordsIngested)
+	}
+	if len(state.saves) != 1 {
+		t.Fatalf("expected exactly one Save, got %+v", state.saves)
+	}
+}
+
+// TestNationalLane_SeedFetchErrorLeavesLaneUnseeded proves rule 5 of the
+// seeding fix: a failed page-0 fetch must not persist ANY watermark — the
+// lane stays unseeded and the next cycle simply retries the seed (bounded to
+// one extra request, harmless).
+func TestNationalLane_SeedFetchErrorLeavesLaneUnseeded(t *testing.T) {
+	t.Parallel()
+	fetcher := newFakeNationalFetcher()
+	fetcher.failNth[1] = errors.New("planit: transport blew up")
+	apps := newFakeApps()
+	state := newFakeStateStore()
+
+	h := newLaneHandler(t, fetcher, apps, state, laneAOpts())
+	out := h.Run(context.Background())
+
+	if out.err == nil {
+		t.Fatal("expected the page-0 fetch error to surface on the outcome")
+	}
+	if len(state.saves) != 0 {
+		t.Errorf("expected NO Save call when the seed fetch fails, got %+v", state.saves)
+	}
+}
+
+// TestNationalLane_SeedRateLimitedLeavesLaneUnseeded mirrors the error case
+// for a 429 on the seeding fetch.
+func TestNationalLane_SeedRateLimitedLeavesLaneUnseeded(t *testing.T) {
+	t.Parallel()
+	retryAfter := 30 * time.Second
+	fetcher := newFakeNationalFetcher()
+	fetcher.failNth[1] = &planit.RateLimitError{RetryAfter: &retryAfter}
+	apps := newFakeApps()
+	state := newFakeStateStore()
+
+	h := newLaneHandler(t, fetcher, apps, state, laneAOpts())
+	out := h.Run(context.Background())
+
+	if !out.rateLimited {
+		t.Fatal("expected rateLimited=true")
+	}
+	if len(state.saves) != 0 {
+		t.Errorf("expected NO Save call when the seed fetch is rate-limited, got %+v", state.saves)
+	}
+}
+
+// TestNationalLane_SeedThenForwardFlow proves seeding does not break steady
+// state: after a seeded run, a second run from that watermark ingests only
+// the record strictly newer than the seed and stops normally at the
+// (re-encountered) boundary.
+func TestNationalLane_SeedThenForwardFlow(t *testing.T) {
+	t.Parallel()
+	seedHead := time.Date(2026, 7, 14, 5, 0, 0, 0, time.UTC)
+	fetcher := newFakeNationalFetcher()
+	fetcher.pages[0] = planit.FetchPageResult{
+		From:         0,
+		Applications: []applications.PlanningApplication{testApp("seed-head", 300, seedHead)},
+		HasMorePages: false,
+	}
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	h := newLaneHandler(t, fetcher, apps, state, laneAOpts())
+
+	seedOut := h.Run(context.Background())
+	if seedOut.recordsIngested != 0 {
+		t.Fatalf("seed run must not ingest: got %d", seedOut.recordsIngested)
+	}
+
+	// Second run: a fresh descending walk (a new fetcher, as a new PlanIt
+	// request would be) finds one genuinely new record ahead of the seeded
+	// watermark, plus the seed-head record again at the exact boundary.
+	newRecord := seedHead.Add(1 * time.Hour)
+	fetcher2 := newFakeNationalFetcher()
+	fetcher2.pages[0] = planit.FetchPageResult{
+		From: 0,
+		Applications: []applications.PlanningApplication{
+			testApp("forward", 300, newRecord),
+			testApp("seed-head-again", 300, seedHead), // == watermark: boundary, must stop here
+		},
+		HasMorePages: false,
+	}
+	h2 := newLaneHandler(t, fetcher2, apps, state, laneAOpts())
+	out2 := h2.Run(context.Background())
+
+	if out2.err != nil {
+		t.Fatalf("Run: %v", out2.err)
+	}
+	if out2.recordsIngested != 1 {
+		t.Errorf("recordsIngested: got %d, want 1 (only the record strictly newer than the seed)", out2.recordsIngested)
+	}
+	if !out2.watermarkAfter.Equal(newRecord) {
+		t.Errorf("watermarkAfter: got %v, want %v", out2.watermarkAfter, newRecord)
 	}
 }
 
@@ -361,6 +528,48 @@ func TestNationalLaneRun_EmitsSpanWithFullAttributeSet(t *testing.T) {
 	if v, ok := attrValue(span, "poll.cap_hit"); !ok || v.AsBool() {
 		t.Errorf("poll.cap_hit: got %v (ok=%v), want false", v, ok)
 	}
+	if v, ok := attrValue(span, "poll.seeded"); !ok || v.AsBool() {
+		t.Errorf("poll.seeded: got %v (ok=%v), want false (this is a steady-state walk, not a seed)", v, ok)
+	}
+	if v, ok := attrValue(span, "poll.different_start"); !ok || v.AsString() != watermark.Format("2006-01-02") {
+		t.Errorf("poll.different_start: got %v (ok=%v), want %v", v, ok, watermark.Format("2006-01-02"))
+	}
+}
+
+// TestNationalLaneRun_SeedingSpanTagsSeededAndDifferentStart proves the two
+// telemetry additions requested on top of the seeding fix: poll.seeded=true
+// on a seeding run, and poll.different_start present (the mask cutoff, since
+// there is no watermark yet to prefilter on).
+func TestNationalLaneRun_SeedingSpanTagsSeededAndDifferentStart(t *testing.T) {
+	fetcher := newFakeNationalFetcher()
+	total := 1717
+	fetcher.pages[0] = planit.FetchPageResult{
+		From:         0,
+		Applications: []applications.PlanningApplication{testApp("a", 300, time.Date(2026, 7, 14, 5, 0, 0, 0, time.UTC))},
+		Total:        &total,
+	}
+	apps := newFakeApps()
+	state := newFakeStateStore() // no sentinel row: never run
+
+	h := newLaneHandler(t, fetcher, apps, state, laneAOpts())
+
+	spans := recordSpans(t, func() {
+		h.Run(context.Background())
+	})
+	span, ok := spanNamed(spans, "PlanIt national lane poll")
+	if !ok {
+		t.Fatalf("expected a %q span", "PlanIt national lane poll")
+	}
+	if v, ok := attrValue(span, "poll.seeded"); !ok || !v.AsBool() {
+		t.Errorf("poll.seeded: got %v (ok=%v), want true", v, ok)
+	}
+	// 2026-07-14 minus the 90-day Lane A mask window.
+	if v, ok := attrValue(span, "poll.different_start"); !ok || v.AsString() != "2026-04-15" {
+		t.Errorf("poll.different_start: got %v (ok=%v), want 2026-04-15", v, ok)
+	}
+	if v, ok := attrValue(span, "planit.total"); !ok || v.AsInt64() != 1717 {
+		t.Errorf("planit.total: got %v (ok=%v), want 1717 (a seed still stamps PlanIt's reported total)", v, ok)
+	}
 }
 
 // TestNationalPollHandler_Handle_AggregatesBothLanes covers the top-level
@@ -369,6 +578,9 @@ func TestNationalLaneRun_EmitsSpanWithFullAttributeSet(t *testing.T) {
 // working with a value that reflects the new design.
 func TestNationalPollHandler_Handle_AggregatesBothLanes(t *testing.T) {
 	t.Parallel()
+	// Both lanes already seeded (a watermark row exists), so this exercises
+	// the steady-state delta walk, not the first-run seed path.
+	watermark := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
 	ldA := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
 	ldB := time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC)
 
@@ -380,6 +592,8 @@ func TestNationalPollHandler_Handle_AggregatesBothLanes(t *testing.T) {
 	appsA := newFakeApps()
 	appsB := newFakeApps()
 	state := newFakeStateStore()
+	state.states[sentinelLaneA] = PollState{HighWaterMark: watermark, LastPollTime: watermark}
+	state.states[sentinelLaneB] = PollState{HighWaterMark: watermark, LastPollTime: watermark}
 	logger := slog.New(slog.NewTextHandler(discard{}, nil))
 	clock := func() time.Time { return time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC) }
 

--- a/api-go/internal/polling/orchestrator_test.go
+++ b/api-go/internal/polling/orchestrator_test.go
@@ -242,8 +242,8 @@ func TestOrchestrator_NaturalResultUsesNaturalCadence(t *testing.T) {
 	if _, err := o.RunOnce(context.Background()); err != nil {
 		t.Fatalf("RunOnce: %v", err)
 	}
-	// Natural cadence (5m): 12:00:00 + 5m = 12:05:00.
-	want := time.Date(2026, 6, 14, 12, 5, 0, 0, time.UTC)
+	// Natural cadence (1h, ADR 0041): 12:00:00 + 1h = 13:00:00.
+	want := time.Date(2026, 6, 14, 13, 0, 0, 0, time.UTC)
 	if !pub.publishedAt.Equal(want) {
 		t.Errorf("scheduled enqueue: got %v, want %v", pub.publishedAt, want)
 	}

--- a/api-go/internal/polling/reconciliation.go
+++ b/api-go/internal/polling/reconciliation.go
@@ -1,0 +1,246 @@
+package polling
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/planit"
+)
+
+// reconciliationFetcher is the consumer-side slice of the PlanIt client Lane C
+// needs: one light per-authority projection page, and a full-record hydration
+// fetch by uid. *planit.Client satisfies both.
+type reconciliationFetcher interface {
+	FetchReconciliationPage(ctx context.Context, authorityID, startIndex int) (planit.FetchPageResult, error)
+	FetchByUID(ctx context.Context, uid string) (planit.FetchPageResult, error)
+}
+
+// ReconciliationOptions tune Lane C's cadence and blast radius (ADR 0041).
+type ReconciliationOptions struct {
+	// Interval is the minimum gap between full sweeps of every pollable
+	// authority ("daily during soak, then weekly" per the ADR's migration
+	// plan — a config dial, not a correctness boundary: Lane C is a
+	// completeness backstop, not the cutover's verification mechanism).
+	Interval time.Duration
+	// MaxStragglersPerAuthority bounds the per-authority hydration fan-out so
+	// one badly-drifted authority cannot balloon a single sweep's PlanIt
+	// request count.
+	MaxStragglersPerAuthority int
+}
+
+// ReconciliationHandler runs ADR 0041's Lane C: per authority, fetch a light
+// projection of its live set (uid, app_state, decided_date, last_different),
+// diff each row against the persisted application, and hydrate (a
+// full-record fetch, then the standard Ingest) only the rows that genuinely
+// differ. It is deliberately NOT the cutover's verification mechanism — that
+// is the planit.total / records_seen invariant stamped on Lane A/B's own
+// spans. Lane C is a completeness backstop for what the delta axis
+// structurally cannot see: decisions with no decided_date, rows with no
+// app_state, and applications discovered so late their start_date falls
+// outside both masks.
+type ReconciliationHandler struct {
+	fetcher     reconciliationFetcher
+	watermark   *laneWatermarkStore
+	ingester    *Ingester
+	authorities activeAuthorityProvider
+	opts        ReconciliationOptions
+	now         func() time.Time
+	logger      *slog.Logger
+}
+
+// NewReconciliationHandler wires Lane C. now is injected so tests pin the
+// clock.
+func NewReconciliationHandler(
+	fetcher reconciliationFetcher,
+	state pollStateAccess,
+	apps applicationStore,
+	authorityProvider activeAuthorityProvider,
+	opts ReconciliationOptions,
+	now func() time.Time,
+	logger *slog.Logger,
+) *ReconciliationHandler {
+	return &ReconciliationHandler{
+		fetcher:     fetcher,
+		watermark:   newLaneWatermarkStore(state, sentinelLaneC),
+		ingester:    NewIngester(apps, nil, nil),
+		authorities: authorityProvider,
+		opts:        opts,
+		now:         now,
+		logger:      logger,
+	}
+}
+
+// WithFanOut wires the notification fan-out collaborators onto Lane C's
+// hydration ingests, mirroring PollPlanItHandler.WithFanOut (including its
+// nil-ingester guard, so calling this on a zero-value ReconciliationHandler —
+// as a wiring test does — never panics). Returns the handler for chaining.
+func (h *ReconciliationHandler) WithFanOut(decision DecisionDispatcher, enqueuer NotificationEnqueuer) *ReconciliationHandler {
+	if h.ingester == nil {
+		h.ingester = &Ingester{}
+	}
+	h.ingester.decision = decision
+	h.ingester.enqueuer = enqueuer
+	return h
+}
+
+// Due reports whether Lane C's sweep interval has elapsed since its last run
+// (or it has never run). A watermark-store read error fails safe (not due):
+// skipping a sweep this cycle is far cheaper than risking an unbounded extra
+// PlanIt load off the back of a store hiccup.
+func (h *ReconciliationHandler) Due(ctx context.Context, now time.Time) bool {
+	_, lastRun, err := h.watermark.get(ctx)
+	if err != nil {
+		h.logger.WarnContext(ctx, "lane C: read last-run watermark failed; skipping this cycle's due check", "error", err)
+		return false
+	}
+	return lastRun.IsZero() || now.Sub(lastRun) >= h.opts.Interval
+}
+
+// reconciliationOutcome is one Lane C sweep's result, carried onto the
+// telemetry span.
+type reconciliationOutcome struct {
+	authoritiesSwept int
+	recordsSeen      int
+	stragglers       int
+	hydrated         int
+	err              error
+}
+
+// Run sweeps every pollable authority's light projection, diffs each row
+// against Postgres, and hydrates genuinely-differing rows one uid at a time
+// (bulk hydration by id_match is unproven — ADR 0041). A per-authority fetch
+// error is logged and skipped, not fatal to the sweep: the next scheduled
+// sweep retries it.
+func (h *ReconciliationHandler) Run(ctx context.Context) reconciliationOutcome {
+	ctx, span := otel.Tracer(tracerName).Start(ctx, "PlanIt reconciliation sweep")
+	defer span.End()
+
+	now := h.now().UTC()
+	var out reconciliationOutcome
+
+	ids, err := h.authorities.ActiveAuthorityIDs(ctx)
+	if err != nil {
+		out.err = fmt.Errorf("lane C: list authorities: %w", err)
+		span.SetAttributes(attribute.String("poll.lane", string(LaneC)))
+		return out
+	}
+
+	for _, authorityID := range ids {
+		if ctx.Err() != nil {
+			break
+		}
+		h.sweepAuthority(ctx, authorityID, &out)
+	}
+
+	// Lane C's watermark row carries only a last-run timestamp (the Due gate)
+	// — it has no delta boundary of its own, so the watermark value itself is
+	// always the zero time.
+	if serr := h.watermark.save(ctx, now, time.Time{}); serr != nil && out.err == nil {
+		out.err = serr
+	}
+
+	span.SetAttributes(
+		attribute.String("poll.lane", string(LaneC)),
+		attribute.Int("poll.records_seen", out.recordsSeen),
+		attribute.Int("poll.records_ingested", out.hydrated),
+		attribute.Int("reconciliation.authorities_swept", out.authoritiesSwept),
+		attribute.Int("reconciliation.stragglers", out.stragglers),
+	)
+	return out
+}
+
+// sweepAuthority fetches one authority's light projection page, diffs each
+// row against the persisted application, and hydrates the stragglers
+// (bounded by MaxStragglersPerAuthority).
+func (h *ReconciliationHandler) sweepAuthority(ctx context.Context, authorityID int, out *reconciliationOutcome) {
+	res, err := h.fetcher.FetchReconciliationPage(ctx, authorityID, 0)
+	if err != nil {
+		h.logger.WarnContext(ctx, "lane C: reconciliation page fetch failed, skipping authority", "authorityId", authorityID, "error", err)
+		return
+	}
+	out.authoritiesSwept++
+	out.recordsSeen += len(res.Applications)
+
+	authorityCode := strconv.Itoa(authorityID)
+	stragglers := 0
+	for _, light := range res.Applications {
+		if stragglers >= h.opts.MaxStragglersPerAuthority {
+			break
+		}
+		existing, found, gerr := h.ingester.apps.GetByUID(ctx, light.UID, authorityCode)
+		if gerr != nil {
+			h.logger.WarnContext(ctx, "lane C: read existing application failed", "uid", light.UID, "error", gerr)
+			continue
+		}
+		if found && !reconciliationDiffers(existing, light) {
+			continue
+		}
+		out.stragglers++
+		stragglers++
+		h.hydrate(ctx, light.UID, out)
+	}
+}
+
+// hydrate fetches one straggler's full record by uid and feeds it through the
+// standard Ingester (identical fan-out to Lane A/B). A miss or a hydration
+// error is logged and skipped; the next sweep retries it.
+func (h *ReconciliationHandler) hydrate(ctx context.Context, uid string, out *reconciliationOutcome) {
+	full, err := h.fetcher.FetchByUID(ctx, uid)
+	if err != nil {
+		h.logger.WarnContext(ctx, "lane C: hydration fetch failed", "uid", uid, "error", err)
+		return
+	}
+	for _, app := range full.Applications {
+		if app.UID != uid {
+			continue
+		}
+		if ierr := h.ingester.Ingest(ctx, app); ierr != nil {
+			h.logger.WarnContext(ctx, "lane C: hydrated ingest failed", "uid", uid, "error", ierr)
+			return
+		}
+		out.hydrated++
+		return
+	}
+	h.logger.WarnContext(ctx, "lane C: hydration fetch returned no matching record", "uid", uid)
+}
+
+// reconciliationDiffers reports whether the light projection row's app_state,
+// decided_date, or last_different differs from the persisted application —
+// Lane C's straggler test. Every other field is deliberately ignored: the
+// light projection never carries them, so comparing full business fields
+// here (applications.PlanningApplication.HasSameBusinessFieldsAs) would flag
+// every row as a false-positive straggler.
+func reconciliationDiffers(existing, light applications.PlanningApplication) bool {
+	if !eqOptionalString(existing.AppState, light.AppState) {
+		return true
+	}
+	if !eqOptionalTime(existing.DecidedDate, light.DecidedDate) {
+		return true
+	}
+	return !existing.LastDifferent.Equal(light.LastDifferent)
+}
+
+// eqOptionalString reports whether two optional string pointers carry the
+// same value (both nil counts as equal).
+func eqOptionalString(a, b *string) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
+// eqOptionalTime reports whether two optional time pointers carry the same
+// instant (both nil counts as equal).
+func eqOptionalTime(a, b *time.Time) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.Equal(*b)
+}

--- a/api-go/internal/polling/reconciliation_test.go
+++ b/api-go/internal/polling/reconciliation_test.go
@@ -1,0 +1,240 @@
+package polling
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/planit"
+)
+
+// fakeReconciliationFetcher serves pre-canned light per-authority pages and
+// per-uid hydration records.
+type fakeReconciliationFetcher struct {
+	pages        map[int]planit.FetchPageResult // authorityID -> light page
+	pageErrs     map[int]error                  // authorityID -> fetch error
+	hydrated     map[string]applications.PlanningApplication
+	hydrateErrs  map[string]error
+	hydrateCalls []string
+}
+
+func newFakeReconciliationFetcher() *fakeReconciliationFetcher {
+	return &fakeReconciliationFetcher{
+		pages:       map[int]planit.FetchPageResult{},
+		pageErrs:    map[int]error{},
+		hydrated:    map[string]applications.PlanningApplication{},
+		hydrateErrs: map[string]error{},
+	}
+}
+
+func (f *fakeReconciliationFetcher) FetchReconciliationPage(_ context.Context, authorityID, _ int) (planit.FetchPageResult, error) {
+	if err, ok := f.pageErrs[authorityID]; ok {
+		return planit.FetchPageResult{}, err
+	}
+	return f.pages[authorityID], nil
+}
+
+func (f *fakeReconciliationFetcher) FetchByUID(_ context.Context, uid string) (planit.FetchPageResult, error) {
+	f.hydrateCalls = append(f.hydrateCalls, uid)
+	if err, ok := f.hydrateErrs[uid]; ok {
+		return planit.FetchPageResult{}, err
+	}
+	app, ok := f.hydrated[uid]
+	if !ok {
+		return planit.FetchPageResult{Applications: nil}, nil
+	}
+	return planit.FetchPageResult{Applications: []applications.PlanningApplication{app}}, nil
+}
+
+// lightApp builds a light-projection record: only uid, area_id, app_state,
+// decided_date and last_different are populated, mirroring what
+// reconciliationSelectFields actually returns.
+func lightApp(uid string, areaID int, state string, lastDifferent time.Time) applications.PlanningApplication {
+	s := state
+	return applications.PlanningApplication{UID: uid, AreaID: areaID, AppState: &s, LastDifferent: lastDifferent}
+}
+
+func newReconciliationHandler(t *testing.T, fetcher *fakeReconciliationFetcher, apps *fakeApps, state *fakeStateStore, authorityIDs []int, opts ReconciliationOptions) *ReconciliationHandler {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(discard{}, nil))
+	clock := func() time.Time { return time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC) }
+	return NewReconciliationHandler(fetcher, state, apps, fakeAuthorities{ids: authorityIDs}, opts, clock, logger)
+}
+
+func defaultReconciliationOpts() ReconciliationOptions {
+	return ReconciliationOptions{Interval: 7 * 24 * time.Hour, MaxStragglersPerAuthority: 10}
+}
+
+// TestReconciliation_HydratesGenuinelyDifferingRow covers the straggler path:
+// a light row whose app_state differs from Postgres is hydrated (full-record
+// fetch by uid) and ingested.
+func TestReconciliation_HydratesGenuinelyDifferingRow(t *testing.T) {
+	t.Parallel()
+	ld := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+	fetcher := newFakeReconciliationFetcher()
+	fetcher.pages[99] = planit.FetchPageResult{
+		Applications: []applications.PlanningApplication{lightApp("24/0001/FUL", 99, "Permitted", ld)},
+	}
+	full := testApp("24/0001", 99, ld)
+	full.UID = "24/0001/FUL"
+	permitted := "Permitted"
+	full.AppState = &permitted
+	fetcher.hydrated["24/0001/FUL"] = full
+
+	apps := newFakeApps()
+	undecided := "Undecided"
+	apps.existing["24/0001/FUL"] = applications.PlanningApplication{UID: "24/0001/FUL", AreaID: 99, AppState: &undecided, LastDifferent: ld.Add(-time.Hour)}
+	state := newFakeStateStore()
+
+	h := newReconciliationHandler(t, fetcher, apps, state, []int{99}, defaultReconciliationOpts())
+	out := h.Run(context.Background())
+
+	if out.err != nil {
+		t.Fatalf("Run: %v", out.err)
+	}
+	if out.stragglers != 1 || out.hydrated != 1 {
+		t.Errorf("stragglers=%d hydrated=%d, want 1/1", out.stragglers, out.hydrated)
+	}
+	if len(fetcher.hydrateCalls) != 1 || fetcher.hydrateCalls[0] != "24/0001/FUL" {
+		t.Errorf("hydrateCalls: got %v", fetcher.hydrateCalls)
+	}
+	if len(apps.upserts) != 1 || apps.upserts[0].UID != "24/0001/FUL" {
+		t.Fatalf("upserts: got %+v", apps.upserts)
+	}
+}
+
+// TestReconciliation_SkipsRowThatMatchesPostgres proves the light-projection
+// diff genuinely gates hydration: an identical row costs no hydration
+// request and no ingest.
+func TestReconciliation_SkipsRowThatMatchesPostgres(t *testing.T) {
+	t.Parallel()
+	ld := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+	fetcher := newFakeReconciliationFetcher()
+	fetcher.pages[99] = planit.FetchPageResult{
+		Applications: []applications.PlanningApplication{lightApp("24/0001/FUL", 99, "Undecided", ld)},
+	}
+	apps := newFakeApps()
+	undecided := "Undecided"
+	apps.existing["24/0001/FUL"] = applications.PlanningApplication{UID: "24/0001/FUL", AreaID: 99, AppState: &undecided, LastDifferent: ld}
+	state := newFakeStateStore()
+
+	h := newReconciliationHandler(t, fetcher, apps, state, []int{99}, defaultReconciliationOpts())
+	out := h.Run(context.Background())
+
+	if out.stragglers != 0 || out.hydrated != 0 {
+		t.Errorf("stragglers=%d hydrated=%d, want 0/0 (unchanged row must not hydrate)", out.stragglers, out.hydrated)
+	}
+	if len(fetcher.hydrateCalls) != 0 {
+		t.Errorf("hydrateCalls: got %v, want none", fetcher.hydrateCalls)
+	}
+}
+
+// TestReconciliation_MissingApplicationIsAStraggler covers a uid Postgres has
+// never seen: found=false must hydrate unconditionally.
+func TestReconciliation_MissingApplicationIsAStraggler(t *testing.T) {
+	t.Parallel()
+	ld := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+	fetcher := newFakeReconciliationFetcher()
+	fetcher.pages[99] = planit.FetchPageResult{
+		Applications: []applications.PlanningApplication{lightApp("24/0002/FUL", 99, "Undecided", ld)},
+	}
+	full := testApp("24/0002", 99, ld)
+	full.UID = "24/0002/FUL"
+	fetcher.hydrated["24/0002/FUL"] = full
+
+	apps := newFakeApps()
+	state := newFakeStateStore()
+
+	h := newReconciliationHandler(t, fetcher, apps, state, []int{99}, defaultReconciliationOpts())
+	out := h.Run(context.Background())
+
+	if out.stragglers != 1 || out.hydrated != 1 {
+		t.Errorf("stragglers=%d hydrated=%d, want 1/1 (never-seen uid must hydrate)", out.stragglers, out.hydrated)
+	}
+}
+
+// TestReconciliation_AuthorityFetchErrorSkipsAuthorityNotSweep proves a
+// single authority's page-fetch error does not fail the whole sweep: the
+// next authority is still swept.
+func TestReconciliation_AuthorityFetchErrorSkipsAuthorityNotSweep(t *testing.T) {
+	t.Parallel()
+	ld := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+	fetcher := newFakeReconciliationFetcher()
+	fetcher.pageErrs[1] = errors.New("planit: transport blew up")
+	fetcher.pages[2] = planit.FetchPageResult{
+		Applications: []applications.PlanningApplication{lightApp("24/0003/FUL", 2, "Undecided", ld)},
+	}
+	apps := newFakeApps()
+	state := newFakeStateStore()
+
+	h := newReconciliationHandler(t, fetcher, apps, state, []int{1, 2}, defaultReconciliationOpts())
+	out := h.Run(context.Background())
+
+	if out.err != nil {
+		t.Fatalf("a per-authority fetch error must not fail the sweep: %v", out.err)
+	}
+	if out.authoritiesSwept != 1 {
+		t.Errorf("authoritiesSwept: got %d, want 1 (authority 1 skipped, authority 2 swept)", out.authoritiesSwept)
+	}
+}
+
+// TestReconciliation_MaxStragglersPerAuthorityBoundsHydration proves the
+// per-authority hydration fan-out is capped.
+func TestReconciliation_MaxStragglersPerAuthorityBoundsHydration(t *testing.T) {
+	t.Parallel()
+	ld := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+	fetcher := newFakeReconciliationFetcher()
+	fetcher.pages[99] = planit.FetchPageResult{
+		Applications: []applications.PlanningApplication{
+			lightApp("a/1", 99, "Permitted", ld),
+			lightApp("a/2", 99, "Permitted", ld),
+			lightApp("a/3", 99, "Permitted", ld),
+		},
+	}
+	apps := newFakeApps()
+	state := newFakeStateStore()
+
+	h := newReconciliationHandler(t, fetcher, apps, state, []int{99}, ReconciliationOptions{Interval: 7 * 24 * time.Hour, MaxStragglersPerAuthority: 2})
+	out := h.Run(context.Background())
+
+	if out.stragglers != 2 {
+		t.Errorf("stragglers: got %d, want 2 (capped)", out.stragglers)
+	}
+}
+
+// TestReconciliationDue covers the interval gate: never-run is due; within
+// the interval is not due; past the interval is due again.
+func TestReconciliationDue(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	opts := ReconciliationOptions{Interval: 7 * 24 * time.Hour, MaxStragglersPerAuthority: 10}
+
+	tests := []struct {
+		name     string
+		lastRun  time.Time
+		hasState bool
+		want     bool
+	}{
+		{name: "never run", want: true},
+		{name: "within interval", lastRun: now.Add(-1 * time.Hour), hasState: true, want: false},
+		{name: "past interval", lastRun: now.Add(-8 * 24 * time.Hour), hasState: true, want: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fetcher := newFakeReconciliationFetcher()
+			apps := newFakeApps()
+			state := newFakeStateStore()
+			if tc.hasState {
+				state.states[sentinelLaneC] = PollState{LastPollTime: tc.lastRun}
+			}
+			h := newReconciliationHandler(t, fetcher, apps, state, nil, opts)
+			if got := h.Due(context.Background(), now); got != tc.want {
+				t.Errorf("Due: got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/api-go/internal/polling/scheduler.go
+++ b/api-go/internal/polling/scheduler.go
@@ -20,10 +20,14 @@ type SchedulerOptions struct {
 	JitterBound        time.Duration
 }
 
-// DefaultSchedulerOptions returns the default scheduler tunables.
+// DefaultSchedulerOptions returns the default scheduler tunables. NaturalCadence
+// is hourly (ADR 0041 / GH#962): the churn-masked national delta poll is
+// measured at ~72 records/hour nationally, so an hourly cadence is the right
+// natural rhythm for the new lanes — replacing the old per-authority drain's
+// 5-minute cadence, which existed to keep a 485-authority LRU queue moving.
 func DefaultSchedulerOptions() SchedulerOptions {
 	return SchedulerOptions{
-		NaturalCadence:     5 * time.Minute,
+		NaturalCadence:     1 * time.Hour,
 		TimeBoundedCadence: 1 * time.Minute,
 		RetryAfterCap:      3 * time.Hour,
 		RateLimitDefault:   5 * time.Minute,

--- a/api-go/internal/polling/scheduler_test.go
+++ b/api-go/internal/polling/scheduler_test.go
@@ -19,9 +19,9 @@ func TestNextRunScheduler_ComputeNextRun(t *testing.T) {
 	}{
 		{
 			name: "natural uses natural cadence",
-			// 5m natural cadence, no jitter (jitter is zero in this test).
+			// 1h natural cadence (ADR 0041), no jitter (jitter is zero in this test).
 			reason: TerminationNatural,
-			want:   now.Add(5 * time.Minute),
+			want:   now.Add(1 * time.Hour),
 		},
 		{
 			name:   "time-bounded uses short resume cadence",
@@ -85,8 +85,8 @@ func TestNextRunScheduler_RateLimitedAppliesJitter(t *testing.T) {
 
 	// Natural cadence does NOT apply jitter (only the rate-limited branch does).
 	gotNatural := s.ComputeNextRun(TerminationNatural, nil, now)
-	if !gotNatural.Equal(now.Add(5 * time.Minute)) {
-		t.Errorf("natural cadence should not jitter: got %v, want %v", gotNatural, now.Add(5*time.Minute))
+	if !gotNatural.Equal(now.Add(1 * time.Hour)) {
+		t.Errorf("natural cadence should not jitter: got %v, want %v", gotNatural, now.Add(1*time.Hour))
 	}
 }
 


### PR DESCRIPTION
Implements **ADR 0041** (churn-masked national delta poll) per **GH #962**, bead **tc-5m3tw**. Committed cutover: replaces the per-authority PlanIt drain with a single national query per lane and one global watermark per lane. No parallel run.

## Changes
- `refactor`: extract shared `fetchPage` helper in the PlanIt client (behaviour unchanged)
- `feat`: national delta query builder + client methods (`FetchNationalDeltaPage`, `FetchReconciliationPage`, `FetchByUID`) — no `auth`, `different_start` prefilter, `start_date`/`decided_start` mask, `sort=-last_different`, `pg_sz=300`, mandatory `select` (contains sort field), `compress=on`
- `feat`: Lane A/B national delta handler with descending-page + in-memory timestamp watermark boundary logic; **first-run seeds at PlanIt's head (page 0 only), never backfills**
- `feat`: Lane C reconciliation handler (weekly per-authority light projection + per-uid hydration)
- `feat`: watermark persistence via reserved `poll_state` sentinel `authority_id` rows (-1/-2/-3) — **no schema migration**, rollback is a pure redeploy
- `feat`: config knobs (mask days, Lane B page cap, Lane C interval/stragglers)
- `chore`: hourly natural poll cadence per ADR 0041
- `test`: real-DB (`pgtest`) integration coverage for the ingest path

## Telemetry (the safety mechanism)
Every Lane A/B span stamps `planit.total`, `poll.records_seen`, `poll.records_ingested`, `poll.watermark_before/after`, `poll.pages`, `poll.lane`, `poll.seeded`, `poll.different_start` — so the `records_seen == planit.total` invariant is checkable from telemetry at zero PlanIt cost.

## Verification
gofmt/vet/build clean; `go test ./...` 1881 pass; integration suite 2071 pass; golangci-lint 0 issues. All PlanIt facts taken from the verified spec — no calls to planit.org.uk from any dev machine or test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WsFe1gyxg1y9tz6Gb2HDCG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced national polling lanes for new applications, decisions, and scheduled reconciliation.
  * Added targeted reconciliation to detect and refresh records that may have changed.
  * Added configurable polling intervals, page limits, masking windows, and reconciliation limits.
  * Improved notification handling across all polling lanes.

* **Bug Fixes**
  * Prevented progress markers from advancing after failed or rate-limited polling.
  * Preserved accurate updates by ignoring reindex-only changes.

* **Tests**
  * Added comprehensive coverage for national polling, reconciliation, configuration, scheduling, and database ingestion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->