### PR TITLE
feat(polling): add paced historical backfill lane (Lane D) (tc-8x9h3)

### DIFF
--- a/api-go/cmd/worker/main.go
+++ b/api-go/cmd/worker/main.go
@@ -64,6 +64,7 @@ type stores struct {
 	offerCode    *offercodes.PostgresStore
 	pollState    *polling.PostgresPollStateStore
 	lease        *polling.PostgresLeaseStore
+	backfill     *polling.PostgresBackfillStateStore
 }
 
 func main() {
@@ -142,6 +143,7 @@ func run() int {
 		offerCode:    offercodes.NewPostgresStore(pool, logger),
 		pollState:    polling.NewPostgresPollStateStore(pool),
 		lease:        polling.NewPostgresLeaseStore(pool, time.Now),
+		backfill:     polling.NewPostgresBackfillStateStore(pool),
 	}
 
 	// The Service Bus client (and thus the bootstrapper and the poll-sb
@@ -322,6 +324,34 @@ func buildPollOrchestrator(cfg platform.Config, sbClient *servicebus.Client, reg
 	}
 
 	handler := polling.NewNationalPollHandler(laneA, laneB, laneC, time.Now, logger)
+
+	// Lane D (GH#967, ADR 0042): the paced historical backfill lane. A
+	// national, date-windowed backward sweep that enriches stale/NULL GH#935
+	// fields and fills coverage gaps via the existing Ingester — structurally
+	// incapable of notifying (its Ingester is always built with nil
+	// decision/enqueuer collaborators, and BackfillHandler has no method that
+	// could wire one; see internal/polling/backfill.go's package doc).
+	//
+	// Gated behind POLLING_BACKFILL_ENABLED (default off), mirroring the
+	// Lane C rollout precedent (tc-5lu8h): ships dark, soaks, then flips on
+	// deliberately. WithBackfill(nil) is the safe default when disabled —
+	// NationalPollHandler.Handle nil-guards it exactly like Lane C.
+	//
+	// Deliberately NOT passed to wirePollFanOut below: there is no fan-out to
+	// wire for this lane, by construction.
+	var laneD *polling.BackfillHandler
+	if cfg.PollingBackfillEnabled {
+		laneD = polling.NewBackfillHandler(
+			planItClient, st.backfill, appStore,
+			polling.BackfillOptions{
+				WindowWidthDays:            cfg.PollingBackfillWindowWidthDays,
+				MaxPagesPerCycle:           cfg.PollingBackfillMaxPagesPerCycle,
+				EmptyWindowsBeforeComplete: cfg.PollingBackfillEmptyWindowsBeforeComplete,
+			},
+			time.Now, logger,
+		).WithMetrics(registry)
+	}
+	handler.WithBackfill(laneD)
 
 	// Wire the poll-path notification fan-out onto all three lanes: each
 	// upserted/hydrated application drives a decision-event dispatch (on a

--- a/api-go/cmd/worker/wiring_test.go
+++ b/api-go/cmd/worker/wiring_test.go
@@ -170,6 +170,52 @@ func TestBuildPollOrchestrator_LaneCGating(t *testing.T) {
 	}
 }
 
+// TestBuildPollOrchestrator_BackfillGating pins GH#967's dark-ship default:
+// Lane D (the paced historical backfill lane) is constructed and wired only
+// when cfg.PollingBackfillEnabled is true (default false). Both gate states
+// must build a working orchestrator without panicking, mirroring
+// TestBuildPollOrchestrator_LaneCGating's rationale — every collaborator
+// buildPollOrchestrator constructs opens no connection and performs no I/O at
+// construction time, so a zero-value *stores works for both branches.
+func TestBuildPollOrchestrator_BackfillGating(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		backfillEnabled bool
+	}{
+		{"disabled (default)", false},
+		{"enabled", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := platform.Config{
+				PlanItBaseURL:                             "https://stub.planit.test/",
+				PollingBackfillEnabled:                    tc.backfillEnabled,
+				PollingBackfillWindowWidthDays:            90,
+				PollingBackfillMaxPagesPerCycle:           2,
+				PollingBackfillEmptyWindowsBeforeComplete: 12,
+			}
+			sbClient := &servicebus.Client{}
+			// Referencing the backfill field by name (even as nil) forces
+			// stores to carry a *polling.PostgresBackfillStateStore field —
+			// buildPollOrchestrator's real construction path reads it when
+			// PollingBackfillEnabled is true.
+			st := &stores{backfill: nil}
+
+			adapter, err := buildPollOrchestrator(cfg, sbClient, testRegistry(), st, discardLogger())
+			if err != nil {
+				t.Fatalf("buildPollOrchestrator: %v", err)
+			}
+			if adapter == nil {
+				t.Fatal("buildPollOrchestrator: got nil adapter, want a configured orchestrator")
+			}
+		})
+	}
+}
+
 // TestLeaseTTLFor_AddsFiveMinuteMargin pins the honest-TTL derivation (GH#938
 // PR1): the polling lease TTL is the handler budget plus a 5-minute margin,
 // covering soft-budget overshoot (the budget is checked between authorities, not

--- a/api-go/internal/planit/backfill.go
+++ b/api-go/internal/planit/backfill.go
@@ -1,0 +1,45 @@
+// GH#967 / ADR 0042: Lane D, the paced historical backfill lane. This file
+// adds the one query shape the ADR 0041 lanes never needed: a national,
+// date-WINDOWED (both start_date and end_date bounded) backward sweep sorted
+// on start_date itself, rather than a delta on last_different. It reuses
+// ingestSelectFields (national.go) verbatim so the sweep enriches every
+// GH#935 field, and nationalPageSize (300) — the same fixed safety rule every
+// ADR 0041 lane uses. No auth param: like Lane A/B/C's own national queries,
+// this touches every authority's applications in the window at once.
+package planit
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// FetchBackfillPage fetches one page of Lane D's national, date-windowed
+// backward sweep: no auth param, bounded both above (windowEnd, fixed for the
+// window's lifetime) and below (windowStart, the window's trailing edge),
+// sorted -start_date, the full ingest select projection (so every returned
+// record can enrich the GH#935 fields via the standard Ingester), pg_sz=300,
+// compress=on. Throttling, retry, and 429 handling are identical to every
+// other fetch method (shared fetchPage tail).
+func (c *Client) FetchBackfillPage(ctx context.Context, windowStart, windowEnd time.Time, startIndex int) (FetchPageResult, error) {
+	target := c.baseURL + buildBackfillPath(windowStart, windowEnd, startIndex)
+	return c.fetchPage(ctx, target, 0, startIndex, nationalPageSize)
+}
+
+// buildBackfillPath builds Lane D's national backward-sweep query path: a
+// two-sided bounded window (start_date AND end_date — the shape ADR 0041
+// measured at 11.7s, never the unbounded one-sided shape it measured at 45s/
+// total:null), sort=-start_date (start_date is already in ingestSelectFields,
+// satisfying PlanIt's "sort field must be selected" rule with no changes
+// there), pg_sz=300, index, the full ingest select projection, and
+// compress=on. No auth param.
+func buildBackfillPath(windowStart, windowEnd time.Time, startIndex int) string {
+	return fmt.Sprintf(
+		"/api/applics/json?start_date=%s&end_date=%s&sort=-start_date&pg_sz=%d&index=%d&select=%s&compress=on",
+		windowStart.UTC().Format("2006-01-02"),
+		windowEnd.UTC().Format("2006-01-02"),
+		nationalPageSize,
+		startIndex,
+		selectParam(ingestSelectFields),
+	)
+}

--- a/api-go/internal/planit/backfill_test.go
+++ b/api-go/internal/planit/backfill_test.go
@@ -1,0 +1,126 @@
+package planit
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestBuildBackfillPath pins Lane D's national, date-windowed backward-sweep
+// query shape (GH#967): both a start_date and end_date bound (never an
+// unbounded one-sided window — the shape ADR 0041 explicitly measured at
+// 11.7s, not the 45s/total:null shape it ruled out), sort=-start_date, the
+// full ingest select projection (so the sweep can enrich every GH#935
+// field), pg_sz=300, compress=on, and critically NO auth param — this is a
+// national sweep, not a per-authority one.
+func TestBuildBackfillPath(t *testing.T) {
+	t.Parallel()
+	windowStart := time.Date(2026, 4, 16, 0, 0, 0, 0, time.UTC)
+	windowEnd := time.Date(2026, 7, 15, 0, 0, 0, 0, time.UTC)
+
+	path := buildBackfillPath(windowStart, windowEnd, 300)
+	u, err := url.Parse(path)
+	if err != nil {
+		t.Fatalf("parse built path %q: %v", path, err)
+	}
+	got := u.Query()
+
+	if got.Get("start_date") != "2026-04-16" {
+		t.Errorf("start_date: got %q, want 2026-04-16", got.Get("start_date"))
+	}
+	if got.Get("end_date") != "2026-07-15" {
+		t.Errorf("end_date: got %q, want 2026-07-15", got.Get("end_date"))
+	}
+	if got.Get("sort") != "-start_date" {
+		t.Errorf("sort: got %q, want -start_date", got.Get("sort"))
+	}
+	if got.Get("pg_sz") != "300" {
+		t.Errorf("pg_sz: got %q, want 300", got.Get("pg_sz"))
+	}
+	if got.Get("index") != "300" {
+		t.Errorf("index: got %q, want 300", got.Get("index"))
+	}
+	if got.Get("compress") != "on" {
+		t.Errorf("compress: got %q, want on", got.Get("compress"))
+	}
+	if got.Has("auth") {
+		t.Error("backfill query must not carry an auth param (national, not per-authority)")
+	}
+	fields := strings.Split(got.Get("select"), ",")
+	if !containsString(fields, "start_date") {
+		t.Errorf("select must contain the sort field start_date: got %v", fields)
+	}
+	if !containsString(fields, "reference") || !containsString(fields, "last_scraped") {
+		t.Errorf("select must be the full ingest projection (GH#935 fields included): got %v", fields)
+	}
+}
+
+// TestFetchBackfillPage_SendsExpectedQueryAndParsesResponse drives the client
+// end-to-end against an httptest server on localhost (never planit.org.uk).
+func TestFetchBackfillPage_SendsExpectedQueryAndParsesResponse(t *testing.T) {
+	t.Parallel()
+	body := `{"total":10,"pg_sz":300,"from":0,"records":[
+		{"name":"19/0001","uid":"19/0001/FUL","area_name":"Camden","area_id":300,"address":"1 High St","description":"A shed","app_type":"Full","app_state":"Permitted","start_date":"2019-04-20","location_x":-0.1,"location_y":51.5,"last_different":"2026-07-14T09:00:00.000000"}
+	]}`
+	var gotQuery url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	clock := &fakeClock{}
+	c := newTestClient(t, srv.URL, clock)
+
+	windowStart := time.Date(2019, 1, 20, 0, 0, 0, 0, time.UTC)
+	windowEnd := time.Date(2019, 4, 20, 0, 0, 0, 0, time.UTC)
+	res, err := c.FetchBackfillPage(context.Background(), windowStart, windowEnd, 0)
+	if err != nil {
+		t.Fatalf("FetchBackfillPage: %v", err)
+	}
+
+	if gotQuery.Get("start_date") != "2019-01-20" ||
+		gotQuery.Get("end_date") != "2019-04-20" ||
+		gotQuery.Get("sort") != "-start_date" ||
+		gotQuery.Get("pg_sz") != "300" ||
+		gotQuery.Get("compress") != "on" ||
+		gotQuery.Has("auth") {
+		t.Errorf("unexpected request query: %s", gotQuery.Encode())
+	}
+
+	if res.Total == nil || *res.Total != 10 {
+		t.Errorf("Total: got %v, want 10", res.Total)
+	}
+	if len(res.Applications) != 1 || res.Applications[0].UID != "19/0001/FUL" {
+		t.Fatalf("Applications: got %+v", res.Applications)
+	}
+}
+
+// TestFetchBackfillPage_RateLimited proves a 429 surfaces as *RateLimitError,
+// identically to every other fetch method.
+func TestFetchBackfillPage_RateLimited(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "30")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	t.Cleanup(srv.Close)
+
+	clock := &fakeClock{}
+	c := newTestClient(t, srv.URL, clock)
+
+	_, err := c.FetchBackfillPage(context.Background(), time.Now(), time.Now(), 0)
+	var rl *RateLimitError
+	if !errors.As(err, &rl) {
+		t.Fatalf("expected *RateLimitError, got %T: %v", err, err)
+	}
+	if rl.RetryAfter == nil || *rl.RetryAfter != 30*time.Second {
+		t.Errorf("RetryAfter: got %v", rl.RetryAfter)
+	}
+}

