### PR TITLE
seo: un-orphan /planning/towns and put the hub in breadcrumbs (tc-3ht16)

### DIFF
--- a/web/scripts/lib/__tests__/render-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-page.test.mjs
@@ -89,8 +89,8 @@ describe('renderPlanningPage', () => {
     expect(html).toContain('"@type":"ItemList"');
   });
 
-  describe('breadcrumb (tc-r4n9.4)', () => {
-    it('renders a visible breadcrumb with exactly two levels: Home, then the authority (no grandparent level)', () => {
+  describe('breadcrumb (tc-r4n9.4, extended to include the /planning hub tc-3ht16)', () => {
+    it('renders a visible breadcrumb with exactly three levels: Home, the hub, then the authority', () => {
       const html = renderPlanningPage(pageData());
       const nav = html.match(
         /<nav class="breadcrumb" aria-label="Breadcrumb">[\s\S]*?<\/nav>/,
@@ -98,8 +98,11 @@ describe('renderPlanningPage', () => {
       expect(nav).not.toBeNull();
       const [navHtml] = nav;
       const liCount = (navHtml.match(/<li/g) ?? []).length;
-      expect(liCount).toBe(2);
+      expect(liCount).toBe(3);
       expect(navHtml).toContain('<li><a href="/">Town Crier</a></li>');
+      expect(navHtml).toContain(
+        '<li><a href="/planning">Planning applications</a></li>',
+      );
       expect(navHtml).toContain('<li>Basingstoke and Deane</li>');
       // The current page is plain text, not a self-link (matches the town-page pattern).
       expect(navHtml).not.toContain('<a href="/planning/basingstoke-and-deane"');
@@ -123,7 +126,7 @@ describe('renderPlanningPage', () => {
       expect(html).toContain('<li>Stoke &amp; &lt;b&gt;Bramley&lt;/b&gt;</li>');
     });
 
-    it('embeds a two-item BreadcrumbList in the schema.org JSON-LD, alongside the ItemList and Dataset', () => {
+    it('embeds a three-item BreadcrumbList in the schema.org JSON-LD, alongside the ItemList and Dataset', () => {
       const html = renderPlanningPage(pageData());
       expect(html).toContain('"@type":"BreadcrumbList"');
       const ld = html.match(
@@ -144,10 +147,64 @@ describe('renderPlanningPage', () => {
         {
           '@type': 'ListItem',
           position: 2,
+          name: 'Planning applications',
+          item: `${SITE_ORIGIN}/planning`,
+        },
+        {
+          '@type': 'ListItem',
+          position: 3,
           name: 'Basingstoke and Deane',
           item: `${SITE_ORIGIN}/planning/basingstoke-and-deane`,
         },
       ]);
+    });
+
+    it('carries the same name sequence, and the same hrefs for every linked crumb, in the visible breadcrumb and the JSON-LD BreadcrumbList', () => {
+      const html = renderPlanningPage(pageData());
+      const navHtml = html.match(
+        /<nav class="breadcrumb" aria-label="Breadcrumb">[\s\S]*?<\/nav>/,
+      )[0];
+      const visibleNames = [
+        ...navHtml.matchAll(/<li>(?:<a[^>]*>)?([^<]+)(?:<\/a>)?<\/li>/g),
+      ].map((m) => m[1]);
+      const visibleLinkedHrefs = [
+        ...navHtml.matchAll(/<li><a href="([^"]+)">/g),
+      ].map((m) => m[1]);
+
+      const [, json] = html.match(
+        /<script type="application\/ld\+json">([\s\S]*?)<\/script>/,
+      );
+      const breadcrumb = JSON.parse(json).find(
+        (entry) => entry['@type'] === 'BreadcrumbList',
+      );
+      const jsonLdNames = breadcrumb.itemListElement.map((entry) => entry.name);
+      // The final crumb (the current page) is plain text in the visible nav, so
+      // only the LINKED crumbs need matching hrefs.
+      const jsonLdLinkedHrefs = breadcrumb.itemListElement
+        .slice(0, -1)
+        .map((entry) => entry.item.replace(SITE_ORIGIN, ''));
+
+      expect(visibleNames).toEqual(jsonLdNames);
+      expect(visibleLinkedHrefs).toEqual(jsonLdLinkedHrefs);
+    });
+  });
+
+  describe('towns-index cross-link (tc-3ht16, GH #990 slice 1)', () => {
+    it('links to /planning/towns when the authority has published towns', () => {
+      const html = renderPlanningPage(
+        pageData({ towns: [{ name: 'Basingstoke', slug: 'basingstoke' }] }),
+      );
+      expect(html).toContain('href="/planning/towns"');
+    });
+
+    it('still links to /planning/towns when the authority has zero published towns (the 29-authority case)', () => {
+      const html = renderPlanningPage(pageData({ towns: [] }));
+      expect(html).toContain('href="/planning/towns"');
+    });
+
+    it('also links to the /planning hub', () => {
+      const html = renderPlanningPage(pageData());
+      expect(html).toContain('href="/planning"');
     });
   });
 

--- a/web/scripts/lib/__tests__/render-planning-index.test.mjs
+++ b/web/scripts/lib/__tests__/render-planning-index.test.mjs
@@ -122,6 +122,23 @@ describe('renderPlanningIndexPage', () => {
     ]);
   });
 
+  describe('towns-index cross-link (tc-3ht16, GH #990 slice 1)', () => {
+    it('links to /planning/towns', () => {
+      const html = renderPlanningIndexPage(indexData());
+      expect(html).toContain('href="/planning/towns"');
+    });
+
+    it('places the cross-link near the lead paragraph, above the A-Z letter sections', () => {
+      const html = renderPlanningIndexPage(indexData());
+      expect(html.indexOf('class="lead"')).toBeLessThan(
+        html.indexOf('href="/planning/towns"'),
+      );
+      expect(html.indexOf('href="/planning/towns"')).toBeLessThan(
+        html.indexOf('class="hubGroup"'),
+      );
+    });
+  });
+
   describe('A-Z grouping', () => {
     it('groups authorities under their first-letter heading', () => {
       const html = renderPlanningIndexPage(indexData());

--- a/web/scripts/lib/__tests__/render-shared.test.mjs
+++ b/web/scripts/lib/__tests__/render-shared.test.mjs
@@ -7,6 +7,7 @@ import {
   renderInlineCta,
   renderMidListCta,
   renderQrBlock,
+  renderPlanningCrossLinks,
   pageStyles,
 } from '../render-shared.mjs';
 import { ATTRIBUTION_LINES } from '../constants.mjs';
@@ -390,6 +391,27 @@ describe('renderAttributionList', () => {
     // HTML in a line is escaped so data can never inject markup.
     expect(html).toContain('<li>Line two &amp; &lt;b&gt;bold&lt;/b&gt;</li>');
     expect((html.match(/<li>/g) ?? []).length).toBe(2);
+  });
+});
+
+describe('renderPlanningCrossLinks (tc-3ht16, GH #990 slice 1: un-orphan /planning/towns)', () => {
+  it('renders a real, crawlable link to /planning/towns', () => {
+    const html = renderPlanningCrossLinks();
+    expect(html).toContain('class="crossLinks"');
+    expect(html).toContain('<a class="crossLinks__link" href="/planning/towns">');
+    expect(html).not.toContain('onclick');
+  });
+
+  it('takes no arguments, so both the hub and every authority page render byte-identical markup', () => {
+    expect(renderPlanningCrossLinks()).toBe(renderPlanningCrossLinks());
+  });
+});
+
+describe('pageStyles cross-link (tc-3ht16)', () => {
+  it('styles the towns-index cross-link as an amber text link, not a filled pill', () => {
+    const css = pageStyles();
+    expect(css).toMatch(/\.crossLinks__link \{[^}]*color: var\(--tc-amber\)/);
+    expect(css).not.toMatch(/\.crossLinks__link \{[^}]*background: var\(--tc-amber\)/);
   });
 });
 

--- a/web/scripts/lib/__tests__/render-town-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-town-page.test.mjs
@@ -104,9 +104,30 @@ describe('renderTownPage', () => {
         '<li><a href="/planning">Planning applications</a></li>',
       );
       expect(navHtml).toContain(
-        `<li><a href="${SITE_ORIGIN}/planning/cornwall">Cornwall</a></li>`,
+        '<li><a href="/planning/cornwall">Cornwall</a></li>',
       );
       expect(navHtml).toContain('<li>Truro</li>');
+    });
+
+    it('links the visible authority crumb with a site-relative href, not the absolute JSON-LD url (so it never jumps off-host on a non-prod origin)', () => {
+      const html = renderTownPage(townData());
+      const navHtml = html.match(
+        /<nav class="breadcrumb" aria-label="Breadcrumb">[\s\S]*?<\/nav>/,
+      )[0];
+      expect(navHtml).toContain('href="/planning/cornwall"');
+      expect(navHtml).not.toContain(`href="${SITE_ORIGIN}/planning/cornwall"`);
+      // The JSON-LD BreadcrumbList `item` is still the full absolute url — only
+      // the VISIBLE nav link is relative, matching every sibling crumb.
+      const [, json] = html.match(
+        /<script type="application\/ld\+json">([\s\S]*?)<\/script>/,
+      );
+      const breadcrumb = JSON.parse(json).find(
+        (entry) => entry['@type'] === 'BreadcrumbList',
+      );
+      const authorityEntry = breadcrumb.itemListElement.find(
+        (entry) => entry.name === 'Cornwall',
+      );
+      expect(authorityEntry.item).toBe(`${SITE_ORIGIN}/planning/cornwall`);
     });
 
     it('embeds a four-item BreadcrumbList in the schema.org JSON-LD', () => {

--- a/web/scripts/lib/__tests__/render-town-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-town-page.test.mjs
@@ -89,12 +89,96 @@ describe('renderTownPage', () => {
     expect(html).toContain('"@type":"BreadcrumbList"');
   });
 
-  it('renders a breadcrumb linking up to the authority page', () => {
-    const html = renderTownPage(townData());
-    expect(html).toContain('class="breadcrumb"');
-    expect(html).toContain(`href="${SITE_ORIGIN}/planning/cornwall"`);
-    // The breadcrumb names the parent authority.
-    expect(html).toMatch(/breadcrumb[\s\S]*?Cornwall/);
+  describe('breadcrumb (tc-3ht16, GH #990 slice 2: includes the /planning hub)', () => {
+    it('renders a visible breadcrumb with exactly four levels: Home, the hub, the authority, then the town', () => {
+      const html = renderTownPage(townData());
+      const nav = html.match(
+        /<nav class="breadcrumb" aria-label="Breadcrumb">[\s\S]*?<\/nav>/,
+      );
+      expect(nav).not.toBeNull();
+      const [navHtml] = nav;
+      const liCount = (navHtml.match(/<li/g) ?? []).length;
+      expect(liCount).toBe(4);
+      expect(navHtml).toContain('<li><a href="/">Town Crier</a></li>');
+      expect(navHtml).toContain(
+        '<li><a href="/planning">Planning applications</a></li>',
+      );
+      expect(navHtml).toContain(
+        `<li><a href="${SITE_ORIGIN}/planning/cornwall">Cornwall</a></li>`,
+      );
+      expect(navHtml).toContain('<li>Truro</li>');
+    });
+
+    it('embeds a four-item BreadcrumbList in the schema.org JSON-LD', () => {
+      const html = renderTownPage(townData());
+      const ld = html.match(
+        /<script type="application\/ld\+json">([\s\S]*?)<\/script>/,
+      );
+      expect(ld).not.toBeNull();
+      const [, json] = ld;
+      const parsed = JSON.parse(json);
+      const breadcrumb = parsed.find((entry) => entry['@type'] === 'BreadcrumbList');
+      expect(breadcrumb).toBeDefined();
+      expect(breadcrumb.itemListElement).toEqual([
+        {
+          '@type': 'ListItem',
+          position: 1,
+          name: 'Town Crier',
+          item: `${SITE_ORIGIN}/`,
+        },
+        {
+          '@type': 'ListItem',
+          position: 2,
+          name: 'Planning applications',
+          item: `${SITE_ORIGIN}/planning`,
+        },
+        {
+          '@type': 'ListItem',
+          position: 3,
+          name: 'Cornwall',
+          item: `${SITE_ORIGIN}/planning/cornwall`,
+        },
+        {
+          '@type': 'ListItem',
+          position: 4,
+          name: 'Truro',
+          item: `${SITE_ORIGIN}/planning/cornwall/truro`,
+        },
+      ]);
+    });
+
+    it('carries the same name sequence, and the same hrefs for every linked crumb, in the visible breadcrumb and the JSON-LD BreadcrumbList', () => {
+      const html = renderTownPage(townData());
+      const navHtml = html.match(
+        /<nav class="breadcrumb" aria-label="Breadcrumb">[\s\S]*?<\/nav>/,
+      )[0];
+      // The authority crumb's visible href is absolute (authorityCanonical);
+      // the Home/hub crumbs are site-relative. Normalise both sides the same
+      // way before comparing so an origin-qualified href and its relative
+      // equivalent aren't treated as a mismatch.
+      const normalize = (href) =>
+        href.startsWith(SITE_ORIGIN) ? href.slice(SITE_ORIGIN.length) : href;
+      const visibleNames = [
+        ...navHtml.matchAll(/<li>(?:<a[^>]*>)?([^<]+)(?:<\/a>)?<\/li>/g),
+      ].map((m) => m[1]);
+      const visibleLinkedHrefs = [
+        ...navHtml.matchAll(/<li><a href="([^"]+)">/g),
+      ].map((m) => normalize(m[1]));
+
+      const [, json] = html.match(
+        /<script type="application\/ld\+json">([\s\S]*?)<\/script>/,
+      );
+      const breadcrumb = JSON.parse(json).find(
+        (entry) => entry['@type'] === 'BreadcrumbList',
+      );
+      const jsonLdNames = breadcrumb.itemListElement.map((entry) => entry.name);
+      const jsonLdLinkedHrefs = breadcrumb.itemListElement
+        .slice(0, -1)
+        .map((entry) => normalize(entry.item));
+
+      expect(visibleNames).toEqual(jsonLdNames);
+      expect(visibleLinkedHrefs).toEqual(jsonLdLinkedHrefs);
+    });
   });
 
   it('renders each application address as the headline and status label', () => {

--- a/web/scripts/lib/render-page.mjs
+++ b/web/scripts/lib/render-page.mjs
@@ -9,6 +9,7 @@ import {
   renderInlineCta,
   renderQrBlock,
   renderAttributionList,
+  renderPlanningCrossLinks,
 } from './render-shared.mjs';
 
 /**
@@ -100,14 +101,22 @@ function buildJsonLd(data, canonical) {
     license:
       'https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/',
   };
-  // An authority page has no parent above it (unlike a town page, which climbs
-  // Home -> Authority -> Town), so this trail is two levels: Home -> Authority.
+  // Mirrors the visible three-level trail (tc-3ht16): Home -> the /planning hub
+  // -> this authority. Matches the hub's own self-referential "Planning
+  // applications" label (render-planning-index.mjs's buildJsonLd) exactly, so
+  // the label is consistent site-wide.
   const breadcrumb = {
     '@context': 'https://schema.org',
     '@type': 'BreadcrumbList',
     itemListElement: [
       { '@type': 'ListItem', position: 1, name: 'Town Crier', item: `${SITE_ORIGIN}/` },
-      { '@type': 'ListItem', position: 2, name: data.areaName, item: canonical },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: 'Planning applications',
+        item: `${SITE_ORIGIN}/planning`,
+      },
+      { '@type': 'ListItem', position: 3, name: data.areaName, item: canonical },
     ],
   };
   // Escape "<" so a malicious data value can never close the <script> element.
@@ -175,6 +184,7 @@ ${pageStyles()}
       <nav class="breadcrumb" aria-label="Breadcrumb">
         <ol>
           <li><a href="/">Town Crier</a></li>
+          <li><a href="/planning">Planning applications</a></li>
           <li>${area}</li>
         </ol>
       </nav>
@@ -183,6 +193,7 @@ ${pageStyles()}
         ${dataUpdated}
         <p class="lead">${lead}</p>
 ${renderInlineCta(data.areaName, appStoreUrl('seo-lpa-inline'))}
+${renderPlanningCrossLinks()}
 
 ${renderStatusSummary(data.statusBreakdown)}
 

--- a/web/scripts/lib/render-planning-index.mjs
+++ b/web/scripts/lib/render-planning-index.mjs
@@ -16,7 +16,12 @@
 
 import { SITE_ORIGIN, APPLE_APP_ID, appStoreUrl } from './constants.mjs';
 import { escapeHtml } from './format.mjs';
-import { pageStyles, renderInlineCta, renderAttributionList } from './render-shared.mjs';
+import {
+  pageStyles,
+  renderInlineCta,
+  renderAttributionList,
+  renderPlanningCrossLinks,
+} from './render-shared.mjs';
 
 /**
  * @typedef {Object} PlanningIndexEntry
@@ -234,6 +239,7 @@ ${pageStyles()}
         <h1>Planning applications by council</h1>
         <p class="lead">Browse recent planning applications for ${count} ${authoritiesNoun} across the UK.</p>
 ${renderInlineCta('your council', storeHref)}
+${renderPlanningCrossLinks()}
 ${letterNav}
 ${letterSections}
 

--- a/web/scripts/lib/render-shared.mjs
+++ b/web/scripts/lib/render-shared.mjs
@@ -335,6 +335,31 @@ export function renderInlineCta(area, storeHref) {
 }
 
 /**
+ * Render the unconditional cross-link to the `/planning/towns` index
+ * (tc-3ht16, GH #990 slice 1). `/planning/towns` links out to all 1,307
+ * published town pages but had zero inbound links of its own, which is the
+ * root cause of 80 pages sitting "Discovered - currently not indexed" in
+ * Search Console. This single link is what un-orphans it.
+ *
+ * Shared between the `/planning` hub (`render-planning-index.mjs`) and every
+ * authority page (`render-page.mjs`), where it must render even for the 29
+ * authorities with zero published towns of their own (the conditional
+ * `renderTownLinks()` section in `render-page.mjs` returns `''` for those, so
+ * this helper is deliberately separate and unconditional). `/planning/towns`
+ * is a static route that always publishes a page (even a "no towns yet" one,
+ * see `render-towns-index.mjs`), so this link can never point at a 404.
+ * Takes no arguments: the copy and target are identical on every page it
+ * appears on.
+ *
+ * @returns {string}
+ */
+export function renderPlanningCrossLinks() {
+  return `        <p class="crossLinks">
+          <a class="crossLinks__link" href="/planning/towns">See planning applications by town →</a>
+        </p>`;
+}
+
+/**
  * Render the QR block for the bottom CTA banner (tc-fgoyj). Hidden on touch
  * devices by the stylesheet (see `.cta__qr`) and shown only where the primary
  * pointer is a mouse/trackpad: a desktop visitor who clicks the App Store link
@@ -596,6 +621,11 @@ export function pageStyles() {
       font-weight: 700;
     }
     .ctaInline__button:hover { background: var(--tc-amber-hover); }
+    /* Towns-index cross-link (tc-3ht16): a lightweight text link, not a
+       filled pill — secondary to the inline alerts CTA above it. */
+    .crossLinks { margin: 0 0 var(--tc-space-lg); }
+    .crossLinks__link { color: var(--tc-amber); font-weight: 600; text-decoration: none; }
+    .crossLinks__link:hover { color: var(--tc-amber-hover); text-decoration: underline; }
     /* ---------- CTA bands: filed-notice card shape, 2px brass top rule,
        display-font heading, one brass button — mid-list pitch (tc-fgoyj) and
        bottom banner both use this treatment. ---------- */

--- a/web/scripts/lib/render-town-page.mjs
+++ b/web/scripts/lib/render-town-page.mjs
@@ -123,6 +123,12 @@ export function renderTownPage(data) {
   const authority = escapeHtml(data.authorityName);
   const canonical = `${SITE_ORIGIN}/planning/${data.authoritySlug}/${data.townSlug}`;
   const authorityCanonical = `${SITE_ORIGIN}/planning/${data.authoritySlug}`;
+  // Site-relative path for the VISIBLE breadcrumb link only — every sibling
+  // crumb (Home, the /planning hub) is relative, so this one must be too, or
+  // it jumps off-host on any non-prod origin (local preview, dev, staging).
+  // `authorityCanonical` stays absolute for the JSON-LD BreadcrumbList `item`,
+  // which schema.org expects as a full url.
+  const authorityPath = `/planning/${data.authoritySlug}`;
   const lead = escapeHtml(leadLine(data.townName, data.total));
   const title = `Planning applications in ${town} | Town Crier`;
   const metaDescription = escapeHtml(
@@ -178,7 +184,7 @@ ${pageStyles()}
         <ol>
           <li><a href="/">Town Crier</a></li>
           <li><a href="/planning">Planning applications</a></li>
-          <li><a href="${authorityCanonical}">${authority}</a></li>
+          <li><a href="${authorityPath}">${authority}</a></li>
           <li>${town}</li>
         </ol>
       </nav>

--- a/web/scripts/lib/render-town-page.mjs
+++ b/web/scripts/lib/render-town-page.mjs
@@ -84,6 +84,10 @@ function buildTownJsonLd(data, canonical, authorityCanonical) {
     license:
       'https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/',
   };
+  // Mirrors the visible four-level trail (tc-3ht16): Home -> the /planning hub
+  // -> the parent authority -> this town. "Planning applications" matches the
+  // hub's own self-referential label (render-planning-index.mjs's buildJsonLd)
+  // and the authority page's breadcrumb (render-page.mjs's buildJsonLd) exactly.
   const breadcrumb = {
     '@context': 'https://schema.org',
     '@type': 'BreadcrumbList',
@@ -92,10 +96,16 @@ function buildTownJsonLd(data, canonical, authorityCanonical) {
       {
         '@type': 'ListItem',
         position: 2,
+        name: 'Planning applications',
+        item: `${SITE_ORIGIN}/planning`,
+      },
+      {
+        '@type': 'ListItem',
+        position: 3,
         name: data.authorityName,
         item: authorityCanonical,
       },
-      { '@type': 'ListItem', position: 3, name: data.townName, item: canonical },
+      { '@type': 'ListItem', position: 4, name: data.townName, item: canonical },
     ],
   };
   // Escape "<" so a malicious data value can never close the <script> element.
@@ -167,6 +177,7 @@ ${pageStyles()}
       <nav class="breadcrumb" aria-label="Breadcrumb">
         <ol>
           <li><a href="/">Town Crier</a></li>
+          <li><a href="/planning">Planning applications</a></li>
           <li><a href="${authorityCanonical}">${authority}</a></li>
           <li>${town}</li>
         </ol>


### PR DESCRIPTION
## Changes

Slices 1+2 of #990 (bead tc-3ht16) — the fast, low-risk half of cross-linking the `/planning` SEO pages so town pages stop being near-orphans reachable only from the sitemap. Slices 3+4 (nearest-neighbour nearby-areas/neighbouring-councils sections) are tracked separately as tc-gyw1q, since they need a two-pass restructure of the prerender pipeline.

- Un-orphan `/planning/towns`: new `renderPlanningCrossLinks()` helper (`render-shared.mjs`) renders a single, always-on link to the town index — called from both the `/planning` hub and every authority page (including the 29 authorities with zero published towns of their own).
- Authority-page breadcrumbs are now 3-level: `Town Crier › Planning applications › <Authority>`, both the visible nav and the JSON-LD `BreadcrumbList`.
- Town-page breadcrumbs are now 4-level: `Town Crier › Planning applications › <Authority> › <Town>`, both the visible nav and the JSON-LD `BreadcrumbList`.
- Visible breadcrumb links are site-relative throughout (fixed one spot that had accidentally reused the absolute JSON-LD URL).
- Extended `render-page.test.mjs`, `render-town-page.test.mjs`, `render-planning-index.test.mjs`, `render-shared.test.mjs` — including tests asserting the visible breadcrumb and JSON-LD `BreadcrumbList` agree exactly on name/href/order.

Verified offline via `node scripts/prerender-planning.mjs --render` against the committed fixture snapshot (two consecutive passes byte-identical), and live in a browser via a dispatched UI-verification subagent driving `agent-browser` against the rendered output — hub → towns-index link, an authority with zero towns still showing the cross-link, and the town-page 4-level breadcrumb all confirmed clickable and correct.

`npx vitest run` (1247/1247) and `npx tsc --noEmit` green in `/web`.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Planning applications” breadcrumb levels across planning authority and town pages.
  * Added links to the planning towns index from planning hub and authority pages.
  * Improved breadcrumb consistency between visible navigation and structured search data.
* **Style**
  * Styled planning cross-links as lightweight text links with hover states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->