### PR TITLE
docs(polling): rewrite verify-polling command for ADR 0044 national-lane model (tc-qnqyq)

### DIFF
--- a/.claude/commands/verify-polling.md
+++ b/.claude/commands/verify-polling.md
@@ -1,195 +1,191 @@
 ---
-description: Verify Town Crier prod polling pipeline health against the five invariants
+description: Verify Town Crier prod polling pipeline health (ADR 0041/0044 national-lane model)
 ---
 
-Verify the Town Crier prod polling pipeline is healthy. Report concisely (green/red per check, evidence inline). Do NOT make code changes. If anything is broken, point at the specific symptom and code location — don't guess at root cause.
+Verify the Town Crier prod polling pipeline is healthy. Report concisely (✅ / ⚠️ / ❌ per check, evidence inline). Do NOT make code changes. If anything is broken, point at the specific symptom and code location — don't guess at root cause.
+
+## Read this first — the model changed (ADR 0041 + 0044)
+
+Polling is no longer per-authority. There are **four national lanes**, driven by a planner/executor loop in one Service-Bus-triggered handler (`api-go/internal/polling/nationallane.go` → `NationalPollHandler.Handle`, planner in `planner.go`). There is **no per-authority state, no `never_polled` cohort, no `authorities_polled`, no `GetLeastRecentlyPolled`** — anything checking those is stale.
+
+| Lane | Sentinel `poll_state.authority_id` | Purpose | Eligible | Notifies? |
+|---|---|---|---|---|
+| A | −1 | new applications (masked delta, descending) | 24/7 | yes |
+| B | −2 | decisions (masked delta, descending) | 24/7 | yes |
+| C | −3 | inverse-mask reconciliation (ascending epoch) | **07:00–19:00 Europe/London only** | yes (hydrations) |
+| D | `backfill_state` singleton | historical backward backfill | **19:00–07:00 Europe/London only** | **never** (nil fan-out, by design) |
+
+Europe/London is UTC+1 in summer (BST) → Lane C runs ~06:00–18:00 UTC, Lane D ~18:00–06:00 UTC; it's UTC in winter. **Compute the current London time first and judge each lane against its window.** A lane that is idle *outside* its window is healthy, not broken.
+
+### The single most important rule: a quiet lane is usually healthy
+
+PlanIt's cost is **rows served**, and its feed is often genuinely quiet (nights, weekends, and outright upstream outages — one ran 2026-07-18→19 for ~35h). Under ADR 0044 the correct response to "nothing new upstream" is:
+
+- **Lane A/B `high_water_mark` stops advancing** and stays put. This is **not** a failure by itself.
+- The cycle ends `TerminationNatural` and reschedules **+1h**, so PlanIt request volume drops to **~2/hour**. Low request volume is **healthy**, not a stalled poller.
+
+Do **not** flag a frozen watermark, an hourly cadence, or ~2 req/hour as problems on their own. The job of this check is to distinguish these states:
+
+| State | Signature | Verdict |
+|---|---|---|
+| **Healthy-quiet** | watermark frozen AND PlanIt's masked head == our watermark (nothing newer exists) | ✅ |
+| **Healthy-active** | watermark advancing and/or backlog draining, notifications firing | ✅ |
+| **Upstream-frozen** | watermark frozen because PlanIt itself serves nothing new (its change axis stopped) | ⚠️ upstream — not our bug |
+| **Broken (silent skip)** | PlanIt's masked head is **newer** than our watermark but we ingest nothing | ❌ point at `nationallane.go RunOnePage` |
+
+The discriminator is the diagnostic log line **`"lane delta page fetched"`** (see Check 3).
 
 ## Fixed environment
 
