### PR TITLE
fix(polling): checkpoint Lane C on hydration 429, prioritise A/B in planner (tc-9tp49)

### DIFF
--- a/api-go/internal/polling/lanec.go
+++ b/api-go/internal/polling/lanec.go
@@ -30,6 +30,17 @@ type inverseMaskFetcher interface {
 	FetchByUID(ctx context.Context, uid string) (planit.FetchPageResult, error)
 }
 
+// maxHydrationsPerPass bounds Lane C's straggler hydration fan-out within a
+// single RunOnePage call (GH#986). Unlike Lane A/B's plain fetch-then-ingest
+// walk, Lane C's page loop can trigger one FetchByUID PER changed row, so an
+// unbounded page (many genuine stragglers clustered together) could burst
+// dozens of hydration requests in a single call and trip PlanIt's 429
+// threshold outright. Once the cap is reached the walk stops cleanly (the
+// same checkpoint-and-return path as a rate limit or hydration error, NOT an
+// error itself) so the pass resumes past the already-hydrated rows next
+// time, bounding the burst without losing progress.
+const maxHydrationsPerPass = 25
+
 // InverseMaskOptions tune Lane C's mask cutoff (ADR 0044).
 type InverseMaskOptions struct {
 	// MaskWindow is Lane A's start_date mask width. Lane C's end_date bound
@@ -114,11 +125,23 @@ func (h *InverseMaskLaneHandler) recorder() metricsRecorder {
 
 // RunOnePage executes exactly one page of Lane C's ascending epoch walk (ADR
 // 0044 §5): anchor a new epoch when none is active, or resume the active one
-// at its persisted NextIndex; fetch one page; diff/hydrate genuinely changed
-// rows; checkpoint. The sentinel row's HighWaterMark holds the pinned
-// epoch_upper, Cursor.DifferentStart doubles as epoch_lower, and
-// Cursor.NextIndex is the ascending record offset — the existing PollCursor
-// shape, reused with no schema migration.
+// (with a resume overlap, GH#986) at its persisted NextIndex; fetch one
+// page; diff/hydrate genuinely changed rows up to maxHydrationsPerPass;
+// checkpoint. The sentinel row's HighWaterMark holds the pinned epoch_upper,
+// Cursor.DifferentStart doubles as epoch_lower, and Cursor.NextIndex is the
+// ascending record offset — the existing PollCursor shape, reused with no
+// schema migration.
+//
+// GH#986: every early-exit path now checkpoints before returning — a page-
+// fetch 429/error re-saves the state exactly as loaded (unchanged epoch,
+// unchanged cursor) with last_poll_time bumped to now, and a mid-page bail
+// (a hydration 429, a straggler error, or the hydration cap) saves a cursor
+// at the offset actually reached. Previously both paths returned with no
+// save at all, so a persistently-failing record froze last_poll_time
+// forever: the planner's pure LRU then read Lane C as perpetually the
+// least-recently-polled lane, picked it every cycle, and it re-walked (and
+// re-failed on) the exact same page — the observed prod livelock that also
+// starved Lane A/B of every daytime cycle.
 func (h *InverseMaskLaneHandler) RunOnePage(ctx context.Context) laneOutcome {
 	ctx, span := otel.Tracer(tracerName).Start(ctx, "PlanIt Lane C inverse-mask poll")
 	defer span.End()
@@ -126,7 +149,7 @@ func (h *InverseMaskLaneHandler) RunOnePage(ctx context.Context) laneOutcome {
 	now := h.now().UTC()
 	var out laneOutcome
 
-	epochUpper, _, cursor, err := h.watermark.get(ctx)
+	loadedEpochUpper, _, cursor, err := h.watermark.get(ctx)
 	if err != nil {
 		out.err = fmt.Errorf("lane C: read epoch state: %w", err)
 		span.SetAttributes(attribute.String("poll.lane", string(LaneC)))
@@ -135,7 +158,7 @@ func (h *InverseMaskLaneHandler) RunOnePage(ctx context.Context) laneOutcome {
 
 	maskCutoff := truncateToDate(now.Add(-h.opts.MaskWindow))
 
-	if epochUpper.IsZero() {
+	if loadedEpochUpper.IsZero() {
 		// Never run: seed like Lane A/B, but Lane C's epoch is purely
 		// time-bound (no "head record" to discover), so seeding needs NO
 		// PlanIt request at all: anchor a zero-width epoch (epoch_lower ==
@@ -155,6 +178,7 @@ func (h *InverseMaskLaneHandler) RunOnePage(ctx context.Context) laneOutcome {
 		return out
 	}
 
+	epochUpper := loadedEpochUpper
 	var epochLower time.Time
 	if cursor != nil {
 		// Resume the active epoch at its persisted position.
@@ -169,9 +193,16 @@ func (h *InverseMaskLaneHandler) RunOnePage(ctx context.Context) laneOutcome {
 	}
 	out.watermarkBefore = epochLower
 
+	// GH#986: resume WITH a safety overlap, mirroring Lane A/B's
+	// resumeOverlapRecords (nationallane.go / handler.go). Safe because Lane
+	// C dedups every row via GetByUID/inverseMaskDiffers plus the Ingester,
+	// so re-processing up to resumeOverlapRecords rows on a resume is
+	// idempotent and cheap — and, now that a mid-page bail checkpoints at
+	// the exact failing offset, the overlap is what makes that checkpoint
+	// genuinely skip-safe against any off-by-one in PlanIt's own ordering.
 	startIndex := 0
 	if cursor != nil {
-		startIndex = cursor.NextIndex
+		startIndex = max(0, cursor.NextIndex-resumeOverlapRecords)
 	}
 
 	differentStart := truncateToDate(epochLower)
@@ -188,6 +219,13 @@ func (h *InverseMaskLaneHandler) RunOnePage(ctx context.Context) laneOutcome {
 		} else {
 			out.err = ferr
 		}
+		// GH#986: re-persist the epoch/cursor exactly as loaded (nothing was
+		// fetched, so no progress exists to checkpoint) but with
+		// last_poll_time advanced to now, so a page-fetch 429/error still
+		// rotates this lane off the LRU front instead of freezing it there.
+		if serr := h.watermark.save(ctx, now, loadedEpochUpper, cursor); serr != nil && out.err == nil {
+			out.err = serr
+		}
 		out.watermarkAfter = epochUpper
 		h.recordOutcome(ctx, out)
 		h.setSpanAttributes(span, out, epochLower, differentStart, false)
@@ -200,7 +238,11 @@ func (h *InverseMaskLaneHandler) RunOnePage(ctx context.Context) laneOutcome {
 
 	reachedCeiling := false
 	stoppedEarly := false
-	for _, light := range res.Applications {
+	hydrationsThisPass := 0
+	hydrationCapHit := false
+	i := 0
+	for ; i < len(res.Applications); i++ {
+		light := res.Applications[i]
 		// Ascending walk, exact-instant skip: a record at or before
 		// epochLower was already handled by the PREVIOUS epoch — the
 		// different_start prefilter is only date-granular, so the boundary
@@ -218,21 +260,33 @@ func (h *InverseMaskLaneHandler) RunOnePage(ctx context.Context) laneOutcome {
 			reachedCeiling = true
 			break
 		}
-		if perr := h.processStraggler(ctx, light, &out); perr != nil {
+		if perr := h.processStraggler(ctx, light, &out, &hydrationsThisPass, &hydrationCapHit); perr != nil {
 			out.err = perr
 			stoppedEarly = true
 			break
 		}
-		if out.rateLimited {
+		if out.rateLimited || hydrationCapHit {
 			// A hydration 429 trips the SAME "stop everything" rule as a
 			// page-fetch 429 (ADR 0044: one break on the first 429 from ANY
 			// lane) — never follow a rejected request with more requests.
+			// The hydration cap (GH#986) is a distinct, non-error reason to
+			// stop the same way: it bounds the FetchByUID burst a page of
+			// clustered stragglers can trigger.
 			stoppedEarly = true
 			break
 		}
 	}
 
 	if stoppedEarly {
+		// GH#986: checkpoint the offset actually reached — startIndex + i,
+		// where i counts every record iterated this page, including the
+		// exact-instant skips above — so both the cursor and last_poll_time
+		// advance even on a mid-page bail, and the next pass resumes past
+		// what this one already handled instead of re-walking it forever.
+		newCursor := &PollCursor{DifferentStart: epochLower, NextIndex: startIndex + i, KnownTotal: res.Total}
+		if serr := h.watermark.save(ctx, now, epochUpper, newCursor); serr != nil && out.err == nil {
+			out.err = serr
+		}
 		out.watermarkAfter = epochUpper
 		h.recordOutcome(ctx, out)
 		h.setSpanAttributes(span, out, epochLower, differentStart, false)
@@ -274,7 +328,15 @@ func (h *InverseMaskLaneHandler) RunOnePage(ctx context.Context) laneOutcome {
 // silently skip, freeze and let the next call resume" behaviour — so it is
 // surfaced as an error rather than logged-and-skipped, unlike the deleted
 // per-authority ReconciliationHandler.
-func (h *InverseMaskLaneHandler) processStraggler(ctx context.Context, light applications.PlanningApplication, out *laneOutcome) error {
+//
+// hydrationsThisPass/hydrationCapHit (GH#986) bound the FetchByUID fan-out a
+// single RunOnePage call can trigger: once hydrationsThisPass reaches
+// maxHydrationsPerPass, a row that would otherwise hydrate is left alone
+// (hydrationCapHit set instead) so the caller stops the walk and checkpoints
+// at this exact record rather than burst-hydrating an unbounded page of
+// clustered stragglers. A row that dedupes via GetByUID/inverseMaskDiffers
+// never counts against the cap — only a genuine FetchByUID attempt does.
+func (h *InverseMaskLaneHandler) processStraggler(ctx context.Context, light applications.PlanningApplication, out *laneOutcome, hydrationsThisPass *int, hydrationCapHit *bool) error {
 	authorityCode := strconv.Itoa(light.AreaID)
 	existing, found, gerr := h.apps.GetByUID(ctx, light.UID, authorityCode)
 	if gerr != nil {
@@ -283,6 +345,11 @@ func (h *InverseMaskLaneHandler) processStraggler(ctx context.Context, light app
 	if found && !inverseMaskDiffers(existing, light) {
 		return nil
 	}
+	if *hydrationsThisPass >= maxHydrationsPerPass {
+		*hydrationCapHit = true
+		return nil
+	}
+	*hydrationsThisPass++
 	return h.hydrate(ctx, light.UID, light.AreaID, out)
 }
 

--- a/api-go/internal/polling/lanec_test.go
+++ b/api-go/internal/polling/lanec_test.go
@@ -3,6 +3,7 @@ package polling
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"testing"
 	"time"
@@ -162,16 +163,19 @@ func TestInverseMaskLane_AnchorsNewEpochFromPriorCeiling(t *testing.T) {
 	}
 }
 
-// TestInverseMaskLane_ResumesActiveEpochAtCheckpointedIndex proves the
-// per-page checkpoint's whole point: an active cursor resumes pagination at
-// its persisted NextIndex within the SAME epoch bounds, rather than
-// re-anchoring.
-func TestInverseMaskLane_ResumesActiveEpochAtCheckpointedIndex(t *testing.T) {
+// TestInverseMaskLane_ResumesActiveEpochWithOverlap proves the per-page
+// checkpoint's resume story (GH#986): an active cursor resumes pagination at
+// max(0, NextIndex-resumeOverlapRecords) within the SAME epoch bounds,
+// mirroring Lane A/B's own resume overlap (nationallane.go), rather than
+// either re-anchoring or resuming at the checkpointed index with no safety
+// margin.
+func TestInverseMaskLane_ResumesActiveEpochWithOverlap(t *testing.T) {
 	t.Parallel()
 	epochLower := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
 	epochUpper := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
 	fetcher := newFakeInverseMaskFetcher()
-	fetcher.pages[300] = planit.FetchPageResult{From: 300, Applications: nil, HasMorePages: false}
+	// 300 - the 100-record resume overlap = 200.
+	fetcher.pages[200] = planit.FetchPageResult{From: 200, Applications: nil, HasMorePages: false}
 	apps := newFakeApps()
 	state := newFakeStateStore()
 	state.states[sentinelLaneC] = PollState{
@@ -185,8 +189,8 @@ func TestInverseMaskLane_ResumesActiveEpochAtCheckpointedIndex(t *testing.T) {
 	if out.err != nil {
 		t.Fatalf("RunOnePage: %v", out.err)
 	}
-	if len(fetcher.queries) != 1 || fetcher.queries[0].StartIndex != 300 {
-		t.Fatalf("expected exactly one fetch at StartIndex 300, got %+v", fetcher.queries)
+	if len(fetcher.queries) != 1 || fetcher.queries[0].StartIndex != 200 {
+		t.Fatalf("expected exactly one fetch at StartIndex 200 (300 - the 100-record resume overlap), got %+v", fetcher.queries)
 	}
 	if !fetcher.queries[0].EpochLower.Equal(epochLower) {
 		t.Errorf("EpochLower: got %v, want the active epoch's floor %v", fetcher.queries[0].EpochLower, epochLower)
@@ -196,6 +200,57 @@ func TestInverseMaskLane_ResumesActiveEpochAtCheckpointedIndex(t *testing.T) {
 	}
 	if !out.watermarkAfter.Equal(epochUpper) {
 		t.Errorf("watermarkAfter: got %v, want the unchanged pinned ceiling %v", out.watermarkAfter, epochUpper)
+	}
+}
+
+// TestInverseMaskLane_ResumeOverlapDedupesAlreadyProcessedRows proves the
+// resume overlap's safety property (GH#986): rows the overlap window
+// re-serves that are ALREADY correct in Postgres dedupe via
+// GetByUID/inverseMaskDiffers and are never re-hydrated or re-notified,
+// while a genuine straggler beyond the overlap zone still hydrates and
+// ingests normally — the overlap costs a few redundant existence reads, not
+// duplicate notifications.
+func TestInverseMaskLane_ResumeOverlapDedupesAlreadyProcessedRows(t *testing.T) {
+	t.Parallel()
+	epochLower := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	epochUpper := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+	ld := epochLower.Add(time.Hour)
+
+	same := "Permitted"
+	fetcher := newFakeInverseMaskFetcher()
+	fetcher.pages[200] = planit.FetchPageResult{ // 300 - the 100-record resume overlap
+		From: 200,
+		Applications: []applications.PlanningApplication{
+			lightApp("already/FUL", 99, same, ld), // in the overlap window: unchanged since last pass
+			lightApp("genuine/FUL", 99, "Permitted", ld),
+		},
+		HasMorePages: false,
+	}
+	full := testApp("genuine", 99, ld)
+	full.UID = "genuine/FUL"
+	permitted := "Permitted"
+	full.AppState = &permitted
+	fetcher.hydrated["genuine/FUL"] = full
+
+	apps := newFakeApps()
+	apps.existing["already/FUL"] = applications.PlanningApplication{UID: "already/FUL", AreaID: 99, AppState: &same, LastDifferent: ld}
+	state := newFakeStateStore()
+	state.states[sentinelLaneC] = PollState{
+		HighWaterMark: epochUpper,
+		Cursor:        &PollCursor{DifferentStart: epochLower, NextIndex: 300},
+	}
+
+	h := newLaneCHandler(t, fetcher, apps, state, defaultInverseMaskOpts())
+	out := h.RunOnePage(context.Background())
+
+	if out.err != nil {
+		t.Fatalf("RunOnePage: %v", out.err)
+	}
+	if len(fetcher.hydrateCalls) != 1 || fetcher.hydrateCalls[0] != "genuine/FUL" {
+		t.Errorf("expected only the genuine straggler to hydrate (the overlap-reprocessed row dedupes via GetByUID/inverseMaskDiffers): got %v", fetcher.hydrateCalls)
+	}
+	if out.recordsIngested != 1 {
+		t.Errorf("recordsIngested: got %d, want 1 (the already-processed row must not be re-notified)", out.recordsIngested)
 	}
 }
 
@@ -392,13 +447,19 @@ func TestInverseMaskLane_UsesAreaIDForAuthorityScopedExistenceCheck(t *testing.T
 	}
 }
 
-// TestInverseMaskLane_RateLimitedPageFetchLeavesCursorUntouched mirrors Lane
-// A/B's "never advance past a 429" invariant for Lane C's epoch cursor.
-func TestInverseMaskLane_RateLimitedPageFetchLeavesCursorUntouched(t *testing.T) {
+// TestInverseMaskLane_RateLimitedPageFetchPreservesCursorAdvancesLastPollTime
+// is GH#986 acceptance criterion (d): a page-fetch 429 must never lose the
+// existing checkpoint (the cursor's NextIndex is re-saved unchanged, exactly
+// as loaded — nothing was actually fetched, so there is no new progress to
+// record), but it MUST advance last_poll_time so the planner's LRU rotates
+// off Lane C instead of freezing it at the front of the queue forever (the
+// observed prod livelock).
+func TestInverseMaskLane_RateLimitedPageFetchPreservesCursorAdvancesLastPollTime(t *testing.T) {
 	t.Parallel()
 	epochLower := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
 	epochUpper := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
 	retryAfter := 30 * time.Second
+	wantNow := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC) // newLaneCHandler's pinned clock
 
 	fetcher := newFakeInverseMaskFetcher()
 	fetcher.failNth[1] = &planit.RateLimitError{RetryAfter: &retryAfter}
@@ -417,7 +478,48 @@ func TestInverseMaskLane_RateLimitedPageFetchLeavesCursorUntouched(t *testing.T)
 	}
 	got := state.states[sentinelLaneC].Cursor
 	if got == nil || got.NextIndex != 300 {
-		t.Errorf("cursor: got %+v, want the untouched checkpoint (NextIndex=300) — the next cycle resumes here, no re-tread", got)
+		t.Errorf("cursor: got %+v, want the preserved checkpoint (NextIndex=300) — the next cycle resumes here, no re-tread", got)
+	}
+	if lastPoll := state.states[sentinelLaneC].LastPollTime; !lastPoll.Equal(wantNow) {
+		t.Errorf("LastPollTime: got %v, want %v (must advance so the planner LRU rotates off this lane)", lastPoll, wantNow)
+	}
+}
+
+// TestInverseMaskLane_FreshAnchorPageFetch429PreservesUnanchoredState covers
+// the page-fetch-429 checkpoint's OTHER shape: a 429 on the very first fetch
+// of a freshly-anchoring epoch (no active cursor yet). The re-save must
+// persist the state EXACTLY as it was loaded — the prior ceiling as
+// HighWaterMark, cursor nil — not the in-memory epochUpper this call
+// provisionally reset to now(); saving that would falsely mark a brand new
+// epoch as already anchored-and-drained (nil cursor) without a single record
+// ever having been walked, silently skipping its entire contents.
+func TestInverseMaskLane_FreshAnchorPageFetch429PreservesUnanchoredState(t *testing.T) {
+	t.Parallel()
+	priorCeiling := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+	retryAfter := 15 * time.Second
+	wantNow := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC) // newLaneCHandler's pinned clock
+
+	fetcher := newFakeInverseMaskFetcher()
+	fetcher.failNth[1] = &planit.RateLimitError{RetryAfter: &retryAfter}
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	state.states[sentinelLaneC] = PollState{HighWaterMark: priorCeiling} // no cursor: about to anchor a new epoch
+
+	h := newLaneCHandler(t, fetcher, apps, state, defaultInverseMaskOpts())
+	out := h.RunOnePage(context.Background())
+
+	if !out.rateLimited {
+		t.Fatal("expected rateLimited=true")
+	}
+	got := state.states[sentinelLaneC]
+	if !got.HighWaterMark.Equal(priorCeiling) {
+		t.Errorf("HighWaterMark: got %v, want the unchanged prior ceiling %v (never falsely advanced to now on a failed anchor fetch)", got.HighWaterMark, priorCeiling)
+	}
+	if got.Cursor != nil {
+		t.Errorf("cursor: got %+v, want nil (still no active cursor -- the epoch never actually anchored)", got.Cursor)
+	}
+	if !got.LastPollTime.Equal(wantNow) {
+		t.Errorf("LastPollTime: got %v, want %v (must still advance so LRU rotates)", got.LastPollTime, wantNow)
 	}
 }
 
@@ -458,15 +560,124 @@ func TestInverseMaskLane_HydrationRateLimitStopsTheWholePage(t *testing.T) {
 	}
 }
 
+// TestInverseMaskLane_MidPageHydrationRateLimitCheckpointsAtFailingOffset is
+// GH#986 acceptance criterion (a): a mid-page hydration 429 must checkpoint
+// the cursor at the FAILING record's own offset (startIndex + i, where i
+// counts every record iterated this page including the exact-instant skip)
+// and advance last_poll_time — previously this path (stoppedEarly) returned
+// with no save at all, which froze the cursor on the same page forever (the
+// observed 59x re-fetch of the same 300-record boundary in prod) and froze
+// last_poll_time, starving Lane A/B via the planner's pure LRU.
+func TestInverseMaskLane_MidPageHydrationRateLimitCheckpointsAtFailingOffset(t *testing.T) {
+	t.Parallel()
+	epochLower := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	epochUpper := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+	newLD := epochLower.Add(time.Hour)
+	retryAfter := 20 * time.Second
+	wantNow := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC) // newLaneCHandler's pinned clock
+
+	full := testApp("ok", 99, newLD)
+	full.UID = "ok/FUL"
+	permitted := "Permitted"
+	full.AppState = &permitted
+
+	fetcher := newFakeInverseMaskFetcher()
+	fetcher.pages[0] = planit.FetchPageResult{
+		From: 0,
+		Applications: []applications.PlanningApplication{
+			lightApp("before/FUL", 99, "Permitted", epochLower), // index 0: <= epochLower, skipped -- still counts toward the offset
+			lightApp("ok/FUL", 99, "Permitted", newLD),          // index 1: hydrates fine
+			lightApp("fails/FUL", 99, "Permitted", newLD),       // index 2: hydration 429s here
+			lightApp("never/FUL", 99, "Permitted", newLD),       // index 3: must never be reached
+		},
+		HasMorePages: false,
+	}
+	fetcher.hydrated["ok/FUL"] = full
+	fetcher.hydrateErr["fails/FUL"] = &planit.RateLimitError{RetryAfter: &retryAfter}
+
+	apps := newFakeApps() // every uid is new: every one would otherwise hydrate
+	state := newFakeStateStore()
+	state.states[sentinelLaneC] = PollState{HighWaterMark: epochUpper, Cursor: &PollCursor{DifferentStart: epochLower, NextIndex: 0}}
+
+	h := newLaneCHandler(t, fetcher, apps, state, defaultInverseMaskOpts())
+	out := h.RunOnePage(context.Background())
+
+	if !out.rateLimited {
+		t.Fatal("expected rateLimited=true")
+	}
+	if len(fetcher.hydrateCalls) != 2 || fetcher.hydrateCalls[0] != "ok/FUL" || fetcher.hydrateCalls[1] != "fails/FUL" {
+		t.Fatalf("expected hydration to stop right after the failing record, never reaching the fourth: got %v", fetcher.hydrateCalls)
+	}
+	got := state.states[sentinelLaneC].Cursor
+	if got == nil || got.NextIndex != 2 {
+		t.Errorf("cursor: got %+v, want NextIndex=2 (the failing record's own offset, so a retry re-attempts it)", got)
+	}
+	if lastPoll := state.states[sentinelLaneC].LastPollTime; !lastPoll.Equal(wantNow) {
+		t.Errorf("LastPollTime: got %v, want %v (must advance so the planner LRU rotates off this lane)", lastPoll, wantNow)
+	}
+}
+
+// TestInverseMaskLane_HydrationCapStopsPassAndCheckpoints is GH#986
+// acceptance criterion (c): once a single RunOnePage call has attempted
+// maxHydrationsPerPass hydrations, it stops the walk as a CLEAN early stop
+// (out.err is nil, not an error) and checkpoints at the offset reached, so
+// the next pass resumes past what this one already hydrated. Bounds the
+// FetchByUID burst a page of many clustered genuine stragglers can trigger.
+func TestInverseMaskLane_HydrationCapStopsPassAndCheckpoints(t *testing.T) {
+	t.Parallel()
+	epochLower := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	epochUpper := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+	ld := epochLower.Add(time.Hour)
+	wantNow := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC) // newLaneCHandler's pinned clock
+
+	const recordCount = maxHydrationsPerPass + 5
+	fetcher := newFakeInverseMaskFetcher()
+	apps := newFakeApps() // every uid is new: every one is a genuine straggler
+	lightRows := make([]applications.PlanningApplication, 0, recordCount)
+	for i := range recordCount {
+		uid := fmt.Sprintf("straggler-%02d/FUL", i)
+		lightRows = append(lightRows, lightApp(uid, 99, "Permitted", ld))
+		full := testApp(fmt.Sprintf("straggler-%02d", i), 99, ld)
+		full.UID = uid
+		fetcher.hydrated[uid] = full
+	}
+	fetcher.pages[0] = planit.FetchPageResult{From: 0, Applications: lightRows, HasMorePages: false}
+
+	state := newFakeStateStore()
+	state.states[sentinelLaneC] = PollState{HighWaterMark: epochUpper, Cursor: &PollCursor{DifferentStart: epochLower, NextIndex: 0}}
+
+	h := newLaneCHandler(t, fetcher, apps, state, defaultInverseMaskOpts())
+	out := h.RunOnePage(context.Background())
+
+	if out.err != nil {
+		t.Fatalf("RunOnePage: %v (the hydration cap is a clean early stop, not an error)", out.err)
+	}
+	if len(fetcher.hydrateCalls) != maxHydrationsPerPass {
+		t.Fatalf("hydrateCalls: got %d, want %d (the per-pass cap)", len(fetcher.hydrateCalls), maxHydrationsPerPass)
+	}
+	got := state.states[sentinelLaneC].Cursor
+	if got == nil || got.NextIndex != maxHydrationsPerPass {
+		t.Errorf("cursor: got %+v, want NextIndex=%d (checkpointed right after the capped hydration run)", got, maxHydrationsPerPass)
+	}
+	if lastPoll := state.states[sentinelLaneC].LastPollTime; !lastPoll.Equal(wantNow) {
+		t.Errorf("LastPollTime: got %v, want %v (LRU must still rotate on a clean cap stop)", lastPoll, wantNow)
+	}
+}
+
 // TestInverseMaskLane_IngestErrorIsAHardStop proves a hydrated Ingest
-// failure freezes state exactly like a page-fetch error: nothing new is
-// persisted this call, so the previous checkpoint stands and a retry simply
-// re-fetches this page.
+// failure checkpoints at the failing record's offset (GH#986) exactly like a
+// mid-page hydration 429 does, and advances last_poll_time, even though the
+// Ingest failure itself surfaces as out.err — the checkpoint and the error
+// are independent: a retry re-fetches from this exact offset (the resume
+// overlap covers any residual doubt), rather than either re-walking the
+// whole page from scratch or freezing the LRU clock.
 func TestInverseMaskLane_IngestErrorIsAHardStop(t *testing.T) {
 	t.Parallel()
 	epochLower := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
 	epochUpper := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
 	newLD := epochLower.Add(time.Hour)
+
+	wantNow := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC) // newLaneCHandler's pinned clock
 
 	fetcher := newFakeInverseMaskFetcher()
 	fetcher.pages[0] = planit.FetchPageResult{
@@ -491,7 +702,10 @@ func TestInverseMaskLane_IngestErrorIsAHardStop(t *testing.T) {
 	}
 	got := state.states[sentinelLaneC].Cursor
 	if got == nil || got.NextIndex != 0 {
-		t.Errorf("cursor: got %+v, want the untouched checkpoint (NextIndex=0, nothing persisted this call)", got)
+		t.Errorf("cursor: got %+v, want the checkpoint at the failing record's own offset (NextIndex=0)", got)
+	}
+	if lastPoll := state.states[sentinelLaneC].LastPollTime; !lastPoll.Equal(wantNow) {
+		t.Errorf("LastPollTime: got %v, want %v (must advance even on an Ingest-error bail)", lastPoll, wantNow)
 	}
 }
 

--- a/api-go/internal/polling/nationallane_integration_test.go
+++ b/api-go/internal/polling/nationallane_integration_test.go
@@ -94,8 +94,8 @@ func TestInverseMaskLane_EpochCursorCrossCycleResume_RealPostgres(t *testing.T) 
 
 	newLD := epochLower.Add(2 * time.Hour)
 	fetcher := newFakeInverseMaskFetcher()
-	fetcher.pages[300] = planit.FetchPageResult{
-		From:         300,
+	fetcher.pages[200] = planit.FetchPageResult{
+		From:         200,
 		Applications: []applications.PlanningApplication{lightApp("resumed/FUL", 99, "Permitted", newLD)},
 		HasMorePages: false,
 	}
@@ -112,8 +112,8 @@ func TestInverseMaskLane_EpochCursorCrossCycleResume_RealPostgres(t *testing.T) 
 	if out.err != nil {
 		t.Fatalf("RunOnePage: %v", out.err)
 	}
-	if len(fetcher.queries) != 1 || fetcher.queries[0].StartIndex != 300 {
-		t.Fatalf("expected the resumed fetch at StartIndex 300 (Lane C's cursor carries no resume overlap), got %+v", fetcher.queries)
+	if len(fetcher.queries) != 1 || fetcher.queries[0].StartIndex != 200 {
+		t.Fatalf("expected the resumed fetch at StartIndex 200 (checkpointed NextIndex 300 minus the 100-record resume overlap, GH#986), got %+v", fetcher.queries)
 	}
 	if !fetcher.queries[0].EpochLower.Equal(epochLower) {
 		t.Errorf("EpochLower: got %v, want the active epoch's floor %v", fetcher.queries[0].EpochLower, epochLower)

--- a/api-go/internal/polling/planner.go
+++ b/api-go/internal/polling/planner.go
@@ -198,29 +198,51 @@ func hasWorkC(s LaneState, now time.Time) bool {
 	return s.LastPollTime.IsZero() || now.Sub(s.LastPollTime) >= laneCIdleAnchorInterval
 }
 
-// NextWork picks the next lane to run: among every eligible lane that
-// currently has work, the one with the oldest LastPollTime (LRU / round-
-// robin — ADR 0044 §3). Returns nil when nothing eligible has work
+// NextWork picks the next lane to run using a TIERED priority (GH#986): Lane
+// A/B (new-application and decision detection, the notification-bearing
+// critical path) always outrank Lane C/D (reconciliation and backfill, both
+// data-quality/coverage lanes) whenever A/B has work at all, regardless of
+// how LRU-stale C or D have become. Only once NEITHER A nor B has work does
+// C/D become candidates. Within whichever tier is in play, selection is
+// unchanged: the eligible-with-work lane with the oldest LastPollTime (LRU /
+// round-robin — ADR 0044 §3). Returns nil when nothing eligible has work
 // (everything is caught up — the "Natural" cycle-end case).
+//
+// Before this fix NextWork ran pure LRU across all four lanes uniformly: a
+// lane whose last_poll_time never advances (e.g. Lane C livelocked on a
+// repeatedly-failing checkpoint, GH#986) looked perpetually
+// least-recently-polled and was picked every single cycle, starving A/B
+// entirely for as long as the underlying failure persisted. Tiering makes
+// that starvation structurally impossible even under a future bug in any
+// lower-tier lane.
 func (p *Planner) NextWork(state PlannerState, now time.Time) *WorkItem {
 	type candidate struct {
 		lane         LaneName
 		lastPollTime time.Time
 		cursor       *PollCursor
 	}
-	var candidates []candidate
 
+	var tier1 []candidate // Lane A/B: the notification-bearing critical path.
 	if p.Eligible(LaneA, now) && hasWorkAB(state.LaneA, now, p.opts.FreshnessInterval) {
-		candidates = append(candidates, candidate{LaneA, state.LaneA.LastPollTime, state.LaneA.Cursor})
+		tier1 = append(tier1, candidate{LaneA, state.LaneA.LastPollTime, state.LaneA.Cursor})
 	}
 	if p.Eligible(LaneB, now) && hasWorkAB(state.LaneB, now, p.opts.FreshnessInterval) {
-		candidates = append(candidates, candidate{LaneB, state.LaneB.LastPollTime, state.LaneB.Cursor})
+		tier1 = append(tier1, candidate{LaneB, state.LaneB.LastPollTime, state.LaneB.Cursor})
 	}
-	if state.LaneC != nil && p.Eligible(LaneC, now) && hasWorkC(*state.LaneC, now) {
-		candidates = append(candidates, candidate{LaneC, state.LaneC.LastPollTime, state.LaneC.Cursor})
-	}
-	if state.LaneD != nil && p.Eligible(LaneD, now) && !state.LaneD.Complete {
-		candidates = append(candidates, candidate{LaneD, state.LaneD.LastPollTime, nil})
+
+	candidates := tier1
+	if len(candidates) == 0 {
+		// Tier 1 has nothing to do this iteration: only now does tier 2
+		// (Lane C/D — reconciliation and backfill) become eligible for
+		// selection at all.
+		var tier2 []candidate
+		if state.LaneC != nil && p.Eligible(LaneC, now) && hasWorkC(*state.LaneC, now) {
+			tier2 = append(tier2, candidate{LaneC, state.LaneC.LastPollTime, state.LaneC.Cursor})
+		}
+		if state.LaneD != nil && p.Eligible(LaneD, now) && !state.LaneD.Complete {
+			tier2 = append(tier2, candidate{LaneD, state.LaneD.LastPollTime, nil})
+		}
+		candidates = tier2
 	}
 
 	if len(candidates) == 0 {

--- a/api-go/internal/polling/planner_test.go
+++ b/api-go/internal/polling/planner_test.go
@@ -281,6 +281,55 @@ func TestPlanner_NextWork_LaneCHasWork(t *testing.T) {
 	}
 }
 
+// TestPlanner_NextWork_TieredSelection_AOutranksStaleLaneC is GH#986
+// acceptance criterion (e): Lane A due AND Lane C holding an active,
+// mid-drain cursor that is FAR more LRU-stale than A must still lose to A —
+// pure LRU across all four lanes (the pre-fix algorithm) would have picked C
+// here, since a stale/livelocked lane's frozen last_poll_time makes it look
+// perpetually least-recently-polled. Tiering makes A/B categorically
+// outrank C/D whenever A/B has work, independent of any staleness on the
+// lower tier.
+func TestPlanner_NextWork_TieredSelection_AOutranksStaleLaneC(t *testing.T) {
+	t.Parallel()
+	p := NewPlanner(testPlannerOptions(t))
+	daytime := time.Date(2026, 1, 15, 15, 0, 0, 0, time.UTC) // Lane C eligible (daytime window)
+
+	state := PlannerState{
+		LaneA: LaneState{LastPollTime: daytime.Add(-20 * time.Minute)}, // due (> 15m freshness)
+		LaneB: LaneState{LastPollTime: daytime},                        // not due
+		LaneC: &LaneState{
+			LastPollTime: daytime.Add(-48 * time.Hour), // vastly older than A: pure LRU would pick C
+			Cursor:       &PollCursor{NextIndex: 300},  // mid-drain: has work regardless of staleness
+		},
+		LaneD: &LaneDState{Complete: true},
+	}
+	item := p.NextWork(state, daytime)
+	if item == nil || item.Lane != LaneA {
+		t.Fatalf("NextWork: got %+v, want lane A (A/B must categorically outrank C/D whenever A/B has work, GH#986)", item)
+	}
+}
+
+// TestPlanner_NextWork_TieredSelection_FallsBackToLaneCWhenABIdle is GH#986
+// acceptance criterion (f): when neither A nor B currently has work, C is
+// still picked in-window — tiering must never starve the lower tier when the
+// upper tier is genuinely caught up, only when the upper tier has work to do.
+func TestPlanner_NextWork_TieredSelection_FallsBackToLaneCWhenABIdle(t *testing.T) {
+	t.Parallel()
+	p := NewPlanner(testPlannerOptions(t))
+	daytime := time.Date(2026, 1, 15, 15, 0, 0, 0, time.UTC)
+
+	state := PlannerState{
+		LaneA: LaneState{LastPollTime: daytime},      // not due
+		LaneB: LaneState{LastPollTime: daytime},      // not due
+		LaneC: &LaneState{LastPollTime: time.Time{}}, // never polled: has work
+		LaneD: &LaneDState{Complete: true},
+	}
+	item := p.NextWork(state, daytime)
+	if item == nil || item.Lane != LaneC {
+		t.Fatalf("NextWork: got %+v, want lane C (A/B idle: the lower tier becomes eligible)", item)
+	}
+}
+
 // TestPlanner_NextWork_NilLaneCSkipsIt covers the test/wiring convenience of
 // a nil Lane C (not wired): NextWork must never pick a lane that is not
 // present in state, even when it would otherwise be eligible.


### PR DESCRIPTION
Fixes the Lane C (ADR 0044 inverse-mask reconciliation) livelock found during a `/verify-polling` session, and the Lane A/B starvation it caused. Closes GH#986.

## The bug (observed in prod 2026-07-21)

Lane C ran **59 times since 07-20 15:48, every one `seen=300 hydrated≈0`** — the same 300-record boundary page re-fetched, cursor pinned at `NextIndex=300`, `last_poll_time` frozen at 07-20 15:48. Two bail paths in `lanec.go` returned **without calling `h.watermark.save`**, so a mid-page hydration 429 froze both the cursor and `last_poll_time`. The pure-LRU planner then read Lane C as perpetually least-recently-polled and picked it every daytime cycle, **starving Lanes A/B (new-app + decision detection) from 06:00–18:00 UTC** — zero apps ingested in 10h, no notification since 07-20 16:00 — and pushing PlanIt to 1,278 calls/24h (near the ~1,500 red line).

## The fix

**`lanec.go`**
1. **Resume overlap** — resume at `max(0, NextIndex - resumeOverlapRecords)`, mirroring Lane A; safe because Lane C dedups every row.
2. **Checkpoint on every early exit** — the mid-page bail (hydration 429 / straggler error / hydration cap) saves the cursor at the offset actually reached (`startIndex + i`) and advances `last_poll_time`; the page-fetch 429/error path re-saves the state *exactly as loaded* (`loadedEpochUpper`, unchanged cursor) with `last_poll_time = now`. `loadedEpochUpper` is captured separately from the reassigned `epochUpper` so a 429 on a fresh-epoch anchor can't falsely persist a drained-epoch marker.
3. **`maxHydrationsPerPass = 25`** — bounds the `FetchByUID` burst a page of clustered stragglers can trigger; hitting the cap stops the pass cleanly (checkpoint, not an error) and resumes next time.

**`planner.go`**
4. **Tiered `NextWork`** — Lane A/B (the notification-bearing critical path) categorically outrank C/D whenever A/B has work; C/D are considered only when neither A nor B does. Round-robin (LRU) preserved within each tier. Makes reconciliation/backfill starving new-app detection structurally impossible, even under a future lower-tier bug.

## Tests
New/updated unit tests in `lanec_test.go` and `planner_test.go` cover: mid-page 429 checkpoint at the failing offset + `last_poll_time` advance; resume-overlap dedupe; hydration-cap stop-and-checkpoint; page-fetch 429 advancing `last_poll_time`; fresh-anchor 429 not falsely draining; and A outranking a 48h-stale livelocked C, with C still selected when A/B are idle.

## Gates (from `api-go/`, run independently)
`go test ./internal/polling/...` 202 passed · `go test -race ./...` 1992 passed · `go build`/`go vet`/`gofmt`/`golangci-lint` clean.

## Known follow-up (not in scope)
`tc-6u4da` (P3): a cluster of ≥`maxHydrationsPerPass` permanently-unhydratable "no matching record" rows can slow Lane C's *own* epoch drain (they re-consume cap slots each pass). A/B are unaffected and PlanIt load stays bounded, so it's reconciliation-lag only, filed as a discovered-from follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved polling reliability by preventing excessive record hydration in a single pass.
  * Added safer checkpointing when rate limits, errors, or ingestion failures interrupt processing.
  * Improved resume behavior with overlap handling to avoid missed or duplicated records.
  * Ensured polling lanes continue progressing after interrupted or incomplete page processing.
  * Updated work scheduling so higher-priority lanes are selected before fallback lanes when eligible.

* **Tests**
  * Added coverage for checkpointing, rate limiting, resume overlap, hydration limits, and tiered scheduling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->