### PR TITLE
test(polling): regression coverage for disabled Lane C (tc-5lu8h)

### DIFF
--- a/api-go/cmd/worker/wiring_test.go
+++ b/api-go/cmd/worker/wiring_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/notifydispatch"
 	"github.com/AmyDe/town-crier/api-go/internal/platform"
 	"github.com/AmyDe/town-crier/api-go/internal/polling"
+	"github.com/AmyDe/town-crier/api-go/internal/servicebus"
 	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
 )
 
@@ -72,6 +73,24 @@ func TestWirePollFanOut_AcceptsZoneStoreInterface(t *testing.T) {
 	wirePollFanOut(platform.Config{}, laneA, laneB, laneC, handler, spy, testRegistry(), nil, discardLogger())
 }
 
+// TestWirePollFanOut_NilLaneCDoesNotPanic pins the tc-5lu8h hotfix: Lane C
+// reconciliation is disabled by default (POLLING_LANE_C_ENABLED=false), so
+// buildPollOrchestrator passes a nil *polling.ReconciliationHandler as laneC.
+// Before the fix, wirePollFanOut called laneC.WithFanOut unconditionally,
+// which nil-panics on a nil receiver method value dereference. This proves
+// the guard: a nil laneC must not panic, and Lane A/B fan-out wiring must be
+// unaffected.
+func TestWirePollFanOut_NilLaneCDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	laneA := &polling.NationalLaneHandler{}
+	laneB := &polling.NationalLaneHandler{}
+	handler := &polling.NationalPollHandler{}
+	spy := newSpyZoneStore()
+
+	wirePollFanOut(platform.Config{}, laneA, laneB, nil, handler, spy, testRegistry(), nil, discardLogger())
+}
+
 // TestEnqueuer_FindZonesContainingFlowsThroughInterface proves the notify fan-out
 // reaches the watch-zone store solely through the watchzones.Store interface:
 // EnqueueForApplication's entry point is FindZonesContaining, so whichever backend
@@ -102,6 +121,52 @@ func TestEnqueuer_FindZonesContainingFlowsThroughInterface(t *testing.T) {
 	if spy.lastFindLat != lat || spy.lastFindLng != lng {
 		t.Fatalf("FindZonesContaining coords = (%v, %v), want (%v, %v)",
 			spy.lastFindLat, spy.lastFindLng, lat, lng)
+	}
+}
+
+// TestBuildPollOrchestrator_LaneCGating pins the tc-5lu8h hotfix: Lane C
+// reconciliation is wired only when cfg.PollingLaneCEnabled is true (default
+// false). Both gate states must build a working orchestrator without
+// panicking — disabled exercises the nil-laneC path through
+// wirePollFanOut's guard; enabled exercises the still-functional (if
+// currently broken upstream, tracked separately as tc-tuge8) construction
+// path so the flag itself introduces no regression when flipped back on.
+// sbClient and st are zero-value: buildPollOrchestrator only needs sbClient
+// non-nil to pass its "no poller configured" guard, and every collaborator
+// it constructs (planit.NewClient, the national lane handlers, the
+// reconciliation handler, the orchestrator) opens no connection and performs
+// no I/O at construction time.
+func TestBuildPollOrchestrator_LaneCGating(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		laneCEnabled bool
+	}{
+		{"disabled (default)", false},
+		{"enabled", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := platform.Config{
+				PlanItBaseURL:                         "https://stub.planit.test/",
+				PollingLaneCEnabled:                   tc.laneCEnabled,
+				PollingLaneCIntervalHours:             168,
+				PollingLaneCMaxStragglersPerAuthority: 10,
+			}
+			sbClient := &servicebus.Client{}
+			st := &stores{}
+
+			adapter, err := buildPollOrchestrator(cfg, sbClient, testRegistry(), st, discardLogger())
+			if err != nil {
+				t.Fatalf("buildPollOrchestrator: %v", err)
+			}
+			if adapter == nil {
+				t.Fatal("buildPollOrchestrator: got nil adapter, want a configured orchestrator")
+			}
+		})
 	}
 }
 

