### PR TITLE
docs: retire PlanIt daily-budget framing, add hard local-session call limits (tc-h1rcb)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,21 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Town Crier is a mobile-first app for monitoring UK local authority planning applications, delivering push notifications to residents, community groups, and property professionals. It uses PlanIt (planit.org.uk) as its primary data provider, with a polling-based ingestion model (see ADR 0006). PlanIt is a free, single-operator service — hammering it is a non-negotiable red line.
+Town Crier is a mobile-first app for monitoring UK local authority planning applications, delivering push notifications to residents, community groups, and property professionals. It uses PlanIt (planit.org.uk) as its primary data provider, with a polling-based ingestion model (see ADR 0006). PlanIt is a free, single-operator service — read the hard call limits below before calling it from a local session.
+
+## PlanIt: Hard Call Limits
+
+PlanIt is a **free service run by one individual** and our sole planning-data provider (ADR 0006). Not hammering it is non-negotiable — but that is a rule about **behaviour, not a daily quota**. There is **no fixed daily call budget**: don't introduce one, don't enforce one, and don't raise findings on the basis of one. (ADR 0041 and ADR 0042 cite a `~1,500 requests/day` figure; that is historical context from when those decisions were made, not a live limit.)
+
+**The deployed poller is not the risk.** It honours `Retry-After` (a 429 is never retried internally — it ends the cycle so the scheduler reschedules), backs off for 2h after a timeout, caps attempts at 4, and sleeps 2s before *every* attempt including retries. That behaviour is what "polite" means here, and it is enforced in `api-go/internal/planit/client.go`.
+
+**A local session is the risk** — a `curl` loop, a throwaway Python script, a "let me just test this quickly" harness. It has none of those brakes and no review. So, binding on any local or agent session calling PlanIt by hand:
+
+- **Never more than 10 requests total in a session.**
+- **Never more than one request per 60 seconds.**
+- **Never write a loop that hits PlanIt without an explicit sleep of 60s or more between iterations.**
+
+No exceptions for "it's only a few more", for batching, or for running it in parallel. If a task looks like it needs more than 10 calls, **stop and ask** rather than proceeding. Prefer the `httptest`-backed doubles in `api-go/internal/planit/*_test.go` over live calls.
 
 ## Business Status
 


### PR DESCRIPTION
## What

Rewrites the PlanIt guidance in `CLAUDE.md`. Two changes:

1. **Retires the daily-budget framing.** There is no fixed daily call budget, and the file now says so explicitly — don't introduce one, don't enforce one, don't raise findings on the basis of one.
2. **Adds hard limits binding on local sessions**, which is where the actual risk sits.

## Why

The `~1,500/day` figure was an internally agreed number from 2026-06-18. It was never PlanIt-published and never enforced in code, and `tc-t7wa` (add a client-side hard rate cap) was already closed on 2026-06-19 on the grounds that honouring `Retry-After` was sufficient. Despite that, the number kept resurfacing — today's SRE observatory run filed a P1 against it, which was re-litigating a settled decision.

Politeness is better defined by behaviour, and **the deployed poller already meets it.** Verified in code at `origin/main` b1bfc608:

| Condition | Where |
|---|---|
| Honour `Retry-After` — 429 never retried internally, ends the cycle so the scheduler reschedules; hint capped at 3h | `internal/planit/retryafter.go`, `client.go` |
| Back off after timeouts — `TerminationTimeout` → 2h `TimeoutCadence` vs 1h `NaturalCadence` | `internal/polling/scheduler.go` (PR #994/#995) |
| No retry storm — attempts capped at `1 + PLANIT_RETRY_MAX_RETRIES`, and the 2s throttle sleeps before **every** attempt including retries | `internal/planit/client.go` `sendWithThrottle` |

The retry-storm one is the strongest: because the throttle sits inside the attempt loop rather than around it, there is a hard floor on request spacing no matter how badly things fail. Telemetry agrees — the worst timeout hour in the last 24h (35.7% timeouts) ran 42 calls against a 36/hr baseline, no amplification.

**The residual risk is a local agent session** writing a `curl` loop or a throwaway script with none of those brakes and no review. That is what the new limits target: 10 requests max per session, one per 60s minimum, and no loop without an explicit ≥60s sleep.

## Deliberately not changed

`docs/adr/0041` and `docs/adr/0042` both cite `~1,500 requests/day` in their Context/Consequences. Those are accepted ADRs recording what was true at decision time — rewriting them would falsify the record. The new section flags them as historical instead.

## Test plan

Docs-only change; no code paths touched. Verified the claims made in the new text against the source rather than restating them from memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U7X9msb5kL4GLzgEHw7HDN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PlanIt usage guidance for local and agent sessions.
  * Added explicit limits of 10 requests per session and one request per 60 seconds.
  * Clarified that local loops must include a 60-second pause between iterations.
  * Documented when to stop and request approval for additional calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->