--- a/api-go/internal/platform/config.go
+++ b/api-go/internal/platform/config.go
@@ -214,6 +214,27 @@ type Config struct {
 	// query and the last-run persistence, then this default flips to true.
 	PollingLaneCEnabled bool
 
+	// PollingBackfill* configure Lane D, the paced historical backfill lane
+	// (GH#967, ADR 0042): a national, date-windowed backward sweep that
+	// enriches stale/NULL GH#935 fields and fills coverage gaps, but never
+	// notifies (its Ingester is always built with nil decision/enqueuer
+	// collaborators, and BackfillHandler has no method that could wire one).
+	// PollingBackfillEnabled gates whether the lane is constructed and wired
+	// into the poll cycle at all. Loaded from POLLING_BACKFILL_ENABLED and
+	// DEFAULT FALSE, mirroring the Lane C rollout precedent (tc-5lu8h): new
+	// polling code ships dark, gets soaked, flips on deliberately.
+	// PollingBackfillWindowWidthDays is the width of each backward-sliding
+	// date window (default 90, mirroring ADR 0041's mask width).
+	// PollingBackfillMaxPagesPerCycle bounds how many pages the lane fetches
+	// per poll cycle (default 2 — "creep a little bit each hour").
+	// PollingBackfillEmptyWindowsBeforeComplete is how many consecutive
+	// fully-drained, zero-record windows the lane tolerates before declaring
+	// itself done (default 12, ~3 years of national silence).
+	PollingBackfillEnabled                    bool
+	PollingBackfillWindowWidthDays            int
+	PollingBackfillMaxPagesPerCycle           int
+	PollingBackfillEmptyWindowsBeforeComplete int
+
 	// NotificationsRetentionDays is the number of days to keep Notifications rows
 	// when running the pg-purge job. Loaded from NOTIFICATIONS_RETENTION_DAYS;
 	// defaults to 90.
@@ -353,6 +374,11 @@ func LoadConfig() (Config, error) {
 		PollingLaneCIntervalHours:             getenvInt("POLLING_LANE_C_INTERVAL_HOURS", 168),
 		PollingLaneCMaxStragglersPerAuthority: getenvInt("POLLING_LANE_C_MAX_STRAGGLERS_PER_AUTHORITY", 10),
 		PollingLaneCEnabled:                   getenvBool("POLLING_LANE_C_ENABLED"),
+
+		PollingBackfillEnabled:                    getenvBool("POLLING_BACKFILL_ENABLED"),
+		PollingBackfillWindowWidthDays:            getenvInt("POLLING_BACKFILL_WINDOW_WIDTH_DAYS", 90),
+		PollingBackfillMaxPagesPerCycle:           getenvInt("POLLING_BACKFILL_MAX_PAGES_PER_CYCLE", 2),
+		PollingBackfillEmptyWindowsBeforeComplete: getenvInt("POLLING_BACKFILL_EMPTY_WINDOWS_BEFORE_COMPLETE", 12),
 
 		NotificationsRetentionDays:       getenvInt("NOTIFICATIONS_RETENTION_DAYS", 90),
 		DeviceRegistrationsRetentionDays: getenvInt("DEVICE_REGISTRATIONS_RETENTION_DAYS", 180),

--- a/api-go/internal/platform/config_test.go
+++ b/api-go/internal/platform/config_test.go
@@ -415,6 +415,8 @@ func TestLoadConfig_PollingDefaults(t *testing.T) {
 		"POLLING_LANE_A_MASK_DAYS", "POLLING_LANE_B_MASK_DAYS", "POLLING_LANE_B_MAX_PAGES",
 		"POLLING_LANE_C_INTERVAL_HOURS", "POLLING_LANE_C_MAX_STRAGGLERS_PER_AUTHORITY",
 		"POLLING_LANE_C_ENABLED",
+		"POLLING_BACKFILL_ENABLED", "POLLING_BACKFILL_WINDOW_WIDTH_DAYS",
+		"POLLING_BACKFILL_MAX_PAGES_PER_CYCLE", "POLLING_BACKFILL_EMPTY_WINDOWS_BEFORE_COMPLETE",
 	} {
 		t.Setenv(k, "")
 	}
@@ -460,6 +462,47 @@ func TestLoadConfig_PollingDefaults(t *testing.T) {
 	}
 	if cfg.PollingLaneCMaxStragglersPerAuthority != 10 {
 		t.Errorf("lane C max stragglers default: got %d, want 10", cfg.PollingLaneCMaxStragglersPerAuthority)
+	}
+	if cfg.PollingBackfillEnabled {
+		t.Error("PollingBackfillEnabled: got true, want false by default (GH#967, ships dark)")
+	}
+	if cfg.PollingBackfillWindowWidthDays != 90 {
+		t.Errorf("backfill window width default: got %d, want 90", cfg.PollingBackfillWindowWidthDays)
+	}
+	if cfg.PollingBackfillMaxPagesPerCycle != 2 {
+		t.Errorf("backfill max pages per cycle default: got %d, want 2", cfg.PollingBackfillMaxPagesPerCycle)
+	}
+	if cfg.PollingBackfillEmptyWindowsBeforeComplete != 12 {
+		t.Errorf("backfill empty-windows-before-complete default: got %d, want 12", cfg.PollingBackfillEmptyWindowsBeforeComplete)
+	}
+}
+
+// TestLoadConfig_PollingBackfillEnabled pins Lane D's dark-ship default
+// (GH#967): POLLING_BACKFILL_ENABLED unset or falsy stays disabled, mirroring
+// the Lane C rollout precedent (tc-5lu8h). An explicit truthy value opts in.
+func TestLoadConfig_PollingBackfillEnabled(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want bool
+	}{
+		{"unset defaults false", "", false},
+		{"true enables", "true", true},
+		{"1 enables", "1", true},
+		{"false stays disabled", "false", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("POLLING_BACKFILL_ENABLED", tc.env)
+
+			cfg, err := LoadConfig()
+			if err != nil {
+				t.Fatalf("LoadConfig: %v", err)
+			}
+			if cfg.PollingBackfillEnabled != tc.want {
+				t.Errorf("PollingBackfillEnabled: got %v, want %v", cfg.PollingBackfillEnabled, tc.want)
+			}
+		})
 	}
 }
 

