### PR TITLE
infra: quiet poll-queue-depth blips, remove retired PlanIt budget alert (tc-vflm7)

### DIFF
--- a/infra/environment.go
+++ b/infra/environment.go
@@ -862,11 +862,26 @@ func createServiceBusPollingInfra(ctx *pulumi.Context, env string, resourceGroup
 }
 
 // createPollQueueDepthAlert creates the metric alert (prod only) that fires when the poll
-// queue's total Messages (active + scheduled + dead-lettered) exceeds 1 for a sustained 15
-// minutes. Steady state holds exactly one in-flight trigger, so this single threshold catches
-// both a forked trigger chain and dead-letter accumulation without needing separate rules per
-// sub-count (tc-ttjor / GH #938 PR3). Wired to the action group created in the shared stack —
-// see the rationale comment on its creation in shared.go.
+// queue's total Messages (active + scheduled + dead-lettered) averages above 1.5 over a
+// trailing 1-hour window. Steady state holds exactly one in-flight trigger, so this single
+// threshold catches both a forked trigger chain and dead-letter accumulation without needing
+// separate rules per sub-count (tc-ttjor / GH #938 PR3).
+//
+// TimeAggregation is Average (not Maximum) and WindowSize is PT1H (not PT15M), tuned by
+// alert-noise pass 2 (tc-vflm7) after this alert fired twice in 30 days (2026-07-16,
+// 2026-07-24) with no corresponding job failures, forked executions, or 429-storm signature —
+// i.e. not real incidents. Maximum aggregation over a short window means a single brief metric
+// sample above threshold stays visible in the trailing window well after the blip itself has
+// passed, so a one-off reads as a sustained breach purely from window/evaluation-frequency
+// mechanics. Average over a longer window requires the elevated depth to actually persist.
+// Threshold is raised from 1 to 1.5 because steady state (1) sits exactly on the old threshold,
+// so any excursion at all, however brief, already counted as a breach; 1.5 gives a brief blip
+// room to dilute below threshold while a genuinely stuck queue (depth 2) stays comfortably
+// above it. There's no historical per-minute Service Bus queue-depth metric to backtest these
+// exact numbers against (az monitor metrics list doesn't support Service Bus queues) — the
+// window is instead sized for headroom against the real incident class this alert guards
+// against, which ran 2.5+ hours. Wired to the action group created in the shared stack — see
+// the rationale comment on its creation in shared.go.
 func createPollQueueDepthAlert(ctx *pulumi.Context, env string, resourceGroupName pulumi.StringOutput, pollingBus *serviceBusPollingInfra, actionGroupID pulumi.StringOutput, tags pulumi.StringMap) error {
 	name := fmt.Sprintf("alert-poll-queue-depth-%s", env)
 	_, err := monitor.NewMetricAlert(ctx, name, &monitor.MetricAlertArgs{
@@ -877,11 +892,11 @@ func createPollQueueDepthAlert(ctx *pulumi.Context, env string, resourceGroupNam
 		// be created on a custom metric", broke the v0.19.3 deploy). Without this
 		// the provider defaults to the resource group's region.
 		Location:            pulumi.String("global"),
-		Description:         pulumi.String("Poll Service Bus queue holds more than 1 message (active + scheduled + dead-lettered); steady state is exactly 1. Indicates a forked trigger chain or dead-letter accumulation. See GH #938."),
+		Description:         pulumi.String("Poll Service Bus queue's total Messages (active + scheduled + dead-lettered) averaged above 1.5 over the last hour; steady state is exactly 1. Indicates a forked trigger chain or dead-letter accumulation. See GH #938."),
 		Severity:            pulumi.Int(2),
 		Enabled:             pulumi.Bool(true),
 		EvaluationFrequency: pulumi.String("PT5M"),
-		WindowSize:          pulumi.String("PT15M"),
+		WindowSize:          pulumi.String("PT1H"),
 		Scopes:              pulumi.StringArray{pollingBus.namespaceID},
 		Criteria: monitor.MetricAlertSingleResourceMultipleMetricCriteriaArgs{
 			OdataType: pulumi.String("Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria"),
@@ -899,8 +914,8 @@ func createPollQueueDepthAlert(ctx *pulumi.Context, env string, resourceGroupNam
 						},
 					},
 					Operator:        pulumi.String("GreaterThan"),
-					Threshold:       pulumi.Float64(1),
-					TimeAggregation: pulumi.String("Maximum"),
+					Threshold:       pulumi.Float64(1.5),
+					TimeAggregation: pulumi.String("Average"),
 				},
 			},
 		},

--- a/infra/shared.go
+++ b/infra/shared.go
@@ -553,52 +553,6 @@ func runSharedStack(ctx *pulumi.Context, conf *config.Config, tags pulumi.String
 		return err
 	}
 
-	// Scheduled query (log) alert — prod PlanIt daily request-volume budget guard rail (GH #955
-	// PR C / tc-oeoga). PlanIt is a free, single-operator service; hammering it is a
-	// non-negotiable red line, measured at ~1,500 requests/day (see CLAUDE.md's PlanIt-red-line
-	// framing and GH #955's Motivation). 1,450 sits just under that red line so this fires with
-	// headroom to react (e.g. step POLLING_PLANIT_PAGE_SIZE back down, GH #955 PR B's documented
-	// rollback lever) before the fleet actually crosses it. Same shape as the PlanIt failure-rate
-	// rule above: the query itself computes the daily count and emits a row only when the
-	// threshold is breached, so the alert condition is just "did the query return anything"
-	// (threshold 0, Count aggregation).
-	const planitRequestBudgetQuery = `AppDependencies
-| where Target == "PlanIt search"
-| where tostring(Properties["deployment.environment"]) == "prod"
-| summarize RequestCount = count()
-| where RequestCount > 1450`
-
-	_, err = monitor.NewScheduledQueryRule(ctx, "alert-planit-request-budget-shared", &monitor.ScheduledQueryRuleArgs{
-		RuleName:            pulumi.String("alert-planit-request-budget-shared"),
-		ResourceGroupName:   resourceGroup.Name,
-		Location:            pulumi.String("uksouth"),
-		Kind:                pulumi.String("LogAlert"),
-		Description:         pulumi.String("Prod PlanIt request volume exceeded 1,450 calls in the last 24 hours — approaching the ~1,500/day red line for this free, single-operator service. See GH #955."),
-		DisplayName:         pulumi.String("PlanIt daily request budget"),
-		Severity:            pulumi.Float64(2), // Warning
-		Enabled:             pulumi.Bool(true),
-		EvaluationFrequency: pulumi.String("PT1H"),
-		WindowSize:          pulumi.String("P1D"),
-		Scopes:              pulumi.StringArray{logAnalytics.ID()},
-		Criteria: monitor.ScheduledQueryRuleCriteriaArgs{
-			AllOf: monitor.ConditionArray{
-				monitor.ConditionArgs{
-					Query:           pulumi.String(planitRequestBudgetQuery),
-					TimeAggregation: pulumi.String("Count"),
-					Operator:        pulumi.String("GreaterThan"),
-					Threshold:       pulumi.Float64(0),
-				},
-			},
-		},
-		Actions: monitor.ActionsArgs{
-			ActionGroups: pulumi.StringArray{actionGroup.ID()},
-		},
-		Tags: tags,
-	})
-	if err != nil {
-		return err
-	}
-
 	// Azure Communication Services (Email) — UK data location.
 	emailServiceUk, err := communication.NewEmailService(ctx, "email-town-crier-uk", &communication.EmailServiceArgs{
 		EmailServiceName:  pulumi.String("email-town-crier-uk"),


### PR DESCRIPTION
## Summary

Alert-noise pass 2, follow-up to tc-k5c9w (PR #994). A fresh 30-day fired-alert audit (`Microsoft.AlertsManagement/alerts`) confirmed pass 1's fixes are working and found two remaining noise sources it didn't touch.

**`alert-poll-queue-depth-prod` (`infra/environment.go`, `createPollQueueDepthAlert`)**
- Fired twice in 30 days (2026-07-16, 2026-07-24), both ~25-min self-resolving windows with no corresponding job failures, forked/paired executions, or 429-storm signature — not real incidents. The real incident class this alert guards against (GH #938) ran 2.5+ hours.
- Root cause: `TimeAggregation: Maximum` over a 15-min `WindowSize` means one brief metric sample above threshold stays visible in the trailing window well after the blip itself passed, so a one-off reads as a sustained breach purely from window/evaluation-frequency mechanics. The queue's healthy steady state (1) also sits exactly on the old threshold (`>1`), so any excursion at all already counted as a breach.
- Fix: `Maximum` → `Average`, `WindowSize` `PT15M` → `PT1H`, `Threshold` `1` → `1.5`. `EvaluationFrequency` (`PT5M`), `Severity`, `Scopes`, the `EntityName=poll` dimension, and action-group wiring are unchanged. Doc comment and the alert `Description` (the literal fired-alert email/push text) rewritten to describe the new condition and the reasoning, without claiming backtested precision — no historical per-minute Service Bus queue-depth metric is available to validate exact numbers against (`az monitor metrics list` doesn't support Service Bus queues).

**`alert-planit-request-budget-shared` (`infra/shared.go`) — removed entirely**
- Kept firing (5x/30d) on the ~1,500/day PlanIt daily-budget figure that tc-h1rcb (PR #997, merged 2026-07-24) formally retired from policy in CLAUDE.md ("no fixed daily budget... don't enforce one, don't raise findings on the basis of one"). #997 was docs-only and never touched this Pulumi resource.
- Removed the `NewScheduledQueryRule` call, its `planitRequestBudgetQuery` const, and the surrounding justification comment block.
- Left untouched: `alert-planit-failure-rate-shared` (different alert, already fixed by tc-k5c9w), and `docs/adr/0041`/`0042` (historical record, per tc-h1rcb's own "deliberately not changed" reasoning).

## Test plan

- [x] `cd infra && gofmt -l .` — clean
- [x] `cd infra && go build ./...` — passes
- [x] `cd infra && go vet ./...` — passes
- [ ] No live `pulumi up`/`pulumi preview` available to this worker (same constraint as tc-97k35); applies via `cd-dev` on merge to main (shared stack, not release-tag-gated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Monitoring Updates**
  * Service Bus queue depth alerts now evaluate average message levels over one hour, reducing sensitivity to brief spikes.
  * Alert thresholds and descriptions have been updated to reflect the revised evaluation window and averaging behavior.
  * The scheduled daily request-volume budget alert has been removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->