### PR TITLE
fix(polling): repair Lane C 400 query, enable steady-state weekly sweep (tc-tuge8)

### DIFF
--- a/api-go/cmd/worker/main.go
+++ b/api-go/cmd/worker/main.go
@@ -305,11 +305,17 @@ func buildPollOrchestrator(cfg platform.Config, sbClient *servicebus.Client, reg
 	// completeness backstop, not on the cutover's critical path. Reuses the
 	// static pollable-authority list the old Seed cycle drained.
 	//
-	// Gated behind POLLING_LANE_C_ENABLED (default off): Lane C shipped broken
-	// in v0.21.0 — its per-authority query 400s on every authority, and it
-	// never records its weekly last-run when the sweep is cut off by the cycle
-	// budget, so it re-runs and hammers PlanIt every cycle. It stays nil (Handle
-	// skips it) until tc-tuge8 fixes both, then the config default flips.
+	// Gated behind POLLING_LANE_C_ENABLED (default ON as of tc-tuge8/GH#971):
+	// Lane C shipped broken in v0.21.0 — its per-authority query 400s because
+	// it carried no date param at all ("Spatial, date or search restrictions
+	// required in query", confirmed from prod's
+	// reconciliation.sample_error_body span attribute), and it never recorded
+	// its weekly last-run when the sweep was cut off by the cycle budget, so
+	// it re-ran and hammered PlanIt every cycle. Both are now fixed —
+	// buildReconciliationPath sends a different_start bound (below) and Run
+	// persists its cursor uncancellably (PR 1, tc-tuge8) — so the config
+	// default now enables Lane C; an operator can still set
+	// POLLING_LANE_C_ENABLED=false to force it off.
 	var laneC *polling.ReconciliationHandler
 	if cfg.PollingLaneCEnabled {
 		laneC = polling.NewReconciliationHandler(
@@ -319,6 +325,7 @@ func buildPollOrchestrator(cfg platform.Config, sbClient *servicebus.Client, reg
 				Interval:                  time.Duration(cfg.PollingLaneCIntervalHours) * time.Hour,
 				MaxStragglersPerAuthority: cfg.PollingLaneCMaxStragglersPerAuthority,
 				AuthoritiesPerCycle:       cfg.PollingLaneCAuthoritiesPerCycle,
+				LookbackDays:              cfg.PollingLaneCLookbackDays,
 			},
 			time.Now, logger,
 		)

--- a/api-go/cmd/worker/wiring_test.go
+++ b/api-go/cmd/worker/wiring_test.go
@@ -124,18 +124,18 @@ func TestEnqueuer_FindZonesContainingFlowsThroughInterface(t *testing.T) {
 	}
 }
 
-// TestBuildPollOrchestrator_LaneCGating pins the tc-5lu8h hotfix: Lane C
-// reconciliation is wired only when cfg.PollingLaneCEnabled is true (default
-// false). Both gate states must build a working orchestrator without
+// TestBuildPollOrchestrator_LaneCGating pins the tc-5lu8h/tc-tuge8 gating
+// behaviour: Lane C reconciliation is wired only when cfg.PollingLaneCEnabled
+// is true (default true as of tc-tuge8/GH#971, now that the 400 root cause
+// and the cursor-persistence bug are both fixed — an operator can still set
+// it false). Both gate states must build a working orchestrator without
 // panicking — disabled exercises the nil-laneC path through
-// wirePollFanOut's guard; enabled exercises the still-functional (if
-// currently broken upstream, tracked separately as tc-tuge8) construction
-// path so the flag itself introduces no regression when flipped back on.
-// sbClient and st are zero-value: buildPollOrchestrator only needs sbClient
-// non-nil to pass its "no poller configured" guard, and every collaborator
-// it constructs (planit.NewClient, the national lane handlers, the
-// reconciliation handler, the orchestrator) opens no connection and performs
-// no I/O at construction time.
+// wirePollFanOut's guard; enabled exercises the construction path so the
+// flag itself introduces no regression. sbClient and st are zero-value:
+// buildPollOrchestrator only needs sbClient non-nil to pass its "no poller
+// configured" guard, and every collaborator it constructs (planit.NewClient,
+// the national lane handlers, the reconciliation handler, the orchestrator)
+// opens no connection and performs no I/O at construction time.
 func TestBuildPollOrchestrator_LaneCGating(t *testing.T) {
 	t.Parallel()
 
@@ -143,8 +143,8 @@ func TestBuildPollOrchestrator_LaneCGating(t *testing.T) {
 		name         string
 		laneCEnabled bool
 	}{
-		{"disabled (default)", false},
-		{"enabled", true},
+		{"disabled", false},
+		{"enabled (default)", true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/api-go/internal/planit/national.go
+++ b/api-go/internal/planit/national.go
@@ -94,8 +94,15 @@ func (c *Client) FetchNationalDeltaPage(ctx context.Context, q NationalDeltaQuer
 // FetchReconciliationPage fetches one page of Lane C's light per-authority
 // projection (ADR 0041): select=uid,app_state,decided_date,last_different,
 // sorted newest-touched-first, pg_sz=300, scoped to authorityID.
-func (c *Client) FetchReconciliationPage(ctx context.Context, authorityID, startIndex int) (FetchPageResult, error) {
-	target := c.baseURL + buildReconciliationPath(authorityID, startIndex)
+// differentStart is the caller-computed date-only cutoff (today minus the
+// configured lookback window) satisfying PlanIt's requirement that every
+// query carry a spatial, date, or search restriction (tc-tuge8/GH#971: an
+// unbounded query 400s with "Spatial, date or search restrictions required
+// in query"). The caller computes it once per sweep from its own injected
+// clock, mirroring how NationalLaneHandler.Run computes MaskCutoff --
+// *Client deliberately has no clock dependency of its own.
+func (c *Client) FetchReconciliationPage(ctx context.Context, authorityID, startIndex int, differentStart time.Time) (FetchPageResult, error) {
+	target := c.baseURL + buildReconciliationPath(authorityID, startIndex, differentStart)
 	return c.fetchPage(ctx, target, authorityID, startIndex, nationalPageSize)
 }
 
@@ -132,11 +139,17 @@ func buildNationalDeltaPath(q NationalDeltaQuery) string {
 	)
 }
 
-// buildReconciliationPath builds Lane C's light per-authority projection path.
-func buildReconciliationPath(authorityID, startIndex int) string {
+// buildReconciliationPath builds Lane C's light per-authority projection
+// path: scoped by auth, a different_start date bound (tc-tuge8/GH#971 -- see
+// FetchReconciliationPage), the light select set, sort=-last_different,
+// pg_sz=300, and compress=on. differentStart is deliberately NOT a churn
+// mask (MaskStartDate/MaskDecidedStart): Lane C's job is detecting drift in
+// what PlanIt has touched, so this stays a wide, date-only prefilter rather
+// than the exact-delta mask Lane A/B compute.
+func buildReconciliationPath(authorityID, startIndex int, differentStart time.Time) string {
 	return fmt.Sprintf(
-		"/api/applics/json?auth=%d&sort=-last_different&pg_sz=%d&index=%d&select=%s&compress=on",
-		authorityID, nationalPageSize, startIndex, selectParam(reconciliationSelectFields),
+		"/api/applics/json?auth=%d&different_start=%s&sort=-last_different&pg_sz=%d&index=%d&select=%s&compress=on",
+		authorityID, differentStart.UTC().Format("2006-01-02"), nationalPageSize, startIndex, selectParam(reconciliationSelectFields),
 	)
 }
 

--- a/api-go/internal/planit/national_test.go
+++ b/api-go/internal/planit/national_test.go
@@ -72,11 +72,16 @@ func TestBuildNationalDeltaPath(t *testing.T) {
 }
 
 // TestBuildReconciliationPath pins Lane C's light per-authority projection
-// shape: scoped by auth, the light select set (containing the sort field),
-// pg_sz=300, compress=on.
+// shape: scoped by auth, a different_start date bound (tc-tuge8/GH#971: PlanIt
+// 400s "Spatial, date or search restrictions required in query" on a query
+// with no date param at all -- confirmed from prod's
+// reconciliation.sample_error_body span attribute), the light select set
+// (containing the sort field), pg_sz=300, compress=on. differentStart is
+// injected (not real time) so the assertion is deterministic.
 func TestBuildReconciliationPath(t *testing.T) {
 	t.Parallel()
-	path := buildReconciliationPath(99, 0)
+	differentStart := time.Date(2025, 7, 17, 0, 0, 0, 0, time.UTC)
+	path := buildReconciliationPath(99, 0, differentStart)
 	u, err := url.Parse(path)
 	if err != nil {
 		t.Fatalf("parse built path %q: %v", path, err)
@@ -85,6 +90,9 @@ func TestBuildReconciliationPath(t *testing.T) {
 
 	if got.Get("auth") != "99" {
 		t.Errorf("auth: got %q, want 99", got.Get("auth"))
+	}
+	if got.Get("different_start") != "2025-07-17" {
+		t.Errorf("different_start: got %q, want 2025-07-17", got.Get("different_start"))
 	}
 	if got.Get("pg_sz") != "300" {
 		t.Errorf("pg_sz: got %q, want 300", got.Get("pg_sz"))

--- a/api-go/internal/platform/config.go
+++ b/api-go/internal/platform/config.go
@@ -205,18 +205,29 @@ type Config struct {
 	// persisting a resumable cursor and continuing next cycle (default 50 —
 	// 50 x 2s throttle = 100s, comfortably inside the ~570s cycle budget; a
 	// full ~485-authority pass takes ~10 cycles — tc-tuge8/GH#971).
+	// PollingLaneCLookbackDays bounds Lane C's different_start date prefilter
+	// (default 365): PlanIt 400s a reconciliation query carrying no date
+	// bound at all ("Spatial, date or search restrictions required in
+	// query" — tc-tuge8/GH#971's confirmed root cause), and 365 days is
+	// deliberately generous since Lane C's job is detecting drift in what
+	// PlanIt has touched, not computing an exact delta.
 	PollingLaneAMaskDays                  int
 	PollingLaneBMaskDays                  int
 	PollingLaneBMaxPages                  int
 	PollingLaneCIntervalHours             int
 	PollingLaneCMaxStragglersPerAuthority int
 	PollingLaneCAuthoritiesPerCycle       int
+	PollingLaneCLookbackDays              int
 	// PollingLaneCEnabled gates whether Lane C (reconciliation) is wired into
 	// the poll cycle at all. Loaded from POLLING_LANE_C_ENABLED and DEFAULT
-	// FALSE: Lane C shipped broken in v0.21.0 (its per-authority query 400s and
-	// it never records its weekly last-run on a budget cut-off, so it re-runs
-	// and hammers PlanIt every cycle). It stays off until tc-tuge8 fixes the
-	// query and the last-run persistence, then this default flips to true.
+	// TRUE (tc-tuge8/GH#971): Lane C shipped broken in v0.21.0 (its
+	// per-authority query 400s because it carried no date param at all, and
+	// it never recorded its weekly last-run on a budget cut-off, so it
+	// re-ran and hammered PlanIt every cycle). Both are now fixed —
+	// buildReconciliationPath sends a different_start bound, and Run
+	// persists its cursor uncancellably (PR 1, tc-tuge8) — so an unset value
+	// now opts IN by default. An operator can still set
+	// POLLING_LANE_C_ENABLED=false to force it off.
 	PollingLaneCEnabled bool
 
 	// PollingBackfill* configure Lane D, the paced historical backfill lane
@@ -379,7 +390,8 @@ func LoadConfig() (Config, error) {
 		PollingLaneCIntervalHours:             getenvInt("POLLING_LANE_C_INTERVAL_HOURS", 168),
 		PollingLaneCMaxStragglersPerAuthority: getenvInt("POLLING_LANE_C_MAX_STRAGGLERS_PER_AUTHORITY", 10),
 		PollingLaneCAuthoritiesPerCycle:       getenvInt("POLLING_LANE_C_AUTHORITIES_PER_CYCLE", 50),
-		PollingLaneCEnabled:                   getenvBool("POLLING_LANE_C_ENABLED"),
+		PollingLaneCLookbackDays:              getenvInt("POLLING_LANE_C_LOOKBACK_DAYS", 365),
+		PollingLaneCEnabled:                   getenvBoolDefault("POLLING_LANE_C_ENABLED", true),
 
 		PollingBackfillEnabled:                    getenvBool("POLLING_BACKFILL_ENABLED"),
 		PollingBackfillWindowWidthDays:            getenvInt("POLLING_BACKFILL_WINDOW_WIDTH_DAYS", 90),
@@ -460,6 +472,28 @@ func getenv(key, fallback string) string {
 // (e.g. APNS_ENABLED defaults to off).
 func getenvBool(key string) bool {
 	v, err := strconv.ParseBool(strings.TrimSpace(os.Getenv(key)))
+	if err != nil {
+		return false
+	}
+	return v
+}
+
+// getenvBoolDefault is getenvBool with a caller-chosen fallback for the
+// unset case, distinguishing "unset" from "explicitly set" via
+// os.LookupEnv (an empty value counts as unset too, matching getenv's and
+// getenvInt's treatment of "" elsewhere in this file). A present,
+// non-empty, but unparseable value still fails safe to false, mirroring
+// getenvBool — only the unset branch honours fallback. Use this (rather
+// than getenvBool) for a flag whose safe default is true once the feature
+// it gates is no longer known-broken (e.g. PollingLaneCEnabled,
+// tc-tuge8/GH#971); every other boolean flag in this file has a safe
+// default of false and should keep using getenvBool.
+func getenvBoolDefault(key string, fallback bool) bool {
+	raw, ok := os.LookupEnv(key)
+	if !ok || strings.TrimSpace(raw) == "" {
+		return fallback
+	}
+	v, err := strconv.ParseBool(strings.TrimSpace(raw))
 	if err != nil {
 		return false
 	}

--- a/api-go/internal/platform/config_test.go
+++ b/api-go/internal/platform/config_test.go
@@ -414,7 +414,7 @@ func TestLoadConfig_PollingDefaults(t *testing.T) {
 		"POLLING_PLANIT_PAGE_SIZE",
 		"POLLING_LANE_A_MASK_DAYS", "POLLING_LANE_B_MASK_DAYS", "POLLING_LANE_B_MAX_PAGES",
 		"POLLING_LANE_C_INTERVAL_HOURS", "POLLING_LANE_C_MAX_STRAGGLERS_PER_AUTHORITY",
-		"POLLING_LANE_C_ENABLED", "POLLING_LANE_C_AUTHORITIES_PER_CYCLE",
+		"POLLING_LANE_C_ENABLED", "POLLING_LANE_C_AUTHORITIES_PER_CYCLE", "POLLING_LANE_C_LOOKBACK_DAYS",
 		"POLLING_BACKFILL_ENABLED", "POLLING_BACKFILL_WINDOW_WIDTH_DAYS",
 		"POLLING_BACKFILL_MAX_PAGES_PER_CYCLE", "POLLING_BACKFILL_EMPTY_WINDOWS_BEFORE_COMPLETE",
 	} {
@@ -457,14 +457,17 @@ func TestLoadConfig_PollingDefaults(t *testing.T) {
 	if cfg.PollingLaneCIntervalHours != 168 {
 		t.Errorf("lane C interval default: got %d, want 168", cfg.PollingLaneCIntervalHours)
 	}
-	if cfg.PollingLaneCEnabled {
-		t.Error("PollingLaneCEnabled: got true, want false by default (Lane C disabled until tc-tuge8)")
+	if !cfg.PollingLaneCEnabled {
+		t.Error("PollingLaneCEnabled: got false, want true by default (tc-tuge8: the 400 is fixed, so Lane C now defaults on)")
 	}
 	if cfg.PollingLaneCMaxStragglersPerAuthority != 10 {
 		t.Errorf("lane C max stragglers default: got %d, want 10", cfg.PollingLaneCMaxStragglersPerAuthority)
 	}
 	if cfg.PollingLaneCAuthoritiesPerCycle != 50 {
 		t.Errorf("lane C authorities-per-cycle default: got %d, want 50 (tc-tuge8: 50 x 2s throttle = 100s, inside the ~570s cycle budget)", cfg.PollingLaneCAuthoritiesPerCycle)
+	}
+	if cfg.PollingLaneCLookbackDays != 365 {
+		t.Errorf("lane C lookback-days default: got %d, want 365 (tc-tuge8: deliberately generous -- detects drift, not an exact delta)", cfg.PollingLaneCLookbackDays)
 	}
 	if cfg.PollingBackfillEnabled {
 		t.Error("PollingBackfillEnabled: got true, want false by default (GH#967, ships dark)")
@@ -509,20 +512,22 @@ func TestLoadConfig_PollingBackfillEnabled(t *testing.T) {
 	}
 }
 
-// TestLoadConfig_PollingLaneCEnabled pins the tc-5lu8h hotfix default: Lane C
-// reconciliation ships OFF (POLLING_LANE_C_ENABLED unset or falsy) until
-// tc-tuge8 fixes its per-authority query and cancelled-context save bug. An
-// explicit truthy value opts back in.
+// TestLoadConfig_PollingLaneCEnabled pins the tc-tuge8 fix: Lane C's 400 root
+// cause (an unbounded query PlanIt rejects) is fixed, so POLLING_LANE_C_ENABLED
+// unset now defaults Lane C ON. An operator who explicitly wants it off must
+// still be able to set POLLING_LANE_C_ENABLED=false -- the fail-safe-off path
+// is preserved, only the unset default direction flips.
 func TestLoadConfig_PollingLaneCEnabled(t *testing.T) {
 	tests := []struct {
 		name string
 		env  string
 		want bool
 	}{
-		{"unset defaults false", "", false},
+		{"unset defaults true", "", true},
 		{"true enables", "true", true},
 		{"1 enables", "1", true},
-		{"false stays disabled", "false", false},
+		{"false explicitly disables", "false", false},
+		{"0 explicitly disables", "0", false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -646,6 +651,7 @@ func TestLoadConfig_PollingOverrides(t *testing.T) {
 	t.Setenv("POLLING_LANE_C_MAX_STRAGGLERS_PER_AUTHORITY", "5")
 	t.Setenv("POLLING_LANE_C_ENABLED", "true")
 	t.Setenv("POLLING_LANE_C_AUTHORITIES_PER_CYCLE", "25")
+	t.Setenv("POLLING_LANE_C_LOOKBACK_DAYS", "180")
 
 	cfg, err := LoadConfig()
 	if err != nil {
@@ -683,5 +689,8 @@ func TestLoadConfig_PollingOverrides(t *testing.T) {
 	}
 	if cfg.PollingLaneCAuthoritiesPerCycle != 25 {
 		t.Errorf("lane C authorities-per-cycle override: got %d, want 25", cfg.PollingLaneCAuthoritiesPerCycle)
+	}
+	if cfg.PollingLaneCLookbackDays != 180 {
+		t.Errorf("lane C lookback-days override: got %d, want 180", cfg.PollingLaneCLookbackDays)
 	}
 }

--- a/api-go/internal/polling/reconciliation.go
+++ b/api-go/internal/polling/reconciliation.go
@@ -20,7 +20,7 @@ import (
 // needs: one light per-authority projection page, and a full-record hydration
 // fetch by uid. *planit.Client satisfies both.
 type reconciliationFetcher interface {
-	FetchReconciliationPage(ctx context.Context, authorityID, startIndex int) (planit.FetchPageResult, error)
+	FetchReconciliationPage(ctx context.Context, authorityID, startIndex int, differentStart time.Time) (planit.FetchPageResult, error)
 	FetchByUID(ctx context.Context, uid string) (planit.FetchPageResult, error)
 }
 
@@ -45,6 +45,18 @@ type ReconciliationOptions struct {
 	// ever reach the authorities that fit one cycle's budget, starving the
 	// rest permanently (tc-tuge8/GH#971).
 	AuthoritiesPerCycle int
+	// LookbackDays bounds how far back Lane C's different_start prefilter
+	// reaches (config: POLLING_LANE_C_LOOKBACK_DAYS, default 365). PlanIt
+	// rejects a reconciliation query with no date bound at all --
+	// "Spatial, date or search restrictions required in query", the
+	// tc-tuge8/GH#971 root cause confirmed from prod's
+	// reconciliation.sample_error_body span attribute. Deliberately generous
+	// and NOT a churn mask (see MaskStartDate/MaskDecidedStart on
+	// planit.NationalDeltaQuery): Lane C's job is detecting drift in what
+	// PlanIt has touched, not computing an exact delta, so a wide, date-only
+	// prefilter satisfies PlanIt's requirement while still scanning each
+	// authority's genuinely-touched-recently set.
+	LookbackDays int
 }
 
 // ReconciliationHandler runs ADR 0041's Lane C: per authority, fetch a light
@@ -214,12 +226,18 @@ func (h *ReconciliationHandler) Run(ctx context.Context) reconciliationOutcome {
 	// sweeping zero authorities forever.
 	end := min(start+h.opts.AuthoritiesPerCycle, len(ids))
 
+	// The different_start cutoff is computed ONCE per sweep from this Run
+	// call's own injected clock (now) and threaded down to every authority's
+	// fetch, mirroring how NationalLaneHandler.Run computes MaskCutoff once
+	// rather than per-page/per-authority (tc-tuge8/GH#971).
+	cutoff := now.AddDate(0, 0, -h.opts.LookbackDays)
+
 	attempted := start
 	for _, authorityID := range ids[start:end] {
 		if ctx.Err() != nil {
 			break
 		}
-		h.sweepAuthority(ctx, authorityID, &out)
+		h.sweepAuthority(ctx, authorityID, cutoff, &out)
 		attempted++
 	}
 
@@ -272,9 +290,10 @@ func (h *ReconciliationHandler) Run(ctx context.Context) reconciliationOutcome {
 
 // sweepAuthority fetches one authority's light projection page, diffs each
 // row against the persisted application, and hydrates the stragglers
-// (bounded by MaxStragglersPerAuthority).
-func (h *ReconciliationHandler) sweepAuthority(ctx context.Context, authorityID int, out *reconciliationOutcome) {
-	res, err := h.fetcher.FetchReconciliationPage(ctx, authorityID, 0)
+// (bounded by MaxStragglersPerAuthority). differentStart is Run's
+// once-per-sweep LookbackDays cutoff.
+func (h *ReconciliationHandler) sweepAuthority(ctx context.Context, authorityID int, differentStart time.Time, out *reconciliationOutcome) {
+	res, err := h.fetcher.FetchReconciliationPage(ctx, authorityID, 0, differentStart)
 	if err != nil {
 		h.logger.WarnContext(ctx, "lane C: reconciliation page fetch failed, skipping authority", "authorityId", authorityID, "error", err)
 		recordFetchError(err, out)

--- a/api-go/internal/polling/reconciliation_test.go
+++ b/api-go/internal/polling/reconciliation_test.go
@@ -26,6 +26,11 @@ type fakeReconciliationFetcher struct {
 	// off (a fake serving a handful of ids can't catch a resume bug; the
 	// caller must supply more ids than AuthoritiesPerCycle).
 	pageCalls []int
+	// differentStarts records the differentStart cutoff FetchReconciliationPage
+	// was called with, in call order -- proves Run computes the
+	// LookbackDays-derived cutoff once per sweep and threads it down to every
+	// fetch (tc-tuge8/GH#971).
+	differentStarts []time.Time
 	// cancelAfter, when > 0, calls cancel once len(pageCalls) reaches it --
 	// simulates a budget/ctx cut-off arriving mid-sweep, so a test can assert
 	// the persisted cursor reflects authorities ACTUALLY attempted, not the
@@ -43,8 +48,9 @@ func newFakeReconciliationFetcher() *fakeReconciliationFetcher {
 	}
 }
 
-func (f *fakeReconciliationFetcher) FetchReconciliationPage(_ context.Context, authorityID, _ int) (planit.FetchPageResult, error) {
+func (f *fakeReconciliationFetcher) FetchReconciliationPage(_ context.Context, authorityID, _ int, differentStart time.Time) (planit.FetchPageResult, error) {
 	f.pageCalls = append(f.pageCalls, authorityID)
+	f.differentStarts = append(f.differentStarts, differentStart)
 	if f.cancelAfter > 0 && len(f.pageCalls) == f.cancelAfter && f.cancel != nil {
 		f.cancel()
 	}
@@ -88,7 +94,7 @@ func newReconciliationHandler(t *testing.T, fetcher *fakeReconciliationFetcher, 
 // own with a deliberately larger id list (see the fake-design note on
 // pageCalls above).
 func defaultReconciliationOpts() ReconciliationOptions {
-	return ReconciliationOptions{Interval: 7 * 24 * time.Hour, MaxStragglersPerAuthority: 10, AuthoritiesPerCycle: 100}
+	return ReconciliationOptions{Interval: 7 * 24 * time.Hour, MaxStragglersPerAuthority: 10, AuthoritiesPerCycle: 100, LookbackDays: 365}
 }
 
 // TestReconciliation_HydratesGenuinelyDifferingRow covers the straggler path:
@@ -176,6 +182,36 @@ func TestReconciliation_MissingApplicationIsAStraggler(t *testing.T) {
 
 	if out.stragglers != 1 || out.hydrated != 1 {
 		t.Errorf("stragglers=%d hydrated=%d, want 1/1 (never-seen uid must hydrate)", out.stragglers, out.hydrated)
+	}
+}
+
+// TestReconciliation_PassesLookbackCutoffToFetchReconciliationPage pins
+// tc-tuge8/GH#971: Run computes the LookbackDays-derived different_start
+// cutoff ONCE from its own injected clock (mirroring how
+// NationalLaneHandler.Run computes MaskCutoff once per run) and threads the
+// SAME cutoff down to every authority's FetchReconciliationPage call.
+func TestReconciliation_PassesLookbackCutoffToFetchReconciliationPage(t *testing.T) {
+	t.Parallel()
+	fetcher := newFakeReconciliationFetcher()
+	fetcher.pages[1] = planit.FetchPageResult{}
+	fetcher.pages[2] = planit.FetchPageResult{}
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	opts := ReconciliationOptions{Interval: 7 * 24 * time.Hour, MaxStragglersPerAuthority: 10, AuthoritiesPerCycle: 100, LookbackDays: 365}
+	h := newReconciliationHandler(t, fetcher, apps, state, []int{1, 2}, opts)
+
+	h.Run(context.Background())
+
+	// newReconciliationHandler pins the clock to 2026-07-14T12:00:00Z; 365
+	// days earlier is 2025-07-14T12:00:00Z (no leap day falls in between).
+	wantCutoff := time.Date(2025, 7, 14, 12, 0, 0, 0, time.UTC)
+	if len(fetcher.differentStarts) != 2 {
+		t.Fatalf("differentStarts: got %d calls, want 2", len(fetcher.differentStarts))
+	}
+	for i, got := range fetcher.differentStarts {
+		if !got.Equal(wantCutoff) {
+			t.Errorf("differentStarts[%d]: got %v, want %v (now - LookbackDays)", i, got, wantCutoff)
+		}
 	}
 }
 

--- a/infra/environment.go
+++ b/infra/environment.go
@@ -709,15 +709,16 @@ func addGoWorkerEnv(envVars app.EnvironmentVarArray, ec envContext, workerMode s
 			// Lane D (ADR 0042 / GH#967, PR #968): dark-shipped disabled, flipped on here.
 			app.EnvironmentVarArgs{Name: pulumi.String("POLLING_BACKFILL_ENABLED"), Value: pulumi.String("true")},
 			// Lane C (ADR 0041 reconciliation/completeness backstop, tc-tuge8 / GH#971):
-			// bounded diagnostic enable only, NOT the eventual steady-state config. Capped
-			// at 10 authorities/cycle (code default is 50) so the next scheduled poll cycle
-			// spends at most 10 PlanIt requests to capture the real 400 error reason onto the
-			// "PlanIt reconciliation sweep" span's reconciliation.sample_error_body attribute
-			// (queryable via App Insights AppDependencies). PR 2 (later, after the prod
-			// observation window) fixes buildReconciliationPath per that captured reason and
-			// raises this to 50 for steady state.
+			// steady-state config. PR 1's bounded diagnostic run (10 authorities/cycle)
+			// captured the real prod 400 reason onto the "PlanIt reconciliation sweep"
+			// span's reconciliation.sample_error_body attribute (queryable via App
+			// Insights AppDependencies): a missing date bound on the reconciliation
+			// query. PR 2 fixed buildReconciliationPath to add that bound, so this now
+			// runs the full weekly reconciliation sweep at the code-default 50
+			// authorities/cycle (50 x 2s PlanIt throttle = 100s/cycle, well inside the
+			// ~570s handler budget; a full ~485-authority pass completes over ~10 cycles).
 			app.EnvironmentVarArgs{Name: pulumi.String("POLLING_LANE_C_ENABLED"), Value: pulumi.String("true")},
-			app.EnvironmentVarArgs{Name: pulumi.String("POLLING_LANE_C_AUTHORITIES_PER_CYCLE"), Value: pulumi.String("10")},
+			app.EnvironmentVarArgs{Name: pulumi.String("POLLING_LANE_C_AUTHORITIES_PER_CYCLE"), Value: pulumi.String("50")},
 		)
 	}
 


### PR DESCRIPTION
## Changes

PR 2 of 2 for GH#971 (tc-tuge8), following the prod observation window from PR 1 (#973, v0.21.6). The real 400 reason was read from prod telemetry (AppDependencies, "PlanIt reconciliation sweep" span, `reconciliation.sample_error_body`, captured 2026-07-17T13:04 UTC):

```
{"error": "Spatial, date or search restrictions required in query"}
```

This confirms the hypothesis in GH#971: unlike every other PlanIt query this codebase sends, Lane C's per-authority query carried no date param at all.

- `internal/planit/national.go`: `buildReconciliationPath` now emits `different_start=<cutoff>` (a wide, date-only prefilter — deliberately not a churn mask like Lane A/B, since Lane C's job is detecting drift in what PlanIt has touched, not computing an exact delta). `FetchReconciliationPage` takes the cutoff as a caller-computed parameter, mirroring how Lane A/B thread their mask cutoff — `planit.Client` still has no clock dependency of its own.
- `internal/polling/reconciliation.go`, `config.go`, `cmd/worker/main.go`: new `PollingLaneCLookbackDays` dial (env `POLLING_LANE_C_LOOKBACK_DAYS`, default 365), computed once per sweep from the handler's injected clock and threaded to every authority's fetch.
- `internal/platform/config.go`: `PollingLaneCEnabled` now defaults to **true** (was false) via a new `getenvBoolDefault` helper — Lane C is fixed, so an unset value now opts in by default; `POLLING_LANE_C_ENABLED=false` still forces it off for an operator who wants that.
- `infra/environment.go`: raises `POLLING_LANE_C_AUTHORITIES_PER_CYCLE` from PR 1's bounded diagnostic value (10) to the steady-state value (50) — 50 × 2s throttle = 100s/cycle, well inside the ~570s handler budget; a full ~485-authority pass completes over ~10 cycles, repeating weekly per `PollingLaneCIntervalHours`.

`TestBuildReconciliationPath` pins the new query shape with the date bound. All existing cursor-resume, `Due()`, and error-body-capture behavior from PR 1 is unchanged — only the fetcher signature threading the new cutoff through.

Once deployed, next step is prod verification: Lane C requests should return 200 (not 400), the `-3` poll_state row's `cursor_next_index` should advance across cycles and `last_poll_time` should populate once a full pass completes, and total PlanIt volume (Lane A+B+C+D combined) should stay comfortably under the ~1500/day red line.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Lane C reconciliation is now enabled by default.
  - Reconciliation checks the previous 365 days by default, with configurable lookback periods.
  - Queries now include a date boundary for more reliable reconciliation results.

- **Improvements**
  - Polling now processes up to 50 authorities per cycle, supporting a complete weekly reconciliation sweep.
  - Lane C can still be disabled explicitly through configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->