-- **App Insights — two query paths (use the right one or you will get false gaps):**
-  - **Short windows (≤1h):** `az monitor app-insights query --app appi-town-crier-shared -g rg-town-crier-shared --analytics-query "..."` with classic schema (`traces`, `customMetrics`, `dependencies`, `exceptions`). Works reliably for recent data.
-  - **Historical windows (≥6h) and ALL deploy-anchored queries:** `az monitor log-analytics query --workspace 842645cf-1439-4a2b-80e8-54bd02e326f9 --analytics-query "..."` with workspace schema (`AppMetrics`, `AppTraces`, `AppDependencies`, `AppExceptions`). Column mapping vs classic: `timestamp`→`TimeGenerated`, `cloud_RoleName`→`AppRoleName`, `cloud_RoleInstance`→`AppRoleInstance`, `name`→`Name`, `value`→`Sum`, `customDimensions['k']`→`Properties['k']`, `message`→`Message`, `target`→`Target`, `resultCode`→`ResultCode`, `success`→`Success`, `duration`→`DurationMs`.
-  - **⚠️ Do NOT use `az monitor app-insights query` for windows > ~1h.** This workspace only surfaces a partial/recent slice of data through the classic API. Longer windows will look like a telemetry gap that does not exist. This is a known false-positive source that has triggered incorrect "9-hour gap" findings in multiple past sessions.
-- **Service Bus**: namespace `sb-town-crier-prod` in `rg-town-crier-prod`, queue `poll`. Use `az servicebus queue show ... --query countDetails` — `az monitor metrics list` does NOT work for `Microsoft.ServiceBus/namespaces/queues`.
-- **Jobs**: `job-tc-poll-prod` (orchestrator, KEDA ~30s cadence), `job-tc-poll-bootstrap-prod` (cron `*/30 * * * *`). Both in `rg-town-crier-prod`.
-- **Worker role name** in telemetry: `town-crier-worker-go` (the Go worker; set via `OTEL_SERVICE_NAME` in `infra/EnvironmentStack.cs`).
-- **Lease counter names** (from PR #291 T17): `towncrier.polling.lease.acquired`, `towncrier.polling.lease.held_by_peer`, `towncrier.polling.lease.released_412`.
+- **Two telemetry query paths — use the right one or get false gaps:**
+  - **Short windows (≤1h), recent:** `az monitor app-insights query --app appi-town-crier-shared -g rg-town-crier-shared --analytics-query "..."` (classic schema: `traces`, `customMetrics`, `dependencies`, `exceptions`).
+  - **Historical (≥6h) and ALL deploy-anchored queries:** `az monitor log-analytics query --workspace 842645cf-1439-4a2b-80e8-54bd02e326f9 --analytics-query "..."` (workspace schema: `AppMetrics`, `AppTraces`, `AppDependencies`, `AppExceptions`). Column map: `timestamp`→`TimeGenerated`, `cloud_RoleName`→`AppRoleName`, `name`→`Name`, `value`→`Sum`, `customDimensions['k']`→`Properties['k']`, `message`→`Message`, `resultCode`→`ResultCode`, `success`→`Success`, `duration`→`DurationMs`.
+  - ⚠️ Do NOT use `az monitor app-insights query` for windows > ~1h — it surfaces only a partial recent slice and looks like a gap that isn't there.
+- **⚠️ Worker role name is `cae-town-crier-shared.town-crier-worker-go`** — the environment prefix is part of the value. Filter with `AppRoleName has 'worker-go'`, never `AppRoleName == 'town-crier-worker-go'` (that matches nothing).
+- **⚠️ AppMetrics can be silently empty.** This has happened in prod (metrics pipeline gap) with the rest of telemetry flowing. **Run Check 0 first**; if AppMetrics is empty, every metric-based check below is BLIND — fall back to Postgres `poll_state` (ground truth) + `AppDependencies` + the `AppTraces` /search API, and say so in the report rather than reporting false-green.
+- **AppTraces & ContainerAppConsoleLogs are Basic Logs tier** — `az monitor log-analytics query` errors on them. Query via the synchronous `/search` endpoint:
+  ```bash
+  az rest --method post \
+    --url "https://api.loganalytics.io/v1/workspaces/842645cf-1439-4a2b-80e8-54bd02e326f9/search" \
+    --resource "https://api.loganalytics.io" --headers "Content-Type=application/json" \
+    --body '{"query":"AppTraces | where TimeGenerated > ago(2h) | where AppRoleName has '\''worker-go'\'' | where Message has '\''lane delta page fetched'\'' | project TimeGenerated, Message, Properties | take 20","timespan":"PT2H"}'
+  ```
+- **⚠️ PlanIt dependency `ResultCode` is the OTel status (0 = ok, 2 = error), NOT the HTTP status.** HTTP 429s live in `Properties['http.response.status_code']`. Any check doing `ResultCode == '429'` matches nothing.
+- **Postgres (ground truth, always available even when AppMetrics is down):** server `psql-town-crier-shared.postgres.database.azure.com`, db `town_crier_prod`, in `rg-town-crier-shared`. Read-only via Entra AD token — **you must be the server's Entra admin** (or a provisioned AD role):
+  ```bash
+  IP=$(curl -s https://api.ipify.org)
+  az postgres flexible-server firewall-rule create --server-name psql-town-crier-shared -g rg-town-crier-shared \
+    --name verify-polling-tmp --start-ip-address "$IP" --end-ip-address "$IP" -o none
+  export PGPASSWORD="$(az account get-access-token --resource-type oss-rdbms --query accessToken -o tsv)"
+  PGUSER="$(az ad signed-in-user show --query userPrincipalName -o tsv)"
+  CONN="host=psql-town-crier-shared.postgres.database.azure.com port=5432 dbname=town_crier_prod user=$PGUSER sslmode=require connect_timeout=15"
+  psql "$CONN" -c "select 1;"   # ... run the queries below ...
+  # cleanup when done:
+  az postgres flexible-server firewall-rule delete --server-name psql-town-crier-shared -g rg-town-crier-shared --name verify-polling-tmp --yes -o none
+  ```
+  The Entra AD token expires ~hourly — refetch `PGPASSWORD` if a session runs long.
+- **Service Bus:** namespace `sb-town-crier-prod` in `rg-town-crier-prod`, queue `poll`. Use `az servicebus queue show ... --query countDetails` (`az monitor metrics list` does NOT work for queues).
+- **Jobs:** `job-tc-poll-prod` (orchestrator, KEDA), `job-tc-poll-bootstrap-prod` (cron `*/30`), both in `rg-town-crier-prod`.
+- **PlanIt cross-checks are a LAST resort and rate-limited.** PlanIt is a free single-operator service; hammering it is a red line, and a blocked laptop IP is unrecoverable. Prefer telemetry + Postgres. If you must confirm PlanIt's head directly: **≤5 calls total, never 2 within 60s, `pg_sz` ≤ 300, always a bounded (`different_start`/`start_date`) query, `select` mandatory.** State plainly in the report that a PlanIt call was made.
 
-## Checks to run (in parallel where possible)
+## Checks
+
+### 0. Telemetry pipeline is alive (gating — run first)
+```bash
+for t in AppMetrics AppDependencies AppExceptions; do
+  c=$(az monitor log-analytics query --workspace 842645cf-1439-4a2b-80e8-54bd02e326f9 \
+      --analytics-query "$t | where TimeGenerated > ago(2h) | where AppRoleName has 'worker-go' | summarize c=count()" \
+      -o tsv --query "[0].c" 2>/dev/null); echo "$t: ${c:-0}"; done
+```
+`AppDependencies` should be non-zero. **If `AppMetrics` is 0**, flag it (it's a real, separate defect) and treat Checks 4/5 and any metric total as UNKNOWN, leaning on Postgres + AppDependencies + AppTraces instead.
 
 ### 1. Deployment is current
 ```bash
-gh pr list --state merged --limit 5
 gh run list --workflow='CD Production' --limit 3
 ```
-Confirm latest `CD Production` run is `completed / success` and newer than the most recent merged polling-related PR.
+Latest `CD Production` run `completed / success` and newer than the most recent merged polling PR.
 
-### 2. Poll job not aborting
+### 2. Worker is running and cycles succeed
 ```bash
-az monitor app-insights query --app appi-town-crier-shared -g rg-town-crier-shared \
-  --analytics-query "traces | where timestamp > ago(1h) | where cloud_RoleName == 'town-crier-worker-go' | where message contains 'HandlerBudget' or message contains 'Aborting' | summarize count() by bin(timestamp, 5m) | order by timestamp asc"
 az containerapp job execution list --name job-tc-poll-prod -g rg-town-crier-prod \
-  --query "[].{start:properties.startTime, status:properties.status, name:name}" -o table | head -20
+  --query "reverse(sort_by([].{start:properties.startTime,status:properties.status},&start))[:8]" -o table
+psql "$CONN" -c "select authority_id, last_poll_time, high_water_mark from poll_state where authority_id<=0 order by authority_id desc;"
 ```
-Expected: 0 aborts in last 15 min. Recent executions should be `Succeeded`, not `Failed`.
+- Recent executions `Succeeded`, not `Failed`.
+- **`last_poll_time` for −1/−2 recent for the current state**: within ~65 min is fine when caught-up (hourly Natural rhythm); minutes apart when a backlog or Lane D is draining. Hours-stale on −1/−2 → worker not running or planner stuck.
 
-### 3. Five invariants vs live telemetry
-
-**3a. Ingesting at a good rate**
+### 3. Lane A/B freshness — healthy-quiet vs broken (the core check)
+Read the diagnostic log (AppTraces, Basic → /search). Its fields (`watermarkBefore`, `firstLastDifferent`, `recordsSeen`, `planitTotal`) are nanosecond-epoch strings:
 ```bash
-az monitor app-insights query --app appi-town-crier-shared -g rg-town-crier-shared \
-  --analytics-query "customMetrics | where timestamp > ago(30m) | where name contains 'polling' or name contains 'ingest' | summarize total=sum(value), count() by name | order by name asc"
+az rest --method post --url "https://api.loganalytics.io/v1/workspaces/842645cf-1439-4a2b-80e8-54bd02e326f9/search" \
+  --resource "https://api.loganalytics.io" --headers "Content-Type=application/json" \
+  --body '{"query":"AppTraces | where TimeGenerated > ago(3h) | where AppRoleName has '\''worker-go'\'' | where Message has '\''lane delta page fetched'\'' | extend lane=tostring(Properties['\''lane'\'']), seen=toint(Properties['\''recordsSeen'\'']), wm=tostring(Properties['\''watermarkBefore'\'']), firstLD=tostring(Properties['\''firstLastDifferent'\'']), ptotal=tostring(Properties['\''planitTotal'\'']) | project TimeGenerated, lane, seen, ptotal, wm, firstLD | order by TimeGenerated desc | take 12","timespan":"PT3H"}'
 ```
-Expect non-zero `applications_ingested`, `authorities_polled`, `cycles_completed`.
+Interpret (convert ns → time with `date -r $((ns/1000000000))` or Python):
+- **`firstLastDifferent` ≤ `watermarkBefore`** → the newest masked record PlanIt has is already ingested. **Healthy-quiet ✅** — the watermark *should* be frozen.
+- **`firstLastDifferent` > `watermarkBefore` and records are being ingested** (walk advancing across pages, watermark moving) → **Healthy-active ✅** (draining a backlog — normal after a quiet spell or outage).
+- **`firstLastDifferent` > `watermarkBefore` but nothing ingested / watermark not moving over multiple cycles** → **Broken ❌**, silent skip. Point at `nationallane.go` `RunOnePage` boundary logic (`!app.LastDifferent.After(watermarkBefore)`).
+- **No `"lane delta page fetched"` lines at all in-window while jobs are running** → worker not reaching the fetch, or a deploy without the diag line. Check the image version.
 
-**3b. Honouring Retry-After on 429**
+**Backlog-drain progress (post-quiet recovery):** if a backlog is draining, the watermark should climb toward PlanIt's masked head (`firstLastDifferent` of the newest page) across cycles. If it advances only by the *boundary* page's span each cycle and re-walks the same range, suspect the per-page `maxIngested` scope in `nationallane.go` under-advancing the watermark on multi-page walks — flag it (it delays catch-up and re-serves rows; it does not double-notify).
 
-**429s from PlanIt are expected and part of normal operation** — the worker deliberately hammers PlanIt serially until it gets a 429, then short-circuits the cycle and schedules the next ASB message using the `Retry-After` header. A 429 in the *middle* of a cycle is the healthy termination signal. Do NOT treat 429 counts, `rate_limited` metrics, or `PlanItRateLimitException` exceptions as watch items by themselves, and do NOT recommend "watching 429 cadence" in the report.
-
-**The actual regression** is a 429 as the **first** PlanIt response in a cycle — that means we didn't honour the previous cycle's `Retry-After` before starting the next one. Check this per cycle:
-
+**Upstream-frozen confirmation (optional, sparing PlanIt call):** if the watermark has been frozen for hours and you need to know whether PlanIt itself is dead vs genuinely quiet, one bounded call settles it (mind the PlanIt budget above):
 ```bash
-az monitor app-insights query --app appi-town-crier-shared -g rg-town-crier-shared \
-  --analytics-query "dependencies | where timestamp > ago(1h) | where target contains 'planit' and cloud_RoleName == 'town-crier-worker-go' | summarize arg_min(timestamp, resultCode) by cloud_RoleInstance | extend first_response_429 = (resultCode == '429') | summarize total_cycles = count(), cycles_with_first_429 = countif(first_response_429)"
+curl -s --compressed "https://www.planit.org.uk/api/applics/json?different_start=$(date -u +%Y-%m-%d)&sort=-last_different&pg_sz=5&select=uid,last_different&compress=on"
 ```
+`total: null` / empty ⇒ PlanIt's change axis is frozen ⇒ our freeze is **⚠️ upstream, expected**, not our bug.
 
-`cycles_with_first_429` **MUST be 0**. If non-zero, that's the symptom — point at `api-go/internal/planit/client.go` / the retry-after handling in the next-run scheduler (`api-go/internal/polling/scheduler.go`).
-
-For context only (not a pass/fail signal), you can also report the 429 distribution, but state it as expected cadence not a concern:
-
-```bash
-az monitor app-insights query --app appi-town-crier-shared -g rg-town-crier-shared \
-  --analytics-query "dependencies | where timestamp > ago(30m) | where target contains 'planit' | summarize total=count(), rate429=countif(resultCode == '429'), failures=countif(success == false and resultCode != '429'), avgDurMs=avg(duration) by bin(timestamp, 5m) | order by timestamp asc"
-```
-
-`failures` (excluding 429) must be near 0. `rate429` being non-zero is fine — that's the cycle termination marker.
-
-**Retry-After value distribution** — what is PlanIt actually asking us to wait? The worker emits `towncrier.polling.retry_after_seconds` (histogram) on every 429 with the parsed `Retry-After` header value, tagged `header_present=true|false`. Use this to confirm whether the configured `RetryAfterCap` (currently 3h, default in [scheduler.go](api-go/internal/polling/scheduler.go) → `SchedulerOptions.RetryAfterCap`) is large enough for the values PlanIt is sending:
-
+### 4. Retry-After / 429 honoured
+429s are the **normal** cycle terminator (the loop hammers PlanIt until one 429, then breaks and reschedules on `Retry-After`, capped 3h in `scheduler.go`). ADR 0044 deleted the old per-lane breaker — the single loop breaks on the first 429 from any lane. Do **not** flag 429 counts, `rate_limited`, or `PlanItRateLimitException` volume.
+- **The regression is a 429 as the *first* PlanIt response of a cycle** (previous `Retry-After` not honoured). Query dependencies with the correct HTTP-status field:
 ```bash
 az monitor log-analytics query --workspace 842645cf-1439-4a2b-80e8-54bd02e326f9 \
-  --analytics-query "AppMetrics | where TimeGenerated > ago(6h) | where Name == 'towncrier.polling.retry_after_seconds' | extend header_present = tostring(Properties['header_present']) | where header_present == 'true' | summarize samples=count(), p50_s=percentile(Sum, 50), p90_s=percentile(Sum, 90), p99_s=percentile(Sum, 99), max_s=max(Sum)"
+  --analytics-query "AppDependencies | where TimeGenerated > ago(2h) | where AppRoleName has 'worker-go' | where Name == 'PlanIt search' | extend http=tostring(Properties['http.response.status_code']) | summarize arg_min(TimeGenerated, http) by AppRoleInstance | summarize cycles=count(), first_429=countif(http=='429')"
 ```
+`first_429` **MUST be 0**. Non-zero → point at `api-go/internal/planit/retryafter.go` + `scheduler.go`.
+- Retry-After distribution (AppMetrics; skip if Check 0 showed it empty): `towncrier.polling.retry_after_seconds`, tagged `lane`, `header_present`. `max_s < 10800` (under the 3h cap).
 
-Pass condition: `max_s < 10800` (3h cap, in seconds). If `max_s ≥ 10800`, PlanIt is asking for backoffs longer than the cap and we are clipping — bump `RetryAfterCap` higher or escalate to a human. If `samples == 0` and `cycles_with_first_429 > 0`, then PlanIt is sending 429s without `Retry-After` headers; check the `header_present='false'` row separately:
-
+### 5. One handler at a time (lease CAS) — ADR 0024
 ```bash
 az monitor log-analytics query --workspace 842645cf-1439-4a2b-80e8-54bd02e326f9 \
-  --analytics-query "AppMetrics | where TimeGenerated > ago(6h) | where Name == 'towncrier.polling.retry_after_seconds' | extend header_present = tostring(Properties['header_present']), authority = tostring(Properties['polling.authority_code']) | summarize samples=count() by header_present, authority | order by samples desc | take 10"
+  --analytics-query "AppMetrics | where TimeGenerated > ago(6h) | where Name startswith 'towncrier.polling.lease' | summarize total=sum(Sum) by Name"
 ```
+`towncrier.polling.lease.released_412` **MUST be 0** (non-zero = concurrent handlers stomping). `acquired` non-zero; `held_by_peer` ≥0 fine. If AppMetrics is empty, mark UNKNOWN.
 
-A high `header_present='false'` count means PlanIt isn't sending `Retry-After` at all, and we're falling back to the configured default — point at the retry-after parsing in `api-go/internal/planit/retryafter.go` / the next-run scheduler (`api-go/internal/polling/scheduler.go`) if `cycles_with_first_429` is also non-zero.
-
-**3c. Only 1 thread at a time (lease CAS)**
-```bash
-az monitor log-analytics query --workspace 842645cf-1439-4a2b-80e8-54bd02e326f9 \
-  --analytics-query "AppMetrics | where TimeGenerated > ago(6h) | where Name startswith 'towncrier.polling.lease' | summarize total=sum(Sum), count() by Name | order by Name asc"
-```
-`released_412` **MUST be 0** (non-zero = concurrent handlers stomping each other). `held_by_peer` ≥0 is fine (bootstrap/orchestrator race is expected; CAS is working). `acquired` should be non-zero.
-
-**3d. ASB queue depth ≤ 1** — sample 5× over ~40s to catch transitions:
+### 6. Queue depth ≤ 1 (+ bootstrap doesn't double-post) — sample 5× over ~40s
 ```bash
 for i in 1 2 3 4 5; do
-  echo -n "t=${i}: "
   az servicebus queue show --namespace-name sb-town-crier-prod --resource-group rg-town-crier-prod --name poll \
-    --query "{a:countDetails.activeMessageCount, s:countDetails.scheduledMessageCount, dlq:countDetails.deadLetterMessageCount}" -o json | tr -d '\n '
-  echo
-  sleep 8
+    --query "{a:countDetails.activeMessageCount,s:countDetails.scheduledMessageCount,dlq:countDetails.deadLetterMessageCount}" -o json | tr -d '\n '; echo; sleep 8
 done
 ```
-Steady state: `active + scheduled ∈ {0, 1}`. `{a:0, s:1}` is healthy (next poll queued). `{a:1, s:0}` is the transient hand-off (handler running). If `active + scheduled > 1` at any sample, a duplicate publish-after-consume chain has appeared — **escalate before touching anything**. Per `bd memories poll-queue-max-one-message` the user has pre-authorised brute-force purge, but confirm the symptom first.
+Steady state: `active + scheduled ∈ {0,1}` (`{a:0,s:1}` healthy, next poll queued; `{a:1,s:0}` handler running). If `> 1` at any sample a duplicate publish-after-consume chain appeared — **escalate before touching anything** (per `bd memories poll-queue-max-one-message` a brute-force purge is pre-authorised, but confirm the symptom first). The `*/30` bootstrap should acquire-probe-publish-only-if-empty-release; the queue must not jump 1→2 at bootstrap ticks.
 
-**3e. Keeping up with the authority backlog (oldest LastPollTime age)**
+### 7. Lane C (reconciliation) — judge against its window and its design
+Lane C is **daytime-only** and **forward-only**: it seeds a zero-width epoch on first run, then idles ~24h (`laneCIdleAnchorInterval`, `planner.go`) before its first real epoch, and it **only reconciles status changes PlanIt stamps after it started — it does NOT recover applications missed before it existed** (that's Lane D). **Finding 0 stragglers is normal.**
+```bash
+psql "$CONN" -c "select last_poll_time, high_water_mark epoch_upper, cursor_different_start epoch_lower, cursor_next_index from poll_state where authority_id=-3;"
+# daytime only: Lane C spans + hydration counts
+az monitor log-analytics query --workspace 842645cf-1439-4a2b-80e8-54bd02e326f9 \
+  --analytics-query "AppDependencies | where TimeGenerated > ago(8h) | where AppRoleName has 'worker-go' | where Name contains 'Lane C' | extend seen=toint(Properties['poll.records_seen']), hydrated=toint(Properties['poll.records_ingested']) | project TimeGenerated, seen, hydrated | order by TimeGenerated desc | take 10"
+```
+- **Outside 07:00–19:00 London: idle is expected ✅.** Don't flag.
+- Inside the window: expect it to run; `hydrated ≥ 0` (0 is fine). Only ❌ on errors, or a cursor that climbs for hours mid-epoch and never drains.
 
-> **Naming note:** the metric is `towncrier.polling.oldest_hwm_age_seconds` for legacy reasons (PR #298 / tc-m6fx split LastPollTime from HighWaterMark but kept the metric name). The value is the **LastPollTime age**, not the HighWaterMark age — the metric is emitted from the polling worker (`api-go/internal/polling`).
+### 8. Lane D (historical backfill) — progress, not freshness
+Lane D is **off-hours-only** and **never notifies** (nil fan-out, by design — don't expect notification metrics from it). Progress lives in `backfill_state`:
+```bash
+psql "$CONN" -c "select window_end, cursor_next_index, window_records_seen, consecutive_empty_windows, complete, last_run_time from backfill_state;"
+az monitor log-analytics query --workspace 842645cf-1439-4a2b-80e8-54bd02e326f9 \
+  --analytics-query "AppDependencies | where TimeGenerated > ago(3h) | where AppRoleName has 'worker-go' | where Name contains 'backfill' | summarize sweeps=count() by bin(TimeGenerated,15m) | order by TimeGenerated desc"
+```
+- **Daytime: idle is expected ✅.**
+- Off-hours: `last_run_time` recent, `cursor_next_index`/`window_records_seen` climbing within a window and/or `window_end` creeping backward across nights, `complete=false`, `consecutive_empty_windows` low. It's a deliberately slow (default 2 pages/cycle), multi-week+ job — slow ≠ broken. Confirm `POLLING_BACKFILL_ENABLED=true` on the job if you expect it running.
 
-This check focuses on **polled** authorities (`never_polled='false'`). The never-polled cohort is covered by 3g — they always report `(now − UnixEpoch)` which is huge by design and would otherwise dominate this signal.
+### 9. Notifications actually delivered (the product outcome)
+The point of all of the above is telling residents about applications. Confirm the pipeline reaches users:
+```bash
+psql "$CONN" -c "select date_trunc('day', created_at) d, count(*), count(*) filter (where push_sent) pushed, count(*) filter (where email_sent) emailed from notifications where created_at > now() - interval '7 days' group by 1 order by 1 desc;"
+psql "$CONN" -c "select max(created_at) as newest_notification from notifications;"
+```
+- A zero-notification day lines up 1:1 with a PlanIt outage/quiet spell and is a **symptom, not a cause** — cross-reference Check 3. During a genuine quiet spell (weekend/outage) low or zero is expected.
+- After recovery, `newest_notification` should track the resumed ingestion; `push_sent`/`email_sent` should be non-zero for recent rows. If apps are ingesting (Check 3) but notifications are NOT being created, that's a real fan-out break — point at the Ingester fan-out wiring and lane `WithFanOut`.
 
+### 10. Exceptions
 ```bash
 az monitor log-analytics query --workspace 842645cf-1439-4a2b-80e8-54bd02e326f9 \
-  --analytics-query "AppMetrics | where TimeGenerated > ago(6h) | where Name == 'towncrier.polling.oldest_hwm_age_seconds' | extend authority = tostring(Properties['polling.authority_code']), never_polled = tostring(Properties['never_polled']) | where never_polled == 'false' | summarize arg_max(TimeGenerated, Sum, authority) by bin(TimeGenerated, 30m) | order by TimeGenerated desc | take 10"
+  --analytics-query "AppExceptions | where TimeGenerated > ago(6h) | where AppRoleName has 'worker-go' | summarize c=count() by ProblemId, tostring(OuterMessage) | top 10 by c"
 ```
-
-Read the most recent row: `value` is how far behind the stalest **polled** authority is, in seconds; `authority` identifies it. Healthy means the latest `value` is within the expected cycle cadence — roughly `authorities_polled_per_cycle × cycle_interval`. A monotonically climbing value over the 6h window means the pipeline is falling behind and needs more frequency or more throughput per cycle. Report the current lag in human units (e.g. "oldest LastPollTime is 47 min behind, authority 123").
-
-**3f. Bootstrap doesn't double-post during active cycle**
-```bash
-az containerapp job execution list --name job-tc-poll-bootstrap-prod -g rg-town-crier-prod \
-  --query "[].{start:properties.startTime, status:properties.status}" -o table | head -10
-az monitor app-insights query --app appi-town-crier-shared -g rg-town-crier-shared \
-  --analytics-query "traces | where timestamp > ago(1h) | where message contains 'Safety-net' or message contains 'queue empty' or message contains 'bootstrap' | project timestamp, cloud_RoleName, message | order by timestamp asc | take 30"
-```
-Bootstrap (`*/30`) should acquire lease, probe, publish only if empty, release. During an orchestrator cycle (lease TTL 4.5 min), a concurrent bootstrap tick should see Held and no-op. Queue must not jump from 1 → 2 at bootstrap tick times.
-
-**3g. Backlog drain rate (never-polled cohort)**
-
-Counts authorities with no PollState document at cycle start. Should monotonically drain to 0 within 24–48h after any deploy that adds new authorities or changes selection logic. **A flat-line non-zero count over 24h is the canonical tc-ews7 starvation regression** — surface it loudly.
-
-```bash
-az monitor log-analytics query --workspace 842645cf-1439-4a2b-80e8-54bd02e326f9 \
-  --analytics-query "AppMetrics | where TimeGenerated > ago(24h) | where Name == 'towncrier.polling.never_polled_count' | extend cycle = tostring(Properties['cycle.type']) | where cycle == 'seed' | summarize count_=avg(Sum) by bin(TimeGenerated, 1h) | order by TimeGenerated asc"
-```
-
-Pass conditions:
-- Latest `count_` is 0, **or**
-- Latest `count_` is strictly less than the value 6h earlier (drain in progress), **or**
-- Latest `count_` equals the count of authorities added in the most recent CD deploy and the deploy was within the last 6h (fresh-deploy transient).
-
-Fail conditions:
-- Latest `count_` is non-zero AND has been flat or rising for ≥6h after a deploy that's been live ≥6h. Point at `CycleAlternatingProvider` (`api-go/internal/polling/authorities.go`), `PollStateStore.GetLeastRecentlyPolled` (`api-go/internal/polling/statestore.go`), and the natural-end branch of the poll handler (`api-go/internal/polling/handler.go`) — that's the drain path.
-- Metric is missing from telemetry. Confirm the worker image is post-tc-ifdl deploy.
-
-The Watched cycle reports its own `never_polled_count` (count of watch-zone authorities with no state — usually 0). Filter on `cycle.type == 'seed'` for the canonical drain signal; report Watched separately only if non-zero.
-
-### 4. Exceptions sanity check
-```bash
-az monitor app-insights query --app appi-town-crier-shared -g rg-town-crier-shared \
-  --analytics-query "exceptions | where timestamp > ago(1h) | where cloud_RoleName == 'town-crier-worker-go' | summarize count() by type, outerMessage | top 10 by count_"
-```
-Should be empty or known-benign. `PlanItRateLimitException` is expected (see 3b) and is not a concern in any volume — do not flag it.
-
-### 5. Runs since last deploy (for the per-run table)
-
-Anchor the window to the most recent successful `CD Production` run, then enumerate orchestrator executions and join to per-run ingestion counts.
-
-```bash
-# Deploy anchor (ISO-8601 UTC). Use updatedAt of the latest successful CD Production run.
-DEPLOY_TS=$(gh run list --workflow='CD Production' --status=success --limit 1 --json updatedAt --jq '.[0].updatedAt')
-echo "Deploy anchor: $DEPLOY_TS"
-
-# Executions since deploy (orchestrator + bootstrap)
-az containerapp job execution list --name job-tc-poll-prod -g rg-town-crier-prod \
-  --query "[?properties.startTime >= '$DEPLOY_TS'].{name:name, start:properties.startTime, end:properties.endTime, status:properties.status}" -o json
-az containerapp job execution list --name job-tc-poll-bootstrap-prod -g rg-town-crier-prod \
-  --query "[?properties.startTime >= '$DEPLOY_TS'].{name:name, start:properties.startTime, end:properties.endTime, status:properties.status}" -o json
-
-# Per-instance counters since deploy — each AppRoleInstance is one job execution
-az monitor log-analytics query --workspace 842645cf-1439-4a2b-80e8-54bd02e326f9 \
-  --analytics-query "AppMetrics | where TimeGenerated > datetime('$DEPLOY_TS') | where AppRoleName == 'town-crier-worker-go' | where Name in ('towncrier.polling.applications_ingested','towncrier.polling.authorities_polled','towncrier.polling.authorities_skipped','towncrier.polling.cycles_completed','towncrier.polling.cursor_advanced','towncrier.polling.rate_limited','towncrier.polling.lease.acquired','towncrier.polling.lease.held_by_peer','towncrier.polling.lease.released_412') | summarize total=sum(Sum) by AppRoleInstance, Name | order by AppRoleInstance asc, Name asc"
-
-# Oldest-LastPollTime age per cycle since deploy — one emission per cycle at cycle start
-az monitor log-analytics query --workspace 842645cf-1439-4a2b-80e8-54bd02e326f9 \
-  --analytics-query "AppMetrics | where TimeGenerated > datetime('$DEPLOY_TS') | where Name == 'towncrier.polling.oldest_hwm_age_seconds' | extend authority = tostring(Properties['polling.authority_code']), never_polled = tostring(Properties['never_polled']) | project TimeGenerated, age_s = Sum, authority, never_polled, AppRoleInstance | order by TimeGenerated asc"
-
-# Never-polled count per cycle since deploy — drains monotonically toward 0 (see 3g)
-az monitor log-analytics query --workspace 842645cf-1439-4a2b-80e8-54bd02e326f9 \
-  --analytics-query "AppMetrics | where TimeGenerated > datetime('$DEPLOY_TS') | where Name == 'towncrier.polling.never_polled_count' | extend cycle = tostring(Properties['cycle.type']) | project TimeGenerated, count_=Sum, cycle, AppRoleInstance | order by TimeGenerated asc"
-
-# Map AppRoleInstance -> execution by first-seen timestamp (matches execution startTime within a few seconds)
-az monitor log-analytics query --workspace 842645cf-1439-4a2b-80e8-54bd02e326f9 \
-  --analytics-query "union AppMetrics, AppTraces | where TimeGenerated > datetime('$DEPLOY_TS') | where AppRoleName == 'town-crier-worker-go' | summarize firstSeen=min(TimeGenerated), lastSeen=max(TimeGenerated) by AppRoleInstance | order by firstSeen asc"
-```
-
-Match each `cloud_RoleInstance` to an execution by taking the execution whose `startTime` is within ~30s before `firstSeen`. Short-lived instances (~6s lifetime, `lease.acquired=1` only) are bootstrap ticks — label them as such.
+Empty or known-benign. `PlanItRateLimitException` is expected — not a concern in any volume.
 
 ## Report format
 
-Output three tables, in this order:
+State the current **London time and which lanes are in-window** up front — every lane verdict depends on it.
 
-1. **Invariants** — seven invariants (3a–3g) + deployment status + abort check. One row each, ✅ / ⚠️ / ❌ + one line of evidence (metric name and value, or trace count, or queue sample). For 3e (oldest LastPollTime), include the authority id and the lag in a human unit (e.g. "47m behind, authority 123"). For 3g (never-polled drain), include the latest count and the trend versus 6h earlier (e.g. "0 (was 12, draining)" or "272 (flat for 18h — STARVATION)").
-2. **Runs since last deploy** — columns: `#`, execution short-name (last segment after `job-tc-poll-prod-`), start UTC, duration, status, apps, auths, cycles, notes. Include bootstrap ticks as separate rows marked `— bootstrap HH:MM —` with dashes for apps/auths/cycles and a note like "lease acquired, no-op reseed" or "reseeded (queue empty)".
-3. **Totals since deploy** — window length, successful cycles, failed cycles, applications ingested, authorities polled, orchestrator lease acquisitions, bootstrap lease acquisitions, `lease.released_412` (must be 0), `cycles_with_first_429` (must be 0 — see 3b), retry-after `p50/p90/max` in seconds with sample count (must have `max_s < 10800`; if no samples but 429s present, surface the `header_present='false'` count instead), oldest-LastPollTime age at start vs. end of window (and whether it grew or shrank — the single most important "are we keeping up?" signal), never-polled count at start vs. end of window (must monotonically drain or stay 0 — the canonical tc-ews7 starvation signal).
+1. **Lane status** — one row each for A, B, C, D: ✅ / ⚠️ / ❌ + eligibility-aware evidence. For A/B give the healthy-quiet / active / upstream-frozen / broken verdict with `watermark` vs `firstLastDifferent`. For C/D say "idle (out of window) — expected" when applicable, else progress.
+2. **Cross-cutting invariants** — deploy current, worker running, lease `released_412`=0, queue ≤1, telemetry-pipeline (AppMetrics present?), notifications flowing, exceptions. One row each, ✅ / ⚠️ / ❌ + one line of evidence.
+3. **Recovery / backlog** (only if a backlog is draining) — watermark at start vs now, PlanIt masked head, rough catch-up trend.
 
-End with 1–3 watch items and one recommendation line. Keep the prose under 200 words — tables can be as long as the data demands.
+End with 1–3 watch items and one recommendation line. Keep prose under 200 words.
 
-**Do not include as watch items**: PlanIt 429 counts or cadence, `PlanItRateLimitException`, `rate_limited` metric totals, or cycles that polled 0 authorities because they hit a 429 on first draw. Those are expected behaviour, not concerns. Only flag a 429-related issue if `cycles_with_first_429 > 0`.
+**Never flag as problems on their own:** a frozen A/B watermark, ~2 req/hour or hourly cadence, PlanIt 429 counts/cadence, `PlanItRateLimitException`, `rate_limited` totals, Lane C finding 0 stragglers, or Lane C/D idle outside their windows. Only escalate a 429 issue if `first_429 > 0`, and only call A/B "stalled" if PlanIt's masked head is provably newer than our watermark.


### PR DESCRIPTION
## Why

The `/verify-polling` command was last meaningfully updated in #469 — the **per-authority** era. Against today's ADR 0041/0044 **national-lane** model it is actively misleading: it treats a frozen Lane A/B watermark and hourly cadence as "falling behind" (they're the *correct* response to a quiet PlanIt), filters on a worker role name that no longer matches, and checks 429s on a field that never holds them. This session hit every one of those false signals while diagnosing the 2026-07-18→19 PlanIt outage.

## What changed

Rewritten around the four national lanes, with Postgres `poll_state` / `backfill_state` as ground truth:

- **Lane eligibility windows** — C is daytime-only (07:00–19:00 Europe/London), D is off-hours-only. Idle *out of window* is healthy, not broken.
- **Healthy-quiet vs upstream-frozen vs broken (silent-skip)** discriminator, driven by the `"lane delta page fetched"` diagnostic log (`firstLastDifferent` vs `watermarkBefore`). A non-advancing watermark is only ❌ when PlanIt's masked head is provably newer than ours.
- **Corrected facts**: worker role name is `cae-town-crier-shared.town-crier-worker-go` (use `has 'worker-go'`); PlanIt dependency `ResultCode` is the OTel status (0/2) — HTTP 429 lives in `Properties['http.response.status_code']`; **AppMetrics can be silently empty** → gating Check 0 + Postgres/AppDependencies/AppTraces fallbacks so the report never reads false-green.
- **New checks**: notification-flow (the actual product outcome), and backlog-drain / watermark-advance progress after a quiet spell (which also surfaces a suspected per-page `maxIngested` under-advance in `nationallane.go` on multi-page walks).
- Documents the read-only Postgres Entra-AD-token + firewall recipe, and the AppTraces Basic-Logs `/search` API.
- Drops obsolete per-authority checks (`never_polled`/tc-ews7 starvation, oldest-LastPollTime-per-authority, `authorities_polled`).

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated production polling verification guidance to use the four national lanes (A–D), including lane-specific freshness and idle expectations.
  - Added clearer telemetry checks, query paths, worker filtering, retry handling, lease validation, and queue-depth checks.
  - Documented Europe/London monitoring windows for Lanes C and D, including Lane D’s intentional no-notification behavior.
  - Revised reporting guidance to include lane- and window-aware results, cross-cutting invariants, and updated exception handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->