### PR TITLE
fix(polling): national lane watermark under-advances after multi-page walk (GH#983)

### DIFF
--- a/api-go/internal/platform/postgres/migrations/0023_poll_state_walk_head.sql
+++ b/api-go/internal/platform/postgres/migrations/0023_poll_state_walk_head.sql
@@ -1,0 +1,22 @@
+-- +goose Up
+
+-- Carries a national lane's descending-walk head across RunOnePage's
+-- per-page checkpoints (ADR 0044 resumable model; GH#983). A multi-page
+-- walk's true maximum LastDifferent is always the first record of the
+-- walk's first page -- but RunOnePage's own maxIngested is scoped to ONE
+-- page, so a walk that resumes across cycles was setting the watermark to
+-- the BOUNDARY (oldest) page's max instead of the whole walk's head.
+-- cursor_walk_head captures that first-page value and threads it through
+-- every resume until the walk completes.
+--
+-- Additive, nullable migration: no backfill. A NULL/absent value on a
+-- pre-migration in-flight row is a supported degrade case, not an error --
+-- the store layer falls back to the existing per-page maxIngested
+-- behaviour when cursor_walk_head is unset (see store_postgres.go).
+ALTER TABLE poll_state
+    ADD COLUMN cursor_walk_head timestamptz;
+
+-- +goose Down
+
+ALTER TABLE poll_state
+    DROP COLUMN IF EXISTS cursor_walk_head;

--- a/api-go/internal/polling/nationallane.go
+++ b/api-go/internal/polling/nationallane.go
@@ -248,6 +248,15 @@ type laneOutcome struct {
 // comes first), so nothing between the old watermark and the new one is
 // dropped.
 //
+// "That walk's max ingested value" is the WHOLE walk's maximum, which for a
+// descending walk is always the very first record of the walk's very first
+// page — never a later page's own max (GH#983: a multi-page walk used to set
+// the watermark to the BOUNDARY page's max instead, since maxIngested was
+// scoped to one page and went out of scope across the ADR 0044 checkpoint).
+// walkHead captures that first-page value once, on the fresh start
+// (startIndex == 0), and carries it through every resume via
+// PollCursor.WalkHead so a later page's completion still uses it.
+//
 // The watermark advances ONLY when THIS page reaches the boundary or the
 // last page (a clean completion of the whole walk): only then is every
 // record between the old watermark and the new one accounted for. Any
@@ -355,6 +364,24 @@ func (h *NationalLaneHandler) RunOnePage(ctx context.Context) laneOutcome {
 	}
 	h.logger.InfoContext(ctx, "lane delta page fetched", logArgs...)
 
+	// walkHead is this DESCENDING walk's true maximum LastDifferent (GH#983):
+	// always the first record of the walk's first page (index 0), never a
+	// later page's own max. A fresh walk (startIndex == 0) captures it
+	// directly off this page; a resumed walk (startIndex != 0) carries it
+	// forward from the persisted cursor, since the page that captured it is
+	// long gone by the time a later page completes the walk. It stays the
+	// zero value (unset) on a fresh walk's empty page 0, or when resuming a
+	// pre-migration cursor that never recorded one -- see the completion
+	// switch below, which degrades to maxIngested in that case.
+	var walkHead time.Time
+	if startIndex == 0 {
+		if len(res.Applications) > 0 {
+			walkHead = res.Applications[0].LastDifferent
+		}
+	} else if cursor != nil {
+		walkHead = cursor.WalkHead
+	}
+
 	reachedBoundary := false
 	var maxIngested time.Time
 	for _, app := range res.Applications {
@@ -379,8 +406,17 @@ func (h *NationalLaneHandler) RunOnePage(ctx context.Context) laneOutcome {
 	complete := reachedBoundary || !res.HasMorePages
 
 	if complete {
+		// walkHead wins whenever it is known: it is the WHOLE walk's true
+		// maximum (GH#983), never just this page's. maxIngested is the
+		// legacy-degrade fallback (acceptance criterion 4) for a pre-migration
+		// cursor that never captured a walk head -- today's exact behaviour,
+		// self-healing the moment the next fresh walk (startIndex == 0)
+		// captures a real one.
 		newWatermark := watermarkBefore
-		if !maxIngested.IsZero() {
+		switch {
+		case !walkHead.IsZero():
+			newWatermark = walkHead
+		case !maxIngested.IsZero():
 			newWatermark = maxIngested
 		}
 		out.watermarkAfter = newWatermark
@@ -389,7 +425,7 @@ func (h *NationalLaneHandler) RunOnePage(ctx context.Context) laneOutcome {
 		}
 	} else {
 		out.watermarkAfter = watermarkBefore
-		newCursor := &PollCursor{DifferentStart: prefilterDate, NextIndex: nextIndex, KnownTotal: res.Total}
+		newCursor := &PollCursor{DifferentStart: prefilterDate, NextIndex: nextIndex, KnownTotal: res.Total, WalkHead: walkHead}
 		if serr := h.watermark.save(ctx, now, watermarkBefore, newCursor); serr != nil && out.err == nil {
 			out.err = serr
 		}

--- a/api-go/internal/polling/nationallane_test.go
+++ b/api-go/internal/polling/nationallane_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"testing"
 	"time"
@@ -38,6 +39,19 @@ func (f *fakeNationalFetcher) FetchNationalDeltaPage(_ context.Context, q planit
 		return planit.FetchPageResult{From: q.StartIndex, HasMorePages: false}, nil
 	}
 	return res, nil
+}
+
+// manyApps builds n synthetic applications with strictly descending
+// LastDifferent values spaced step apart, starting at head. Used to push a
+// walk's cursor.NextIndex past the 100-record resume overlap
+// (handler.go's resumeOverlapRecords) in a multi-page test without needing
+// a real PlanIt page.
+func manyApps(n int, head time.Time, step time.Duration) []applications.PlanningApplication {
+	apps := make([]applications.PlanningApplication, n)
+	for i := 0; i < n; i++ {
+		apps[i] = testApp(fmt.Sprintf("bulk-%d", i), 300, head.Add(-time.Duration(i)*step))
+	}
+	return apps
 }
 
 // newLaneHandler wires a NationalLaneHandler pinned to a fixed clock
@@ -356,6 +370,14 @@ func TestNationalLane_NeverAdvancesWatermarkOn429(t *testing.T) {
 // checkpoint's whole point (ADR 0044 §2, GH#955/tc-nlvpz): a second
 // RunOnePage call resumes pagination at the persisted (minus the resume
 // overlap) NextIndex rather than re-fetching from index 0.
+//
+// It doubles as the GH#983 acceptance-criterion-4 regression test: the
+// pre-seeded cursor here never sets WalkHead (its zero value, matching a
+// row read back from before the cursor_walk_head column existed), so
+// completion must fall back to this page's own maxIngested -- exactly
+// today's behaviour -- rather than erroring or leaving the watermark
+// stuck. See TestNationalLane_ResumeWithCarriedWalkHead_CompletionUsesCarriedHead
+// for the counterpart proving a genuinely carried WalkHead wins instead.
 func TestNationalLane_MidDrainResumesAtCheckpointedIndex(t *testing.T) {
 	t.Parallel()
 	watermark := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
@@ -396,6 +418,182 @@ func TestNationalLane_MidDrainResumesAtCheckpointedIndex(t *testing.T) {
 	}
 	if state.states[sentinelLaneA].Cursor != nil {
 		t.Errorf("cursor: got %+v, want nil (walk completed)", state.states[sentinelLaneA].Cursor)
+	}
+}
+
+// TestNationalLane_MultiPageWalk_WatermarkUsesPageZeroHead is the primary
+// regression test for GH#983: a two-page walk driven the way
+// NationalPollHandler.Handle's planner loop drives it (RunOnePage called
+// repeatedly, feeding the persisted cursor forward) must land the final
+// watermark on page 0's head -- the walk's true maximum for a descending
+// walk -- never the boundary (oldest) page's own max.
+func TestNationalLane_MultiPageWalk_WatermarkUsesPageZeroHead(t *testing.T) {
+	t.Parallel()
+	watermark := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	head := watermark.Add(48 * time.Hour)
+
+	fetcher := newFakeNationalFetcher()
+	fetcher.pages[0] = planit.FetchPageResult{
+		From:         0,
+		Applications: manyApps(110, head, time.Minute),
+		HasMorePages: true, // walk continues past this page
+	}
+	fetcher.pages[10] = planit.FetchPageResult{
+		From: 10,
+		Applications: []applications.PlanningApplication{
+			testApp("boundary-page-newer", 300, watermark.Add(2*time.Hour)), // ingested, but far below the true walk head
+			testApp("boundary-page-stop", 300, watermark),                   // == watermark: stops the walk here
+		},
+		HasMorePages: false,
+	}
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	state.states[sentinelLaneA] = PollState{HighWaterMark: watermark, LastPollTime: watermark}
+
+	h := newLaneHandler(t, fetcher, apps, state, laneAOpts())
+
+	firstOut := h.RunOnePage(context.Background())
+	if firstOut.err != nil {
+		t.Fatalf("page 0 RunOnePage: %v", firstOut.err)
+	}
+	if !firstOut.watermarkAfter.Equal(watermark) {
+		t.Errorf("watermarkAfter after page 0: got %v, want unchanged %v (mid-walk)", firstOut.watermarkAfter, watermark)
+	}
+
+	secondOut := h.RunOnePage(context.Background())
+	if secondOut.err != nil {
+		t.Fatalf("page 1 RunOnePage: %v", secondOut.err)
+	}
+	if !secondOut.watermarkAfter.Equal(head) {
+		t.Errorf("watermarkAfter after completion: got %v, want the WHOLE walk's head %v, not the boundary page's own max", secondOut.watermarkAfter, head)
+	}
+	if state.states[sentinelLaneA].Cursor != nil {
+		t.Errorf("cursor: got %+v, want nil (walk completed)", state.states[sentinelLaneA].Cursor)
+	}
+}
+
+// TestNationalLane_InterruptedWalk_CursorCarriesWalkHead proves an
+// interrupted (more-pages-remain, boundary not reached) walk captures page
+// 0's head into the persisted cursor's WalkHead even though it goes unused
+// this call -- it is the value a LATER RunOnePage call (this cycle or a
+// future one) needs to complete the walk correctly (GH#983).
+func TestNationalLane_InterruptedWalk_CursorCarriesWalkHead(t *testing.T) {
+	t.Parallel()
+	watermark := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	head := watermark.Add(10 * time.Hour)
+
+	fetcher := newFakeNationalFetcher()
+	fetcher.pages[0] = planit.FetchPageResult{
+		From:         0,
+		Applications: manyApps(110, head, time.Minute),
+		HasMorePages: true, // more pages remain: the walk does not complete this call
+	}
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	state.states[sentinelLaneA] = PollState{HighWaterMark: watermark, LastPollTime: watermark}
+
+	h := newLaneHandler(t, fetcher, apps, state, laneAOpts())
+	out := h.RunOnePage(context.Background())
+
+	if out.err != nil {
+		t.Fatalf("RunOnePage: %v", out.err)
+	}
+	if !out.watermarkAfter.Equal(watermark) {
+		t.Errorf("watermarkAfter: got %v, want unchanged %v (walk interrupted, not complete)", out.watermarkAfter, watermark)
+	}
+	cursor := state.states[sentinelLaneA].Cursor
+	if cursor == nil {
+		t.Fatal("expected a resume cursor to be persisted")
+	}
+	if !cursor.WalkHead.Equal(head) {
+		t.Errorf("cursor.WalkHead: got %v, want %v (page 0's first record, captured even though unused this call)", cursor.WalkHead, head)
+	}
+}
+
+// TestNationalLane_ResumeWithCarriedWalkHead_CompletionUsesCarriedHead is
+// the core regression test for GH#983: when a resume completes the walk,
+// the persisted watermark must come from the CARRIED cursor.WalkHead --
+// never a comparison against or blend with this page's own maxIngested,
+// even when maxIngested happens to be numerically newer than the carried
+// head. That proves the fix genuinely replaces the per-page-scoped
+// variable as the source of truth rather than just widening its scope
+// with a max().
+func TestNationalLane_ResumeWithCarriedWalkHead_CompletionUsesCarriedHead(t *testing.T) {
+	t.Parallel()
+	watermark := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	prefilterDate := watermark
+	carriedHead := watermark.Add(3 * time.Hour) // the walk's true head, captured on page 0
+	pageMax := watermark.Add(10 * time.Hour)    // THIS resumed page's own max -- numerically newer, must be ignored
+
+	fetcher := newFakeNationalFetcher()
+	fetcher.pages[200] = planit.FetchPageResult{
+		From: 200,
+		Applications: []applications.PlanningApplication{
+			testApp("resumed-max", 300, pageMax),
+			testApp("resumed-boundary", 300, watermark),
+		},
+		HasMorePages: false,
+	}
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	state.states[sentinelLaneA] = PollState{
+		HighWaterMark: watermark,
+		Cursor:        &PollCursor{DifferentStart: prefilterDate, NextIndex: 300, WalkHead: carriedHead},
+	}
+
+	h := newLaneHandler(t, fetcher, apps, state, laneAOpts())
+	out := h.RunOnePage(context.Background())
+
+	if out.err != nil {
+		t.Fatalf("RunOnePage: %v", out.err)
+	}
+	if !out.watermarkAfter.Equal(carriedHead) {
+		t.Errorf("watermarkAfter: got %v, want the carried WalkHead %v, not this page's own max %v", out.watermarkAfter, carriedHead, pageMax)
+	}
+	if state.states[sentinelLaneA].Cursor != nil {
+		t.Errorf("cursor: got %+v, want nil (walk completed)", state.states[sentinelLaneA].Cursor)
+	}
+}
+
+// TestNationalLane_BoundaryHitAtIndexZero_WatermarkUnchanged pins the
+// healthy-quiet path from the 07-18->19 PlanIt outage (GH#983 "NOT the
+// bug"): when the walk's very FIRST record already sits at the watermark,
+// the walk completes on iteration 0 having ingested nothing. Because
+// walkHead is captured from that same first record, newWatermark ==
+// walkHead == watermarkBefore -- numerically a no-op -- so the fix must
+// not regress this previously-verified freeze-safe behaviour.
+func TestNationalLane_BoundaryHitAtIndexZero_WatermarkUnchanged(t *testing.T) {
+	t.Parallel()
+	watermark := time.Date(2026, 7, 18, 7, 1, 28, 0, time.UTC)
+	older := watermark.Add(-1 * time.Hour)
+
+	fetcher := newFakeNationalFetcher()
+	fetcher.pages[0] = planit.FetchPageResult{
+		From: 0,
+		Applications: []applications.PlanningApplication{
+			testApp("boundary", 300, watermark), // == watermark: stops the walk immediately
+			testApp("older", 300, older),        // must never be reached
+		},
+		HasMorePages: false,
+	}
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	state.states[sentinelLaneA] = PollState{HighWaterMark: watermark, LastPollTime: watermark}
+
+	h := newLaneHandler(t, fetcher, apps, state, laneAOpts())
+	out := h.RunOnePage(context.Background())
+
+	if out.err != nil {
+		t.Fatalf("RunOnePage: %v", out.err)
+	}
+	if out.recordsIngested != 0 {
+		t.Errorf("recordsIngested: got %d, want 0 (boundary hit on the very first record)", out.recordsIngested)
+	}
+	if !out.watermarkAfter.Equal(watermark) {
+		t.Errorf("watermarkAfter: got %v, want unchanged %v (healthy-quiet path, GH#983 'NOT the bug')", out.watermarkAfter, watermark)
+	}
+	if state.states[sentinelLaneA].Cursor != nil {
+		t.Errorf("cursor: got %+v, want nil (clean completion)", state.states[sentinelLaneA].Cursor)
 	}
 }
 

--- a/api-go/internal/polling/nationallane_test.go
+++ b/api-go/internal/polling/nationallane_test.go
@@ -48,7 +48,7 @@ func (f *fakeNationalFetcher) FetchNationalDeltaPage(_ context.Context, q planit
 // a real PlanIt page.
 func manyApps(n int, head time.Time, step time.Duration) []applications.PlanningApplication {
 	apps := make([]applications.PlanningApplication, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		apps[i] = testApp(fmt.Sprintf("bulk-%d", i), 300, head.Add(-time.Duration(i)*step))
 	}
 	return apps

--- a/api-go/internal/polling/state.go
+++ b/api-go/internal/polling/state.go
@@ -19,6 +19,15 @@ type PollCursor struct {
 	// KnownTotal is the total PlanIt reported on the first page of the cycle that
 	// recorded the cursor, if known. Telemetry only. nil when unknown.
 	KnownTotal *int
+	// WalkHead is a national lane's descending-walk true maximum LastDifferent
+	// (ADR 0044 / GH#983), captured from the first record of the walk's first
+	// page (index 0) and carried unchanged through every resume until the
+	// walk completes. The zero value means unset -- no walk-head captured yet,
+	// or a pre-migration legacy cursor -- same zero-time convention as
+	// HighWaterMark elsewhere in this package. Unused by Lane C's ascending
+	// epoch walk (lanec.go) and the legacy per-authority drain (handler.go),
+	// which never set or read it.
+	WalkHead time.Time
 }
 
 // PollState is the combined poll-state snapshot for one authority: when it was

--- a/api-go/internal/polling/store_postgres.go
+++ b/api-go/internal/polling/store_postgres.go
@@ -61,10 +61,13 @@ const legacyPageSize = 100
 // are read so Get can fall back to the legacy column for a row the additive
 // migration backfilled but a concurrent old-code writer might still be
 // touching during the deploy-overlap window (cursor_next_page is kept for one
-// release after tc-nlvpz for exactly this reason).
+// release after tc-nlvpz for exactly this reason). cursor_walk_head (0023,
+// GH#983) is nullable too: NULL on a pre-migration row degrades to the
+// PollCursor.WalkHead zero value, which RunOnePage's completion switch
+// treats as "unset" and falls back to its own maxIngested.
 const getPollStateQuery = `
 SELECT last_poll_time, high_water_mark,
-       cursor_different_start, cursor_next_index, cursor_next_page, cursor_known_total
+       cursor_different_start, cursor_next_index, cursor_next_page, cursor_known_total, cursor_walk_head
 FROM poll_state
 WHERE authority_id = $1`
 
@@ -78,10 +81,11 @@ func (s *PostgresPollStateStore) Get(ctx context.Context, authorityID int) (Poll
 		cursorNextIndex  *int
 		cursorNextPage   *int
 		cursorKnownTotal *int
+		cursorWalkHead   *time.Time
 	)
 	err := s.db.QueryRow(ctx, getPollStateQuery, authorityID).Scan(
 		&lastPollTime, &highWaterMark,
-		&cursorDiffStart, &cursorNextIndex, &cursorNextPage, &cursorKnownTotal,
+		&cursorDiffStart, &cursorNextIndex, &cursorNextPage, &cursorKnownTotal, &cursorWalkHead,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return PollState{}, false, nil
@@ -105,11 +109,15 @@ func (s *PostgresPollStateStore) Get(ctx context.Context, authorityID int) (Poll
 			// Convert on read so callers never see the old shape.
 			nextIndex = (*cursorNextPage - 1) * legacyPageSize
 		}
-		state.Cursor = &PollCursor{
+		cursor := &PollCursor{
 			DifferentStart: cursorDiffStart.UTC(),
 			NextIndex:      nextIndex,
 			KnownTotal:     cursorKnownTotal,
 		}
+		if cursorWalkHead != nil {
+			cursor.WalkHead = cursorWalkHead.UTC()
+		}
+		state.Cursor = cursor
 	}
 	return state, true, nil
 }
@@ -119,19 +127,23 @@ func (s *PostgresPollStateStore) Get(ctx context.Context, authorityID int) (Poll
 // NULL, which Get interprets as "no active cursor". cursor_next_page is always
 // nulled on write — every save migrates the row forward to the index-only
 // shape, matching the "writes always set cursor_next_index and null out
-// cursor_next_page" plan (tc-nlvpz).
+// cursor_next_page" plan (tc-nlvpz). cursor_walk_head (0023, GH#983) is
+// written unconditionally alongside the rest of the set whenever a cursor is
+// present — including its zero value, mirroring cursor_different_start; only
+// Get/RunOnePage special-case zero vs non-zero.
 const savePollStateQuery = `
 INSERT INTO poll_state (
     authority_id, last_poll_time, high_water_mark,
-    cursor_different_start, cursor_next_index, cursor_next_page, cursor_known_total
-) VALUES ($1, $2, $3, $4, $5, NULL, $6)
+    cursor_different_start, cursor_next_index, cursor_next_page, cursor_known_total, cursor_walk_head
+) VALUES ($1, $2, $3, $4, $5, NULL, $6, $7)
 ON CONFLICT (authority_id) DO UPDATE SET
     last_poll_time         = EXCLUDED.last_poll_time,
     high_water_mark        = EXCLUDED.high_water_mark,
     cursor_different_start = EXCLUDED.cursor_different_start,
     cursor_next_index      = EXCLUDED.cursor_next_index,
     cursor_next_page       = NULL,
-    cursor_known_total     = EXCLUDED.cursor_known_total`
+    cursor_known_total     = EXCLUDED.cursor_known_total,
+    cursor_walk_head       = EXCLUDED.cursor_walk_head`
 
 // Save upserts the poll state for authorityID. A nil cursor clears any active
 // cursor. The poll-state fields are written together as a set, and every save
@@ -142,12 +154,15 @@ func (s *PostgresPollStateStore) Save(ctx context.Context, authorityID int, last
 		cursorDiffStart  *time.Time
 		cursorNextIndex  *int
 		cursorKnownTotal *int
+		cursorWalkHead   *time.Time
 	)
 	if cursor != nil {
 		ds := cursor.DifferentStart.UTC()
 		cursorDiffStart = &ds
 		cursorNextIndex = &cursor.NextIndex
 		cursorKnownTotal = cursor.KnownTotal
+		wh := cursor.WalkHead.UTC()
+		cursorWalkHead = &wh
 	}
 
 	_, err := s.db.Exec(ctx, savePollStateQuery,
@@ -157,6 +172,7 @@ func (s *PostgresPollStateStore) Save(ctx context.Context, authorityID int, last
 		cursorDiffStart,
 		cursorNextIndex,
 		cursorKnownTotal,
+		cursorWalkHead,
 	)
 	if err != nil {
 		return fmt.Errorf("save poll state %d: %w", authorityID, err)

--- a/api-go/internal/polling/store_postgres_integration_test.go
+++ b/api-go/internal/polling/store_postgres_integration_test.go
@@ -48,6 +48,7 @@ func TestPostgresPollStateStore_RoundTrip(t *testing.T) {
 		DifferentStart: time.Date(2026, 6, 13, 0, 0, 0, 0, time.UTC),
 		NextIndex:      300,
 		KnownTotal:     platform.Ptr(250),
+		WalkHead:       time.Date(2026, 6, 13, 3, 0, 0, 0, time.UTC),
 	}
 
 	if err := store.Save(ctx, 99, lastPoll, hwm, cursor); err != nil {
@@ -78,6 +79,46 @@ func TestPostgresPollStateStore_RoundTrip(t *testing.T) {
 	}
 	if got.Cursor.KnownTotal == nil || *got.Cursor.KnownTotal != 250 {
 		t.Errorf("KnownTotal: got %v, want 250", got.Cursor.KnownTotal)
+	}
+	if !got.Cursor.WalkHead.Equal(cursor.WalkHead) {
+		t.Errorf("WalkHead: got %v, want %v", got.Cursor.WalkHead, cursor.WalkHead)
+	}
+}
+
+// TestPostgresPollStateStore_RoundTrip_WalkHeadZeroWhenNeverSet proves
+// acceptance criterion 4 of GH#983: a row whose cursor_walk_head column is
+// NULL -- simulating one written before the 0023 migration added the
+// column, or one this release's Save has not yet touched -- reads back with
+// PollCursor.WalkHead at its zero value rather than erroring. The row is
+// seeded with a direct INSERT (not Save) precisely to avoid ever writing
+// cursor_walk_head, standing in for a genuinely pre-migration row.
+func TestPostgresPollStateStore_RoundTrip_WalkHeadZeroWhenNeverSet(t *testing.T) {
+	ctx := context.Background()
+	pool := pgtest.New(t)
+	pgtest.Truncate(t, pool, "poll_state", "leases")
+
+	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO poll_state (authority_id, last_poll_time, high_water_mark, cursor_different_start, cursor_next_index)
+		VALUES ($1, $2, $2, $3, $4)`,
+		600, now, now, 300,
+	); err != nil {
+		t.Fatalf("seed legacy row: %v", err)
+	}
+
+	store := NewPostgresPollStateStore(pool)
+	got, ok, err := store.Get(ctx, 600)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !ok {
+		t.Fatal("Get: expected ok=true for seeded state")
+	}
+	if got.Cursor == nil {
+		t.Fatal("Cursor: expected non-nil (cursor_different_start was set)")
+	}
+	if !got.Cursor.WalkHead.IsZero() {
+		t.Errorf("WalkHead: got %v, want the zero value (never set on this row)", got.Cursor.WalkHead)
 	}
 }
 


### PR DESCRIPTION
## Changes
- Add `PollCursor.WalkHead time.Time` — a descending national-lane walk's true maximum `LastDifferent`, captured once from the first record of the walk's first page and carried unchanged through every resume.
- `RunOnePage` (nationallane.go): capture `walkHead` on a fresh walk (`startIndex == 0`), carry it via the persisted cursor on resume, and on completion prefer `walkHead` over the old per-page `maxIngested` (which only tracked the boundary page's own max — the root bug).
- Additive migration `0023_poll_state_walk_head.sql`: nullable `poll_state.cursor_walk_head`, no backfill. A NULL value on a pre-migration in-flight cursor degrades gracefully to the old per-page-max behaviour rather than erroring.
- `store_postgres.go`: round-trip `cursor_walk_head` through `Get`/`Save`, mirroring the existing `cursor_different_start` pattern.
- Unit tests (fake fetcher) covering: multi-page walk watermark = page 0's head; boundary hit at index 0 leaves watermark unchanged (healthy-quiet, unaffected); interrupted walk carries `WalkHead` without advancing; resumed walk's completion uses the carried head, not the resumed page's own max; legacy NULL walk head falls back to old behaviour. Real-DB round-trip test for the new column (`pgtest` harness, ADR 0032).

Fixes GH#983. Closes tc-8exsa.

## Test plan
- `go build ./...`, `go test ./...`, `go test -race ./...` — all green (1986 tests)
- `go test -tags=integration ./...` against local Postgres — green
- `golangci-lint run ./...`, `gofmt -l .`, `go vet ./...` — clean

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved polling progress tracking across multi-page and resumed national-lane walks.
  * Prevented watermarks from advancing to an incorrect page boundary.
  * Preserved polling state reliably when walks are interrupted and resumed.
  * Maintained compatibility with existing polling records where the new state is unavailable.

* **Tests**
  * Added coverage for multi-page walks, interrupted resumes, completion behavior, and boundary conditions.
  * Verified polling state persists and restores correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->