### PR TITLE
fix(polling): fold Lane D Retry-After into national poll backoff (tc-hew73)

### DIFF
--- a/api-go/internal/polling/nationallane.go
+++ b/api-go/internal/polling/nationallane.go
@@ -592,23 +592,6 @@ func (h *NationalPollHandler) Handle(ctx context.Context) (PollPlanItResult, err
 		laneErrors++
 	}
 
-	rateLimited := outA.rateLimited || outB.rateLimited
-	var retryAfter *time.Duration
-	switch {
-	case outA.retryAfter != nil:
-		retryAfter = outA.retryAfter
-	case outB.retryAfter != nil:
-		retryAfter = outB.retryAfter
-	}
-
-	reason := TerminationNatural
-	switch {
-	case rateLimited:
-		reason = TerminationRateLimited
-	case outA.capHit || outB.capHit:
-		reason = TerminationTimeBounded
-	}
-
 	if h.laneC != nil {
 		now := h.now().UTC()
 		if h.laneC.Due(ctx, now) {
@@ -621,16 +604,40 @@ func (h *NationalPollHandler) Handle(ctx context.Context) (PollPlanItResult, err
 
 	// Lane D (GH#967, ADR 0042): runs unconditionally every cycle, nil-guarded
 	// — unlike Lane C it is never Due-gated (there is no interval to check, it
-	// always spends its small fixed page budget) and it never contributes to
-	// ApplicationCount/AuthorityErrors/termination reason below: it is a
-	// data-quality/coverage lane, not part of the critical path those fields
-	// describe, and it structurally cannot notify (nil decision/enqueuer,
-	// no WithFanOut method), so there is nothing here for it to affect.
+	// always spends its small fixed page budget). It never contributes to
+	// ApplicationCount/AuthorityErrors below: it is a data-quality/coverage
+	// lane, not part of the critical path those fields describe, and it
+	// structurally cannot notify (nil decision/enqueuer, no WithFanOut
+	// method), so there is nothing here for it to affect. It DOES fold into
+	// the rate-limit backoff below (rateLimited/retryAfter/reason, tc-hew73):
+	// a 429 against Lane D specifically must still slow the next poll cycle,
+	// exactly as an A/B 429 does, or PlanIt's Retry-After hint gets silently
+	// dropped on the floor.
+	var outD backfillOutcome
 	if h.laneD != nil {
-		outD := h.laneD.Run(ctx)
+		outD = h.laneD.Run(ctx)
 		if outD.err != nil {
 			h.logger.ErrorContext(ctx, "lane D backfill error", "error", outD.err)
 		}
+	}
+
+	rateLimited := outA.rateLimited || outB.rateLimited || outD.rateLimited
+	var retryAfter *time.Duration
+	switch {
+	case outA.retryAfter != nil:
+		retryAfter = outA.retryAfter
+	case outB.retryAfter != nil:
+		retryAfter = outB.retryAfter
+	case outD.retryAfter != nil:
+		retryAfter = outD.retryAfter
+	}
+
+	reason := TerminationNatural
+	switch {
+	case rateLimited:
+		reason = TerminationRateLimited
+	case outA.capHit || outB.capHit:
+		reason = TerminationTimeBounded
 	}
 
 	h.recorder().CycleCompleted(ctx, "National", reason.TelemetryValue())

--- a/api-go/internal/polling/nationallane_test.go
+++ b/api-go/internal/polling/nationallane_test.go
@@ -751,3 +751,42 @@ func TestNationalPollHandler_Handle_RunsBackfillLaneAfterLaneC(t *testing.T) {
 		t.Error("backfill fetcher: got 0 calls, want Lane D to have run")
 	}
 }
+
+// TestNationalPollHandler_Handle_LaneDRateLimitBubblesToNextCycle proves a
+// 429 hitting Lane D alone (A and B both run cleanly) still bubbles into the
+// cycle's RateLimited/TerminationReason/RetryAfter fields, so
+// Orchestrator.RunOnce -> NextRunScheduler.ComputeNextRun backs off the next
+// poll cycle exactly as it would for an A/B rate limit (tc-hew73).
+func TestNationalPollHandler_Handle_LaneDRateLimitBubblesToNextCycle(t *testing.T) {
+	t.Parallel()
+	fetcherA := newFakeNationalFetcher()
+	fetcherB := newFakeNationalFetcher()
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	logger := slog.New(slog.NewTextHandler(discard{}, nil))
+	clock := func() time.Time { return time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC) }
+
+	laneAHandler := NewNationalLaneHandler(fetcherA, state, apps, laneAOpts(), clock, logger)
+	laneBHandler := NewNationalLaneHandler(fetcherB, state, apps, laneBOpts(20), clock, logger)
+	handler := NewNationalPollHandler(laneAHandler, laneBHandler, nil, clock, logger)
+
+	retryAfter := 45 * time.Second
+	backfillFetcher := newFakeBackfillFetcher(fakeBackfillResponse{err: &planit.RateLimitError{RetryAfter: &retryAfter}})
+	backfillState := newFakeBackfillStateStore()
+	backfillHandler := NewBackfillHandler(backfillFetcher, backfillState, apps, defaultBackfillOpts(), clock, logger)
+	handler.WithBackfill(backfillHandler)
+
+	res, err := handler.Handle(context.Background())
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if !res.RateLimited {
+		t.Error("RateLimited: got false, want true (Lane D was rate-limited)")
+	}
+	if res.TerminationReason != TerminationRateLimited {
+		t.Errorf("TerminationReason: got %v, want %v", res.TerminationReason, TerminationRateLimited)
+	}
+	if res.RetryAfter == nil || *res.RetryAfter != retryAfter {
+		t.Errorf("RetryAfter: got %v, want %v", res.RetryAfter, retryAfter)
+	}
+}


### PR DESCRIPTION
## Changes
- Move Lane D's `Run(ctx)` call before the rateLimited/retryAfter/reason computation in `NationalPollHandler.Handle` so its outcome is available for bubbling.
- Fold `outD.rateLimited`/`outD.retryAfter` into the same `rateLimited`/`retryAfter`/`reason` variables A/B already use, so a 429 hitting Lane D alone still triggers `TerminationRateLimited` and backs off the next poll cycle via `NextRunScheduler.ComputeNextRun` — previously only A/B 429s did.
- `ApplicationCount`/`AuthorityErrors` remain untouched by Lane D, per existing intentional scoping.
- Update the stale comment above the Lane D block that claimed it never affects "termination reason."
- Add `TestNationalPollHandler_Handle_LaneDRateLimitBubblesToNextCycle` (red confirmed against pre-fix code, green after).

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * National polling now includes configured Lane D backfill processing in every poll cycle.
  * Rate-limit responses from Lane D are reflected in cycle status and backoff timing.
  * Improved handling of rate-limited polling cycles, including accurate termination details and retry timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->