### PR TITLE
Fix CodeRabbit-flagged timeout-provenance gaps and stale alert text from PR #994

### DIFF
--- a/api-go/internal/polling/lanec.go
+++ b/api-go/internal/polling/lanec.go
@@ -262,8 +262,13 @@ func (h *InverseMaskLaneHandler) RunOnePage(ctx context.Context) laneOutcome {
 			break
 		}
 		if perr := h.processStraggler(ctx, light, &out, &hydrationsThisPass, &hydrationCapHit); perr != nil {
+			// timedOut (when applicable) is set inside hydrate itself, not
+			// re-derived here from the aggregate perr: processStraggler wraps
+			// errors from TWO sources (a Postgres GetByUID read, and a PlanIt
+			// hydrate() fetch), and isTimeoutError must only ever be
+			// consulted against the PlanIt one (tc-c5tmz, CodeRabbit
+			// follow-up on tc-pmh5y).
 			out.err = perr
-			out.timedOut = isTimeoutError(perr)
 			stoppedEarly = true
 			break
 		}
@@ -372,6 +377,12 @@ func (h *InverseMaskLaneHandler) hydrate(ctx context.Context, uid string, wantAr
 			out.retryAfter = rl.RetryAfter
 			return nil
 		}
+		// timedOut is set here, at the actual PlanIt fetch site, rather than
+		// re-derived from processStraggler's aggregate error at the
+		// RunOnePage call site -- so a Postgres GetByUID error (the sibling
+		// error source processStraggler wraps) never gets misclassified as a
+		// PlanIt timeout (tc-c5tmz, CodeRabbit follow-up on tc-pmh5y).
+		out.timedOut = isTimeoutError(err)
 		return fmt.Errorf("lane C: hydration fetch %q: %w", uid, err)
 	}
 	for _, app := range full.Applications {

--- a/api-go/internal/polling/lanec_test.go
+++ b/api-go/internal/polling/lanec_test.go
@@ -623,6 +623,50 @@ func TestInverseMaskLane_HydrationTimeoutSetsTimedOut(t *testing.T) {
 	}
 }
 
+// TestInverseMaskLane_GetByUIDTimeoutDoesNotSetTimedOut proves
+// processStraggler's two error sources are classified by provenance
+// (tc-c5tmz, a CodeRabbit follow-up on tc-pmh5y): a Postgres GetByUID read
+// failure -- even one that happens to satisfy net.Error/Timeout(),
+// deliberately atypical for a real Postgres fake, but that is exactly the
+// point -- must never be run through isTimeoutError. Only a genuine PlanIt
+// hydrate() fetch timeout may set timedOut, so a GetByUID failure stays
+// classified as TerminationNatural (1h cadence), never misclassified as
+// TerminationTimeout (2h cadence).
+func TestInverseMaskLane_GetByUIDTimeoutDoesNotSetTimedOut(t *testing.T) {
+	t.Parallel()
+	epochLower := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	epochUpper := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+	newLD := epochLower.Add(time.Hour)
+
+	fetcher := newFakeInverseMaskFetcher()
+	fetcher.pages[0] = planit.FetchPageResult{
+		From:         0,
+		Applications: []applications.PlanningApplication{lightApp("first/FUL", 99, "Permitted", newLD)},
+		HasMorePages: false,
+	}
+
+	apps := newFakeApps()
+	// Deliberately atypical for a Postgres fake: a *url.Error satisfying
+	// net.Error/Timeout()==true, to prove isTimeoutError is never even
+	// consulted on the GetByUID path -- it is Postgres, never PlanIt.
+	apps.getErr = &url.Error{Op: "Get", URL: "postgres://irrelevant", Err: context.DeadlineExceeded}
+	state := newFakeStateStore()
+	state.states[sentinelLaneC] = PollState{HighWaterMark: epochUpper, Cursor: &PollCursor{DifferentStart: epochLower, NextIndex: 0}}
+
+	h := newLaneCHandler(t, fetcher, apps, state, defaultInverseMaskOpts())
+	out := h.RunOnePage(context.Background())
+
+	if out.err == nil {
+		t.Fatal("expected the GetByUID failure to surface as out.err")
+	}
+	if out.timedOut {
+		t.Error("timedOut: got true, want false (GetByUID is Postgres, never PlanIt -- isTimeoutError must never be consulted on this path)")
+	}
+	if len(fetcher.hydrateCalls) != 0 {
+		t.Errorf("expected hydrate() never called when GetByUID fails, got %v", fetcher.hydrateCalls)
+	}
+}
+
 // TestInverseMaskLane_MidPageHydrationRateLimitCheckpointsAtFailingOffset is
 // GH#986 acceptance criterion (a): a mid-page hydration 429 must checkpoint
 // the cursor at the FAILING record's own offset (startIndex + i, where i

--- a/api-go/internal/polling/nationallane.go
+++ b/api-go/internal/polling/nationallane.go
@@ -485,6 +485,7 @@ func (h *NationalLaneHandler) seed(ctx context.Context, span trace.Span, now, ma
 			out.retryAfter = rl.RetryAfter
 		} else {
 			out.err = ferr
+			out.timedOut = isTimeoutError(ferr)
 		}
 		// out.watermarkAfter is still the zero time here — the seeding fetch
 		// itself failed, so nothing was ever established this run. Recording