--- a/api-go/internal/platform/postgres/migrations/0022_backfill_state.sql
+++ b/api-go/internal/platform/postgres/migrations/0022_backfill_state.sql
@@ -1,0 +1,28 @@
+-- +goose Up
+
+-- backfill_state is a SINGLETON row (id is always `true`; the CHECK forces at
+-- most one row ever) tracking Lane D's national, date-windowed backward
+-- sweep (GH#967, ADR 0042): the current window's fixed upper start_date
+-- bound (window_end), how far pagination has progressed within it
+-- (cursor_next_index), whether the window in progress has produced anything
+-- yet (window_records_seen — decides if a fully-drained window counts toward
+-- consecutive_empty_windows), and complete, set once the sweep has crept back
+-- far enough that it can stop for good. Deliberately a NEW table, not a reuse
+-- of poll_state: poll_state's cursor/HWM columns are slated for deletion once
+-- the ADR 0041 soak completes, and this lane only ever needs one row, not the
+-- per-authority shape poll_state carries.
+CREATE TABLE backfill_state (
+    id                        boolean     PRIMARY KEY DEFAULT true CHECK (id),
+    window_end                date,
+    cursor_next_index         integer     NOT NULL DEFAULT 0,
+    window_records_seen       integer     NOT NULL DEFAULT 0,
+    consecutive_empty_windows integer     NOT NULL DEFAULT 0,
+    complete                  boolean     NOT NULL DEFAULT false,
+    last_run_time             timestamptz
+);
+
+INSERT INTO backfill_state (id) VALUES (true);
+
+-- +goose Down
+
+DROP TABLE IF EXISTS backfill_state;

--- a/api-go/internal/polling/backfill.go
+++ b/api-go/internal/polling/backfill.go
@@ -1,0 +1,316 @@
+// GH#967 / ADR 0042: Lane D, the paced historical backfill lane. Where Lanes
+// A/B/C (nationallane.go, reconciliation.go) walk PlanIt FORWARD from a
+// watermark, Lane D creeps BACKWARD through PlanIt's national history one
+// fixed-width date window at a time, feeding every record it sees through the
+// existing, unmodified Ingester so GH#935's three-bucket classification does
+// the enrichment (stale/NULL silent fields) and gap-fill (missing rows) work
+// for free. It holds ONE piece of persisted state — not one row per authority
+// — because it isn't checking any single authority's freshness, it is
+// walking the whole national timeline once.
+//
+// The one invariant every other design choice here serves: a resident must
+// never be notified about something found by looking backward. This lane's
+// Ingester is constructed with nil decision/enqueuer collaborators
+// (NewIngester(apps, nil, nil)), and — unlike NationalLaneHandler and
+// ReconciliationHandler — BackfillHandler has NO WithFanOut method. There is
+// no call cmd/worker's wiring could make, today or in a future edit, that
+// attaches a notifier to this lane. That is a compile-time guarantee, not a
+// runtime flag.
+package polling
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/AmyDe/town-crier/api-go/internal/planit"
+)
+
+// backfillMetricsLane tags the backfill lane's metrics/telemetry, mirroring
+// LaneA/LaneB/LaneC's single-letter tag convention without extending the ADR
+// 0041 LaneName type: Lane D belongs to ADR 0042, a different design (no
+// watermark, no per-authority sentinel row) that only shares the tag
+// vocabulary for dashboard consistency.
+const backfillMetricsLane = "D"
+
+// backfillFetcher is the consumer-side slice of the PlanIt client Lane D
+// needs: one page of the national, date-windowed backward sweep.
+// *planit.Client satisfies it.
+type backfillFetcher interface {
+	FetchBackfillPage(ctx context.Context, windowStart, windowEnd time.Time, startIndex int) (planit.FetchPageResult, error)
+}
+
+// BackfillState is Lane D's ENTIRE persisted state: a singleton, not one row
+// per authority. WindowEnd is the fixed upper start_date bound of the date
+// window currently being drained (zero = never started). CursorNextIndex is
+// how far pagination has progressed within that window. WindowRecordsSeen
+// counts records seen so far in the window currently in progress, deciding
+// whether a fully-drained window counts toward ConsecutiveEmptyWindows.
+// Complete, once set, makes every subsequent Run a no-op forever — the lane
+// has crept back far enough that consecutive windows have come back empty.
+type BackfillState struct {
+	WindowEnd               time.Time
+	CursorNextIndex         int
+	WindowRecordsSeen       int
+	ConsecutiveEmptyWindows int
+	Complete                bool
+	LastRunTime             time.Time
+}
+
+// backfillStateAccess is the consumer-side slice of the backfill-state store
+// BackfillHandler needs. Get/Save operate on the one singleton row — no
+// candidate-id list, no LRU query, because there is exactly one thing to
+// track.
+type backfillStateAccess interface {
+	Get(ctx context.Context) (BackfillState, error)
+	Save(ctx context.Context, state BackfillState) error
+}
+
+// BackfillOptions tune Lane D's pace. WindowWidthDays is the width of each
+// backward-sliding date window (default 90, mirrored from ADR 0041's mask
+// width). MaxPagesPerCycle bounds how many pages Run fetches in a single
+// call — small on purpose ("creep a little bit each hour", default 2).
+// EmptyWindowsBeforeComplete is how many consecutive fully-drained,
+// zero-record windows the lane tolerates before declaring itself done
+// (default 12 ~= 3 years of national silence — conservative enough that it
+// should never trip on real data, only on genuinely running out of history).
+type BackfillOptions struct {
+	WindowWidthDays            int
+	MaxPagesPerCycle           int
+	EmptyWindowsBeforeComplete int
+}
+
+// BackfillHandler runs ADR 0042's Lane D: a national, date-windowed backward
+// sweep that enriches stale/NULL fields and fills coverage gaps via the
+// existing Ingester, with no per-authority state and — structurally — no
+// notification fan-out ever reachable from it.
+type BackfillHandler struct {
+	fetcher  backfillFetcher
+	state    backfillStateAccess
+	ingester *Ingester
+	opts     BackfillOptions
+	now      func() time.Time
+	logger   *slog.Logger
+
+	// metrics records towncrier.polling.applications_ingested (tagged "D") for
+	// this lane's runs, wired via WithMetrics, mirroring the other lanes'
+	// metrics field. nil until wired (the no-metrics default).
+	metrics metricsRecorder
+}
+
+// NewBackfillHandler wires Lane D. now is injected so tests pin the clock.
+// The ingester is ALWAYS constructed with nil decision/enqueuer collaborators
+// — see the package doc above. There is no setter that can change that after
+// construction.
+func NewBackfillHandler(
+	fetcher backfillFetcher,
+	state backfillStateAccess,
+	apps applicationStore,
+	opts BackfillOptions,
+	now func() time.Time,
+	logger *slog.Logger,
+) *BackfillHandler {
+	return &BackfillHandler{
+		fetcher:  fetcher,
+		state:    state,
+		ingester: NewIngester(apps, nil, nil), // notification safety: never wired, never wireable
+		opts:     opts,
+		now:      now,
+		logger:   logger,
+	}
+}
+
+// WithMetrics wires the metrics recorder this lane records its per-run
+// applications-ingested count on, mirroring the other lanes' WithMetrics. A
+// post-construction setter, so tests that don't supply one are unaffected;
+// cmd/worker calls it once after construction (only when the lane is built at
+// all — POLLING_BACKFILL_ENABLED gates that). Returns the handler for
+// chaining.
+func (h *BackfillHandler) WithMetrics(rec metricsRecorder) *BackfillHandler {
+	h.metrics = rec
+	return h
+}
+
+// recorder returns a non-nil recorder so call sites can record
+// unconditionally, mirroring the other lanes' recorder.
+func (h *BackfillHandler) recorder() metricsRecorder {
+	if h.metrics == nil {
+		return noopMetrics{}
+	}
+	return h.metrics
+}
+
+// backfillOutcome is one Run call's result, carried onto the telemetry span.
+type backfillOutcome struct {
+	pages           int
+	recordsSeen     int
+	recordsIngested int
+	rateLimited     bool
+	retryAfter      *time.Duration
+	err             error
+	planitTotal     *int
+	complete        bool
+}
+
+// Run fetches up to MaxPagesPerCycle pages of the current backward-sliding
+// window, ingesting every record through the existing Ingester (enrichment
+// and gap-fill, for free, via GH#935's three-bucket classification). State is
+// persisted after every successfully-processed page — a crash mid-cycle loses
+// nothing, because re-fetching an already-ingested page is a free no-op under
+// Ingest's HasSameBusinessFieldsAs/HasSameSilentFieldsAs gates.
+//
+// A fetch error or an ingest error stops the loop for this cycle WITHOUT
+// persisting the failed page's progress — whatever prior pages in this same
+// call succeeded stays persisted (mirrors NationalLaneHandler's "never
+// advance past a page that errored").
+//
+// When a window is fully drained (HasMorePages goes false), the window slides
+// back by WindowWidthDays unless EmptyWindowsBeforeComplete consecutive
+// zero-record windows have now been seen, in which case the lane marks itself
+// Complete and stops for good — every subsequent Run is then a no-op with no
+// fetch at all.
+func (h *BackfillHandler) Run(ctx context.Context) backfillOutcome {
+	ctx, span := otel.Tracer(tracerName).Start(ctx, "PlanIt backfill sweep")
+	defer span.End()
+
+	now := h.now().UTC()
+	var out backfillOutcome
+
+	state, err := h.state.Get(ctx)
+	if err != nil {
+		out.err = fmt.Errorf("lane D: read backfill state: %w", err)
+		return out
+	}
+
+	if state.Complete {
+		out.complete = true
+		span.SetAttributes(attribute.Bool("backfill.complete", true))
+		return out
+	}
+
+	if state.WindowEnd.IsZero() {
+		state.WindowEnd = truncateToDate(now)
+		state.CursorNextIndex = 0
+		state.WindowRecordsSeen = 0
+	}
+
+pageLoop:
+	for out.pages < h.opts.MaxPagesPerCycle {
+		if ctx.Err() != nil {
+			break
+		}
+
+		windowStart := state.WindowEnd.AddDate(0, 0, -h.opts.WindowWidthDays)
+
+		res, ferr := h.fetcher.FetchBackfillPage(ctx, windowStart, state.WindowEnd, state.CursorNextIndex)
+		if ferr != nil {
+			var rl *planit.RateLimitError
+			if errors.As(ferr, &rl) {
+				out.rateLimited = true
+				out.retryAfter = rl.RetryAfter
+			} else {
+				out.err = ferr
+			}
+			break pageLoop
+		}
+
+		out.pages++
+		if out.planitTotal == nil {
+			out.planitTotal = res.Total
+		}
+		out.recordsSeen += len(res.Applications)
+
+		ingestFailed := false
+		for _, app := range res.Applications {
+			if ierr := h.ingester.Ingest(ctx, app); ierr != nil {
+				out.err = ierr
+				ingestFailed = true
+				break
+			}
+			out.recordsIngested++
+		}
+		if ingestFailed {
+			break pageLoop
+		}
+
+		state.CursorNextIndex += len(res.Applications)
+		state.WindowRecordsSeen += len(res.Applications)
+		state.LastRunTime = now
+
+		if !res.HasMorePages {
+			if state.WindowRecordsSeen == 0 {
+				state.ConsecutiveEmptyWindows++
+			} else {
+				state.ConsecutiveEmptyWindows = 0
+			}
+
+			if state.ConsecutiveEmptyWindows >= h.opts.EmptyWindowsBeforeComplete {
+				state.Complete = true
+				out.complete = true
+				if serr := h.state.Save(ctx, state); serr != nil && out.err == nil {
+					out.err = serr
+				}
+				break pageLoop
+			}
+
+			// Window fully drained but the lane isn't done: slide back and keep
+			// walking if this cycle's page budget allows.
+			state.WindowEnd = windowStart
+			state.CursorNextIndex = 0
+			state.WindowRecordsSeen = 0
+		}
+
+		if serr := h.state.Save(ctx, state); serr != nil {
+			out.err = serr
+			break pageLoop
+		}
+	}
+
+	h.recordRunMetrics(ctx, out)
+	h.setSpanAttributes(span, out)
+	return out
+}
+
+// recordRunMetrics records one Run invocation's applications-ingested count
+// (tagged "D") and, on a 429, the rate-limit counter and Retry-After value —
+// mirroring the other lanes' recordRunMetrics. Lane D has no forward
+// watermark, so it does not record OldestHighWaterMarkAge: that gauge feeds
+// the ADR 0041 freshness alert, and a backward-creeping window's "age" would
+// be a meaningless, permanently-stale signal on that surface.
+func (h *BackfillHandler) recordRunMetrics(ctx context.Context, out backfillOutcome) {
+	rec := h.recorder()
+	rec.ApplicationsIngested(ctx, out.recordsIngested, backfillMetricsLane)
+	if out.rateLimited {
+		rec.RateLimited(ctx, backfillMetricsLane)
+		if out.retryAfter == nil {
+			rec.RetryAfterSeconds(ctx, 0, backfillMetricsLane, 0, false)
+		} else {
+			rec.RetryAfterSeconds(ctx, out.retryAfter.Seconds(), backfillMetricsLane, 0, true)
+		}
+	}
+}
+
+// setSpanAttributes stamps the "PlanIt backfill sweep" span with Lane D's
+// telemetry set, mirroring the other lanes' setSpanAttributes.
+func (h *BackfillHandler) setSpanAttributes(span trace.Span, out backfillOutcome) {
+	attrs := []attribute.KeyValue{
+		attribute.Int("backfill.pages", out.pages),
+		attribute.Int("backfill.records_seen", out.recordsSeen),
+		attribute.Int("backfill.records_ingested", out.recordsIngested),
+		attribute.Bool("backfill.complete", out.complete),
+		attribute.Bool("backfill.rate_limited", out.rateLimited),
+	}
+	if out.planitTotal != nil {
+		attrs = append(attrs, attribute.Int("planit.total", *out.planitTotal))
+	}
+	if out.err != nil {
+		attrs = append(attrs, attribute.String("backfill.error", out.err.Error()))
+	}
+	span.SetAttributes(attrs...)
+}

