### PR TITLE
feat(infra): flip POLLING_BACKFILL_ENABLED on for prod worker

### DIFF
--- a/infra/environment.go
+++ b/infra/environment.go
@@ -706,6 +706,8 @@ func addGoWorkerEnv(envVars app.EnvironmentVarArray, ec envContext, workerMode s
 			app.EnvironmentVarArgs{Name: pulumi.String("POLLING_HANDLER_BUDGET_SECONDS"), Value: pulumi.String("240")},
 			app.EnvironmentVarArgs{Name: pulumi.String("POLL_REPLICA_TIMEOUT_SECONDS"), Value: pulumi.String("600")},
 			app.EnvironmentVarArgs{Name: pulumi.String("POLL_SHUTDOWN_GRACE_SECONDS"), Value: pulumi.String("30")},
+			// Lane D (ADR 0042 / GH#967, PR #968): dark-shipped disabled, flipped on here.
+			app.EnvironmentVarArgs{Name: pulumi.String("POLLING_BACKFILL_ENABLED"), Value: pulumi.String("true")},
 		)
 	}
 


### PR DESCRIPTION
## Summary
- Lane D (ADR 0042 / GH#967, PR #968) shipped dark-shipped-disabled (`POLLING_BACKFILL_ENABLED` default `false`), per the same soak-before-flip posture as Lane C (PR #964).
- Wires `POLLING_BACKFILL_ENABLED=true` into `infra/environment.go`'s `addGoWorkerEnv` poll-sb block so the prod worker constructs and runs the paced historical backfill lane.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean in `/infra`
- [ ] Watch `cd-prod` deploy succeed
- [ ] Confirm Lane D is running post-deploy (AppTraces / `backfill_state` row advancing), no notification fan-out, PlanIt request volume stays within the ~1,500/day red line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pNwTRXmh1c8Jr5RbdUXW6