--- a/api-go/internal/polling/nationallane_test.go
+++ b/api-go/internal/polling/nationallane_test.go
@@ -745,6 +745,36 @@ func TestNationalLane_SeedRateLimitedLeavesLaneUnseeded(t *testing.T) {
 	}
 }
 
+// TestNationalLane_SeedFetchTimeoutSetsTimedOut proves seed() -- a lane's
+// first-ever run, used only while watermarkBefore.IsZero() -- classifies a
+// PlanIt fetch timeout the same way RunOnePage's steady-state branch already
+// does (tc-62z2i, a CodeRabbit follow-up on tc-pmh5y: seed() has its own
+// separate FetchNationalDeltaPage error branch that was never wired to
+// isTimeoutError at all). Left unfixed, a timeout during a lane's bootstrap
+// seed falls through to TerminationNatural's 1h cadence instead of
+// TerminationTimeout's 2h backoff.
+func TestNationalLane_SeedFetchTimeoutSetsTimedOut(t *testing.T) {
+	t.Parallel()
+	timeoutErr := &url.Error{Op: "Get", URL: "https://www.planit.org.uk/api/applics/json", Err: context.DeadlineExceeded}
+	fetcher := newFakeNationalFetcher()
+	fetcher.failNth[1] = timeoutErr
+	apps := newFakeApps()
+	state := newFakeStateStore() // no sentinel row: never run -- exercises seed()
+
+	h := newLaneHandler(t, fetcher, apps, state, laneAOpts())
+	out := h.RunOnePage(context.Background())
+
+	if out.err == nil {
+		t.Fatal("expected the timed-out seed fetch to surface as out.err")
+	}
+	if !out.timedOut {
+		t.Error("timedOut: got false, want true (seed()'s FetchNationalDeltaPage error branch must be wired to isTimeoutError, same as RunOnePage's)")
+	}
+	if len(state.saves) != 0 {
+		t.Errorf("expected NO Save call when the seed fetch times out, got %+v", state.saves)
+	}
+}
+
 // TestNationalLane_SeedThenForwardFlow proves seeding does not break steady
 // state: after a seeded call, a second call from that watermark ingests only
 // the record strictly newer than the seed and stops normally at the

--- a/infra/shared.go
+++ b/infra/shared.go
@@ -491,7 +491,7 @@ func runSharedStack(ctx *pulumi.Context, conf *config.Config, tags pulumi.String
 		return err
 	}
 
-	// Scheduled query (log) alert — PlanIt non-429 dependency failure ratio over the last hour,
+	// Scheduled query (log) alert — PlanIt non-429 dependency failure ratio over the last 3 hours,
 	// computed from AppDependencies on this shared Log Analytics workspace (tc-ttjor / GH #938
 	// PR3). Go emits no AppMetrics by design (no Go Azure Monitor metrics exporter), so a
 	// log-based alert is the only option here. The query requires >=20 calls in the window so a
@@ -515,7 +515,7 @@ func runSharedStack(ctx *pulumi.Context, conf *config.Config, tags pulumi.String
 		ResourceGroupName:   resourceGroup.Name,
 		Location:            pulumi.String("uksouth"),
 		Kind:                pulumi.String("LogAlert"),
-		Description:         pulumi.String("PlanIt non-429 dependency failure ratio exceeded 30% over the last hour (>=20 calls). See GH #938."),
+		Description:         pulumi.String("PlanIt non-429 dependency failure ratio exceeded 30% over the last 3 hours (>=20 calls). See GH #938."),
 		DisplayName:         pulumi.String("PlanIt non-429 failure rate"),
 		Severity:            pulumi.Float64(2), // Warning
 		Enabled:             pulumi.Bool(true),


### PR DESCRIPTION
## Changes

Three follow-ups from CodeRabbit's review on #994, all verified against current code before fixing (not blindly applied):

- **tc-c5tmz**: `lanec.go`'s `processStraggler` conflated a Postgres `GetByUID` error with the actual PlanIt `hydrate()` fetch error under one `isTimeoutError` check — a DB-side timeout could have been misclassified as "PlanIt needs space" and gotten the 2h backoff instead of normal handling. Fixed by moving `timedOut` classification into `hydrate()` itself (mirrors how it already handles a 429), so `GetByUID` errors never touch `isTimeoutError` at all.
- **tc-62z2i**: `nationallane.go`'s `seed()` (a lane's first-ever-run path) has its own separate `FetchNationalDeltaPage` error branch that was never wired to `isTimeoutError`, unlike the equivalent branch in `RunOnePage`. A timeout during initial lane seeding was falling through to the 1h natural cadence instead of the 2h timeout cadence. One-line fix, plus a regression test.
- **tc-l89v4**: `alert-planit-failure-rate-shared`'s description and a code comment still said "over the last hour" after #994 widened the window to 3h — the description is the literal text in the fired-alert email/push. Text-only fix.

All three are correctness/accuracy gaps in what #994 shipped, not new scope.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout classification for PlanIt fetch failures.
  * Prevented unrelated database errors from being incorrectly reported as timeouts.
  * Ensured failed fetches do not trigger unnecessary hydration or state persistence.

* **Documentation**
  * Updated monitoring alert text to accurately describe its three-hour evaluation window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->