--- a/api-go/internal/polling/backfill_test.go
+++ b/api-go/internal/polling/backfill_test.go
@@ -1,0 +1,510 @@
+package polling
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/planit"
+)
+
+// fakeBackfillResponse is one pre-canned FetchBackfillPage call outcome: either
+// a page result or an error, served in call order (not keyed by query) so
+// tests can script a precise sequence across window slides without having to
+// predict every intermediate window boundary.
+type fakeBackfillResponse struct {
+	result planit.FetchPageResult
+	err    error
+}
+
+// backfillQuery records one FetchBackfillPage call's arguments for assertion.
+type backfillQuery struct {
+	windowStart time.Time
+	windowEnd   time.Time
+	startIndex  int
+}
+
+// fakeBackfillFetcher serves pre-canned backfill pages in call order. A call
+// past the end of the scripted responses returns an empty, fully-drained page
+// (mirrors PlanIt genuinely running out of matching records).
+type fakeBackfillFetcher struct {
+	responses []fakeBackfillResponse
+	calls     int
+	queries   []backfillQuery
+}
+
+func newFakeBackfillFetcher(responses ...fakeBackfillResponse) *fakeBackfillFetcher {
+	return &fakeBackfillFetcher{responses: responses}
+}
+
+func (f *fakeBackfillFetcher) FetchBackfillPage(_ context.Context, windowStart, windowEnd time.Time, startIndex int) (planit.FetchPageResult, error) {
+	f.queries = append(f.queries, backfillQuery{windowStart, windowEnd, startIndex})
+	if f.calls >= len(f.responses) {
+		f.calls++
+		return planit.FetchPageResult{From: startIndex, HasMorePages: false}, nil
+	}
+	r := f.responses[f.calls]
+	f.calls++
+	return r.result, r.err
+}
+
+// fakeBackfillStateStore is a single-row in-memory stand-in for
+// backfillStateAccess, mirroring the real singleton row (one Get, one Save,
+// no candidate-id list).
+type fakeBackfillStateStore struct {
+	state   BackfillState
+	saves   []BackfillState
+	getErr  error
+	saveErr error
+}
+
+func newFakeBackfillStateStore() *fakeBackfillStateStore {
+	return &fakeBackfillStateStore{}
+}
+
+func (f *fakeBackfillStateStore) Get(context.Context) (BackfillState, error) {
+	if f.getErr != nil {
+		return BackfillState{}, f.getErr
+	}
+	return f.state, nil
+}
+
+func (f *fakeBackfillStateStore) Save(_ context.Context, s BackfillState) error {
+	if f.saveErr != nil {
+		return f.saveErr
+	}
+	f.state = s
+	f.saves = append(f.saves, s)
+	return nil
+}
+
+// backfillClock pins the handler's clock to 2026-07-14T12:00:00Z, matching
+// the rest of the polling package's test fixtures (nationallane_test.go).
+func backfillClock() time.Time { return time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC) }
+
+func newBackfillHandler(t *testing.T, fetcher *fakeBackfillFetcher, apps *fakeApps, state *fakeBackfillStateStore, opts BackfillOptions) *BackfillHandler {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(discard{}, nil))
+	return NewBackfillHandler(fetcher, state, apps, opts, backfillClock, logger)
+}
+
+func defaultBackfillOpts() BackfillOptions {
+	return BackfillOptions{WindowWidthDays: 90, MaxPagesPerCycle: 2, EmptyWindowsBeforeComplete: 12}
+}
+
+// TestNewBackfillHandler_NoFanOutCollaborators is the structural safety
+// guarantee (GH#967): the ingester BackfillHandler builds is ALWAYS
+// constructed with nil decision/enqueuer collaborators, and BackfillHandler
+// has no method that could ever attach one (there is no WithFanOut in this
+// file — verified by the absence of that method in the diff, not by a test,
+// since Go cannot assert the non-existence of a method).
+func TestNewBackfillHandler_NoFanOutCollaborators(t *testing.T) {
+	t.Parallel()
+	h := newBackfillHandler(t, newFakeBackfillFetcher(), newFakeApps(), newFakeBackfillStateStore(), defaultBackfillOpts())
+
+	if h.ingester.decision != nil {
+		t.Error("ingester.decision: got non-nil, want nil (backfill must never dispatch decision events)")
+	}
+	if h.ingester.enqueuer != nil {
+		t.Error("ingester.enqueuer: got non-nil, want nil (backfill must never fan out watch-zone notifications)")
+	}
+}
+
+// TestBackfillHandler_Run_InsertsGapWithoutFanOut proves the gap-fill path: a
+// first-seen application PlanIt returns gets inserted even though it is
+// already in a decision state (app_state=Permitted — under the ordinary
+// Ingester this would trigger both a decision dispatch AND a watch-zone
+// fan-out). Because BackfillHandler's ingester carries nil collaborators,
+// neither is reachable; the only observable effect is the upsert.
+func TestBackfillHandler_Run_InsertsGapWithoutFanOut(t *testing.T) {
+	t.Parallel()
+	windowEnd := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	app := testApp("gap", 300, time.Date(2019, 3, 1, 0, 0, 0, 0, time.UTC))
+	permitted := "Permitted"
+	app.AppState = &permitted
+
+	fetcher := newFakeBackfillFetcher(fakeBackfillResponse{
+		result: planit.FetchPageResult{Applications: []applications.PlanningApplication{app}, HasMorePages: false},
+	})
+	apps := newFakeApps()
+	state := newFakeBackfillStateStore()
+	state.state = BackfillState{WindowEnd: windowEnd}
+
+	h := newBackfillHandler(t, fetcher, apps, state, BackfillOptions{WindowWidthDays: 90, MaxPagesPerCycle: 1, EmptyWindowsBeforeComplete: 12})
+	out := h.Run(context.Background())
+
+	if out.err != nil {
+		t.Fatalf("Run: %v", out.err)
+	}
+	if out.recordsIngested != 1 {
+		t.Errorf("recordsIngested: got %d, want 1", out.recordsIngested)
+	}
+	if len(apps.upserts) != 1 || apps.upserts[0].UID != "gap/FUL" {
+		t.Fatalf("upserts: got %+v, want exactly the gap-fill record", apps.upserts)
+	}
+	if apps.upserts[0].AppState == nil || *apps.upserts[0].AppState != "Permitted" {
+		t.Errorf("AppState: got %v, want Permitted", apps.upserts[0].AppState)
+	}
+}
+
+// TestBackfillHandler_Run_EnrichesNullFieldsWithoutFanOut proves the
+// enrichment path (GH#935 staleness): an existing application whose silent
+// fields (Reference, Altid, ...) are NULL gets them populated by a re-ingest
+// through the backfill path, with no business-field change (so no fan-out
+// would fire even with a wired Ingester).
+func TestBackfillHandler_Run_EnrichesNullFieldsWithoutFanOut(t *testing.T) {
+	t.Parallel()
+	windowEnd := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	t0 := time.Date(2019, 3, 1, 0, 0, 0, 0, time.UTC)
+	t1 := time.Date(2019, 3, 2, 0, 0, 0, 0, time.UTC)
+
+	existing := testApp("enrich", 300, t0) // Reference/Altid/etc left nil, mirroring a pre-GH#935 row
+	apps := newFakeApps()
+	apps.existing["enrich/FUL"] = existing
+
+	fetched := testApp("enrich", 300, t1) // identical business fields, LastDifferent bumped
+	ref := "24/00099/FUL"
+	fetched.Reference = &ref
+	fetched.Altid = []byte(`"ALT1"`)
+
+	fetcher := newFakeBackfillFetcher(fakeBackfillResponse{
+		result: planit.FetchPageResult{Applications: []applications.PlanningApplication{fetched}, HasMorePages: false},
+	})
+	state := newFakeBackfillStateStore()
+	state.state = BackfillState{WindowEnd: windowEnd}
+
+	h := newBackfillHandler(t, fetcher, apps, state, BackfillOptions{WindowWidthDays: 90, MaxPagesPerCycle: 1, EmptyWindowsBeforeComplete: 12})
+	out := h.Run(context.Background())
+
+	if out.err != nil {
+		t.Fatalf("Run: %v", out.err)
+	}
+	if len(apps.upserts) != 1 {
+		t.Fatalf("upserts: got %d, want 1 (silent-field change must still upsert)", len(apps.upserts))
+	}
+	if apps.upserts[0].Reference == nil || *apps.upserts[0].Reference != ref {
+		t.Errorf("Reference: got %v, want %q", apps.upserts[0].Reference, ref)
+	}
+}
+
+// TestBackfillHandler_Run_BookkeepingOnlyChangeSkipsWrite proves the
+// reindex-flood guard still applies through the backfill path: a record that
+// differs only in LastDifferent (identical business AND silent fields) causes
+// no upsert at all.
+func TestBackfillHandler_Run_BookkeepingOnlyChangeSkipsWrite(t *testing.T) {
+	t.Parallel()
+	windowEnd := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	t0 := time.Date(2019, 3, 1, 0, 0, 0, 0, time.UTC)
+	t1 := time.Date(2019, 3, 2, 0, 0, 0, 0, time.UTC)
+
+	existing := testApp("noop", 300, t0)
+	apps := newFakeApps()
+	apps.existing["noop/FUL"] = existing
+
+	fetched := testApp("noop", 300, t1) // only LastDifferent differs
+
+	fetcher := newFakeBackfillFetcher(fakeBackfillResponse{
+		result: planit.FetchPageResult{Applications: []applications.PlanningApplication{fetched}, HasMorePages: false},
+	})
+	state := newFakeBackfillStateStore()
+	state.state = BackfillState{WindowEnd: windowEnd}
+
+	h := newBackfillHandler(t, fetcher, apps, state, BackfillOptions{WindowWidthDays: 90, MaxPagesPerCycle: 1, EmptyWindowsBeforeComplete: 12})
+	out := h.Run(context.Background())
+
+	if out.err != nil {
+		t.Fatalf("Run: %v", out.err)
+	}
+	if len(apps.upserts) != 0 {
+		t.Errorf("upserts: got %d, want 0 (bookkeeping-only touch must not write)", len(apps.upserts))
+	}
+}
+
+// TestBackfillHandler_Run_FirstRunFixesWindowEndToNow proves the first-ever
+// run's window fixing: WindowEnd starts zero (never run) and is set to the
+// injected clock's date on the first Run, with the fetched window bounded
+// [now-WindowWidthDays, now].
+func TestBackfillHandler_Run_FirstRunFixesWindowEndToNow(t *testing.T) {
+	t.Parallel()
+	fetcher := newFakeBackfillFetcher(fakeBackfillResponse{
+		result: planit.FetchPageResult{
+			Applications: []applications.PlanningApplication{testApp("a", 300, time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))},
+			HasMorePages: true, // mid-window: no slide, isolates the window-fixing behaviour
+		},
+	})
+	apps := newFakeApps()
+	state := newFakeBackfillStateStore() // zero value: never run
+
+	h := newBackfillHandler(t, fetcher, apps, state, BackfillOptions{WindowWidthDays: 90, MaxPagesPerCycle: 1, EmptyWindowsBeforeComplete: 12})
+	out := h.Run(context.Background())
+
+	if out.err != nil {
+		t.Fatalf("Run: %v", out.err)
+	}
+	if len(fetcher.queries) != 1 {
+		t.Fatalf("expected exactly one fetch, got %d", len(fetcher.queries))
+	}
+	wantEnd := time.Date(2026, 7, 14, 0, 0, 0, 0, time.UTC)
+	wantStart := wantEnd.AddDate(0, 0, -90)
+	if !fetcher.queries[0].windowEnd.Equal(wantEnd) {
+		t.Errorf("windowEnd: got %v, want %v (today's date)", fetcher.queries[0].windowEnd, wantEnd)
+	}
+	if !fetcher.queries[0].windowStart.Equal(wantStart) {
+		t.Errorf("windowStart: got %v, want %v", fetcher.queries[0].windowStart, wantStart)
+	}
+	if !state.state.WindowEnd.Equal(wantEnd) {
+		t.Errorf("persisted WindowEnd: got %v, want %v", state.state.WindowEnd, wantEnd)
+	}
+	if state.state.CursorNextIndex != 1 {
+		t.Errorf("persisted CursorNextIndex: got %d, want 1", state.state.CursorNextIndex)
+	}
+}
+
+// TestBackfillHandler_Run_SlidesWindowOnFullDrain proves window sliding: a
+// fetch that fully drains a window (HasMorePages=false) with non-zero records
+// seen resets ConsecutiveEmptyWindows to 0 and moves WindowEnd back by
+// WindowWidthDays, resetting the cursor and per-window counter for the new
+// window.
+func TestBackfillHandler_Run_SlidesWindowOnFullDrain(t *testing.T) {
+	t.Parallel()
+	windowEnd := time.Date(2026, 7, 14, 0, 0, 0, 0, time.UTC)
+	fetcher := newFakeBackfillFetcher(fakeBackfillResponse{
+		result: planit.FetchPageResult{
+			Applications: []applications.PlanningApplication{
+				testApp("a", 300, time.Date(2026, 4, 20, 0, 0, 0, 0, time.UTC)),
+				testApp("b", 300, time.Date(2026, 4, 21, 0, 0, 0, 0, time.UTC)),
+			},
+			HasMorePages: false,
+		},
+	})
+	apps := newFakeApps()
+	state := newFakeBackfillStateStore()
+	state.state = BackfillState{WindowEnd: windowEnd, ConsecutiveEmptyWindows: 3}
+
+	h := newBackfillHandler(t, fetcher, apps, state, BackfillOptions{WindowWidthDays: 90, MaxPagesPerCycle: 1, EmptyWindowsBeforeComplete: 12})
+	out := h.Run(context.Background())
+
+	if out.err != nil {
+		t.Fatalf("Run: %v", out.err)
+	}
+	wantSlid := windowEnd.AddDate(0, 0, -90)
+	if !state.state.WindowEnd.Equal(wantSlid) {
+		t.Errorf("WindowEnd: got %v, want %v", state.state.WindowEnd, wantSlid)
+	}
+	if state.state.CursorNextIndex != 0 {
+		t.Errorf("CursorNextIndex: got %d, want 0 (reset for new window)", state.state.CursorNextIndex)
+	}
+	if state.state.WindowRecordsSeen != 0 {
+		t.Errorf("WindowRecordsSeen: got %d, want 0 (reset for new window)", state.state.WindowRecordsSeen)
+	}
+	if state.state.ConsecutiveEmptyWindows != 0 {
+		t.Errorf("ConsecutiveEmptyWindows: got %d, want 0 (this window was not empty)", state.state.ConsecutiveEmptyWindows)
+	}
+	if state.state.Complete {
+		t.Error("Complete: got true, want false")
+	}
+}
+
+// TestBackfillHandler_Run_IncrementsEmptyWindowCounter proves a window that
+// drains with zero records increments ConsecutiveEmptyWindows and, while
+// still below the threshold, keeps the lane going (window slides back).
+func TestBackfillHandler_Run_IncrementsEmptyWindowCounter(t *testing.T) {
+	t.Parallel()
+	windowEnd := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	fetcher := newFakeBackfillFetcher(fakeBackfillResponse{
+		result: planit.FetchPageResult{Applications: nil, HasMorePages: false},
+	})
+	apps := newFakeApps()
+	state := newFakeBackfillStateStore()
+	state.state = BackfillState{WindowEnd: windowEnd, ConsecutiveEmptyWindows: 2}
+
+	h := newBackfillHandler(t, fetcher, apps, state, BackfillOptions{WindowWidthDays: 90, MaxPagesPerCycle: 1, EmptyWindowsBeforeComplete: 12})
+	out := h.Run(context.Background())
+
+	if out.err != nil {
+		t.Fatalf("Run: %v", out.err)
+	}
+	if state.state.ConsecutiveEmptyWindows != 3 {
+		t.Errorf("ConsecutiveEmptyWindows: got %d, want 3", state.state.ConsecutiveEmptyWindows)
+	}
+	if state.state.Complete {
+		t.Error("Complete: got true, want false (below threshold)")
+	}
+	wantSlid := windowEnd.AddDate(0, 0, -90)
+	if !state.state.WindowEnd.Equal(wantSlid) {
+		t.Errorf("WindowEnd: got %v, want %v (still creeping backward)", state.state.WindowEnd, wantSlid)
+	}
+}
+
+// TestBackfillHandler_Run_MarksCompleteAtThreshold proves the terminal
+// transition: the EmptyWindowsBeforeComplete-th consecutive empty window sets
+// Complete=true.
+func TestBackfillHandler_Run_MarksCompleteAtThreshold(t *testing.T) {
+	t.Parallel()
+	windowEnd := time.Date(2015, 1, 1, 0, 0, 0, 0, time.UTC)
+	fetcher := newFakeBackfillFetcher(fakeBackfillResponse{
+		result: planit.FetchPageResult{Applications: nil, HasMorePages: false},
+	})
+	apps := newFakeApps()
+	state := newFakeBackfillStateStore()
+	state.state = BackfillState{WindowEnd: windowEnd, ConsecutiveEmptyWindows: 11}
+
+	h := newBackfillHandler(t, fetcher, apps, state, BackfillOptions{WindowWidthDays: 90, MaxPagesPerCycle: 1, EmptyWindowsBeforeComplete: 12})
+	out := h.Run(context.Background())
+
+	if out.err != nil {
+		t.Fatalf("Run: %v", out.err)
+	}
+	if !out.complete {
+		t.Error("outcome complete: got false, want true")
+	}
+	if state.state.ConsecutiveEmptyWindows != 12 {
+		t.Errorf("ConsecutiveEmptyWindows: got %d, want 12", state.state.ConsecutiveEmptyWindows)
+	}
+	if !state.state.Complete {
+		t.Error("persisted Complete: got false, want true")
+	}
+}
+
+// TestBackfillHandler_Run_NoOpWhenComplete proves completion is terminal:
+// once Complete is true, Run makes no fetch calls at all, forever.
+func TestBackfillHandler_Run_NoOpWhenComplete(t *testing.T) {
+	t.Parallel()
+	fetcher := newFakeBackfillFetcher()
+	apps := newFakeApps()
+	state := newFakeBackfillStateStore()
+	state.state = BackfillState{Complete: true}
+
+	h := newBackfillHandler(t, fetcher, apps, state, defaultBackfillOpts())
+	out := h.Run(context.Background())
+
+	if out.err != nil {
+		t.Fatalf("Run: %v", out.err)
+	}
+	if !out.complete {
+		t.Error("outcome complete: got false, want true")
+	}
+	if fetcher.calls != 0 {
+		t.Errorf("fetcher.calls: got %d, want 0 (a complete lane must never fetch)", fetcher.calls)
+	}
+	if len(state.saves) != 0 {
+		t.Errorf("saves: got %d, want 0 (nothing changed)", len(state.saves))
+	}
+}
+
+// TestBackfillHandler_Run_RespectsMaxPagesPerCycle proves the page cap:
+// exactly MaxPagesPerCycle pages are fetched per Run, with CursorNextIndex
+// correctly reflecting partial progress mid-window for the next cycle to
+// resume from.
+func TestBackfillHandler_Run_RespectsMaxPagesPerCycle(t *testing.T) {
+	t.Parallel()
+	windowEnd := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	ld := time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC)
+	fetcher := newFakeBackfillFetcher(
+		fakeBackfillResponse{result: planit.FetchPageResult{
+			Applications: []applications.PlanningApplication{testApp("p0a", 300, ld), testApp("p0b", 300, ld), testApp("p0c", 300, ld)},
+			HasMorePages: true,
+		}},
+		fakeBackfillResponse{result: planit.FetchPageResult{
+			Applications: []applications.PlanningApplication{testApp("p1a", 300, ld), testApp("p1b", 300, ld)},
+			HasMorePages: true,
+		}},
+	)
+	apps := newFakeApps()
+	state := newFakeBackfillStateStore()
+	state.state = BackfillState{WindowEnd: windowEnd}
+
+	h := newBackfillHandler(t, fetcher, apps, state, BackfillOptions{WindowWidthDays: 90, MaxPagesPerCycle: 2, EmptyWindowsBeforeComplete: 12})
+	out := h.Run(context.Background())
+
+	if out.err != nil {
+		t.Fatalf("Run: %v", out.err)
+	}
+	if out.pages != 2 {
+		t.Errorf("pages: got %d, want 2 (capped)", out.pages)
+	}
+	if fetcher.calls != 2 {
+		t.Errorf("fetcher.calls: got %d, want 2", fetcher.calls)
+	}
+	if state.state.CursorNextIndex != 5 {
+		t.Errorf("CursorNextIndex: got %d, want 5 (3+2, ready for next cycle to resume)", state.state.CursorNextIndex)
+	}
+	if state.state.WindowEnd != windowEnd {
+		t.Errorf("WindowEnd: got %v, want unchanged %v (mid-window, no slide)", state.state.WindowEnd, windowEnd)
+	}
+}
+
+// TestBackfillHandler_Run_FetchErrorDoesNotAdvanceCursor proves the error
+// handling contract: a fetch error mid-cycle stops further pages without
+// advancing CursorNextIndex past the failed page, while whatever earlier
+// pages in the same Run call succeeded stays persisted.
+func TestBackfillHandler_Run_FetchErrorDoesNotAdvanceCursor(t *testing.T) {
+	t.Parallel()
+	windowEnd := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	ld := time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC)
+	fetcher := newFakeBackfillFetcher(
+		fakeBackfillResponse{result: planit.FetchPageResult{
+			Applications: []applications.PlanningApplication{testApp("p0a", 300, ld), testApp("p0b", 300, ld)},
+			HasMorePages: true,
+		}},
+		fakeBackfillResponse{err: errors.New("planit: transport blew up")},
+	)
+	apps := newFakeApps()
+	state := newFakeBackfillStateStore()
+	state.state = BackfillState{WindowEnd: windowEnd}
+
+	h := newBackfillHandler(t, fetcher, apps, state, BackfillOptions{WindowWidthDays: 90, MaxPagesPerCycle: 3, EmptyWindowsBeforeComplete: 12})
+	out := h.Run(context.Background())
+
+	if out.err == nil {
+		t.Fatal("expected the second page's fetch error to surface on the outcome")
+	}
+	if fetcher.calls != 2 {
+		t.Errorf("fetcher.calls: got %d, want 2 (loop stops after the failed page)", fetcher.calls)
+	}
+	if state.state.CursorNextIndex != 2 {
+		t.Errorf("CursorNextIndex: got %d, want 2 (only page 0's advance persisted)", state.state.CursorNextIndex)
+	}
+	if len(state.saves) != 1 {
+		t.Errorf("saves: got %d, want 1 (exactly the successful page)", len(state.saves))
+	}
+	if len(apps.upserts) != 2 {
+		t.Errorf("upserts: got %d, want 2 (page 0's records were still ingested)", len(apps.upserts))
+	}
+}
+
+// TestBackfillHandler_Run_RateLimitedDoesNotAdvanceCursor mirrors the fetch-
+// error test for a 429: the cursor freezes at the last successful page and
+// the outcome carries the parsed Retry-After hint.
+func TestBackfillHandler_Run_RateLimitedDoesNotAdvanceCursor(t *testing.T) {
+	t.Parallel()
+	windowEnd := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	ld := time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC)
+	retryAfter := 30 * time.Second
+	fetcher := newFakeBackfillFetcher(
+		fakeBackfillResponse{result: planit.FetchPageResult{
+			Applications: []applications.PlanningApplication{testApp("p0a", 300, ld)},
+			HasMorePages: true,
+		}},
+		fakeBackfillResponse{err: &planit.RateLimitError{RetryAfter: &retryAfter}},
+	)
+	apps := newFakeApps()
+	state := newFakeBackfillStateStore()
+	state.state = BackfillState{WindowEnd: windowEnd}
+
+	h := newBackfillHandler(t, fetcher, apps, state, BackfillOptions{WindowWidthDays: 90, MaxPagesPerCycle: 3, EmptyWindowsBeforeComplete: 12})
+	out := h.Run(context.Background())
+
+	if !out.rateLimited {
+		t.Fatal("expected rateLimited=true")
+	}
+	if out.retryAfter == nil || *out.retryAfter != retryAfter {
+		t.Errorf("retryAfter: got %v, want %v", out.retryAfter, retryAfter)
+	}
+	if state.state.CursorNextIndex != 1 {
+		t.Errorf("CursorNextIndex: got %d, want 1 (only page 0's advance persisted)", state.state.CursorNextIndex)
+	}
+}

