### PR TITLE
fix(polling): disable broken Lane C reconciliation (400-storm) behind config flag (tc-5lu8h)

### DIFF
--- a/api-go/cmd/worker/main.go
+++ b/api-go/cmd/worker/main.go
@@ -302,15 +302,24 @@ func buildPollOrchestrator(cfg platform.Config, sbClient *servicebus.Client, reg
 	// Lane C (reconciliation): a weekly (config-dialable) per-authority
 	// completeness backstop, not on the cutover's critical path. Reuses the
 	// static pollable-authority list the old Seed cycle drained.
-	laneC := polling.NewReconciliationHandler(
-		planItClient, stateStore, appStore,
-		polling.NewAllAuthorityProvider(authorities.NewLookup()),
-		polling.ReconciliationOptions{
-			Interval:                  time.Duration(cfg.PollingLaneCIntervalHours) * time.Hour,
-			MaxStragglersPerAuthority: cfg.PollingLaneCMaxStragglersPerAuthority,
-		},
-		time.Now, logger,
-	)
+	//
+	// Gated behind POLLING_LANE_C_ENABLED (default off): Lane C shipped broken
+	// in v0.21.0 — its per-authority query 400s on every authority, and it
+	// never records its weekly last-run when the sweep is cut off by the cycle
+	// budget, so it re-runs and hammers PlanIt every cycle. It stays nil (Handle
+	// skips it) until tc-tuge8 fixes both, then the config default flips.
+	var laneC *polling.ReconciliationHandler
+	if cfg.PollingLaneCEnabled {
+		laneC = polling.NewReconciliationHandler(
+			planItClient, stateStore, appStore,
+			polling.NewAllAuthorityProvider(authorities.NewLookup()),
+			polling.ReconciliationOptions{
+				Interval:                  time.Duration(cfg.PollingLaneCIntervalHours) * time.Hour,
+				MaxStragglersPerAuthority: cfg.PollingLaneCMaxStragglersPerAuthority,
+			},
+			time.Now, logger,
+		)
+	}
 
 	handler := polling.NewNationalPollHandler(laneA, laneB, laneC, time.Now, logger)
 
@@ -389,7 +398,11 @@ func wirePollFanOut(cfg platform.Config, laneA, laneB *polling.NationalLaneHandl
 
 	laneA.WithFanOut(dispatcher, enqueuer)
 	laneB.WithFanOut(dispatcher, enqueuer)
-	laneC.WithFanOut(dispatcher, enqueuer)
+	// laneC is nil when POLLING_LANE_C_ENABLED is off (its default) — Lane C is
+	// disabled until tc-tuge8 fixes it, so there is nothing to wire.
+	if laneC != nil {
+		laneC.WithFanOut(dispatcher, enqueuer)
+	}
 	handler.WithPushFlusher(coalescer)
 }
 

--- a/api-go/internal/platform/config.go
+++ b/api-go/internal/platform/config.go
@@ -206,6 +206,13 @@ type Config struct {
 	PollingLaneBMaxPages                  int
 	PollingLaneCIntervalHours             int
 	PollingLaneCMaxStragglersPerAuthority int
+	// PollingLaneCEnabled gates whether Lane C (reconciliation) is wired into
+	// the poll cycle at all. Loaded from POLLING_LANE_C_ENABLED and DEFAULT
+	// FALSE: Lane C shipped broken in v0.21.0 (its per-authority query 400s and
+	// it never records its weekly last-run on a budget cut-off, so it re-runs
+	// and hammers PlanIt every cycle). It stays off until tc-tuge8 fixes the
+	// query and the last-run persistence, then this default flips to true.
+	PollingLaneCEnabled bool
 
 	// NotificationsRetentionDays is the number of days to keep Notifications rows
 	// when running the pg-purge job. Loaded from NOTIFICATIONS_RETENTION_DAYS;
@@ -345,6 +352,7 @@ func LoadConfig() (Config, error) {
 		PollingLaneBMaxPages:                  getenvInt("POLLING_LANE_B_MAX_PAGES", 20),
 		PollingLaneCIntervalHours:             getenvInt("POLLING_LANE_C_INTERVAL_HOURS", 168),
 		PollingLaneCMaxStragglersPerAuthority: getenvInt("POLLING_LANE_C_MAX_STRAGGLERS_PER_AUTHORITY", 10),
+		PollingLaneCEnabled:                   getenvBool("POLLING_LANE_C_ENABLED"),
 
 		NotificationsRetentionDays:       getenvInt("NOTIFICATIONS_RETENTION_DAYS", 90),
 		DeviceRegistrationsRetentionDays: getenvInt("DEVICE_REGISTRATIONS_RETENTION_DAYS", 180),

--- a/api-go/internal/platform/config_test.go
+++ b/api-go/internal/platform/config_test.go
@@ -414,6 +414,7 @@ func TestLoadConfig_PollingDefaults(t *testing.T) {
 		"POLLING_PLANIT_PAGE_SIZE",
 		"POLLING_LANE_A_MASK_DAYS", "POLLING_LANE_B_MASK_DAYS", "POLLING_LANE_B_MAX_PAGES",
 		"POLLING_LANE_C_INTERVAL_HOURS", "POLLING_LANE_C_MAX_STRAGGLERS_PER_AUTHORITY",
+		"POLLING_LANE_C_ENABLED",
 	} {
 		t.Setenv(k, "")
 	}
@@ -454,8 +455,41 @@ func TestLoadConfig_PollingDefaults(t *testing.T) {
 	if cfg.PollingLaneCIntervalHours != 168 {
 		t.Errorf("lane C interval default: got %d, want 168", cfg.PollingLaneCIntervalHours)
 	}
+	if cfg.PollingLaneCEnabled {
+		t.Error("PollingLaneCEnabled: got true, want false by default (Lane C disabled until tc-tuge8)")
+	}
 	if cfg.PollingLaneCMaxStragglersPerAuthority != 10 {
 		t.Errorf("lane C max stragglers default: got %d, want 10", cfg.PollingLaneCMaxStragglersPerAuthority)
+	}
+}
+
+// TestLoadConfig_PollingLaneCEnabled pins the tc-5lu8h hotfix default: Lane C
+// reconciliation ships OFF (POLLING_LANE_C_ENABLED unset or falsy) until
+// tc-tuge8 fixes its per-authority query and cancelled-context save bug. An
+// explicit truthy value opts back in.
+func TestLoadConfig_PollingLaneCEnabled(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want bool
+	}{
+		{"unset defaults false", "", false},
+		{"true enables", "true", true},
+		{"1 enables", "1", true},
+		{"false stays disabled", "false", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("POLLING_LANE_C_ENABLED", tc.env)
+
+			cfg, err := LoadConfig()
+			if err != nil {
+				t.Fatalf("LoadConfig: %v", err)
+			}
+			if cfg.PollingLaneCEnabled != tc.want {
+				t.Errorf("PollingLaneCEnabled: got %v, want %v", cfg.PollingLaneCEnabled, tc.want)
+			}
+		})
 	}
 }
 
@@ -564,6 +598,7 @@ func TestLoadConfig_PollingOverrides(t *testing.T) {
 	t.Setenv("POLLING_LANE_B_MAX_PAGES", "10")
 	t.Setenv("POLLING_LANE_C_INTERVAL_HOURS", "24")
 	t.Setenv("POLLING_LANE_C_MAX_STRAGGLERS_PER_AUTHORITY", "5")
+	t.Setenv("POLLING_LANE_C_ENABLED", "true")
 
 	cfg, err := LoadConfig()
 	if err != nil {
@@ -595,5 +630,8 @@ func TestLoadConfig_PollingOverrides(t *testing.T) {
 	}
 	if cfg.PollingLaneCMaxStragglersPerAuthority != 5 {
 		t.Errorf("lane C max stragglers override: got %d, want 5", cfg.PollingLaneCMaxStragglersPerAuthority)
+	}
+	if !cfg.PollingLaneCEnabled {
+		t.Error("PollingLaneCEnabled override: got false, want true")
 	}
 }


### PR DESCRIPTION
## Hotfix for v0.21.0

Lane C (reconciliation) shipped broken in v0.21.0 (ADR 0041 cutover, #963):

1. Its per-authority query returns **HTTP 400** for every authority (`?auth=…&sort=-last_different&pg_sz=300&select=…&compress=on` with no date param).
2. `ReconciliationHandler.Run` persists its weekly last-run via the **request context** *after* the authority loop. The ~485-authority sweep (×2s throttle) exceeds the 570s cycle budget, so `ctx` is cancelled mid-sweep, the save fails, the last-run is never recorded, and Lane C re-runs and **400-storms PlanIt every cycle** (~250 bad requests/cycle observed in prod).

Lanes A and B (the product delta poll) are healthy in prod — seeded at PlanIt's head and forward-flowing (1,743 apps ingested on the first forward-flow cycle). This hotfix does **not** touch them.

## Change
- New `POLLING_LANE_C_ENABLED` config flag, **default false**.
- `buildPollOrchestrator` only constructs/wires Lane C when enabled; otherwise passes `nil` (`NationalPollHandler.Handle` already skips a nil Lane C, fan-out wiring guarded).

The 400 query and the last-run persistence bug are fixed under **tc-tuge8** before Lane C is re-enabled.

## Verification
gofmt/vet/build clean; `go test ./...` 1886 pass; golangci-lint 0 issues. No calls to planit.org.uk from any dev machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WsFe1gyxg1y9tz6Gb2HDCG