### PR TITLE
fix(polling): wire metrics registry into ADR 0041 lane handlers (tc-7ef9g)

### DIFF
--- a/api-go/cmd/worker/main.go
+++ b/api-go/cmd/worker/main.go
@@ -404,6 +404,19 @@ func wirePollFanOut(cfg platform.Config, laneA, laneB *polling.NationalLaneHandl
 		laneC.WithFanOut(dispatcher, enqueuer)
 	}
 	handler.WithPushFlusher(coalescer)
+
+	// Record towncrier.polling.applications_ingested / cycles_completed /
+	// oldest_hwm_age_seconds on the three ADR 0041 lanes and the top-level
+	// handler (tc-7ef9g) — the same registry already wired onto the
+	// notification fan-out above. Without this the new national-lane code
+	// path is invisible on those instruments even though ingestion itself
+	// works (confirmed via AppDependencies span inspection).
+	laneA.WithMetrics(registry)
+	laneB.WithMetrics(registry)
+	if laneC != nil {
+		laneC.WithMetrics(registry)
+	}
+	handler.WithMetrics(registry)
 }
 
 // buildNotifyFanOut constructs the decision-dispatch, zone-enqueue and

--- a/api-go/internal/polling/metrics_test.go
+++ b/api-go/internal/polling/metrics_test.go
@@ -2,6 +2,7 @@ package polling
 
 import (
 	"context"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -12,29 +13,42 @@ import (
 // fakePollMetrics records every metrics call the handler makes so a test can
 // assert on the recorded business metrics without a real OTel pipeline. It
 // satisfies the polling package's consumer-side metricsRecorder interface.
+// The *Tags slices capture the cycleType/lane tag passed on each call (in
+// call order), which the ADR 0041 lane handlers' tests need to assert on —
+// unlike the older per-authority tags, a national lane's tag IS the fact
+// under test (which lane produced the metric).
 type fakePollMetrics struct {
-	authoritiesPolled  int
-	authoritiesSkipped int
-	applicationsIngest int
-	rateLimited        int
-	retryAfter         []float64
-	authorityProcMs    int
-	authorityTotals    []int
-	cyclesCompleted    []string // termination per completed cycle
-	cursorAdvanced     int
-	cursorCleared      int
-	oldestHwmCalls     int
-	neverPolledCalls   int
+	authoritiesPolled      int
+	authoritiesSkipped     int
+	applicationsIngest     int
+	applicationsIngestTags []string
+	rateLimited            int
+	rateLimitedTags        []string
+	retryAfter             []float64
+	retryAfterTags         []string
+	authorityProcMs        int
+	authorityTotals        []int
+	cyclesCompleted        []string // termination per completed cycle
+	cyclesCompletedTags    []string // cycleType per completed cycle
+	cursorAdvanced         int
+	cursorCleared          int
+	oldestHwmCalls         int
+	neverPolledCalls       int
 }
 
 func (f *fakePollMetrics) AuthorityPolled(context.Context, string)  { f.authoritiesPolled++ }
 func (f *fakePollMetrics) AuthoritySkipped(context.Context, string) { f.authoritiesSkipped++ }
-func (f *fakePollMetrics) ApplicationsIngested(_ context.Context, n int, _ string) {
+func (f *fakePollMetrics) ApplicationsIngested(_ context.Context, n int, cycleType string) {
 	f.applicationsIngest += n
+	f.applicationsIngestTags = append(f.applicationsIngestTags, cycleType)
 }
-func (f *fakePollMetrics) RateLimited(context.Context, string) { f.rateLimited++ }
-func (f *fakePollMetrics) RetryAfterSeconds(_ context.Context, s float64, _ string, _ int, _ bool) {
+func (f *fakePollMetrics) RateLimited(_ context.Context, cycleType string) {
+	f.rateLimited++
+	f.rateLimitedTags = append(f.rateLimitedTags, cycleType)
+}
+func (f *fakePollMetrics) RetryAfterSeconds(_ context.Context, s float64, cycleType string, _ int, _ bool) {
 	f.retryAfter = append(f.retryAfter, s)
+	f.retryAfterTags = append(f.retryAfterTags, cycleType)
 }
 func (f *fakePollMetrics) AuthorityProcessingMillis(context.Context, float64, string) {
 	f.authorityProcMs++
@@ -42,8 +56,9 @@ func (f *fakePollMetrics) AuthorityProcessingMillis(context.Context, float64, st
 func (f *fakePollMetrics) AuthorityTotal(_ context.Context, total int, _ string, _ int) {
 	f.authorityTotals = append(f.authorityTotals, total)
 }
-func (f *fakePollMetrics) CycleCompleted(_ context.Context, _ string, termination string) {
+func (f *fakePollMetrics) CycleCompleted(_ context.Context, cycleType string, termination string) {
 	f.cyclesCompleted = append(f.cyclesCompleted, termination)
+	f.cyclesCompletedTags = append(f.cyclesCompletedTags, cycleType)
 }
 func (f *fakePollMetrics) CursorAdvanced(context.Context, string) { f.cursorAdvanced++ }
 func (f *fakePollMetrics) CursorCleared(context.Context, string)  { f.cursorCleared++ }
@@ -208,6 +223,230 @@ func TestHandler_NilMetricsRecorderIsNoOp(t *testing.T) {
 	// No WithMetrics call: the handler must record nothing and not panic.
 	h := newHandler(t, pi, apps, state, fakeAuthorities{ids: []int{99}}, CycleSeed, defaultHandlerOpts())
 	if _, err := h.Handle(context.Background()); err != nil {
+		t.Fatalf("Handle without metrics recorder: %v", err)
+	}
+}
+
+// TestNationalLaneRun_RecordsApplicationsIngestedWithLaneTag covers the ADR
+// 0041 lane wiring (tc-7ef9g): a national lane's Run records
+// ApplicationsIngested tagged with its own lane letter ("A"/"B") — there is
+// no Watched/Seed cycle concept on this code path, so the lane IS the tag.
+// The oldest-HWM staleness gauge should fire too (asserted via the existing
+// call-count field; the value/tag detail isn't asserted here).
+func TestNationalLaneRun_RecordsApplicationsIngestedWithLaneTag(t *testing.T) {
+	t.Parallel()
+	watermark := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+	newer := watermark.Add(1 * time.Hour)
+
+	fetcher := newFakeNationalFetcher()
+	fetcher.pages[0] = planit.FetchPageResult{
+		From:         0,
+		Applications: []applications.PlanningApplication{testApp("newer", 300, newer)},
+		HasMorePages: false,
+	}
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	state.states[sentinelLaneA] = PollState{HighWaterMark: watermark, LastPollTime: watermark}
+
+	rec := &fakePollMetrics{}
+	h := newLaneHandler(t, fetcher, apps, state, laneAOpts())
+	h.WithMetrics(rec)
+
+	out := h.Run(context.Background())
+	if out.err != nil {
+		t.Fatalf("Run: %v", out.err)
+	}
+	if rec.applicationsIngest != 1 {
+		t.Errorf("ApplicationsIngested total = %d, want 1", rec.applicationsIngest)
+	}
+	if len(rec.applicationsIngestTags) != 1 || rec.applicationsIngestTags[0] != "A" {
+		t.Errorf("ApplicationsIngested tags = %v, want [A]", rec.applicationsIngestTags)
+	}
+	if rec.oldestHwmCalls != 1 {
+		t.Errorf("OldestHighWaterMarkAge calls = %d, want 1 (a clean run always ends with a non-zero watermark)", rec.oldestHwmCalls)
+	}
+}
+
+// TestNationalLaneRun_RecordsRateLimitMetrics covers a lane hitting a 429
+// mid-walk: RateLimited and RetryAfterSeconds must both fire, tagged with the
+// lane letter, mirroring PollPlanItHandler.recordRetryAfter.
+func TestNationalLaneRun_RecordsRateLimitMetrics(t *testing.T) {
+	t.Parallel()
+	watermark := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	page1LD := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+	retryAfter := 30 * time.Second
+
+	fetcher := newFakeNationalFetcher()
+	fetcher.pages[0] = planit.FetchPageResult{
+		From:         0,
+		Applications: []applications.PlanningApplication{testApp("page1", 300, page1LD)},
+		HasMorePages: true,
+	}
+	fetcher.failNth[2] = &planit.RateLimitError{RetryAfter: &retryAfter}
+
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	state.states[sentinelLaneA] = PollState{HighWaterMark: watermark, LastPollTime: watermark}
+
+	rec := &fakePollMetrics{}
+	h := newLaneHandler(t, fetcher, apps, state, laneAOpts())
+	h.WithMetrics(rec)
+
+	out := h.Run(context.Background())
+	if !out.rateLimited {
+		t.Fatal("expected rateLimited=true")
+	}
+	if rec.rateLimited != 1 {
+		t.Errorf("RateLimited calls = %d, want 1", rec.rateLimited)
+	}
+	if len(rec.rateLimitedTags) != 1 || rec.rateLimitedTags[0] != "A" {
+		t.Errorf("RateLimited tags = %v, want [A]", rec.rateLimitedTags)
+	}
+	if len(rec.retryAfter) != 1 || rec.retryAfter[0] != 30 {
+		t.Errorf("RetryAfterSeconds = %v, want [30]", rec.retryAfter)
+	}
+	if len(rec.retryAfterTags) != 1 || rec.retryAfterTags[0] != "A" {
+		t.Errorf("RetryAfterSeconds tags = %v, want [A]", rec.retryAfterTags)
+	}
+}
+
+// TestNationalLane_NilMetricsRecorderIsNoOp mirrors
+// TestHandler_NilMetricsRecorderIsNoOp for a national lane: no WithMetrics
+// call must mean no panic (the noopMetrics fallback).
+func TestNationalLane_NilMetricsRecorderIsNoOp(t *testing.T) {
+	t.Parallel()
+	watermark := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+	fetcher := newFakeNationalFetcher()
+	fetcher.pages[0] = planit.FetchPageResult{
+		From:         0,
+		Applications: []applications.PlanningApplication{testApp("a", 300, watermark.Add(time.Hour))},
+		HasMorePages: false,
+	}
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	state.states[sentinelLaneA] = PollState{HighWaterMark: watermark, LastPollTime: watermark}
+
+	// No WithMetrics call: Run must not panic.
+	h := newLaneHandler(t, fetcher, apps, state, laneAOpts())
+	if out := h.Run(context.Background()); out.err != nil {
+		t.Fatalf("Run without metrics recorder: %v", out.err)
+	}
+}
+
+// TestReconciliationRun_RecordsApplicationsIngestedWithHydratedCount covers
+// Lane C: Run records ApplicationsIngested tagged "C" with the count of
+// stragglers actually hydrated this sweep.
+func TestReconciliationRun_RecordsApplicationsIngestedWithHydratedCount(t *testing.T) {
+	t.Parallel()
+	ld := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+	fetcher := newFakeReconciliationFetcher()
+	fetcher.pages[99] = planit.FetchPageResult{
+		Applications: []applications.PlanningApplication{lightApp("24/0001/FUL", 99, "Permitted", ld)},
+	}
+	full := testApp("24/0001", 99, ld)
+	full.UID = "24/0001/FUL"
+	permitted := "Permitted"
+	full.AppState = &permitted
+	fetcher.hydrated["24/0001/FUL"] = full
+
+	apps := newFakeApps()
+	undecided := "Undecided"
+	apps.existing["24/0001/FUL"] = applications.PlanningApplication{UID: "24/0001/FUL", AreaID: 99, AppState: &undecided, LastDifferent: ld.Add(-time.Hour)}
+	state := newFakeStateStore()
+
+	rec := &fakePollMetrics{}
+	h := newReconciliationHandler(t, fetcher, apps, state, []int{99}, defaultReconciliationOpts())
+	h.WithMetrics(rec)
+
+	out := h.Run(context.Background())
+	if out.err != nil {
+		t.Fatalf("Run: %v", out.err)
+	}
+	if rec.applicationsIngest != 1 {
+		t.Errorf("ApplicationsIngested total = %d, want 1", rec.applicationsIngest)
+	}
+	if len(rec.applicationsIngestTags) != 1 || rec.applicationsIngestTags[0] != "C" {
+		t.Errorf("ApplicationsIngested tags = %v, want [C]", rec.applicationsIngestTags)
+	}
+}
+
+// TestReconciliation_NilMetricsRecorderIsNoOp mirrors
+// TestHandler_NilMetricsRecorderIsNoOp for Lane C.
+func TestReconciliation_NilMetricsRecorderIsNoOp(t *testing.T) {
+	t.Parallel()
+	ld := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+	fetcher := newFakeReconciliationFetcher()
+	fetcher.pages[99] = planit.FetchPageResult{
+		Applications: []applications.PlanningApplication{lightApp("24/0001/FUL", 99, "Permitted", ld)},
+	}
+	apps := newFakeApps()
+	state := newFakeStateStore()
+
+	// No WithMetrics call: Run must not panic.
+	h := newReconciliationHandler(t, fetcher, apps, state, []int{99}, defaultReconciliationOpts())
+	if out := h.Run(context.Background()); out.err != nil {
+		t.Fatalf("Run without metrics recorder: %v", out.err)
+	}
+}
+
+// TestNationalPollHandler_RecordsCycleCompletedOnce covers the top-level
+// orchestration handler: exactly one CycleCompleted("National", <termination>)
+// per Handle call, regardless of how many lanes ran underneath it.
+func TestNationalPollHandler_RecordsCycleCompletedOnce(t *testing.T) {
+	t.Parallel()
+	watermark := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	ldA := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+	ldB := time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC)
+
+	fetcherA := newFakeNationalFetcher()
+	fetcherA.pages[0] = planit.FetchPageResult{From: 0, Applications: []applications.PlanningApplication{testApp("a", 300, ldA)}}
+	fetcherB := newFakeNationalFetcher()
+	fetcherB.pages[0] = planit.FetchPageResult{From: 0, Applications: []applications.PlanningApplication{testApp("b", 300, ldB)}}
+
+	appsA := newFakeApps()
+	appsB := newFakeApps()
+	state := newFakeStateStore()
+	state.states[sentinelLaneA] = PollState{HighWaterMark: watermark, LastPollTime: watermark}
+	state.states[sentinelLaneB] = PollState{HighWaterMark: watermark, LastPollTime: watermark}
+	logger := slog.New(slog.NewTextHandler(discard{}, nil))
+	clock := func() time.Time { return time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC) }
+
+	laneAHandler := NewNationalLaneHandler(fetcherA, state, appsA, laneAOpts(), clock, logger)
+	laneBHandler := NewNationalLaneHandler(fetcherB, state, appsB, laneBOpts(20), clock, logger)
+	handler := NewNationalPollHandler(laneAHandler, laneBHandler, nil, clock, logger)
+
+	rec := &fakePollMetrics{}
+	handler.WithMetrics(rec)
+
+	res, err := handler.Handle(context.Background())
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if len(rec.cyclesCompleted) != 1 || rec.cyclesCompleted[0] != res.TerminationReason.TelemetryValue() {
+		t.Errorf("CycleCompleted terminations = %v, want [%s]", rec.cyclesCompleted, res.TerminationReason.TelemetryValue())
+	}
+	if len(rec.cyclesCompletedTags) != 1 || rec.cyclesCompletedTags[0] != "National" {
+		t.Errorf("CycleCompleted cycleType tags = %v, want [National]", rec.cyclesCompletedTags)
+	}
+}
+
+// TestNationalPollHandler_NilMetricsRecorderIsNoOp mirrors
+// TestHandler_NilMetricsRecorderIsNoOp for the top-level handler.
+func TestNationalPollHandler_NilMetricsRecorderIsNoOp(t *testing.T) {
+	t.Parallel()
+	fetcherA := newFakeNationalFetcher()
+	fetcherB := newFakeNationalFetcher()
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	logger := slog.New(slog.NewTextHandler(discard{}, nil))
+	clock := func() time.Time { return time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC) }
+
+	laneAHandler := NewNationalLaneHandler(fetcherA, state, apps, laneAOpts(), clock, logger)
+	laneBHandler := NewNationalLaneHandler(fetcherB, state, apps, laneBOpts(20), clock, logger)
+	handler := NewNationalPollHandler(laneAHandler, laneBHandler, nil, clock, logger)
+
+	// No WithMetrics call: Handle must not panic.
+	if _, err := handler.Handle(context.Background()); err != nil {
 		t.Fatalf("Handle without metrics recorder: %v", err)
 	}
 }

--- a/api-go/internal/polling/nationallane.go
+++ b/api-go/internal/polling/nationallane.go
@@ -131,6 +131,12 @@ type NationalLaneHandler struct {
 	opts      NationalLaneOptions
 	now       func() time.Time
 	logger    *slog.Logger
+
+	// metrics records the towncrier.polling.* business KPIs for this lane's
+	// runs, wired via WithMetrics, mirroring PollPlanItHandler.metrics. nil
+	// until wired (the no-metrics default), so the many ingestion-only tests
+	// and call sites that don't supply one record nothing.
+	metrics metricsRecorder
 }
 
 // NewNationalLaneHandler wires a national lane. now is injected so tests pin
@@ -164,6 +170,25 @@ func (h *NationalLaneHandler) WithFanOut(decision DecisionDispatcher, enqueuer N
 	h.ingester.decision = decision
 	h.ingester.enqueuer = enqueuer
 	return h
+}
+
+// WithMetrics wires the metrics recorder this lane records its per-run
+// business KPIs on, mirroring PollPlanItHandler.WithMetrics. A
+// post-construction setter, so the many ingestion-only call sites and tests
+// are unaffected; cmd/worker calls it once per lane after construction.
+// Returns the handler for chaining.
+func (h *NationalLaneHandler) WithMetrics(rec metricsRecorder) *NationalLaneHandler {
+	h.metrics = rec
+	return h
+}
+
+// recorder returns a non-nil recorder so call sites can record
+// unconditionally, mirroring PollPlanItHandler.recorder.
+func (h *NationalLaneHandler) recorder() metricsRecorder {
+	if h.metrics == nil {
+		return noopMetrics{}
+	}
+	return h.metrics
 }
 
 // laneOutcome is one national lane run's result, carried both into
@@ -218,6 +243,11 @@ func (h *NationalLaneHandler) Run(ctx context.Context) laneOutcome {
 	if err != nil {
 		out.err = fmt.Errorf("lane %s: read watermark: %w", h.opts.Lane, err)
 		span.SetAttributes(attribute.String("poll.lane", string(h.opts.Lane)))
+		// out is not fully computed here — the watermark read itself failed,
+		// so there is nothing yet to report ingested and no watermark to age
+		// (out.watermarkAfter is still the zero time). No metrics recorded,
+		// mirroring the absence of a setSpanAttributes call on this early
+		// bail-out.
 		return out
 	}
 	out.watermarkBefore = watermarkBefore
@@ -317,6 +347,7 @@ pageLoop:
 		out.err = serr
 	}
 
+	h.recordRunMetrics(ctx, out, now)
 	h.setSpanAttributes(span, out, watermarkBefore, prefilterDate, false)
 	return out
 }
@@ -348,6 +379,12 @@ func (h *NationalLaneHandler) seed(ctx context.Context, span trace.Span, now, ma
 		} else {
 			out.err = ferr
 		}
+		// out.watermarkAfter is still the zero time here — the seeding fetch
+		// itself failed, so nothing was ever established this run. Recording
+		// an epoch-to-now "age" would mislead rather than signal genuine
+		// staleness, so recordRunMetrics's own IsZero guard skips that call;
+		// the rate-limit counters still fire when applicable.
+		h.recordRunMetrics(ctx, out, now)
 		h.setSpanAttributes(span, out, time.Time{}, maskCutoff, true)
 		return out
 	}
@@ -371,8 +408,49 @@ func (h *NationalLaneHandler) seed(ctx context.Context, span trace.Span, now, ma
 		out.err = serr
 	}
 
+	h.recordRunMetrics(ctx, out, now)
 	h.setSpanAttributes(span, out, time.Time{}, maskCutoff, true)
 	return out
+}
+
+// recordRunMetrics records one Run or seed invocation's lane-tagged business
+// KPIs: applications ingested, the lane's watermark staleness, and — on a
+// 429 — the rate-limit counter and Retry-After value (mirroring
+// PollPlanItHandler.recordRetryAfter's header-present/absent branching).
+//
+// OldestHighWaterMarkAge repurposes the per-authority staleness gauge as
+// "how far this lane's single global watermark trails now" — the correct
+// analogue for a cursor-less national lane. It is skipped whenever
+// out.watermarkAfter is still the zero time: that only happens when this
+// run (or seed) bailed out before establishing any watermark at all (a
+// watermark-read failure, or a failed/rate-limited seed fetch), and an
+// epoch-to-now "age" in that case would mislead rather than signal
+// staleness.
+func (h *NationalLaneHandler) recordRunMetrics(ctx context.Context, out laneOutcome, now time.Time) {
+	rec := h.recorder()
+	lane := string(h.opts.Lane)
+
+	rec.ApplicationsIngested(ctx, out.recordsIngested, lane)
+	if !out.watermarkAfter.IsZero() {
+		rec.OldestHighWaterMarkAge(ctx, now.Sub(out.watermarkAfter).Seconds(), lane, sentinelIDForLane(h.opts.Lane), out.watermarkAfter.IsZero())
+	}
+	if out.rateLimited {
+		rec.RateLimited(ctx, lane)
+		h.recordRetryAfter(ctx, rec, out.retryAfter, lane)
+	}
+}
+
+// recordRetryAfter records the parsed Retry-After value (seconds) for a
+// lane's 429, tagging header_present so dashboards distinguish a PlanIt 429
+// with no Retry-After header (value 0, header_present=false) from a real
+// small backoff — mirroring PollPlanItHandler.recordRetryAfter.
+func (h *NationalLaneHandler) recordRetryAfter(ctx context.Context, rec metricsRecorder, retryAfter *time.Duration, lane string) {
+	sentinelID := sentinelIDForLane(h.opts.Lane)
+	if retryAfter == nil {
+		rec.RetryAfterSeconds(ctx, 0, lane, sentinelID, false)
+		return
+	}
+	rec.RetryAfterSeconds(ctx, retryAfter.Seconds(), lane, sentinelID, true)
 }
 
 // setSpanAttributes stamps the "PlanIt national lane poll" span with the full
@@ -428,6 +506,11 @@ type NationalPollHandler struct {
 	flusher pushFlusher
 	now     func() time.Time
 	logger  *slog.Logger
+
+	// metrics records towncrier.polling.cycles_completed for this handler's
+	// cycles, wired via WithMetrics, mirroring PollPlanItHandler.metrics. nil
+	// until wired (the no-metrics default).
+	metrics metricsRecorder
 }
 
 // NewNationalPollHandler wires the three lanes. laneC may be nil to skip
@@ -441,6 +524,25 @@ func NewNationalPollHandler(laneA, laneB *NationalLaneHandler, laneC *Reconcilia
 func (h *NationalPollHandler) WithPushFlusher(f pushFlusher) *NationalPollHandler {
 	h.flusher = f
 	return h
+}
+
+// WithMetrics wires the metrics recorder this handler records
+// towncrier.polling.cycles_completed on, mirroring
+// PollPlanItHandler.WithMetrics. A post-construction setter, so tests that
+// don't supply one are unaffected; cmd/worker calls it once after
+// construction. Returns the handler for chaining.
+func (h *NationalPollHandler) WithMetrics(rec metricsRecorder) *NationalPollHandler {
+	h.metrics = rec
+	return h
+}
+
+// recorder returns a non-nil recorder so call sites can record
+// unconditionally, mirroring PollPlanItHandler.recorder.
+func (h *NationalPollHandler) recorder() metricsRecorder {
+	if h.metrics == nil {
+		return noopMetrics{}
+	}
+	return h.metrics
 }
 
 // Handle runs one national poll cycle: Lane A, then Lane B, then — only when
@@ -505,6 +607,8 @@ func (h *NationalPollHandler) Handle(ctx context.Context) (PollPlanItResult, err
 			}
 		}
 	}