--- a/api-go/internal/polling/nationallane_test.go
+++ b/api-go/internal/polling/nationallane_test.go
@@ -647,3 +647,49 @@ func TestNationalPollHandler_Handle_CountsLaneErrorsWithoutFailingTheCycle(t *te
 		t.Errorf("AuthorityErrors: got %d, want 1", res.AuthorityErrors)
 	}
 }
+
+// TestNationalPollHandler_Handle_SkipsLaneCWhenNil pins the tc-5lu8h hotfix
+// contract at the handler level: NewNationalPollHandler(laneA, laneB, nil,
+// ...) — the shape cmd/worker's buildPollOrchestrator produces when
+// POLLING_LANE_C_ENABLED is off (its default) — must run Lane A and Lane B to
+// completion and return cleanly, with no reconciliation work attempted (there
+// is no Lane C to fetch from: h.laneC is nil, so Handle's `if h.laneC != nil`
+// guard skips the Due/Run call entirely rather than dereferencing a nil
+// *ReconciliationHandler).
+func TestNationalPollHandler_Handle_SkipsLaneCWhenNil(t *testing.T) {
+	t.Parallel()
+	watermark := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	ldA := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+	ldB := time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC)
+
+	fetcherA := newFakeNationalFetcher()
+	fetcherA.pages[0] = planit.FetchPageResult{From: 0, Applications: []applications.PlanningApplication{testApp("a", 300, ldA)}}
+	fetcherB := newFakeNationalFetcher()
+	fetcherB.pages[0] = planit.FetchPageResult{From: 0, Applications: []applications.PlanningApplication{testApp("b", 300, ldB)}}
+
+	appsA := newFakeApps()
+	appsB := newFakeApps()
+	state := newFakeStateStore()
+	state.states[sentinelLaneA] = PollState{HighWaterMark: watermark, LastPollTime: watermark}
+	state.states[sentinelLaneB] = PollState{HighWaterMark: watermark, LastPollTime: watermark}
+	logger := slog.New(slog.NewTextHandler(discard{}, nil))
+	clock := func() time.Time { return time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC) }
+
+	laneAHandler := NewNationalLaneHandler(fetcherA, state, appsA, laneAOpts(), clock, logger)
+	laneBHandler := NewNationalLaneHandler(fetcherB, state, appsB, laneBOpts(20), clock, logger)
+	handler := NewNationalPollHandler(laneAHandler, laneBHandler, nil, clock, logger)
+
+	res, err := handler.Handle(context.Background())
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if fetcherA.calls == 0 {
+		t.Error("Lane A fetcher: got 0 calls, want Lane A to have run")
+	}
+	if fetcherB.calls == 0 {
+		t.Error("Lane B fetcher: got 0 calls, want Lane B to have run")
+	}
+	if res.ApplicationCount != 2 {
+		t.Errorf("ApplicationCount: got %d, want 2 (both lanes ingested, nil Lane C contributed nothing)", res.ApplicationCount)
+	}
+}


### PR DESCRIPTION
## Summary
- Fast-follow to #964 (already merged/shipped as v0.21.1): adds the wiring/handler-level regression tests the original hotfix brief asked for, which the time-critical fast-pass fix didn't include.
- `TestWirePollFanOut_NilLaneCDoesNotPanic` — proves the `if laneC != nil` guard in `wirePollFanOut` itself.
- `TestBuildPollOrchestrator_LaneCGating` — exercises `buildPollOrchestrator` with `POLLING_LANE_C_ENABLED` both off (default) and on, proving neither gate state panics or fails construction.
- `TestNationalPollHandler_Handle_SkipsLaneCWhenNil` (internal/polling) — proves `Handle` runs Lane A and Lane B to completion and returns cleanly with `laneC == nil`, the exact shape the disabled flag produces.

Test-only — no production code changed. Lane A/B and `reconciliation.go` untouched.

## Test plan
- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `golangci-lint run ./...` — no issues
- [x] `go test ./...` — 1891 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for optional Lane C polling and reconciliation.
  * Verified polling continues safely when Lane C is disabled or unavailable.
  * Confirmed Lane A and Lane B processing remains functional without Lane C.
  * Validated poll orchestration succeeds with Lane C both enabled and disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->