### PR TITLE
Back off on PlanIt timeouts like a soft rate-limit; quiet poll-failure/PlanIt alert noise

### DIFF
--- a/api-go/internal/polling/lanec.go
+++ b/api-go/internal/polling/lanec.go
@@ -218,6 +218,7 @@ func (h *InverseMaskLaneHandler) RunOnePage(ctx context.Context) laneOutcome {
 			out.retryAfter = rl.RetryAfter
 		} else {
 			out.err = ferr
+			out.timedOut = isTimeoutError(ferr)
 		}
 		// GH#986: re-persist the epoch/cursor exactly as loaded (nothing was
 		// fetched, so no progress exists to checkpoint) but with
@@ -262,6 +263,7 @@ func (h *InverseMaskLaneHandler) RunOnePage(ctx context.Context) laneOutcome {
 		}
 		if perr := h.processStraggler(ctx, light, &out, &hydrationsThisPass, &hydrationCapHit); perr != nil {
 			out.err = perr
+			out.timedOut = isTimeoutError(perr)
 			stoppedEarly = true
 			break
 		}

--- a/api-go/internal/polling/lanec_test.go
+++ b/api-go/internal/polling/lanec_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"testing"
 	"time"
 
@@ -560,6 +561,68 @@ func TestInverseMaskLane_HydrationRateLimitStopsTheWholePage(t *testing.T) {
 	}
 }
 
+// TestInverseMaskLane_PageFetchTimeoutSetsTimedOut proves a page-fetch
+// client-side timeout (the real prod shape: a *url.Error wrapping
+// context.DeadlineExceeded once PlanIt's HTTP client's retries are
+// exhausted) is flagged on the outcome via timedOut, distinguishing it from
+// a plain fetch error so NationalPollHandler.Handle can classify the cycle
+// as TerminationTimeout rather than TerminationNatural (tc-pmh5y).
+func TestInverseMaskLane_PageFetchTimeoutSetsTimedOut(t *testing.T) {
+	t.Parallel()
+	epochLower := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	epochUpper := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+
+	fetcher := newFakeInverseMaskFetcher()
+	fetcher.failNth[1] = &url.Error{Op: "Get", URL: "https://www.planit.org.uk/api/applics/json", Err: context.DeadlineExceeded}
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	state.states[sentinelLaneC] = PollState{HighWaterMark: epochUpper, Cursor: &PollCursor{DifferentStart: epochLower, NextIndex: 300}}
+
+	h := newLaneCHandler(t, fetcher, apps, state, defaultInverseMaskOpts())
+	out := h.RunOnePage(context.Background())
+
+	if out.err == nil {
+		t.Fatal("expected the timed-out fetch to surface as out.err")
+	}
+	if !out.timedOut {
+		t.Error("timedOut: got false, want true (page-fetch client timeout)")
+	}
+}
+
+// TestInverseMaskLane_HydrationTimeoutSetsTimedOut mirrors
+// TestInverseMaskLane_PageFetchTimeoutSetsTimedOut for a HYDRATION
+// sub-fetch timeout — the exact site that produced the real 2026-07-23 prod
+// failure ("lane C: hydration fetch ... context deadline exceeded", via
+// FetchByUID).
+func TestInverseMaskLane_HydrationTimeoutSetsTimedOut(t *testing.T) {
+	t.Parallel()
+	epochLower := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	epochUpper := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+	newLD := epochLower.Add(time.Hour)
+
+	fetcher := newFakeInverseMaskFetcher()
+	fetcher.pages[0] = planit.FetchPageResult{
+		From:         0,
+		Applications: []applications.PlanningApplication{lightApp("first/FUL", 99, "Permitted", newLD)},
+		HasMorePages: false,
+	}
+	fetcher.hydrateErr["first/FUL"] = &url.Error{Op: "Get", URL: "https://www.planit.org.uk/api/applics/json", Err: context.DeadlineExceeded}
+
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	state.states[sentinelLaneC] = PollState{HighWaterMark: epochUpper, Cursor: &PollCursor{DifferentStart: epochLower, NextIndex: 0}}
+
+	h := newLaneCHandler(t, fetcher, apps, state, defaultInverseMaskOpts())
+	out := h.RunOnePage(context.Background())
+
+	if out.err == nil {
+		t.Fatal("expected the timed-out hydration fetch to surface as out.err")
+	}
+	if !out.timedOut {
+		t.Error("timedOut: got false, want true (hydration client timeout)")
+	}
+}
+
 // TestInverseMaskLane_MidPageHydrationRateLimitCheckpointsAtFailingOffset is
 // GH#986 acceptance criterion (a): a mid-page hydration 429 must checkpoint
 // the cursor at the FAILING record's own offset (startIndex + i, where i