--- a/api-go/internal/polling/nationallane.go
+++ b/api-go/internal/polling/nationallane.go
@@ -503,6 +503,7 @@ type NationalPollHandler struct {
 	laneA   *NationalLaneHandler
 	laneB   *NationalLaneHandler
 	laneC   *ReconciliationHandler // nil skips Lane C entirely (e.g. a test exercising only the critical path)
+	laneD   *BackfillHandler       // nil skips Lane D (GH#967, ADR 0042) — the shape until POLLING_BACKFILL_ENABLED flips on
 	flusher pushFlusher
 	now     func() time.Time
 	logger  *slog.Logger
@@ -517,6 +518,16 @@ type NationalPollHandler struct {
 // reconciliation.
 func NewNationalPollHandler(laneA, laneB *NationalLaneHandler, laneC *ReconciliationHandler, now func() time.Time, logger *slog.Logger) *NationalPollHandler {
 	return &NationalPollHandler{laneA: laneA, laneB: laneB, laneC: laneC, now: now, logger: logger}
+}
+
+// WithBackfill wires Lane D (GH#967, ADR 0042), the paced historical backfill
+// lane. nil is the safe default — Handle's nil guard skips it entirely — so
+// cmd/worker's buildPollOrchestrator can call this unconditionally with
+// whatever POLLING_BACKFILL_ENABLED produced (a real *BackfillHandler, or
+// nil) without a separate branch. Returns the handler for chaining.
+func (h *NationalPollHandler) WithBackfill(laneD *BackfillHandler) *NationalPollHandler {
+	h.laneD = laneD
+	return h
 }
 
 // WithPushFlusher wires the poll-cycle push coalescer (GH#784), mirroring
@@ -605,6 +616,20 @@ func (h *NationalPollHandler) Handle(ctx context.Context) (PollPlanItResult, err
 			if outC.err != nil {
 				h.logger.ErrorContext(ctx, "lane C reconciliation error", "error", outC.err)
 			}
+		}
+	}
+
+	// Lane D (GH#967, ADR 0042): runs unconditionally every cycle, nil-guarded
+	// — unlike Lane C it is never Due-gated (there is no interval to check, it
+	// always spends its small fixed page budget) and it never contributes to
+	// ApplicationCount/AuthorityErrors/termination reason below: it is a
+	// data-quality/coverage lane, not part of the critical path those fields
+	// describe, and it structurally cannot notify (nil decision/enqueuer,
+	// no WithFanOut method), so there is nothing here for it to affect.
+	if h.laneD != nil {
+		outD := h.laneD.Run(ctx)
+		if outD.err != nil {
+			h.logger.ErrorContext(ctx, "lane D backfill error", "error", outD.err)
 		}
 	}
 

--- a/api-go/internal/polling/nationallane_test.go
+++ b/api-go/internal/polling/nationallane_test.go
@@ -693,3 +693,61 @@ func TestNationalPollHandler_Handle_SkipsLaneCWhenNil(t *testing.T) {
 		t.Errorf("ApplicationCount: got %d, want 2 (both lanes ingested, nil Lane C contributed nothing)", res.ApplicationCount)
 	}
 }
