### PR TITLE
fix(polling): Lane C 429 circuit-breaker — stop hammering PlanIt after rate-limit (tc-mc0hf)

### DIFF
--- a/api-go/internal/polling/reconciliation.go
+++ b/api-go/internal/polling/reconciliation.go
@@ -176,6 +176,19 @@ type reconciliationOutcome struct {
 	// inflate this counter -- it exists to answer "is every authority 400ing
 	// the same way", the v0.21.0 storm signature.
 	badRequestCount int
+	// rateLimited is set once, the first time ANY PlanIt call this Run makes
+	// -- a per-authority sweep fetch (FetchReconciliationPage) or a straggler
+	// hydration fetch (FetchByUID) -- returns a *planit.RateLimitError, and
+	// is never cleared afterwards (tc-mc0hf). It is Lane C's circuit breaker:
+	// once tripped, sweepAuthority stops hydrating further stragglers for the
+	// rest of that authority and Run stops sweeping further authorities for
+	// the rest of this cycle, mirroring NationalLaneHandler's "stop on first
+	// 429" behavior for Lane A/B. Without this, a single 429 was previously
+	// followed by every remaining straggler hydration and authority sweep
+	// still firing anyway -- 141 of 187 hydration requests rejected with 429
+	// over 8.5 minutes in one prod cycle, a live violation of PlanIt's
+	// never-hammer red line.
+	rateLimited bool
 }
 
 // Run sweeps up to AuthoritiesPerCycle authorities' light projections, diffs