+
+	h.recorder().CycleCompleted(ctx, "National", reason.TelemetryValue())
 
 	return PollPlanItResult{
 		ApplicationCount:  outA.recordsIngested + outB.recordsIngested,

--- a/api-go/internal/polling/reconciliation.go
+++ b/api-go/internal/polling/reconciliation.go
@@ -53,6 +53,11 @@ type ReconciliationHandler struct {
 	opts        ReconciliationOptions
 	now         func() time.Time
 	logger      *slog.Logger
+
+	// metrics records towncrier.polling.applications_ingested (tagged "C")
+	// for this lane's sweeps, wired via WithMetrics, mirroring
+	// PollPlanItHandler.metrics. nil until wired (the no-metrics default).
+	metrics metricsRecorder
 }
 
 // NewReconciliationHandler wires Lane C. now is injected so tests pin the
@@ -88,6 +93,25 @@ func (h *ReconciliationHandler) WithFanOut(decision DecisionDispatcher, enqueuer
 	h.ingester.decision = decision
 	h.ingester.enqueuer = enqueuer
 	return h
+}
+
+// WithMetrics wires the metrics recorder Lane C records its per-sweep
+// ApplicationsIngested count on, mirroring PollPlanItHandler.WithMetrics. A
+// post-construction setter, so the many tests that don't supply one are
+// unaffected; cmd/worker calls it once after construction. Returns the
+// handler for chaining.
+func (h *ReconciliationHandler) WithMetrics(rec metricsRecorder) *ReconciliationHandler {
+	h.metrics = rec
+	return h
+}
+
+// recorder returns a non-nil recorder so call sites can record
+// unconditionally, mirroring PollPlanItHandler.recorder.
+func (h *ReconciliationHandler) recorder() metricsRecorder {
+	if h.metrics == nil {
+		return noopMetrics{}
+	}
+	return h.metrics
 }
 
 // Due reports whether Lane C's sweep interval has elapsed since its last run
@@ -129,6 +153,9 @@ func (h *ReconciliationHandler) Run(ctx context.Context) reconciliationOutcome {
 	if err != nil {
 		out.err = fmt.Errorf("lane C: list authorities: %w", err)
 		span.SetAttributes(attribute.String("poll.lane", string(LaneC)))
+		// out is not fully computed here (the authority list itself failed to
+		// load, so nothing was swept) — no metrics recorded, mirroring the
+		// absence of the full span attribute set on this early bail-out.
 		return out
 	}
 
@@ -145,6 +172,8 @@ func (h *ReconciliationHandler) Run(ctx context.Context) reconciliationOutcome {
 	if serr := h.watermark.save(ctx, now, time.Time{}); serr != nil && out.err == nil {
 		out.err = serr
 	}
+
+	h.recorder().ApplicationsIngested(ctx, out.hydrated, string(LaneC))
 
 	span.SetAttributes(
 		attribute.String("poll.lane", string(LaneC)),


### PR DESCRIPTION
## Summary

- The ADR 0041 rewrite (PR #963/#964) replaced `PollPlanItHandler` with `NationalLaneHandler` (Lane A/B), `ReconciliationHandler` (Lane C), and `NationalPollHandler`, but never ported the old handler's `WithMetrics` wiring. `towncrier.polling.applications_ingested`, `cycles_completed`, and `oldest_hwm_age_seconds` have been dark for the new code path since cutover, even though ingestion itself works (confirmed via App Insights span inspection).
- Adds `metricsRecorder` field + `WithMetrics(...)` + `recorder()` to all three handlers, mirroring `PollPlanItHandler`'s exact pattern (`handler.go`), and records:
  - `NationalLaneHandler.Run`/`seed`: `ApplicationsIngested` tagged with the lane letter (`"A"`/`"B"`, since there's no Watched/Seed cycle concept here), `OldestHighWaterMarkAge` as "how far this lane's single global watermark trails now" (skipped only when `watermarkAfter` is still the zero time — a hard failure before any watermark was ever established, so an epoch-to-now age would mislead), and `RateLimited` + `RetryAfterSeconds` on a 429 (mirrors `recordRetryAfter`'s header-present/absent branching).
  - `ReconciliationHandler.Run`: `ApplicationsIngested` tagged `"C"` with the hydrated-straggler count — no rate-limit or watermark-staleness concept on Lane C.
  - `NationalPollHandler.Handle`: exactly one `CycleCompleted("National", <termination>)` per cycle.
- Deliberately does **not** port `AuthorityPolled`/`AuthoritySkipped`/`NeverPolledCount`/`AuthorityTotal`/`AuthorityProcessingMillis`/`CursorAdvanced`/`CursorCleared` — those are per-authority/cursor concepts that don't exist in the cursor-less, single-global-watermark national lane design (per bead scope). They stay `PollPlanItHandler`-only.
- Wires the registry into `laneA`/`laneB`/`laneC` (nil-guarded, since Lane C is disabled by default) and `handler` inside `wirePollFanOut` in `cmd/worker/main.go`, next to the existing notification-metrics wiring that already threads the same `registry` through.

## Test plan

- [x] Extended `fakePollMetrics` in `metrics_test.go` to capture per-call `cycleType` tags (previously discarded), backward-compatible with existing assertions.
- [x] Added 8 new tests: lane `Run` records `ApplicationsIngested` with correct count + lane tag; rate-limited lane records `RateLimited` + `RetryAfterSeconds`; `NationalPollHandler.Handle` records exactly one `CycleCompleted("National", ...)`; `ReconciliationHandler.Run` records `ApplicationsIngested` with hydrated count; nil-recorder no-op for all three handlers (mirrors `TestHandler_NilMetricsRecorderIsNoOp`).
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` (empty), `go test -race ./...` (1898 passed, 49 packages), `golangci-lint run ./...` (no issues) — all green from `api-go/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enhanced monitoring for polling cycles, including lane-level application ingestion, rate limiting, retry timing, watermark staleness, and cycle completion metrics.
  * Added visibility into national, reconciliation, and handler performance through the existing metrics dashboard.

* **Bug Fixes**
  * Improved metric accuracy for successful and partially completed polling runs.
  * Ensured monitoring remains safe and inactive when metrics collection is unavailable.

* **Tests**
  * Expanded coverage for lane-specific metrics, retry handling, cycle completion, and no-metrics scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->