+
+// TestNationalPollHandler_WithBackfillNilNeverPanics pins the wiring safety
+// contract for Lane D (GH#967): WithBackfill(nil) — the shape cmd/worker's
+// buildPollOrchestrator produces when POLLING_BACKFILL_ENABLED is off (its
+// default) — must never panic, and Handle must complete normally with no
+// backfill work attempted.
+func TestNationalPollHandler_WithBackfillNilNeverPanics(t *testing.T) {
+	t.Parallel()
+	fetcherA := newFakeNationalFetcher()
+	fetcherB := newFakeNationalFetcher()
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	logger := slog.New(slog.NewTextHandler(discard{}, nil))
+	clock := func() time.Time { return time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC) }
+
+	laneAHandler := NewNationalLaneHandler(fetcherA, state, apps, laneAOpts(), clock, logger)
+	laneBHandler := NewNationalLaneHandler(fetcherB, state, apps, laneBOpts(20), clock, logger)
+	handler := NewNationalPollHandler(laneAHandler, laneBHandler, nil, clock, logger)
+
+	handler.WithBackfill(nil)
+
+	res, err := handler.Handle(context.Background())
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if res.CycleType != "National" {
+		t.Errorf("CycleType: got %q, want National", res.CycleType)
+	}
+}
+
+// TestNationalPollHandler_Handle_RunsBackfillLaneAfterLaneC proves Lane D runs
+// unconditionally every cycle (nil-guarded, not Due-gated like Lane C) once
+// wired via WithBackfill.
+func TestNationalPollHandler_Handle_RunsBackfillLaneAfterLaneC(t *testing.T) {
+	t.Parallel()
+	fetcherA := newFakeNationalFetcher()
+	fetcherB := newFakeNationalFetcher()
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	logger := slog.New(slog.NewTextHandler(discard{}, nil))
+	clock := func() time.Time { return time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC) }
+
+	laneAHandler := NewNationalLaneHandler(fetcherA, state, apps, laneAOpts(), clock, logger)
+	laneBHandler := NewNationalLaneHandler(fetcherB, state, apps, laneBOpts(20), clock, logger)
+	handler := NewNationalPollHandler(laneAHandler, laneBHandler, nil, clock, logger)
+
+	backfillFetcher := newFakeBackfillFetcher()
+	backfillState := newFakeBackfillStateStore()
+	backfillHandler := NewBackfillHandler(backfillFetcher, backfillState, apps, defaultBackfillOpts(), clock, logger)
+	handler.WithBackfill(backfillHandler)
+
+	if _, err := handler.Handle(context.Background()); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if backfillFetcher.calls == 0 {
+		t.Error("backfill fetcher: got 0 calls, want Lane D to have run")
+	}
+}

