### PR TITLE
fix(privacy): stop recording end-user IPs on request spans (tc-ig52w)

### DIFF
--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -438,10 +438,16 @@ func newRouter(
 	// mux directly (the same lookup RequireAuth uses), which is why it takes mux
 	// rather than relying on r.Pattern (lost across the chain's context copies).
 	chain = middleware.RouteSpan(mux)(chain)
-	// otelhttp is the outermost wrapper so its span covers the whole request,
+	// otelhttp wraps the whole chain so its span covers the request end to end,
 	// including the CORS, error-envelope and panic-recovery middleware. When
 	// telemetry is disabled (no OTLP endpoint) the global no-op TracerProvider
 	// makes this produce no-op spans at negligible cost, so the wiring stays
 	// unconditional and every existing httptest assertion is unaffected.
-	return otelhttp.NewHandler(chain, "town-crier-api-go")
+	instrumented := otelhttp.NewHandler(chain, "town-crier-api-go")
+	// StripForwardedFor is the true outermost wrapper, and has to be: otelhttp
+	// reads X-Forwarded-For when it starts the span, so the header must already
+	// be gone by then or the caller's IP lands on the span (and in App Insights).
+	// Nothing downstream reads the header — internal/clientip uses
+	// CF-Connecting-IP validated against the Cloudflare ranges.
+	return middleware.StripForwardedFor(instrumented)
 }

--- a/api-go/internal/middleware/stripforwardedfor.go
+++ b/api-go/internal/middleware/stripforwardedfor.go
@@ -1,0 +1,38 @@
+package middleware
+
+import "net/http"
+
+// StripForwardedFor removes the X-Forwarded-For header from every inbound
+// request before anything downstream sees it.
+//
+// The point is privacy, not hygiene. otelhttp feeds the header into the
+// OpenTelemetry client.address span attribute, which was putting real end-user
+// IP addresses into Application Insights AppRequests, retained for 30 days.
+// That contradicts the project's stated position that we do not log client IPs
+// (privacy.json: "we do not track"). Azure's own built-in ClientIP column is
+// already masked to 0.0.0.0, so this custom attribute was the only leak.
+//
+// This demotes the attribute rather than deleting it. otelhttp resolves the
+// client IP as options -> X-Forwarded-For -> TCP peer, so with the header gone
+// client.address falls back to the peer, which behind Cloudflare and Container
+// Apps ingress is the ingress address (100.100.0.x) — infrastructure, identical
+// for every caller, not a person. Forcing the attribute to disappear outright
+// would mean blanking r.RemoteAddr too, and that is not worth it: internal/
+// clientip parses RemoteAddr to decide whether CF-Connecting-IP can be trusted,
+// and per anonratelimit.go an unparseable RemoteAddr collapses every anonymous
+// caller onto one shared rate-limit bucket. Cosmetic gain, availability risk.
+//
+// Nothing in this codebase reads X-Forwarded-For: internal/clientip documents
+// that it is deliberately never read (it is trivially spoofable), and takes the
+// caller's IP from CF-Connecting-IP validated against the published Cloudflare
+// ranges instead. That header is untouched here, so the anonymous rate limiter
+// keeps working.
+//
+// This must wrap OUTSIDE otelhttp.NewHandler so the header is gone before the
+// span is started; see cmd/api/wiring.go.
+func StripForwardedFor(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Header.Del("X-Forwarded-For")
+		next.ServeHTTP(w, r)
+	})
+}

