### PR TITLE
feat(digest): show free-tier plan-status line in weekly digest email (tc-m1pb5)

### DIFF
--- a/api-go/internal/digest/email.go
+++ b/api-go/internal/digest/email.go
@@ -33,10 +33,11 @@ const (
 
 // pageTemplate is the outer Public Notice shell: a paper-toned page holding a
 // single 600px card, a lettered masthead over a double rule, the per-zone
-// notification blocks, an amber CTA, and a footer with the unsubscribe link.
-// It is light-only by design (the color-scheme/supported-color-schemes meta
-// pair): email client dark-mode colour inversion is unreliable enough that a
-// dark variant is out of scope for v1 (issue 859).
+// notification blocks, an optional free-tier account-status line, an amber
+// CTA, and a footer with the unsubscribe link. It is light-only by design
+// (the color-scheme/supported-color-schemes meta pair): email client
+// dark-mode colour inversion is unreliable enough that a dark variant is out
+// of scope for v1 (issue 859).
 const pageTemplate = `<!DOCTYPE html>
 <html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width">
 <meta name="color-scheme" content="light">
@@ -56,6 +57,7 @@ const pageTemplate = `<!DOCTYPE html>
       %s
     </table>
     <table width="100%%" cellpadding="0" cellspacing="0" role="presentation" style="margin-top:24px;">
+      %s
       <tr><td align="center">
         <a href="https://towncrierapp.uk/applications" style="display:inline-block;background:%s;color:%s;padding:12px 32px;border-radius:6px;text-decoration:none;font-weight:600;">Open Town Crier</a>
       </td></tr>
@@ -67,6 +69,21 @@ const pageTemplate = `<!DOCTYPE html>
 </table>
 </td></tr></table>
 </body></html>`
+
+// freeTierNoticeText is the account-status line shown on the weekly digest to
+// Free-tier recipients only (tc-m1pb5). It is a factual account statement,
+// not marketing copy: no benefit claim, no pricing, no urgency, and no CTA of
+// its own — the digest stays a service message rather than a promotion (the
+// Privacy Policy states "we do not send marketing email"). It must never
+// become a link and must never point at a paywall/plans/pricing page: it
+// leans on the existing "Open Town Crier" button rendered directly beneath
+// it.
+const freeTierNoticeText = "You're on the free weekly digest."
+
+// freeTierNoticeTemplate renders the free-tier notice as its own row directly
+// above the CTA button, inside the same centered table: small, muted,
+// secondary-coloured text, centre-aligned like the button below it.
+const freeTierNoticeTemplate = `<tr><td align="center" data-testid="digest-free-tier-notice" style="padding-bottom:12px;font-size:12px;color:%s;">%s</td></tr>`
 
 // sectionHeaderTemplate renders a zone or "Saved Applications" section label.
 const sectionHeaderTemplate = `<tr><td style="padding:16px 0 8px 0;font-size:14px;color:%s;text-transform:uppercase;letter-spacing:0.08em;">
@@ -121,11 +138,15 @@ func buildDigestSubject(totalCount int) string {
 // buildDigestHTML renders the full digest email body as a Public Notice
 // masthead-and-card layout (issue 859): a paper-toned page, a lettered
 // masthead over a double rule, one filed-notice card per watch zone (plus an
-// optional Saved Applications section), an amber CTA, and a footer carrying
-// the count and the unsubscribe link. All user-supplied content is
-// HTML-encoded. The markup stays table-based with inline styles throughout —
-// email-client reality, no external stylesheet, no flexbox/grid.
-func buildDigestHTML(zoneSections []watchZoneDigest, savedApplications []notifications.DigestNotification, totalCount int) string {
+// optional Saved Applications section), an optional free-tier account-status
+// line, an amber CTA, and a footer carrying the count and the unsubscribe
+// link. All user-supplied content is HTML-encoded. The markup stays
+// table-based with inline styles throughout — email-client reality, no
+// external stylesheet, no flexbox/grid. showFreeTierNotice renders the
+// "You're on the free weekly digest." line directly above the CTA button
+// (tc-m1pb5); callers pass true only for Free-tier recipients on the weekly
+// cycle — never the hourly cycle, which is paid-only anyway.
+func buildDigestHTML(zoneSections []watchZoneDigest, savedApplications []notifications.DigestNotification, totalCount int, showFreeTierNotice bool) string {
 	var zoneBlocks strings.Builder
 	for _, section := range zoneSections {
 		var cards strings.Builder
@@ -150,6 +171,11 @@ func buildDigestHTML(zoneSections []watchZoneDigest, savedApplications []notific
 		plural = ""
 	}
 
+	freeTierNotice := ""
+	if showFreeTierNotice {
+		freeTierNotice = fmt.Sprintf(freeTierNoticeTemplate, designtokens.TextSecondaryLightHex, htmlEncode(freeTierNoticeText))
+	}
+
 	return fmt.Sprintf(pageTemplate,
 		designtokens.BackgroundLightHex, bodyFontStack,
 		designtokens.SurfaceLightHex, designtokens.BorderLightHex, designtokens.TextPrimaryLightHex,
@@ -159,6 +185,7 @@ func buildDigestHTML(zoneSections []watchZoneDigest, savedApplications []notific
 		designtokens.TextPrimaryLightHex,
 		designtokens.BorderLightHex,
 		zoneBlocks.String(),
+		freeTierNotice,
 		designtokens.AmberLightHex, designtokens.TextOnAccentLightHex,
 		designtokens.TextSecondaryLightHex, designtokens.BorderLightHex,
 		totalCount, plural,

--- a/api-go/internal/digest/email_test.go
+++ b/api-go/internal/digest/email_test.go
@@ -53,7 +53,7 @@ func TestBuildDigestHTML_RendersZoneAndSavedSections(t *testing.T) {
 		testNotification("20/00045/FUL", "", "5 Mill Ln", "Full", "New dwelling"),
 	}
 
-	html := buildDigestHTML(zones, saved, 2)
+	html := buildDigestHTML(zones, saved, 2, false)
 
 	for _, want := range []string{
 		"Town Crier",
@@ -81,7 +81,7 @@ func TestBuildDigestHTML_DecisionLabelBadge(t *testing.T) {
 	n.Decision = strptr("Permitted")
 	zones := []watchZoneDigest{{name: "Home", notifications: []notifications.DigestNotification{n}}}
 
-	html := buildDigestHTML(zones, nil, 1)
+	html := buildDigestHTML(zones, nil, 1, false)
 
 	if !strings.Contains(html, "[Approved]") {
 		t.Errorf("decision badge should show UK label [Approved], got:\n%s", html)
@@ -103,7 +103,7 @@ func TestBuildDigestHTML_SavedIndicatorOnZoneCard(t *testing.T) {
 	n.Sources = "Zone, Saved"
 	zones := []watchZoneDigest{{name: "Home", notifications: []notifications.DigestNotification{n}}}
 
-	html := buildDigestHTML(zones, nil, 1)
+	html := buildDigestHTML(zones, nil, 1, false)
 
 	if !strings.Contains(html, "★ saved") {
 		t.Errorf("expected saved indicator on zone card, got:\n%s", html)
@@ -116,7 +116,7 @@ func TestBuildDigestHTML_EscapesUserContent(t *testing.T) {
 	n := testNotification("19/0011", "zone-1", "<script>alert(1)</script>", "Householder", "x & y")
 	zones := []watchZoneDigest{{name: "Home & Garden", notifications: []notifications.DigestNotification{n}}}
 
-	html := buildDigestHTML(zones, nil, 1)
+	html := buildDigestHTML(zones, nil, 1, false)
 
 	if strings.Contains(html, "<script>alert(1)</script>") {
 		t.Errorf("address must be HTML-encoded, got:\n%s", html)
@@ -150,7 +150,7 @@ func TestBuildDigestHTML_NoLegacyBrandHexLiterals(t *testing.T) {
 	// now comes from designtokens.
 	n := testNotification("19/00123/FUL", "zone-1", "10 High St", "Householder", "Rear extension")
 	zones := []watchZoneDigest{{name: "Home", notifications: []notifications.DigestNotification{n}}}
-	html := buildDigestHTML(zones, nil, 1)
+	html := buildDigestHTML(zones, nil, 1, false)
 
 	for _, legacy := range []string{"#1a1a2e", "#4a6cf7", "#f0f0f0", "#eef1ff", "#fff3cd", "#f8f9fa", "#666", "#999", "#888", "#eee"} {
 		if strings.Contains(html, legacy) {
@@ -163,7 +163,7 @@ func TestBuildDigestHTML_UsesDesignTokenColours(t *testing.T) {
 	t.Parallel()
 	n := testNotification("19/00123/FUL", "zone-1", "10 High St", "Householder", "Rear extension")
 	zones := []watchZoneDigest{{name: "Home", notifications: []notifications.DigestNotification{n}}}
-	html := buildDigestHTML(zones, nil, 1)
+	html := buildDigestHTML(zones, nil, 1, false)
 
 	for _, want := range []string{
 		designtokens.BackgroundLightHex,
@@ -182,7 +182,7 @@ func TestBuildDigestHTML_UsesDesignTokenColours(t *testing.T) {
 
 func TestBuildDigestHTML_MastheadAndDoubleRule(t *testing.T) {
 	t.Parallel()
-	html := buildDigestHTML(nil, nil, 0)
+	html := buildDigestHTML(nil, nil, 0, false)
 
 	if !strings.Contains(html, "Town Crier") {
 		t.Errorf("masthead should render the Town Crier wordmark, got:\n%s", html)
@@ -196,7 +196,7 @@ func TestBuildDigestHTML_MastheadAndDoubleRule(t *testing.T) {
 
 func TestBuildDigestHTML_CTAIsVerbFirstAmber(t *testing.T) {
 	t.Parallel()
-	html := buildDigestHTML(nil, nil, 0)
+	html := buildDigestHTML(nil, nil, 0, false)
 
 	if !strings.Contains(html, "Open Town Crier") {
 		t.Errorf("CTA label should be verb-first (\"Open Town Crier\"), got:\n%s", html)
@@ -218,7 +218,7 @@ func TestBuildDigestHTML_HeadlinesUseSansStack(t *testing.T) {
 
 	n := testNotification("19/00123/FUL", "zone-1", "10 High St", "Householder", "Rear extension")
 	zones := []watchZoneDigest{{name: "Home", notifications: []notifications.DigestNotification{n}}}
-	html := buildDigestHTML(zones, nil, 1)
+	html := buildDigestHTML(zones, nil, 1, false)
 
 	if !strings.Contains(html, fmt.Sprintf(`font-family:%s;font-weight:700`, bodyFontStack)) {
 		t.Errorf("headlines should render with the sans stack, got:\n%s", html)
@@ -229,7 +229,7 @@ func TestBuildDigestHTML_ReferenceAndDateUseMonospace(t *testing.T) {
 	t.Parallel()
 	n := testNotification("19/00123/FUL", "zone-1", "10 High St", "Householder", "Rear extension")
 	zones := []watchZoneDigest{{name: "Home", notifications: []notifications.DigestNotification{n}}}
-	html := buildDigestHTML(zones, nil, 1)
+	html := buildDigestHTML(zones, nil, 1, false)
 
 	if !strings.Contains(html, "'Courier New', monospace") {
 		t.Errorf("references/dates should use the Courier New monospace stack, got:\n%s", html)
@@ -249,7 +249,7 @@ func TestBuildDigestHTML_ChipsAreOutlinedTransparent(t *testing.T) {
 	n.Decision = strptr("Permitted")
 	n.Sources = "Zone, Saved"
 	zones := []watchZoneDigest{{name: "Home", notifications: []notifications.DigestNotification{n}}}
-	html := buildDigestHTML(zones, nil, 1)
+	html := buildDigestHTML(zones, nil, 1, false)
 
 	if !strings.Contains(html, "background:transparent") {
 		t.Errorf("type chip and saved indicator should have a transparent background, got:\n%s", html)
@@ -264,7 +264,7 @@ func TestBuildDigestHTML_ChipsAreOutlinedTransparent(t *testing.T) {
 
 func TestBuildDigestHTML_LightOnlyMetaTags(t *testing.T) {
 	t.Parallel()
-	html := buildDigestHTML(nil, nil, 0)
+	html := buildDigestHTML(nil, nil, 0, false)
 
 	if !strings.Contains(html, `<meta name="color-scheme" content="light">`) {
 		t.Errorf("expected a light-only color-scheme meta tag, got:\n%s", html)
@@ -278,7 +278,7 @@ func TestBuildDigestHTML_StructuralSafety(t *testing.T) {
 	t.Parallel()
 	n := testNotification("19/00123/FUL", "zone-1", "10 High St", "Householder", "Rear extension")
 	zones := []watchZoneDigest{{name: "Home", notifications: []notifications.DigestNotification{n}}}
-	html := buildDigestHTML(zones, nil, 1)
+	html := buildDigestHTML(zones, nil, 1, false)
 
 	if got := strings.Count(html, `width="600"`); got != 1 {
 		t.Errorf("expected exactly one 600-wide table, got %d in:\n%s", got, html)

--- a/api-go/internal/digest/email_test.go
+++ b/api-go/internal/digest/email_test.go
@@ -292,3 +292,47 @@ func TestBuildDigestHTML_StructuralSafety(t *testing.T) {
 		t.Errorf("expected an unsubscribe link, got:\n%s", html)
 	}
 }
+
+// --- Free-tier account-status line (tc-m1pb5) ---
+
+func TestBuildDigestHTML_FreeTierNotice_ShownAndPositionedAboveCTA(t *testing.T) {
+	t.Parallel()
+	html := buildDigestHTML(nil, nil, 0, true)
+
+	if !strings.Contains(html, "You&#39;re on the free weekly digest.") {
+		t.Errorf("expected the free-tier notice copy (apostrophe HTML-encoded), got:\n%s", html)
+	}
+	if !strings.Contains(html, `data-testid="digest-free-tier-notice"`) {
+		t.Errorf("expected the free-tier notice testid, got:\n%s", html)
+	}
+
+	noticeIdx := strings.Index(html, `data-testid="digest-free-tier-notice"`)
+	ctaIdx := strings.Index(html, "Open Town Crier")
+	if noticeIdx == -1 || ctaIdx == -1 || noticeIdx > ctaIdx {
+		t.Fatalf("free-tier notice must render above the Open Town Crier CTA, notice=%d cta=%d in:\n%s", noticeIdx, ctaIdx, html)
+	}
+
+	// The notice must not introduce a new anchor tag: extract just its row and
+	// confirm no <a> lives inside it. It leans on the existing CTA button
+	// beneath it instead of linking itself.
+	rowEnd := strings.Index(html[noticeIdx:], "</tr>")
+	if rowEnd == -1 {
+		t.Fatalf("could not find closing </tr> for the free-tier notice row in:\n%s", html)
+	}
+	noticeRow := html[noticeIdx : noticeIdx+rowEnd]
+	if strings.Contains(noticeRow, "<a ") || strings.Contains(noticeRow, "<a>") {
+		t.Errorf("free-tier notice must not itself be a link, got row:\n%s", noticeRow)
+	}
+}
+
+func TestBuildDigestHTML_FreeTierNotice_HiddenWhenNotRequested(t *testing.T) {
+	t.Parallel()
+	html := buildDigestHTML(nil, nil, 0, false)
+
+	if strings.Contains(html, "free weekly digest") {
+		t.Errorf("paid-tier digest must not show the free-tier notice copy, got:\n%s", html)
+	}
+	if strings.Contains(html, `data-testid="digest-free-tier-notice"`) {
+		t.Errorf("paid-tier digest must not render the free-tier notice row at all, got:\n%s", html)
+	}
+}

--- a/api-go/internal/digest/handler.go
+++ b/api-go/internal/digest/handler.go
@@ -172,9 +172,13 @@ func (h *Handler) RunWeekly(ctx context.Context) error {
 			// The weekly cycle does not track emailSent (it re-derives the digest from
 			// the look-back window each run), so a failed send is already logged inside
 			// sendDigestEmail; we just move on to the next user.
-			// TODO(tc-m1pb5): wire the real Free-tier check here; a following TDD
-			// cycle drives this via a failing handler-level test.
-			if err := h.sendDigestEmail(ctx, emailKindWeekly, profile.UserID, *profile.Email, notifs, false); err != nil {
+			// The free-tier account-status line is Free-tier only (tc-m1pb5):
+			// IsPaid() covers every paid tier (Personal and Pro alike), not just
+			// Pro — a Personal subscriber must never see "You're on the free
+			// weekly digest." A lapsed paid tier reads as Free via EffectiveTier
+			// and correctly sees the line too.
+			showFreeTierNotice := !profile.EffectiveTier(now).IsPaid()
+			if err := h.sendDigestEmail(ctx, emailKindWeekly, profile.UserID, *profile.Email, notifs, showFreeTierNotice); err != nil {
 				continue
 			}
 		}

--- a/api-go/internal/digest/handler.go
+++ b/api-go/internal/digest/handler.go
@@ -172,7 +172,9 @@ func (h *Handler) RunWeekly(ctx context.Context) error {
 			// The weekly cycle does not track emailSent (it re-derives the digest from
 			// the look-back window each run), so a failed send is already logged inside
 			// sendDigestEmail; we just move on to the next user.
-			if err := h.sendDigestEmail(ctx, emailKindWeekly, profile.UserID, *profile.Email, notifs); err != nil {
+			// TODO(tc-m1pb5): wire the real Free-tier check here; a following TDD
+			// cycle drives this via a failing handler-level test.
+			if err := h.sendDigestEmail(ctx, emailKindWeekly, profile.UserID, *profile.Email, notifs, false); err != nil {
 				continue
 			}
 		}
@@ -298,7 +300,10 @@ func (h *Handler) RunHourly(ctx context.Context) error {
 		// batches every included notification for this user, so a failed send must
 		// leave the whole batch unmarked for the next cycle to retry. Marking on a
 		// swallowed send error is silent data loss (tc-qvds).
-		if err := h.sendDigestEmail(ctx, emailKindHourly, userID, *profile.Email, included); err != nil {
+		// The hourly digest never shows the free-tier notice: it is a paid-only
+		// entitlement (RunHourly already excludes Free tier above), and the line
+		// is scoped to the weekly cycle only (tc-m1pb5).
+		if err := h.sendDigestEmail(ctx, emailKindHourly, userID, *profile.Email, included, false); err != nil {
 			continue
 		}
 
@@ -355,8 +360,11 @@ func markSent(n notifications.DigestNotification) notifications.DigestNotificati
 // never retried — tc-qvds), while the weekly cycle simply moves on to the next
 // user. A failed email never aborts the rest of the cycle either way. kind is
 // the "Email send" span's email.kind tag (emailKindWeekly / emailKindHourly),
-// distinguishing the two cycles that share this method.
-func (h *Handler) sendDigestEmail(ctx context.Context, kind, userID, email string, notifs []notifications.DigestNotification) error {
+// distinguishing the two cycles that share this method. showFreeTierNotice
+// controls the "You're on the free weekly digest." line (tc-m1pb5); the
+// hourly cycle always passes false (it is paid-only anyway), so only
+// RunWeekly ever shows it.
+func (h *Handler) sendDigestEmail(ctx context.Context, kind, userID, email string, notifs []notifications.DigestNotification, showFreeTierNotice bool) error {
 	zones, err := h.zones.GetByUserID(ctx, userID)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "digest email: load zones failed", "user", userID, "error", err)
@@ -374,7 +382,7 @@ func (h *Handler) sendDigestEmail(ctx context.Context, kind, userID, email strin
 		Sender:    senderAddress,
 		Recipient: email,
 		Subject:   buildDigestSubject(total),
-		HTMLBody:  buildDigestHTML(sections, saved, total),
+		HTMLBody:  buildDigestHTML(sections, saved, total, showFreeTierNotice),
 	}
 	if err := h.email.Send(ctx, kind, msg); err != nil {
 		h.logger.ErrorContext(ctx, "digest email: send failed", "user", userID, "error", err)

--- a/api-go/internal/digest/handler_test.go
+++ b/api-go/internal/digest/handler_test.go
@@ -763,6 +763,168 @@ func TestRunWeekly_DuplicatePairCollapsesPushCountToUniqueApplications(t *testin
 	}
 }
 
+// ---- free-tier account-status line (tc-m1pb5) ----
+
+const freeTierNoticeSnippet = "free weekly digest"
+
+func TestRunWeekly_FreeTierEmailIncludesFreeTierNotice(t *testing.T) {
+	t.Parallel()
+	prefs := profiles.DefaultPreferences()
+	prefs.EmailDigestEnabled = true
+	p := mkProfile(t, profiles.TierFree, prefs)
+
+	fp := &fakeProfiles{byDay: map[time.Weekday][]*profiles.UserProfile{time.Wednesday: {p}}}
+	fn := &fakeNotifications{sinceByUser: map[string][]notifications.DigestNotification{
+		"user-1": {zoneNotif("uid-A", "zone-1")},
+	}}
+	fz := &fakeZones{byUser: map[string][]watchzones.WatchZone{
+		"user-1": {mkZone(t, "zone-1", "Home", true)},
+	}}
+	email := &spyEmail{}
+	h := newHandler(fp, fn, fz, &fakeState{}, &fakeDevices{}, email, &spyPush{})
+
+	if err := h.RunWeekly(context.Background()); err != nil {
+		t.Fatalf("RunWeekly: %v", err)
+	}
+	if len(email.sent) != 1 {
+		t.Fatalf("emails sent: got %d, want 1", len(email.sent))
+	}
+	if !contains(email.sent[0].HTMLBody, freeTierNoticeSnippet) {
+		t.Errorf("Free tier weekly digest should show the free-tier notice, got:\n%s", email.sent[0].HTMLBody)
+	}
+}
+
+// TestRunWeekly_PersonalTierEmailExcludesFreeTierNotice guards the exact
+// regression this bead exists to prevent: Personal is a real, paid,
+// purchasable tier (uk.towncrierapp.personal.monthly). Deriving the notice
+// from IsPaidPro() (Pro-only) instead of IsPaid() (any paid tier) would show
+// paying Personal subscribers "You're on the free weekly digest.", which
+// directly violates "paid users' emails are unchanged".
+func TestRunWeekly_PersonalTierEmailExcludesFreeTierNotice(t *testing.T) {
+	t.Parallel()
+	prefs := profiles.DefaultPreferences()
+	prefs.EmailDigestEnabled = true
+	p := mkProfile(t, profiles.TierPersonal, prefs)
+
+	fp := &fakeProfiles{byDay: map[time.Weekday][]*profiles.UserProfile{time.Wednesday: {p}}}
+	fn := &fakeNotifications{sinceByUser: map[string][]notifications.DigestNotification{
+		"user-1": {zoneNotif("uid-A", "zone-1")},
+	}}
+	fz := &fakeZones{byUser: map[string][]watchzones.WatchZone{
+		"user-1": {mkZone(t, "zone-1", "Home", true)},
+	}}
+	email := &spyEmail{}
+	h := newHandler(fp, fn, fz, &fakeState{}, &fakeDevices{}, email, &spyPush{})
+
+	if err := h.RunWeekly(context.Background()); err != nil {
+		t.Fatalf("RunWeekly: %v", err)
+	}
+	if len(email.sent) != 1 {
+		t.Fatalf("emails sent: got %d, want 1", len(email.sent))
+	}
+	if contains(email.sent[0].HTMLBody, freeTierNoticeSnippet) {
+		t.Errorf("Personal (paid) tier weekly digest must NOT show the free-tier notice, got:\n%s", email.sent[0].HTMLBody)
+	}
+}
+
+func TestRunWeekly_ProTierEmailExcludesFreeTierNotice(t *testing.T) {
+	t.Parallel()
+	prefs := profiles.DefaultPreferences()
+	prefs.EmailDigestEnabled = true
+	prefs.PushEnabled = false
+	p := mkProfile(t, profiles.TierPro, prefs)
+
+	fp := &fakeProfiles{byDay: map[time.Weekday][]*profiles.UserProfile{time.Wednesday: {p}}}
+	fn := &fakeNotifications{sinceByUser: map[string][]notifications.DigestNotification{
+		"user-1": {zoneNotif("uid-A", "zone-1")},
+	}}
+	fz := &fakeZones{byUser: map[string][]watchzones.WatchZone{
+		"user-1": {mkZone(t, "zone-1", "Home", true)},
+	}}
+	email := &spyEmail{}
+	h := newHandler(fp, fn, fz, &fakeState{}, &fakeDevices{}, email, &spyPush{})
+
+	if err := h.RunWeekly(context.Background()); err != nil {
+		t.Fatalf("RunWeekly: %v", err)
+	}
+	if len(email.sent) != 1 {
+		t.Fatalf("emails sent: got %d, want 1", len(email.sent))
+	}
+	if contains(email.sent[0].HTMLBody, freeTierNoticeSnippet) {
+		t.Errorf("Pro tier weekly digest must NOT show the free-tier notice, got:\n%s", email.sent[0].HTMLBody)
+	}
+}
+
+func TestRunWeekly_ExpiredProTierEmailIncludesFreeTierNotice(t *testing.T) {
+	t.Parallel()
+	// A lapsed Pro subscription reads as Free via EffectiveTier and correctly
+	// sees the notice, same as any other Free-tier recipient.
+	prefs := profiles.DefaultPreferences()
+	prefs.EmailDigestEnabled = true
+	prefs.PushEnabled = false
+	p := mkProfile(t, profiles.TierPro, prefs)
+	past := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) // before the harness clock (2026-02-04)
+	p.SubscriptionExpiry = &past
+
+	fp := &fakeProfiles{byDay: map[time.Weekday][]*profiles.UserProfile{time.Wednesday: {p}}}
+	fn := &fakeNotifications{sinceByUser: map[string][]notifications.DigestNotification{
+		"user-1": {zoneNotif("uid-A", "zone-1")},
+	}}
+	fz := &fakeZones{byUser: map[string][]watchzones.WatchZone{
+		"user-1": {mkZone(t, "zone-1", "Home", true)},
+	}}
+	email := &spyEmail{}
+	h := newHandler(fp, fn, fz, &fakeState{}, &fakeDevices{}, email, &spyPush{})
+
+	if err := h.RunWeekly(context.Background()); err != nil {
+		t.Fatalf("RunWeekly: %v", err)
+	}
+	if len(email.sent) != 1 {
+		t.Fatalf("emails sent: got %d, want 1", len(email.sent))
+	}
+	if !contains(email.sent[0].HTMLBody, freeTierNoticeSnippet) {
+		t.Errorf("lapsed Pro tier (reads as Free) weekly digest should show the free-tier notice, got:\n%s", email.sent[0].HTMLBody)
+	}
+}
+
+func TestRunHourly_NeverIncludesFreeTierNoticeRegardlessOfTier(t *testing.T) {
+	t.Parallel()
+	// The free-tier notice is weekly-only. Hourly is already paid-only
+	// (Free is skipped entirely — TestRunHourly_FreeTierSkipped), so exercise
+	// both paid tiers the hourly cycle can actually reach and confirm neither
+	// ever renders the notice.
+	for _, tier := range []profiles.SubscriptionTier{profiles.TierPersonal, profiles.TierPro} {
+		tier := tier
+		t.Run(tier.String(), func(t *testing.T) {
+			t.Parallel()
+			prefs := profiles.DefaultPreferences()
+			prefs.EmailDigestEnabled = true
+			p := mkProfile(t, tier, prefs)
+
+			fp := &fakeProfiles{byID: map[string]*profiles.UserProfile{"user-1": p}}
+			fn := &fakeNotifications{
+				unsentUserIDs: []string{"user-1"},
+				unsentByUser:  map[string][]notifications.DigestNotification{"user-1": {zoneNotif("uid-A", "zone-1")}},
+			}
+			fz := &fakeZones{byUser: map[string][]watchzones.WatchZone{
+				"user-1": {mkZone(t, "zone-1", "Home", true)},
+			}}
+			email := &spyEmail{}
+			h := newHandler(fp, fn, fz, &fakeState{}, &fakeDevices{}, email, &spyPush{})
+
+			if err := h.RunHourly(context.Background()); err != nil {
+				t.Fatalf("RunHourly: %v", err)
+			}
+			if len(email.sent) != 1 {
+				t.Fatalf("emails sent: got %d, want 1", len(email.sent))
+			}
+			if contains(email.sent[0].HTMLBody, freeTierNoticeSnippet) {
+				t.Errorf("hourly digest must never show the free-tier notice, got:\n%s", email.sent[0].HTMLBody)
+			}
+		})
+	}
+}
+
 func TestRunHourly_DistinctApplicationsStillBothRenderAndBothMarkSent(t *testing.T) {
 	t.Parallel()
 	// Regression guard: dedup must only collapse genuine duplicates. Two

--- a/api-go/internal/digest/handler_test.go
+++ b/api-go/internal/digest/handler_test.go
@@ -894,7 +894,6 @@ func TestRunHourly_NeverIncludesFreeTierNoticeRegardlessOfTier(t *testing.T) {
 	// both paid tiers the hourly cycle can actually reach and confirm neither
 	// ever renders the notice.
 	for _, tier := range []profiles.SubscriptionTier{profiles.TierPersonal, profiles.TierPro} {
-		tier := tier
 		t.Run(tier.String(), func(t *testing.T) {
 			t.Parallel()
 			prefs := profiles.DefaultPreferences()


### PR DESCRIPTION
Adds a one-line account-status notice to the weekly digest email, shown to Free-tier recipients only:

> You're on the free weekly digest.

It renders directly above the existing "Open Town Crier" button. Paid-tier emails are unchanged.

## Why it is worded this way

The original ask was an upsell ("want these instantly? sign up for a paid tier"). That was rejected. Our published Privacy Policy (`api-go/internal/legal/resources/privacy.json`, served at `/v1/legal/privacy` and mirrored into the iOS app) states verbatim:

> "We do not process any data on the basis of consent, we do not make automated decisions with legal effects on you, and we do not send marketing email."

The ICO treats a service message carrying promotional content as a marketing message for PECR purposes, so a pitch would have made that sentence false and pulled the digest under PECR. A neutral statement of the reader's own plan is service information, not promotion, so the digest stays a service message.

Three constraints follow from that, and they are load-bearing rather than stylistic:

1. The line is **not a link** and never becomes one. A test asserts no anchor tag inside the notice row.
2. It **never points at a paywall, pricing, or plans page**. Status line plus "View Plans" is a promotion with a fig leaf. It leans on the existing CTA to `/applications`.
3. **No tracking was added**: no open pixel, no click-wrapped URL, no UTM params, no analytics. If conversion is ever measured, do it server-side via tier transitions.

## Tier selection

Gated on `!profile.EffectiveTier(now).IsPaid()`, **not** `IsPaidPro()`.

There are three tiers. `IsPaid()` is `t != TierFree`; `IsPaidPro()` is `t == TierPro` and is deliberately scoped to the Pro-only weekly push. Using `IsPaidPro()` would have told every Personal (£1.99/mo) subscriber they were on the free tier. `TestRunWeekly_PersonalTierEmailExcludesFreeTierNotice` guards that specifically.

A lapsed paid tier reads as Free via `EffectiveTier` and correctly sees the line.

The hourly digest shares `sendDigestEmail` and hardcodes `false`: it is a paid-only entitlement, and the line is weekly-only.

## Testing

Seven new tests covering all three tiers by name, plus lapsed-Pro and the hourly exclusion:

- Free shows it, Personal does not, Pro does not
- Lapsed Pro (reads Free) shows it
- Hourly never shows it regardless of tier
- Renders above the CTA, and introduces no new anchor tag
- Hidden entirely when not requested

Gates: `gofmt` clean, `go build`, `go vet`, `go test ./...` 2001 passed, `-race` clean, `golangci-lint` no issues.

Verified by sending both variants through the real ACS sender to a personal inbox and reading them in a mail client, not just a browser render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MMbXpb6ymd8DnW4QgdCY4Q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Weekly digest emails now display a free-tier account-status notice when applicable.
  * The notice appears above the “Open Town Crier” call to action and is omitted for paid accounts.
  * Hourly digest emails continue to exclude this notice.

* **Tests**
  * Added coverage for free-tier, paid, expired, weekly, and hourly digest scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->