--- a/api-go/internal/polling/store_postgres_backfill.go
+++ b/api-go/internal/polling/store_postgres_backfill.go
@@ -1,0 +1,88 @@
+package polling
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// Compile-time check: the store satisfies the consumer-side interface.
+var _ backfillStateAccess = (*PostgresBackfillStateStore)(nil)
+
+// PostgresBackfillStateStore reads and writes Lane D's singleton
+// backfill_state row (GH#967, ADR 0042; migration 0022_backfill_state.sql).
+// The migration seeds the one row, so the store never has a "not found"
+// case: Get is a plain point SELECT, Save a plain UPDATE — no upsert, no
+// candidate-id list, no LRU query, because there is exactly one thing to
+// track.
+type PostgresBackfillStateStore struct {
+	db querier
+}
+
+// NewPostgresBackfillStateStore returns a store over the given pgx pool (or
+// any querier — a pgx.Tx also satisfies the interface).
+func NewPostgresBackfillStateStore(db querier) *PostgresBackfillStateStore {
+	return &PostgresBackfillStateStore{db: db}
+}
+
+const getBackfillStateQuery = `
+SELECT window_end, cursor_next_index, window_records_seen, consecutive_empty_windows, complete, last_run_time
+FROM backfill_state
+LIMIT 1`
+
+// Get point-reads the singleton backfill state row. window_end and
+// last_run_time are nullable columns (NULL before the lane's first-ever
+// run); a nil scan target maps to BackfillState's documented zero-time
+// "never started"/"never run" sentinel.
+func (s *PostgresBackfillStateStore) Get(ctx context.Context) (BackfillState, error) {
+	var (
+		windowEnd   *time.Time
+		lastRunTime *time.Time
+		state       BackfillState
+	)
+	err := s.db.QueryRow(ctx, getBackfillStateQuery).Scan(
+		&windowEnd, &state.CursorNextIndex, &state.WindowRecordsSeen, &state.ConsecutiveEmptyWindows, &state.Complete, &lastRunTime,
+	)
+	if err != nil {
+		return BackfillState{}, fmt.Errorf("read backfill state: %w", err)
+	}
+	if windowEnd != nil {
+		state.WindowEnd = windowEnd.UTC()
+	}
+	if lastRunTime != nil {
+		state.LastRunTime = lastRunTime.UTC()
+	}
+	return state, nil
+}
+
+const saveBackfillStateQuery = `
+UPDATE backfill_state SET
+    window_end                = $1,
+    cursor_next_index         = $2,
+    window_records_seen       = $3,
+    consecutive_empty_windows = $4,
+    complete                  = $5,
+    last_run_time             = $6`
+
+// Save updates the singleton backfill state row. A zero WindowEnd or
+// LastRunTime writes SQL NULL, matching Get's "never started"/"never run"
+// sentinel.
+func (s *PostgresBackfillStateStore) Save(ctx context.Context, state BackfillState) error {
+	var windowEnd, lastRunTime *time.Time
+	if !state.WindowEnd.IsZero() {
+		w := state.WindowEnd.UTC()
+		windowEnd = &w
+	}
+	if !state.LastRunTime.IsZero() {
+		l := state.LastRunTime.UTC()
+		lastRunTime = &l
+	}
+
+	_, err := s.db.Exec(ctx, saveBackfillStateQuery,
+		windowEnd, state.CursorNextIndex, state.WindowRecordsSeen, state.ConsecutiveEmptyWindows, state.Complete, lastRunTime,
+	)
+	if err != nil {
+		return fmt.Errorf("save backfill state: %w", err)
+	}
+	return nil
+}