@@ -699,6 +762,9 @@ func TestInverseMaskLane_IngestErrorIsAHardStop(t *testing.T) {
 
 	if out.err == nil {
 		t.Fatal("expected the Ingest failure to surface as out.err")
+	}
+	if out.timedOut {
+		t.Error("timedOut: got true, want false (a plain persistence/ingest error must not be misclassified as a timeout)")
 	}
 	got := state.states[sentinelLaneC].Cursor
 	if got == nil || got.NextIndex != 0 {

--- a/api-go/internal/polling/nationallane.go
+++ b/api-go/internal/polling/nationallane.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -225,6 +226,12 @@ type laneOutcome struct {
 	rateLimited     bool
 	retryAfter      *time.Duration
 	err             error
+	// timedOut is true when err came from a PlanIt fetch call (page fetch or
+	// hydration) whose client-side timeout expired — never from a
+	// watermark/cursor persistence error, which is unrelated to PlanIt. It
+	// lets Handle's loop distinguish "PlanIt needs space" (TerminationTimeout)
+	// from a genuine natural completion (tc-pmh5y).
+	timedOut        bool
 	planitTotal     *int
 	watermarkBefore time.Time
 	watermarkAfter  time.Time
@@ -234,6 +241,21 @@ type laneOutcome struct {
 	// lane from planner candidacy, not by the one-page executor itself (see
 	// NationalLaneOptions.MaxPages).
 	capHit bool
+}
+
+// isTimeoutError reports whether err is (or wraps, via %w) a net.Error whose
+// Timeout() reports true — the client-side-timeout shape a PlanIt fetch
+// produces once its retries are exhausted (internal/planit/client.go's
+// sendWithThrottle wraps the underlying *url.Error as
+// "planit request failed: %w", which errors.As unwraps through).
+// context.DeadlineExceeded alone is not a net.Error; the *url.Error (or
+// similar) that wraps it is what implements Timeout().
+func isTimeoutError(err error) bool {
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return netErr.Timeout()
+	}
+	return false
 }
 
 // RunOnePage executes exactly ONE page of this lane's descending delta walk
@@ -323,6 +345,7 @@ func (h *NationalLaneHandler) RunOnePage(ctx context.Context) laneOutcome {
 			out.retryAfter = rl.RetryAfter
 		} else {
 			out.err = ferr
+			out.timedOut = isTimeoutError(ferr)
 		}
 		out.watermarkAfter = watermarkBefore
 		h.recordRunMetrics(ctx, out, now)
@@ -675,6 +698,10 @@ type commonLaneOutcome struct {
 	rateLimited     bool
 	retryAfter      *time.Duration
 	err             error
+	// timedOut mirrors laneOutcome.timedOut (Lane D's backfillOutcome carries
+	// no equivalent, so it always reads false from that branch — Lane D is
+	// out of scope for tc-pmh5y's timeout classification).
+	timedOut bool
 }
 
 // Handle runs one ADR 0044 poll cycle: a planner/executor loop replacing the
@@ -744,6 +771,9 @@ loop:
 
 		if out.err != nil {
 			lastErr = out.err
+			if out.timedOut {
+				reason = TerminationTimeout
+			}
 			break loop
 		}
 		if out.rateLimited {
@@ -850,13 +880,13 @@ func (h *NationalPollHandler) execOnePage(ctx context.Context, lane LaneName) co
 		if out.err != nil {
 			h.logger.ErrorContext(ctx, "lane A poll error", "error", out.err)
 		}
-		return commonLaneOutcome{recordsIngested: out.recordsIngested, rateLimited: out.rateLimited, retryAfter: out.retryAfter, err: out.err}
+		return commonLaneOutcome{recordsIngested: out.recordsIngested, rateLimited: out.rateLimited, retryAfter: out.retryAfter, err: out.err, timedOut: out.timedOut}
 	case LaneB:
 		out := h.laneB.RunOnePage(ctx)
 		if out.err != nil {
 			h.logger.ErrorContext(ctx, "lane B poll error", "error", out.err)
 		}
-		return commonLaneOutcome{recordsIngested: out.recordsIngested, rateLimited: out.rateLimited, retryAfter: out.retryAfter, err: out.err}
+		return commonLaneOutcome{recordsIngested: out.recordsIngested, rateLimited: out.rateLimited, retryAfter: out.retryAfter, err: out.err, timedOut: out.timedOut}
 	case LaneC:
 		if h.laneC == nil {
 			return commonLaneOutcome{}
@@ -865,7 +895,7 @@ func (h *NationalPollHandler) execOnePage(ctx context.Context, lane LaneName) co
 		if out.err != nil {
 			h.logger.ErrorContext(ctx, "lane C poll error", "error", out.err)
 		}
-		return commonLaneOutcome{recordsIngested: out.recordsIngested, rateLimited: out.rateLimited, retryAfter: out.retryAfter, err: out.err}
+		return commonLaneOutcome{recordsIngested: out.recordsIngested, rateLimited: out.rateLimited, retryAfter: out.retryAfter, err: out.err, timedOut: out.timedOut}
 	case LaneD:
 		if h.laneD == nil {
 			return commonLaneOutcome{}

--- a/api-go/internal/polling/nationallane_test.go
+++ b/api-go/internal/polling/nationallane_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"testing"
 	"time"
 
@@ -1018,6 +1019,12 @@ func TestNationalPollHandler_Handle_StopsOnFirstLaneError(t *testing.T) {
 	if res.AuthorityErrors != 1 {
 		t.Errorf("AuthorityErrors: got %d, want 1", res.AuthorityErrors)
 	}
+	// A plain, non-timeout transport error must NOT be misclassified as
+	// TerminationTimeout (tc-pmh5y regression guard: isTimeoutError must not
+	// over-match a generic error).
+	if res.TerminationReason != TerminationNatural {
+		t.Errorf("TerminationReason: got %v, want %v (a non-timeout error must not trip TerminationTimeout)", res.TerminationReason, TerminationNatural)
+	}
 	// Lane A is the older (longAgo) and therefore LRU-first candidate, so it
 	// runs (and fails) before Lane B ever gets a turn — the single break
 	// covers whichever lane errors, without a per-lane fold to omit one.
@@ -1179,6 +1186,48 @@ func TestNationalPollHandler_Handle_LaneDRateLimitBubblesToNextCycle(t *testing.
 	}
 	if res.RetryAfter == nil || *res.RetryAfter != retryAfter {
 		t.Errorf("RetryAfter: got %v, want %v", res.RetryAfter, retryAfter)
+	}
+}
+
+// TestNationalPollHandler_Handle_LaneTimeoutSetsTerminationTimeout proves a
+// PlanIt fetch that times out — the real 2026-07-23 prod shape: a
+// *url.Error wrapping context.DeadlineExceeded from an exhausted-retries
+// PlanIt HTTP client (tc-pmh5y) — is classified as TerminationTimeout, not
+// TerminationNatural's "nothing happened" cadence. context.DeadlineExceeded
+// itself is not a net.Error; the wrapping *url.Error is what reports
+// Timeout()==true, so the fake must return the wrapped form to be faithful
+// to production.
+func TestNationalPollHandler_Handle_LaneTimeoutSetsTerminationTimeout(t *testing.T) {
+	t.Parallel()
+	clockTime := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	longAgo := clockTime.Add(-time.Hour)
+
+	timeoutErr := &url.Error{Op: "Get", URL: "https://www.planit.org.uk/api/applics/json", Err: context.DeadlineExceeded}
+
+	fetcherA := newFakeNationalFetcher()
+	fetcherA.failNth[1] = timeoutErr
+	fetcherB := newFakeNationalFetcher()
+	fetcherB.pages[0] = planit.FetchPageResult{From: 0, Applications: nil, HasMorePages: false}
+
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	watermark := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	state.states[sentinelLaneA] = PollState{HighWaterMark: watermark, LastPollTime: longAgo}
+	state.states[sentinelLaneB] = PollState{HighWaterMark: watermark, LastPollTime: longAgo}
+	logger := slog.New(slog.NewTextHandler(discard{}, nil))
+	clock := func() time.Time { return clockTime }
+
+	laneAHandler := NewNationalLaneHandler(fetcherA, state, apps, laneAOpts(), clock, logger)
+	laneBHandler := NewNationalLaneHandler(fetcherB, state, apps, laneBOpts(20), clock, logger)
+	planner := NewPlanner(newTestPlannerOpts())
+	handler := NewNationalPollHandler(laneAHandler, laneBHandler, nil, planner, NationalPollOptions{HandlerBudget: 4 * time.Minute}, clock, logger)
+
+	res, err := handler.Handle(context.Background())
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if res.TerminationReason != TerminationTimeout {
+		t.Errorf("TerminationReason: got %v, want %v", res.TerminationReason, TerminationTimeout)
 	}
 }
 

--- a/api-go/internal/polling/scheduler.go
+++ b/api-go/internal/polling/scheduler.go
@@ -9,14 +9,15 @@ type Jitter interface {
 	NextOffset(bound time.Duration) time.Duration
 }
 
-// SchedulerOptions are the next-run scheduler tunables: 5m natural cadence, 1m
+// SchedulerOptions are the next-run scheduler tunables: 1h natural cadence, 1m
 // resume after a time-bounded cut-off, 3h cap on a Retry-After hint, 5m
-// rate-limit default, 10s jitter bound.
+// rate-limit default, 2h timeout cadence, 10s jitter bound.
 type SchedulerOptions struct {
 	NaturalCadence     time.Duration
 	TimeBoundedCadence time.Duration
 	RetryAfterCap      time.Duration
 	RateLimitDefault   time.Duration
+	TimeoutCadence     time.Duration
 	JitterBound        time.Duration
 }
 
@@ -31,7 +32,12 @@ func DefaultSchedulerOptions() SchedulerOptions {
 		TimeBoundedCadence: 1 * time.Minute,
 		RetryAfterCap:      3 * time.Hour,
 		RateLimitDefault:   5 * time.Minute,
-		JitterBound:        10 * time.Second,
+		// TimeoutCadence is deliberately longer than NaturalCadence: a
+		// client-side timeout is more than "nothing happened" (ADR 0041's
+		// natural-cadence rationale), so it should back off further than a
+		// quiet cycle would, not resume sooner than the 429 default either.
+		TimeoutCadence: 2 * time.Hour,
+		JitterBound:    10 * time.Second,
 	}
 }
 
@@ -56,6 +62,8 @@ func (s *NextRunScheduler) ComputeNextRun(reason TerminationReason, retryAfter *
 		return now.Add(s.rateLimitedDelay(retryAfter))
 	case TerminationTimeBounded:
 		return now.Add(s.opts.TimeBoundedCadence)
+	case TerminationTimeout:
+		return now.Add(s.timeoutDelay())
 	case TerminationNatural:
 		return now.Add(s.opts.NaturalCadence)
 	default:
@@ -74,4 +82,10 @@ func (s *NextRunScheduler) rateLimitedDelay(retryAfter *time.Duration) time.Dura
 		}
 	}
 	return base + s.jitter.NextOffset(s.opts.JitterBound)
+}
+
+// timeoutDelay adds a symmetric jitter to TimeoutCadence, mirroring
+// rateLimitedDelay's base+jitter shape.
+func (s *NextRunScheduler) timeoutDelay() time.Duration {
+	return s.opts.TimeoutCadence + s.jitter.NextOffset(s.opts.JitterBound)
 }

--- a/api-go/internal/polling/scheduler_test.go
+++ b/api-go/internal/polling/scheduler_test.go
@@ -48,6 +48,14 @@ func TestNextRunScheduler_ComputeNextRun(t *testing.T) {
 			// no retry-after -> RateLimitDefault (5m)
 			want: now.Add(5 * time.Minute),
 		},
+		{
+			name: "timeout uses timeout cadence",
+			// 2h timeout cadence, deliberately longer than the 1h natural
+			// cadence -- a client-side timeout is more than "nothing
+			// happened", so it should back off further, not resume sooner.
+			reason: TerminationTimeout,
+			want:   now.Add(2 * time.Hour),
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -87,6 +95,21 @@ func TestNextRunScheduler_RateLimitedAppliesJitter(t *testing.T) {
 	gotNatural := s.ComputeNextRun(TerminationNatural, nil, now)
 	if !gotNatural.Equal(now.Add(1 * time.Hour)) {
 		t.Errorf("natural cadence should not jitter: got %v, want %v", gotNatural, now.Add(1*time.Hour))
+	}
+}
+
+func TestNextRunScheduler_TimeoutAppliesJitter(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+	opts := DefaultSchedulerOptions()
+	// A fixed +7s jitter must be added on top of the timeout cadence, mirroring
+	// the rate-limited path's jitter application.
+	s := NewNextRunScheduler(opts, fixedJitter{offset: 7 * time.Second})
+
+	got := s.ComputeNextRun(TerminationTimeout, nil, now)
+	want := now.Add(2*time.Hour + 7*time.Second)
+	if !got.Equal(want) {
+		t.Errorf("timeout jittered next run: got %v, want %v", got, want)
 	}
 }
 

--- a/api-go/internal/polling/termination.go
+++ b/api-go/internal/polling/termination.go
@@ -15,6 +15,12 @@ const (
 	// TerminationRateLimited means the cycle stopped early because PlanIt returned
 	// HTTP 429.
 	TerminationRateLimited
+	// TerminationTimeout means the cycle stopped early because a PlanIt fetch
+	// (page fetch or hydration) exceeded its client-side timeout — distinct
+	// from TerminationNatural ("nothing happened") because a timeout is a real
+	// signal that PlanIt needs space, even though it never surfaced as an
+	// explicit 429.
+	TerminationTimeout
 )
 
 // TelemetryValue returns the span-tag string for this reason.
@@ -24,6 +30,8 @@ func (r TerminationReason) TelemetryValue() string {
 		return "TimeBounded"
 	case TerminationRateLimited:
 		return "RateLimited"
+	case TerminationTimeout:
+		return "Timeout"
 	case TerminationNatural:
 		return "Natural"
 	default:

--- a/api-go/internal/polling/termination_test.go
+++ b/api-go/internal/polling/termination_test.go
@@ -1,0 +1,30 @@
+package polling
+
+import "testing"
+
+// TestTerminationReason_TelemetryValue pins the span-tag string each
+// TerminationReason maps to — these strings are stable (existing App
+// Insights queries depend on them), so a new reason must be added here
+// explicitly rather than falling through to the default.
+func TestTerminationReason_TelemetryValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		reason TerminationReason
+		want   string
+	}{
+		{name: "natural", reason: TerminationNatural, want: "Natural"},
+		{name: "time-bounded", reason: TerminationTimeBounded, want: "TimeBounded"},
+		{name: "rate-limited", reason: TerminationRateLimited, want: "RateLimited"},
+		{name: "timeout", reason: TerminationTimeout, want: "Timeout"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.reason.TelemetryValue(); got != tc.want {
+				t.Errorf("TelemetryValue(): got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/infra/shared.go
+++ b/infra/shared.go
@@ -520,8 +520,16 @@ func runSharedStack(ctx *pulumi.Context, conf *config.Config, tags pulumi.String
 		Severity:            pulumi.Float64(2), // Warning
 		Enabled:             pulumi.Bool(true),
 		EvaluationFrequency: pulumi.String("PT15M"),
-		WindowSize:          pulumi.String("PT1H"),
-		Scopes:              pulumi.StringArray{logAnalytics.ID()},
+		// WindowSize is PT3H, not PT1H (widened by tc-k5c9w, alert-noise audit 2026-07-23). A 3x
+		// wider rolling window dilutes the failure-ratio calc by ~3x more total calls before it
+		// can cross 30%, so a short-lived blip that would trip a 1h window won't trip a 3h one,
+		// while a genuinely sustained PlanIt outage — the only kind of event this alert should
+		// page for — still comfortably breaches within the window. Same "give it space to prove
+		// it's a real trend, not a blip" principle as the polling-code timeout backoff change in
+		// the companion bead (tc-pmh5y), applied on the alerting side instead of the scheduling
+		// side.
+		WindowSize: pulumi.String("PT3H"),
+		Scopes:     pulumi.StringArray{logAnalytics.ID()},
 		Criteria: monitor.ScheduledQueryRuleCriteriaArgs{
 			AllOf: monitor.ConditionArray{
 				monitor.ConditionArgs{
@@ -728,33 +736,64 @@ func runSharedStack(ctx *pulumi.Context, conf *config.Config, tags pulumi.String
 	}
 
 	// Container Apps jobs — one failed-execution alert per prod job, generated via a loop over
-	// the job-name slice (rather than seven copy-pasted blocks). Scopes are constructed ARM IDs:
-	// these jobs live in the prod stack (infra/environment.go, createWorkerJob), named
+	// a per-job spec slice (rather than seven copy-pasted blocks), same "same alert shape,
+	// per-item tunables" idiom as postgresAlertSpec above. Scopes are constructed ARM IDs: these
+	// jobs live in the prod stack (infra/environment.go, createWorkerJob), named
 	// job-tc-<name>-prod.
-	prodFailedExecutionJobs := []string{
-		"poll",
-		"poll-bootstrap",
-		"digest",
-		"digest-hourly",
-		"dormant-cleanup",
-		"subscription-sweep",
-		"pg-purge",
+	//
+	// "poll" carries a wider window/higher threshold than the rest (tc-k5c9w, alert-noise audit
+	// 2026-07-23): it was the dominant noise source at 13 firings/30d, because the default
+	// shape (WindowSize PT30M, Threshold GreaterThan 0) fires on ANY single Failed execution.
+	// Root cause of most of those firings was isolated single-execution PlanIt hydration
+	// timeouts (Lane C, "context deadline exceeded") that self-recover on the next 15-min
+	// schedule tick — not a real incident. Validated against 7 days of real execution history:
+	// with WindowSize=PT6H/Threshold>1, 6 of 7 days with a poll failure would NOT have fired
+	// (isolated singles suppressed), while the one real cluster (2026-07-17, 4 failures in a
+	// day) still would. The other six jobs are unchanged: they have never fired in 30 days and
+	// have a different failure profile (daily/lower-frequency cadence, no quick retry), so
+	// there's no evidence they need the same relaxation.
+	type failedExecutionJobSpec struct {
+		name       string
+		windowSize string
+		threshold  float64
+		// description overrides the default "reported a Failed execution" text when non-empty;
+		// used for "poll" so the fired-alert email states the new >=2-in-6h semantics rather than
+		// implying a single-failure trigger.
+		description string
+	}
+	prodFailedExecutionJobs := []failedExecutionJobSpec{
+		{
+			name:        "poll",
+			windowSize:  "PT6H",
+			threshold:   1,
+			description: "Container Apps job job-tc-poll-prod reported 2 or more Failed executions within 6 hours.",
+		},
+		{name: "poll-bootstrap", windowSize: "PT30M", threshold: 0},
+		{name: "digest", windowSize: "PT30M", threshold: 0},
+		{name: "digest-hourly", windowSize: "PT30M", threshold: 0},
+		{name: "dormant-cleanup", windowSize: "PT30M", threshold: 0},
+		{name: "subscription-sweep", windowSize: "PT30M", threshold: 0},
+		{name: "pg-purge", windowSize: "PT30M", threshold: 0},
 	}
 	for _, job := range prodFailedExecutionJobs {
-		alertName := fmt.Sprintf("alert-job-failed-%s-prod", job)
+		alertName := fmt.Sprintf("alert-job-failed-%s-prod", job.name)
 		jobID := fmt.Sprintf(
 			"/subscriptions/%s/resourceGroups/rg-town-crier-prod/providers/Microsoft.App/jobs/job-tc-%s-prod",
-			armSubscriptionID, job)
+			armSubscriptionID, job.name)
+		description := job.description
+		if description == "" {
+			description = fmt.Sprintf("Container Apps job job-tc-%s-prod reported a Failed execution.", job.name)
+		}
 		_, err = monitor.NewMetricAlert(ctx, alertName, &monitor.MetricAlertArgs{
 			RuleName:            pulumi.String(alertName),
 			ResourceGroupName:   resourceGroup.Name,
 			Location:            pulumi.String("global"),
-			Description:         pulumi.String(fmt.Sprintf("Container Apps job job-tc-%s-prod reported a Failed execution.", job)),
+			Description:         pulumi.String(description),
 			Severity:            pulumi.Int(2),
 			Enabled:             pulumi.Bool(true),
 			AutoMitigate:        pulumi.Bool(true),
 			EvaluationFrequency: pulumi.String("PT15M"),
-			WindowSize:          pulumi.String("PT30M"),
+			WindowSize:          pulumi.String(job.windowSize),
 			Scopes:              pulumi.StringArray{pulumi.String(jobID)},
 			Criteria: monitor.MetricAlertSingleResourceMultipleMetricCriteriaArgs{
 				OdataType: pulumi.String("Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria"),
@@ -772,7 +811,7 @@ func runSharedStack(ctx *pulumi.Context, conf *config.Config, tags pulumi.String
 							},
 						},
 						Operator:        pulumi.String("GreaterThan"),
-						Threshold:       pulumi.Float64(0),
+						Threshold:       pulumi.Float64(job.threshold),
 						TimeAggregation: pulumi.String("Total"),
 					},
 				},


### PR DESCRIPTION
## Changes

Bundled fix for Azure Monitor alert noise (multiple pages/day, none actionable) traced back to two related root causes: PlanIt hydration timeouts during PlanIt busy periods, and alert thresholds that fire on a single isolated blip.

**Polling (tc-pmh5y):**
- New `TerminationTimeout` reason, distinct from `TerminationNatural` and `TerminationRateLimited`. A PlanIt fetch timeout (`context deadline exceeded`, confirmed via a real 2026-07-23 prod crash on Lane C hydration) is now scheduled with its own 2h backoff (`TimeoutCadence`, longer than the 1h natural cadence — a timeout isn't "nothing happened") instead of silently falling through to natural cadence and being invisible in telemetry.
- Wired at all three PlanIt-fetch-error sites: Lane A/B national delta fetch, Lane C inverse-mask fetch, Lane C straggler hydration (the site that produced the real prod incident).
- Non-timeout errors (persistence failures, non-timeout HTTP errors) are unaffected — regression-tested.

**Alerting (tc-k5c9w):** informed by a real 30-day fired-alert audit (`Microsoft.AlertsManagement/alerts`), not guesswork — only 3 of 25 alert resources in the shared stack have fired at all in 30 days.
- `alert-job-failed-poll-prod` (13 firings/30d, the dominant source — 6 of the last 7 were isolated single-execution blips that self-recovered): window widened `PT30M` → `PT6H`, threshold raised to require ≥2 failed executions, not any single one. The other six job-failure alerts are untouched (never fired, different failure profile).
- `alert-planit-failure-rate-shared` (3 firings/30d): window widened `PT1H` → `PT3H` so a short blip gets diluted out; a genuine sustained outage still trips it comfortably.
- `alert-planit-request-budget-shared` deliberately left alone — it protects PlanIt's actual daily rate-limit red line and is already the least blip-sensitive of the three (full-day rolling aggregate). We considered Azure's `FailingPeriods` mechanism for "require 2 consecutive breaches" on both PlanIt alerts, but verified against Microsoft's docs that it only works correctly against a datetime-bucketed query, which neither PlanIt query is — doing it properly needs a KQL rewrite, out of scope here.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout detection for polling operations, including page fetches and hydration.
  * Polling cycles now distinguish timeout failures from other errors.
  * Timeout failures are recorded with dedicated telemetry and termination status.

* **Scheduling**
  * Timeout-terminated polls now use a two-hour retry cadence with jitter.

* **Monitoring**
  * Updated dependency failure alerts to evaluate a three-hour window.
  * Refined failed-execution alerts with job-specific thresholds and evaluation windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->