--- a/api-go/internal/middleware/stripforwardedfor_test.go
+++ b/api-go/internal/middleware/stripforwardedfor_test.go
@@ -1,0 +1,177 @@
+package middleware
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// TestStripForwardedFor_RemovesHeaderBeforeNextHandler confirms the header is
+// gone by the time the wrapped handler runs, for both the single-hop and the
+// Cloudflare-style appended list.
+func TestStripForwardedFor_RemovesHeaderBeforeNextHandler(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		value string
+	}{
+		{"single hop", "82.132.213.185"},
+		{"appended list", "82.132.213.185, 172.70.42.11"},
+		{"ipv6", "2a00:23c8:8ab:801:7026:db85:2b2b:9aee"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var got string
+			var present bool
+			next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				got = r.Header.Get("X-Forwarded-For")
+				_, present = r.Header["X-Forwarded-For"]
+			})
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v1/health", nil)
+			req.Header.Set("X-Forwarded-For", tc.value)
+			StripForwardedFor(next).ServeHTTP(httptest.NewRecorder(), req)
+
+			if present {
+				t.Errorf("X-Forwarded-For still present downstream with value %q", got)
+			}
+		})
+	}
+}
+
+// TestStripForwardedFor_LeavesOtherHeadersAlone guards the blast radius: only
+// X-Forwarded-For goes. CF-Connecting-IP in particular must survive, because
+// internal/clientip reads it (validated against Cloudflare ranges) for the
+// anonymous rate limiter.
+func TestStripForwardedFor_LeavesOtherHeadersAlone(t *testing.T) {
+	var seen http.Header
+	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		seen = r.Header.Clone()
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v1/health", nil)
+	req.Header.Set("X-Forwarded-For", "82.132.213.185")
+	req.Header.Set("CF-Connecting-IP", "82.132.213.185")
+	req.Header.Set("Authorization", "Bearer token")
+	req.Header.Set("User-Agent", "TownCrierApp/64 CFNetwork/3860.600.12 Darwin/25.5.0")
+	StripForwardedFor(next).ServeHTTP(httptest.NewRecorder(), req)
+
+	for _, key := range []string{"Cf-Connecting-Ip", "Authorization", "User-Agent"} {
+		if seen.Get(key) == "" {
+			t.Errorf("%s was dropped, want it preserved", key)
+		}
+	}
+}
+
+// TestStripForwardedFor_NoHeaderIsANoOp confirms a request that never carried
+// the header passes through untouched.
+func TestStripForwardedFor_NoHeaderIsANoOp(t *testing.T) {
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	rec := httptest.NewRecorder()
+	StripForwardedFor(next).ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v1/health", nil))
+
+	if !called {
+		t.Error("next handler was not called")
+	}
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusNoContent)
+	}
+}
+
+// serveThroughOtelHTTP drives a GET through StripForwardedFor -> otelhttp (the
+// production nesting from cmd/api/wiring.go) with the given X-Forwarded-For and
+// returns the recorded server span.
+func serveThroughOtelHTTP(t *testing.T, forwardedFor string) sdktrace.ReadOnlySpan {
+	t.Helper()
+
+	prev := otel.GetTracerProvider()
+	rec := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+		otel.SetTracerProvider(prev)
+	})
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(StripForwardedFor(otelhttp.NewHandler(inner, "town-crier-api-go")))
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/v1/health", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if forwardedFor != "" {
+		req.Header.Set("X-Forwarded-For", forwardedFor)
+	}
+	resp, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	spans := rec.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	return spans[0]
+}
+
+// TestStripForwardedFor_SpanNeverCarriesTheForwardedIP is the regression test
+// that matters: it pins the OUTCOME rather than the mechanism. Real UK
+// residential IPs were reaching App Insights AppRequests through the
+// client.address attribute (30-day retention), against the project's
+// no-client-IP-logging stance.
+//
+// otelhttp resolves client.address as options -> X-Forwarded-For -> peer
+// address, so removing the header does not delete the attribute; it demotes it
+// to the TCP peer, which behind Cloudflare and Container Apps ingress is the
+// ingress address, not a person. What must never happen is a forwarded value
+// surviving, and that is what this asserts.
+//
+// If a future otelhttp bump starts sourcing the client IP from somewhere else
+// (X-Real-IP, Forwarded), this test fails and the strip needs widening.
+func TestStripForwardedFor_SpanNeverCarriesTheForwardedIP(t *testing.T) {
+	const userIP = "82.132.213.185"
+	span := serveThroughOtelHTTP(t, userIP+", 172.70.42.11")
+
+	clientAddr := attrString(span, "client.address")
+	if clientAddr == userIP {
+		t.Errorf("client.address = %q — the forwarded end-user IP reached the span", clientAddr)
+	}
+	// Whatever survives must be the TCP peer, i.e. infrastructure. Pinning the
+	// equality (rather than just "not the user IP") is what catches a future
+	// otelhttp picking up some other client-supplied header.
+	if peer := attrString(span, "network.peer.address"); clientAddr != peer {
+		t.Errorf("client.address = %q, want it to equal network.peer.address %q", clientAddr, peer)
+	}
+}
+
+// TestStripForwardedFor_KeepsUsefulSpanAttributes confirms the strip is
+// surgical: the non-PII request attributes the dashboards and the web-vs-iOS
+// client split depend on still reach the span.
+func TestStripForwardedFor_KeepsUsefulSpanAttributes(t *testing.T) {
+	span := serveThroughOtelHTTP(t, "82.132.213.185")
+
+	for _, key := range []string{"http.request.method", "url.path", "user_agent.original"} {
+		if attrString(span, key) == "" {
+			t.Errorf("%s missing from the span, want it preserved", key)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`otelhttp` feeds `X-Forwarded-For` into the OpenTelemetry `client.address` span attribute, so **real end-user IP addresses have been landing in Application Insights `AppRequests`** and sitting there for the full 30-day retention window.

This was found while answering an unrelated question about telemetry. Live prod data, UK residential and mobile ranges, tied to authenticated users:

```
82.132.213.185                          607 reqs
2a00:23c8:8ab:801:7026:db85:2b2b:9aee    90
31.121.40.18                             81
148.252.145.80                           64
```

It contradicts the project's stated position that we do not log client IPs (`privacy.json`: "we do not track"). Azure's own built-in `ClientIP` column is **already masked to `0.0.0.0`** — only city/country geo survives — so this custom OTel attribute was the sole leak.

## Fix

`middleware.StripForwardedFor` removes the header **outside** `otelhttp.NewHandler`, so it is gone before the span starts.

## Why the attribute is demoted, not deleted

`otelhttp` resolves the client IP as `options` → `X-Forwarded-For` → **TCP peer** (`internal/semconv/server.go:138-148`). With the header gone, `client.address` falls back to the Container Apps ingress address (`100.100.0.x`) — infrastructure, identical for every caller, not a person.

Deleting the key outright would require blanking `r.RemoteAddr` as well, and that trade is bad:

- `internal/clientip` parses `RemoteAddr` to decide whether `CF-Connecting-IP` can be trusted
- per `anonratelimit.go:38`, an unparseable `RemoteAddr` **collapses every anonymous caller onto one shared rate-limit bucket**

Cosmetic gain, real availability risk. Not worth it.

## Blast radius

Nothing downstream reads `X-Forwarded-For` — `internal/clientip/clientip.go:11` documents that it is *deliberately* never read because it is trivially spoofable; the app uses `CF-Connecting-IP` validated against published Cloudflare ranges. `CF-Connecting-IP`, `Authorization` and `User-Agent` are explicitly asserted to survive.

Retained on spans: `user_agent.original`, `url.path`, `http.request.method`, `network.peer.address`. Nothing dashboard-facing is lost.

## Tests

The span test asserts the **outcome, not the mechanism** — a future `otelhttp` that sources the client IP from some other client-supplied header fails the build rather than silently leaking again. I verified the premise with a throwaway probe first: without the strip, `client.address` is exactly the forwarded user IP.

- header removed downstream (single hop, appended CF-style list, IPv6)
- other headers untouched
- no-header request is a no-op
- through real `otelhttp`: forwarded IP never reaches the span, and `client.address == network.peer.address`
- useful attributes preserved

## Gates

`go build` / `go vet` / `gofmt` clean, `golangci-lint` clean, full unit suite **2021 passed**. Real-Postgres integration suite run locally (no DB surface in this change).

## Note on existing data

This stops new IPs being recorded. Roughly 30 days of already-collected IPs remain in the Log Analytics workspace and will age out on their own — say if you want them purged sooner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ComwNeJQBWYJcroknrqrbN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Privacy & Security**
  * Improved request handling to prevent forwarded client IP addresses from being recorded as client telemetry.
  * Preserved other request headers and useful operational telemetry.

* **Bug Fixes**
  * Ensured forwarded IP information is removed consistently, including when requests pass through tracing instrumentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->