@@ -308,6 +321,13 @@ func (h *ReconciliationHandler) sweepAuthority(ctx context.Context, authorityID 
 		if stragglers >= h.opts.MaxStragglersPerAuthority {
 			break
 		}
+		// A 429 from hydrating an earlier straggler in THIS authority trips
+		// the circuit breaker: stop hydrating the rest of this authority's
+		// stragglers rather than following a rejected request with more
+		// rejected requests (tc-mc0hf).
+		if out.rateLimited {
+			break
+		}
 		existing, found, gerr := h.ingester.apps.GetByUID(ctx, light.UID, authorityCode)
 		if gerr != nil {
 			h.logger.WarnContext(ctx, "lane C: read existing application failed", "uid", light.UID, "error", gerr)
@@ -322,11 +342,20 @@ func (h *ReconciliationHandler) sweepAuthority(ctx context.Context, authorityID 
 	}
 }
 
-// recordFetchError captures a PlanIt HTTP error's status/body onto the sweep
-// outcome (tc-tuge8/GH#971): a non-*planit.HTTPError (e.g. a transport
-// failure) is a no-op here -- it stays logged, as before, with nothing to add
-// to the span.
+// recordFetchError captures a PlanIt fetch error onto the sweep outcome.
+// *planit.HTTPError's status/body is captured as before (tc-tuge8/GH#971).
+// Independently, *planit.RateLimitError -- a distinct sibling error type,
+// never an HTTPError -- trips out.rateLimited (tc-mc0hf), Lane C's circuit
+// breaker: Run and sweepAuthority's straggler loop both check it to stop
+// making further PlanIt requests for the rest of this cycle. Any other error
+// type (e.g. a transport failure) is a no-op here -- it stays logged, as
+// before, with nothing to add to the span.
 func recordFetchError(err error, out *reconciliationOutcome) {
+	var rlErr *planit.RateLimitError
+	if errors.As(err, &rlErr) {
+		out.rateLimited = true
+	}
+
 	var herr *planit.HTTPError
 	if !errors.As(err, &herr) {
 		return
@@ -346,6 +375,7 @@ func (h *ReconciliationHandler) hydrate(ctx context.Context, uid string, out *re
 	full, err := h.fetcher.FetchByUID(ctx, uid)
 	if err != nil {
 		h.logger.WarnContext(ctx, "lane C: hydration fetch failed", "uid", uid, "error", err)
+		recordFetchError(err, out)
 		return
 	}
 	for _, app := range full.Applications {

--- a/api-go/internal/polling/reconciliation.go
+++ b/api-go/internal/polling/reconciliation.go
@@ -252,6 +252,15 @@ func (h *ReconciliationHandler) Run(ctx context.Context) reconciliationOutcome {
 		}
 		h.sweepAuthority(ctx, authorityID, cutoff, &out)
 		attempted++
+		// The authority just swept above DID make its request (and is
+		// correctly counted in attempted immediately above) even when that
+		// request came back rate-limited -- only the NEXT authority's sweep
+		// is skipped. Mirrors NationalLaneHandler's "stop on first 429" and
+		// feeds the exact same actually-attempted persistence path as the
+		// ctx.Err() break above (tc-mc0hf).
+		if out.rateLimited {
+			break
+		}
 	}
 
 	// The persisted next-index must reflect how many authorities were

--- a/api-go/internal/polling/reconciliation.go
+++ b/api-go/internal/polling/reconciliation.go
@@ -306,6 +306,14 @@ func (h *ReconciliationHandler) Run(ctx context.Context) reconciliationOutcome {
 		attribute.Int("reconciliation.stragglers", out.stragglers),
 		attribute.String("reconciliation.sample_error_body", out.sampleErrorBody),
 		attribute.Int("reconciliation.error_count", out.badRequestCount),
+		// tc-mc0hf: lets a prod check confirm the 429 circuit breaker fired
+		// by reading this attribute directly (Properties in AppDependencies)
+		// instead of cross-referencing raw 429 counts by hand. Absent
+		// entirely on the two early-bail-out paths above (authority list
+		// load / watermark read failure) along with every other
+		// reconciliation.* attribute -- nothing was swept, so there is
+		// nothing to report.
+		attribute.Bool("reconciliation.rate_limited", out.rateLimited),
 	)
 	return out
 }

--- a/api-go/internal/polling/reconciliation_test.go
+++ b/api-go/internal/polling/reconciliation_test.go
@@ -328,6 +328,61 @@ func TestReconciliation_NonHTTPErrorLeavesSampleErrorBodyEmpty(t *testing.T) {
 	}
 }
 
+// TestReconciliation_StampsRateLimitedOnSpan pins tc-mc0hf's observability
+// requirement: reconciliation.rate_limited must read true on the sweep span
+// when a PlanIt call this Run made was rejected with a 429, and false when it
+// wasn't -- so a prod check can confirm the circuit breaker fired by reading
+// AppDependencies' Properties['reconciliation.rate_limited'] directly, rather
+// than cross-referencing raw 429 counts by hand (as this bug was first
+// diagnosed).
+func TestReconciliation_StampsRateLimitedOnSpan(t *testing.T) {
+	// Not t.Parallel(): recordSpans swaps the global TracerProvider (see its
+	// doc comment in span_test.go).
+	tests := []struct {
+		name string
+		// setup configures the fetcher to trip (or not trip) the rate limit.
+		setup func(f *fakeReconciliationFetcher)
+		want  bool
+	}{
+		{
+			name:  "no rate limit hit",
+			setup: func(f *fakeReconciliationFetcher) {},
+			want:  false,
+		},
+		{
+			name: "sweep fetch rate limited",
+			setup: func(f *fakeReconciliationFetcher) {
+				f.pageErrs[1] = &planit.RateLimitError{}
+			},
+			want: true,
+		},
+	}
+	for _, tc := range tests {
+		fetcher := newFakeReconciliationFetcher()
+		fetcher.pages[1] = planit.FetchPageResult{}
+		tc.setup(fetcher)
+		apps := newFakeApps()
+		state := newFakeStateStore()
+		h := newReconciliationHandler(t, fetcher, apps, state, []int{1}, defaultReconciliationOpts())
+
+		spans := recordSpans(t, func() {
+			h.Run(context.Background())
+		})
+
+		span, ok := spanNamed(spans, "PlanIt reconciliation sweep")
+		if !ok {
+			t.Fatalf("%s: expected a %q span", tc.name, "PlanIt reconciliation sweep")
+		}
+		v, ok := attrValue(span, "reconciliation.rate_limited")
+		if !ok {
+			t.Fatalf("%s: reconciliation.rate_limited missing from span", tc.name)
+		}
+		if got := v.AsBool(); got != tc.want {
+			t.Errorf("%s: reconciliation.rate_limited: got %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
 // TestReconciliation_PersistsLastRunDespiteCancelledCtx pins tc-tuge8/GH#971
 // root cause 2: the request ctx can already be cancelled (a budget cut-off)
 // by the time Run reaches its state save. The save must still land --

--- a/api-go/internal/polling/reconciliation_test.go
+++ b/api-go/internal/polling/reconciliation_test.go
@@ -350,6 +350,44 @@ func TestReconciliation_PersistsLastRunDespiteCancelledCtx(t *testing.T) {
 	}
 }
 
+// TestReconciliation_HydrationRateLimitStopsHydratingFurtherStragglersInAuthority
+// pins tc-mc0hf: once a straggler hydration fetch (FetchByUID) returns a
+// *planit.RateLimitError, sweepAuthority must stop hydrating further
+// stragglers for the REST of that same authority -- mirroring
+// NationalLaneHandler's "stop on first 429" circuit breaker (Lane A/B). The
+// fake page carries three never-seen (unconditionally-straggler) uids so the
+// break can be distinguished from merely running out of rows: if the loop
+// didn't actually stop, uids 2 and 3 would still be hydrated.
+func TestReconciliation_HydrationRateLimitStopsHydratingFurtherStragglersInAuthority(t *testing.T) {
+	t.Parallel()
+	ld := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+	fetcher := newFakeReconciliationFetcher()
+	fetcher.pages[99] = planit.FetchPageResult{
+		Applications: []applications.PlanningApplication{
+			lightApp("a/1", 99, "Permitted", ld),
+			lightApp("a/2", 99, "Permitted", ld),
+			lightApp("a/3", 99, "Permitted", ld),
+		},
+	}
+	fetcher.hydrateErrs["a/1"] = &planit.RateLimitError{}
+	apps := newFakeApps()
+	state := newFakeStateStore()
+
+	opts := ReconciliationOptions{Interval: 7 * 24 * time.Hour, MaxStragglersPerAuthority: 10, AuthoritiesPerCycle: 100}
+	h := newReconciliationHandler(t, fetcher, apps, state, []int{99}, opts)
+	out := h.Run(context.Background())
+
+	if !out.rateLimited {
+		t.Error("out.rateLimited: got false, want true (FetchByUID returned a *planit.RateLimitError)")
+	}
+	if len(fetcher.hydrateCalls) != 1 || fetcher.hydrateCalls[0] != "a/1" {
+		t.Errorf("hydrateCalls: got %v, want [a/1] only (a/2 and a/3 must not be attempted after the 429)", fetcher.hydrateCalls)
+	}
+	if out.stragglers != 1 {
+		t.Errorf("stragglers: got %d, want 1 (a/2 and a/3 never reach the straggler count once rate-limited)", out.stragglers)
+	}
+}
+
 // intsEqual compares two int slices for the pageCalls assertions below.
 func intsEqual(a, b []int) bool {
 	if len(a) != len(b) {

--- a/api-go/internal/polling/reconciliation_test.go
+++ b/api-go/internal/polling/reconciliation_test.go
@@ -512,6 +512,74 @@ func TestReconciliation_EarlyCtxCancelPersistsActuallyAttemptedCountNotPlannedEn
 	}
 }
 
+// TestReconciliation_RateLimitStopsSweepingFurtherAuthorities pins tc-mc0hf:
+// once a per-authority sweep fetch (FetchReconciliationPage) returns a
+// *planit.RateLimitError, Run must stop sweeping further authorities for the
+// rest of this cycle -- mirroring NationalLaneHandler's "stop on first 429"
+// behavior. The fake authority list supplies MORE ids than the point where
+// the 429 hits, so a broken loop is distinguishable from one that merely ran
+// out of authorities to sweep.
+func TestReconciliation_RateLimitStopsSweepingFurtherAuthorities(t *testing.T) {
+	t.Parallel()
+	ids := []int{1, 2, 3, 4, 5}
+	fetcher := newFakeReconciliationFetcher()
+	for _, id := range ids {
+		fetcher.pages[id] = planit.FetchPageResult{}
+	}
+	fetcher.pageErrs[2] = &planit.RateLimitError{}
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	opts := ReconciliationOptions{Interval: 7 * 24 * time.Hour, MaxStragglersPerAuthority: 10, AuthoritiesPerCycle: 100}
+	h := newReconciliationHandler(t, fetcher, apps, state, ids, opts)
+
+	out := h.Run(context.Background())
+
+	if !out.rateLimited {
+		t.Error("out.rateLimited: got false, want true (authority 2's sweep fetch returned a *planit.RateLimitError)")
+	}
+	if !intsEqual(fetcher.pageCalls, []int{1, 2}) {
+		t.Errorf("pageCalls: got %v, want [1 2] (authorities 3, 4, 5 must not be swept after the 429)", fetcher.pageCalls)
+	}
+	if out.authoritiesSwept != 1 {
+		t.Errorf("authoritiesSwept: got %d, want 1 (authority 1 succeeded; authority 2's fetch errored, so it never increments)", out.authoritiesSwept)
+	}
+}
+
+// TestReconciliation_RateLimitedEarlyExitPersistsActuallyAttemptedCount pins
+// the correctness-critical edge case for the rate-limit circuit breaker,
+// mirroring TestReconciliation_EarlyCtxCancelPersistsActuallyAttemptedCountNotPlannedEnd
+// with a 429 as the trigger instead of ctx-cancel: the persisted cursor must
+// reflect how many authorities were ACTUALLY attempted (including the one
+// that got rate-limited -- it WAS attempted, just rejected), not the planned
+// AuthoritiesPerCycle slice end. This reuses the exact same "persist what was
+// actually attempted" mechanism as the ctx-cancel case, not a parallel one.
+func TestReconciliation_RateLimitedEarlyExitPersistsActuallyAttemptedCount(t *testing.T) {
+	t.Parallel()
+	ids := []int{1, 2, 3, 4, 5}
+	fetcher := newFakeReconciliationFetcher()
+	for _, id := range ids {
+		fetcher.pages[id] = planit.FetchPageResult{}
+	}
+	fetcher.pageErrs[2] = &planit.RateLimitError{}
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	opts := ReconciliationOptions{Interval: 7 * 24 * time.Hour, MaxStragglersPerAuthority: 10, AuthoritiesPerCycle: 5} // planned to sweep all 5 this cycle
+	h := newReconciliationHandler(t, fetcher, apps, state, ids, opts)
+
+	h.Run(context.Background())
+
+	if len(state.saves) != 1 {
+		t.Fatalf("expected exactly one state save, got %d", len(state.saves))
+	}
+	saved := state.saves[0]
+	if saved.cursor == nil || saved.cursor.NextIndex != 2 {
+		t.Errorf("cursor: got %+v, want NextIndex=2 (authorities 1 and 2 actually attempted, NOT the planned slice end of 5)", saved.cursor)
+	}
+	if !saved.lastPollTime.IsZero() {
+		t.Errorf("lastPollTime: got %v, want zero (pass cut short by rate limit, not completed, so last-run must not advance)", saved.lastPollTime)
+	}
+}
+
 // TestReconciliation_CompletedPassResetsCursorAndStampsLastPollTime proves a
 // pass that reaches the end of the authority list resets the cursor to nil
 // and stamps LastPollTime -- the only branch that advances it -- and that Due


### PR DESCRIPTION
## Changes

Lane C's query-level 400 fix (tc-tuge8/GH#971) worked correctly in its first prod cycle, but revealed a separate bug: its straggler hydration loop has no rate-limit awareness. Once it hit a PlanIt 429, it kept firing anyway — 141 of 187 hydration requests were rejected with 429 over 8.5 minutes in one cycle, one every ~2s, all wasted. This is a live violation of the project's non-negotiable "never hammer PlanIt" rule, distinct from Lane A/B which are designed to stop immediately on their first 429. Lane C was disabled again in prod (`POLLING_LANE_C_ENABLED=false`, v0.21.8) as an emergency stop while this fix was prepared.

- `internal/polling/reconciliation.go`: `reconciliationOutcome` gains `rateLimited bool`, set once by `recordFetchError` detecting a `*planit.RateLimitError` (a distinct sibling type from `*planit.HTTPError`, existing 400-capture behavior unchanged). `hydrate`'s error path now calls `recordFetchError` (previously didn't at all — the actual gap). Once tripped: `sweepAuthority`'s straggler loop stops hydrating further stragglers in that authority; `Run`'s authority loop stops sweeping further authorities for the rest of the cycle — mirroring Lane A/B's "stop on first 429". Reuses the existing partial-progress cursor-persistence mechanism unchanged (the same code path that already handles an early `ctx.Err()` exit). New span attribute `reconciliation.rate_limited` for direct prod observability going forward.

New tests cover: hydration-triggered mid-authority stop, sweep-triggered stop-sweeping-further-authorities, correct cursor persistence on a rate-limited early exit, and the new span attribute. All existing tests (400 capture, sample-body capture, cursor resume/wrap, `Due()` semantics, ctx-cancel persistence) pass unmodified.

`infra/` is untouched — Lane C stays disabled in prod until this merges, deploys, and is verified; re-enabling is a separate follow-up step.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reconciliation sweeps now stop promptly when rate limits are encountered.
  * Prevents additional authority processing and record hydration after a rate-limit response.
  * Preserves accurate progress tracking when a sweep ends early.
  * Prevents incomplete cycles from being marked as fully completed.
  * Adds visibility into rate-limited reconciliation cycles through sweep telemetry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->