--- a/api-go/internal/polling/store_postgres_backfill_integration_test.go
+++ b/api-go/internal/polling/store_postgres_backfill_integration_test.go
@@ -1,0 +1,114 @@
+//go:build integration
+
+package polling
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform/postgres/pgtest"
+)
+
+// newPGBackfillStateStore returns a PostgresBackfillStateStore over a
+// migrated test database, with the migration's seeded singleton row restored
+// after Truncate (TRUNCATE removes it along with everything else). Integration
+// tests MUST NOT call t.Parallel: the pgtest harness holds a session-level
+// advisory lock so all integration tests in all packages serialise on the
+// single docker-compose database (see pgtest.New doc).
+func newPGBackfillStateStore(t *testing.T) *PostgresBackfillStateStore {
+	t.Helper()
+	pool := pgtest.New(t)
+	pgtest.Truncate(t, pool, "backfill_state")
+	if _, err := pool.Exec(context.Background(), "INSERT INTO backfill_state (id) VALUES (true)"); err != nil {
+		t.Fatalf("reseed singleton backfill_state row: %v", err)
+	}
+	return NewPostgresBackfillStateStore(pool)
+}
+
+// TestPostgresBackfillStateStore_SaveThenGet_RoundTrips proves a full Save
+// then Get round-trips every field against real Postgres, including the
+// date-typed window_end column and the nullable last_run_time.
+func TestPostgresBackfillStateStore_SaveThenGet_RoundTrips(t *testing.T) {
+	ctx := context.Background()
+	store := newPGBackfillStateStore(t)
+
+	windowEnd := time.Date(2019, 4, 20, 0, 0, 0, 0, time.UTC)
+	lastRun := time.Date(2026, 7, 15, 3, 0, 0, 0, time.UTC)
+	want := BackfillState{
+		WindowEnd:               windowEnd,
+		CursorNextIndex:         600,
+		WindowRecordsSeen:       120,
+		ConsecutiveEmptyWindows: 4,
+		Complete:                false,
+		LastRunTime:             lastRun,
+	}
+
+	if err := store.Save(ctx, want); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := store.Get(ctx)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !got.WindowEnd.Equal(want.WindowEnd) {
+		t.Errorf("WindowEnd: got %v, want %v", got.WindowEnd, want.WindowEnd)
+	}
+	if got.CursorNextIndex != want.CursorNextIndex {
+		t.Errorf("CursorNextIndex: got %d, want %d", got.CursorNextIndex, want.CursorNextIndex)
+	}
+	if got.WindowRecordsSeen != want.WindowRecordsSeen {
+		t.Errorf("WindowRecordsSeen: got %d, want %d", got.WindowRecordsSeen, want.WindowRecordsSeen)
+	}
+	if got.ConsecutiveEmptyWindows != want.ConsecutiveEmptyWindows {
+		t.Errorf("ConsecutiveEmptyWindows: got %d, want %d", got.ConsecutiveEmptyWindows, want.ConsecutiveEmptyWindows)
+	}
+	if got.Complete != want.Complete {
+		t.Errorf("Complete: got %v, want %v", got.Complete, want.Complete)
+	}
+	if !got.LastRunTime.Equal(want.LastRunTime) {
+		t.Errorf("LastRunTime: got %v, want %v", got.LastRunTime, want.LastRunTime)
+	}
+}
+
+// TestPostgresBackfillStateStore_GetReturnsSeededRowBeforeAnySave proves the
+// migration's own seed row is readable with no prior Save: the store never
+// has a "not found" case.
+func TestPostgresBackfillStateStore_GetReturnsSeededRowBeforeAnySave(t *testing.T) {
+	ctx := context.Background()
+	store := newPGBackfillStateStore(t)
+
+	got, err := store.Get(ctx)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !got.WindowEnd.IsZero() {
+		t.Errorf("WindowEnd: got %v, want zero (never started)", got.WindowEnd)
+	}
+	if got.Complete {
+		t.Error("Complete: got true, want false")
+	}
+	if got.CursorNextIndex != 0 {
+		t.Errorf("CursorNextIndex: got %d, want 0", got.CursorNextIndex)
+	}
+}
+
+// TestPostgresBackfillStateStore_CompleteRoundTrips proves the terminal
+// Complete=true state persists correctly.
+func TestPostgresBackfillStateStore_CompleteRoundTrips(t *testing.T) {
+	ctx := context.Background()
+	store := newPGBackfillStateStore(t)
+
+	if err := store.Save(ctx, BackfillState{Complete: true, ConsecutiveEmptyWindows: 12}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := store.Get(ctx)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !got.Complete {
+		t.Error("Complete: got false, want true")
+	}
+}

--- a/docs/adr/0042-historical-backward-backfill-lane.md
+++ b/docs/adr/0042-historical-backward-backfill-lane.md
@@ -1,0 +1,79 @@
+# 0042. A national, date-windowed backward backfill lane (Lane D)
+
+Date: 2026-07-15
+
+## Status
+
+Accepted — additive to [0041](0041-poll-planit-on-a-churn-masked-delta-axis.md), ships disabled (`POLLING_BACKFILL_ENABLED=false`)
+
+## Context
+
+ADR 0041 replaced the per-authority drain with a churn-masked national delta poll (Lanes A/B/C), fixing the *flow* of new applications but explicitly deferring the *stock*: "Camden stays at 66/300 until a separate historical sweep runs... filling it is a separate exercise (a paced, worker-side historical sweep backwards on `start_date`) with its own budget and its own risks." This ADR is that separate exercise.
+
+Two more gaps stack on top of the coverage hole:
+
+1. **Field-level staleness.** GH#935 (PR #937, 2026-07-12) added seven columns (`reference`, `altid`, `associated_id`, `last_changed`, `last_scraped`, `scraper_name`, `other_fields`) that only populate on rows touched by a lane *after* that release. Every application ingested before it is missing those fields and stays missing forever unless something re-touches the row.
+2. **A hard floor at "when we started polling".** Lanes A/B seed their watermark from PlanIt's current head specifically so a lane's first run is never a backfill (ADR 0041's rule 2, `c4f2a5ef`). Nothing in the current design ever looks further back than "now" for data no lane has fully swept.
+
+Both are fixed by the same mechanism as the coverage-gap fix: a full-projection backward sweep. That is why this is one lane, not three.
+
+**The constraint that overrides everything else in this design:** a resident must never get a push or email about something we only found by looking backward. Only Lane A (new applications) and Lane B (decisions) are allowed to notify. The backfill lane is a data-quality and coverage exercise, full stop.
+
+### Why national and date-windowed, not per-authority
+
+The first draft of this design scoped the sweep per-authority, mirroring Lane C's shape. That was wrong:
+
+- **Lane C takes exactly one page, always** (`ReconciliationHandler.sweepAuthority`), fetching the top 300 most-recently-touched records per authority and stopping. Per-authority scoping there is a semantic requirement, not a cost optimisation: Lane C needs breadth *across* all 485 authorities every sweep, so a national top-300-by-`-last_different` query would be dominated by whichever authorities scraped most recently and would starve the rest.
+- **Backfill's job is exhaustive, not a snapshot**, so it cannot get away with one page. But it does not need per-authority breadth either — it is not checking "is authority X's current state right", it is walking the whole national timeline once, and every authority's applications get touched as the window reaches their era regardless of whether the query names an authority.
+- The failure ADR 0041 warns against — "an unbounded national sweep is the query we must never send" (`start_date >= today-365` -> `total: null` after 45s) — is about query *scope*, not pagination depth. That failure was a single request, one-sided, no upper bound. A **two-sided** bounded window (`start_date` *and* `end_date` both present) is the same shape ADR 0041 itself measured at 11.7s for a masked-but-unprefiltered national query.
+- So: national, date-windowed, sliding backward — the same "one cursor, not 485" simplification ADR 0041 already proved out for Lanes A/B, inverted (shrinking the window's bound instead of growing a watermark) and applied to a full resweep instead of a delta.
+
+## Decision
+
+Add a fourth lane, `BackfillHandler` (`internal/polling/backfill.go`), that runs every poll cycle alongside Lanes A/B/C and spends a small, fixed page budget creeping backward through PlanIt's national history one date window at a time.
+
+**State.** One singleton row (`backfill_state`, migration `0022_backfill_state.sql`) — not one row per authority: the fixed upper bound (`window_end`) of the date window currently being drained, a resumable record index within that window (`cursor_next_index`), a running count of records seen in the current window (`window_records_seen`), a count of consecutive fully-empty windows (`consecutive_empty_windows`), and a `complete` flag.
+
+**Query shape.** Each cycle fetches up to `MaxPagesPerCycle` pages (default 2) of `FetchBackfillPage` (`internal/planit/backfill.go`): `start_date=<window_end - WindowWidthDays>&end_date=<window_end>`, `sort=-start_date`, `pg_sz=300`, the full `ingestSelectFields` projection (so the sweep can enrich every GH#935 field), `compress=on`, and — critically — **no `auth` param**. Every record returned is fed through the *existing, unmodified* `Ingester.Ingest`: identical records no-op, changed-or-NULL fields upsert (enrichment and gap-fill, for free, via the existing GH#935 three-bucket classification), first-seen records insert.
+
+**Window sliding.** When a window is fully drained (`HasMorePages` goes false), the window slides back by `WindowWidthDays` and pagination resets to index 0. If a fully-drained window produced zero records, `consecutive_empty_windows` increments; after `EmptyWindowsBeforeComplete` (default 12, ~3 years of national silence) consecutive empty windows, the lane marks itself `complete` and every subsequent `Run` is a no-op — no fetch, forever.
+
+**Crash safety.** State is persisted after every successfully-processed page, not batched to the end of a cycle. A crash mid-cycle loses nothing: re-fetching an already-ingested page is a free no-op under `Ingest`'s existing `HasSameBusinessFieldsAs`/`HasSameSilentFieldsAs` gates (the same reasoning ADR 0041 already relies on for Lanes A/B). A fetch or ingest error stops the loop for that cycle without persisting the failed page's progress — whatever prior pages in the same `Run` call succeeded stays persisted.
+
+**The notification-safety guarantee is structural, not a runtime flag.** The backfill lane's `Ingester` is constructed with `NewIngester(apps, nil, nil)` — nil decision dispatcher, nil notification enqueuer. `BackfillHandler` has **no `WithFanOut` method at all**, unlike `NationalLaneHandler` and `ReconciliationHandler`. There is no call `cmd/worker`'s wiring could make, today or in a future edit, that attaches a notifier to this lane. A boolean or origin-tag that "suppresses" fan-out is one bug away from a resident getting a push about a 2019 application; omitting the method makes the unsafe wiring a compile error, not a code-review miss. `NationalPollHandler.Handle` runs Lane D unconditionally (nil-guarded) after Lane C, but never folds its counts into `ApplicationCount`/`AuthorityErrors`/termination reason — those describe the critical path, and Lane D is not on it.
+
+**"Beyond when we first started polling" is discovered from the data, not a hardcoded floor date.** There is no reliable a-priori floor — different authorities' histories start at different points, and PlanIt's own digitisation depth is unknown — so the lane runs until enough consecutive windows come back empty.
+
+**This is expected to be slow, and that is correct, not a shortfall.** Default `MaxPagesPerCycle=2` adds ~48 requests and ~14,400 records/day at an hourly cadence — comfortably inside the PlanIt red line (~1,500 requests/day) and a modest addition to ADR 0041's steady-state total (~140-150 requests/day, ~23,000 records/day). A full national sweep back through years of history is a multi-month background process by design. That trade — small budget, long horizon — is the point.
+
+**Ships disabled** (`POLLING_BACKFILL_ENABLED=false`), mirroring the Lane C rollout precedent (`51eac0f0`, tc-5lu8h): brand-new polling code gets the dark-ship-then-soak treatment before flipping on.
+
+## Consequences
+
+### Positive
+
+- Closes the coverage hole ADR 0041 deliberately deferred, using the exact mechanism (GH#935's three-bucket classification) that already exists — no new diffing logic.
+- Every application ingested before GH#935 (2026-07-12) eventually gets its silent fields (`reference`, `altid`, `associated_id`, `scraper_name`, `other_fields`) populated as the sweep re-touches its era.
+- Structurally cannot regress the one invariant that matters most: no backward-discovered application ever notifies a resident.
+- Costs a small, fixed, indefinitely-sustainable slice of the PlanIt request budget — no growth cliff, no per-authority state to strand.
+
+### Negative / risks
+
+- **Slow by design.** Reaching the beginning of PlanIt's history is plausibly months away. Coverage metrics improve gradually, not immediately — anyone reading them must not mistake the pace for a bug.
+- **No dashboard gauge yet** for how far back the window has reached, or a "% of estimated history covered" metric. Follow-up bead, not blocking this ship.
+- **No reset mechanism for `complete`.** If the ingest field set widens again in future (another GH#935-style addition), there is currently no deliberate way to re-arm a completed sweep. Follow-up bead.
+- **Unverified against the live API** (PlanIt is called from the deployed worker only, never a dev machine, per standing policy): that `sort=-start_date` behaves as every other PlanIt sort param does, and that a bounded-both-sides window stays in the ~11.7s territory ADR 0041 measured rather than degrading for an older, differently-shaped slice of history. Verified from telemetry after the first soak deploy, not before.
+
+### Neutral
+
+- `poll_state` is untouched — Lane D gets its own table (`backfill_state`) specifically to avoid colliding with `poll_state`'s planned column drop once the ADR 0041 soak completes.
+- `internal/polling/handler.go` (the old, unwired per-authority drain) remains untouched and is not resurrected or built upon.
+- `wirePollFanOut` (`cmd/worker/main.go`) is unchanged — there is nothing for it to wire onto Lane D.
+
+## References
+
+- ADR 0041 — the design this ADR fulfils the deferred half of ("filling it is a separate exercise... with its own budget and its own risks").
+- GH#967 — the issue this ADR and its implementation (bead tc-8x9h3) satisfy.
+- GH#935 / commit `1f450e2e` — the three-bucket ingest classification this design reuses unchanged as its enrichment/gap-fill mechanism.
+- PR #964 / bead tc-5lu8h — the Lane C disable-behind-flag precedent this ADR's rollout posture mirrors.
+- Commit `c4f2a5ef` / bead tc-5m3tw — the "seed from head, never backfill" fix for Lanes A/B, whose reasoning this design's own first-run window-fixing directly parallels.


### PR DESCRIPTION
## Summary

Adds a fourth PlanIt polling lane, Lane D — a paced, national, date-windowed backward sweep that creeps through PlanIt's history one date window at a time, feeding every returned record through the existing, unmodified `Ingester.Ingest` to enrich stale/NULL GH#935 fields and fill coverage gaps left by ADR 0041's forward-only cutover.

**It is structurally incapable of notifying a resident.** Its `Ingester` is always constructed `NewIngester(apps, nil, nil)` (nil decision dispatcher, nil notification enqueuer), and `BackfillHandler` has **no `WithFanOut` method at all** — unlike `NationalLaneHandler`/`ReconciliationHandler`, there is no call any future wiring edit could make to attach a notifier to this lane. That is a compile-time guarantee, verified by a same-package unit test asserting `handler.ingester.decision == nil && handler.ingester.enqueuer == nil`.

Ships **disabled** (`POLLING_BACKFILL_ENABLED=false`), mirroring the Lane C dark-ship-then-soak precedent (tc-5lu8h). This PR flips nothing on in any environment.

Closes #967

## What's included

- `internal/platform/postgres/migrations/0022_backfill_state.sql` — singleton `backfill_state` table (boolean PK + CHECK), seeded row.
- `internal/planit/backfill.go` — `FetchBackfillPage`/`buildBackfillPath`: national (no `auth` param), both `start_date` and `end_date` bounded, `sort=-start_date`, `pg_sz=300`, full ingest projection, `compress=on`.
- `internal/polling/backfill.go` — `BackfillState`, `BackfillOptions`, `BackfillHandler`, `NewBackfillHandler`, `WithMetrics`, `Run` (page-budgeted, crash-safe per-page persistence, window sliding, empty-window completion counter).
- `internal/polling/store_postgres_backfill.go` — Postgres `Get`/`Save` over the singleton row.
- `internal/polling/nationallane.go` — `NationalPollHandler.WithBackfill` + a nil-guarded `laneD` field; `Handle` runs Lane D unconditionally after Lane C, but never folds its counts into the critical-path result fields.
- `internal/platform/config.go` — `PollingBackfillEnabled` (default `false`), `PollingBackfillWindowWidthDays` (90), `PollingBackfillMaxPagesPerCycle` (2), `PollingBackfillEmptyWindowsBeforeComplete` (12).
- `cmd/worker/main.go` — `buildPollOrchestrator` constructs/wires Lane D only when enabled; `wirePollFanOut` is **untouched** (nothing to wire).
- `docs/adr/0042-historical-backward-backfill-lane.md` — new ADR recording the design, explicitly requested by the task brief as deliverable #8 (flagged in the scope-check below, not an unauthorised addition).

## Deviations from the issue spec

None functionally. One implementation judgment call the spec left open: once `ConsecutiveEmptyWindows` reaches `EmptyWindowsBeforeComplete` and `Complete` is set, the window does **not** slide back further (`WindowEnd` freezes at its last value) — since `Complete=true` makes every subsequent `Run` a no-op forever, the frozen value is never read again, so this is inconsequential either way.

## Test plan

- [x] `gofmt -l .` — clean
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./...` — clean
- [x] `go test -race ./...` — 1923 tests pass
- [x] `go build ./...` — clean
- [x] `make test-integration` (real Postgres+PostGIS via Docker) — 2116 tests pass, including 3 new `pgtest`-harness round-trip tests for the singleton store
- [x] Full Red→Green TDD cycle per commit history (13 commits: red/green pairs per component)
- [x] No PlanIt request issued from this machine at any point (per standing policy) — all PlanIt interaction in tests goes through hand-written fakes/stubs, mirroring `nationallane_test.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional historical backfill process that scans older records in paced, date-based windows.
  * Backfill progress is saved between runs and resumes safely after interruptions.
  * Added configurable controls for enabling backfill, window size, page limits, and completion thresholds.
  * Backfill updates missing or outdated application data without triggering notifications.

* **Documentation**
  * Added documentation describing the historical backfill process, rollout behavior, and operational considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->