### PR TITLE
chore(deps): bump react-router-dom to v8, clear 5 Dependabot vuln alerts (tc-ct5vz)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -14,7 +14,7 @@
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-leaflet": "^5.0.0",
-        "react-router-dom": "^7.16.0"
+        "react-router": "^8.3.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -2117,18 +2117,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3660,24 +3653,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.4"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-is": {
@@ -3703,41 +3696,24 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
-      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.16.0.tgz",
-      "integrity": "sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.16.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/redent": {
@@ -3867,12 +3843,6 @@
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -16,7 +16,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-leaflet": "^5.0.0",
-    "react-router-dom": "^7.16.0"
+    "react-router": "^8.3.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router';
 import { Auth0Provider, type AppState } from '@auth0/auth0-react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { loadAuthConfig } from './auth/auth-config';

--- a/web/src/AppRoutes.tsx
+++ b/web/src/AppRoutes.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense } from 'react';
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router';
 import { LandingPage } from './features/LandingPage/LandingPage';
 import { CallbackPage } from './auth/CallbackPage';
 import { ConnectedLegalPage } from './features/legal/ConnectedLegalPage';

--- a/web/src/__tests__/App.test.tsx
+++ b/web/src/__tests__/App.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { AuthProvider } from '../auth/auth-context';
 import { SpyAuthPort } from '../auth/__tests__/spies/spy-auth-port';

--- a/web/src/__tests__/routes.test.tsx
+++ b/web/src/__tests__/routes.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { AuthProvider } from '../auth/auth-context';
 import { ProfileRepositoryProvider } from '../auth/profile-context';

--- a/web/src/auth/AuthGuard.tsx
+++ b/web/src/auth/AuthGuard.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { Outlet, useLocation } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router';
 import { FullPageLoader } from '../components/FullPageLoader/FullPageLoader.tsx';
 import { useAuth } from './auth-context.ts';
 

--- a/web/src/auth/CallbackPage.tsx
+++ b/web/src/auth/CallbackPage.tsx
@@ -1,4 +1,4 @@
-import { Navigate } from 'react-router-dom';
+import { Navigate } from 'react-router';
 import { useAuth } from './auth-context';
 
 export function CallbackPage() {

--- a/web/src/auth/OnboardingGate.tsx
+++ b/web/src/auth/OnboardingGate.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { Outlet, Navigate } from 'react-router-dom';
+import { Outlet, Navigate } from 'react-router';
 import { FullPageLoader } from '../components/FullPageLoader/FullPageLoader.tsx';
 import { FullPageError } from '../components/FullPageError/FullPageError.tsx';
 import { useProfileRepository } from './profile-context.ts';

--- a/web/src/auth/__tests__/AuthGuard.test.tsx
+++ b/web/src/auth/__tests__/AuthGuard.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router';
 import { AuthProvider } from '../auth-context.ts';
 import { AuthGuard } from '../AuthGuard.tsx';
 import { SpyAuthPort } from './spies/spy-auth-port.ts';

--- a/web/src/auth/__tests__/CallbackPage.test.tsx
+++ b/web/src/auth/__tests__/CallbackPage.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router';
 import { CallbackPage } from '../CallbackPage.tsx';
 import { AuthProvider } from '../auth-context.ts';
 import type { AuthPort } from '../../domain/ports/auth-port.ts';

--- a/web/src/auth/__tests__/OnboardingGate.test.tsx
+++ b/web/src/auth/__tests__/OnboardingGate.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router';
 import { ProfileRepositoryProvider } from '../profile-context.ts';
 import { AuthProvider } from '../auth-context.ts';
 import { OnboardingGate } from '../OnboardingGate.tsx';

--- a/web/src/components/AppShell/AppShell.tsx
+++ b/web/src/components/AppShell/AppShell.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useState } from 'react';
-import { Outlet } from 'react-router-dom';
+import { Outlet } from 'react-router';
 import { Sidebar } from '../Sidebar/Sidebar';
 import { LoadingSkeleton } from '../LoadingSkeleton/LoadingSkeleton';
 import styles from './AppShell.module.css';

--- a/web/src/components/AppShell/__tests__/AppShell.test.tsx
+++ b/web/src/components/AppShell/__tests__/AppShell.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { lazy } from 'react';
 import { describe, it, expect } from 'vitest';
 import { AppShell } from '../AppShell';

--- a/web/src/components/ApplicationCard/ApplicationCard.tsx
+++ b/web/src/components/ApplicationCard/ApplicationCard.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import type { PlanningApplicationSummary } from '../../domain/types';
 import { formatDate, statusClassName, statusDisplayLabel } from '../../utils/formatting';
 import { StatusIcon } from '../StatusIcon/StatusIcon';

--- a/web/src/components/ApplicationCard/__tests__/ApplicationCard.test.tsx
+++ b/web/src/components/ApplicationCard/__tests__/ApplicationCard.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect } from 'vitest';
-import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
 import { ApplicationCard } from '../ApplicationCard';
 import {
   undecidedApplication,

--- a/web/src/components/Navbar/__tests__/Navbar.test.tsx
+++ b/web/src/components/Navbar/__tests__/Navbar.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { appStoreUrl } from '../../../config/links';
 import { AuthProvider } from '../../../auth/auth-context';

--- a/web/src/components/Sidebar/Sidebar.tsx
+++ b/web/src/components/Sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { NavLink } from 'react-router-dom';
+import { NavLink } from 'react-router';
 import styles from './Sidebar.module.css';
 
 const NAV_ITEMS = [

--- a/web/src/components/Sidebar/__tests__/Sidebar.test.tsx
+++ b/web/src/components/Sidebar/__tests__/Sidebar.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, within } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { describe, it, expect } from 'vitest';
 import { Sidebar } from '../Sidebar';
 

--- a/web/src/features/ApplicationDetail/ApplicationDetailPage.tsx
+++ b/web/src/features/ApplicationDetail/ApplicationDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router';
 import { asApplicationUid } from '../../domain/types';
 import type { ApplicationRepository } from '../../domain/ports/application-repository';
 import type { DesignationRepository } from '../../domain/ports/designation-repository';

--- a/web/src/features/ApplicationDetail/__tests__/ApplicationDetailPage.test.tsx
+++ b/web/src/features/ApplicationDetail/__tests__/ApplicationDetailPage.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect } from 'vitest';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { ApplicationDetailPage } from '../ApplicationDetailPage';
 import { SpyApplicationRepository } from './spies/spy-application-repository';
 import { SpyDesignationRepository } from './spies/spy-designation-repository';

--- a/web/src/features/Applications/ApplicationsPage.tsx
+++ b/web/src/features/Applications/ApplicationsPage.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import type { WatchZoneSummary, ApplicationStatus } from '../../domain/types';
 import type { ApplicationsBrowsePort } from '../../domain/ports/applications-browse-port';
 import type { NotificationStateRepository } from '../../domain/ports/notification-state-repository';

--- a/web/src/features/Applications/__tests__/ApplicationsPage.test.tsx
+++ b/web/src/features/Applications/__tests__/ApplicationsPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { ApplicationsPage } from '../ApplicationsPage';
 import { SpyApplicationsBrowsePort } from './spies/spy-applications-browse-port';

--- a/web/src/features/Dashboard/DashboardPage.tsx
+++ b/web/src/features/Dashboard/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import type { DashboardPort } from '../../domain/ports/dashboard-port';
 import { useDashboard } from './useDashboard';
 import { ApplicationCard } from '../../components/ApplicationCard/ApplicationCard';

--- a/web/src/features/Dashboard/__tests__/DashboardPage.test.tsx
+++ b/web/src/features/Dashboard/__tests__/DashboardPage.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { DashboardPage } from '../DashboardPage';
 import { SpyDashboardPort } from './spies/spy-dashboard-port';
 import {

--- a/web/src/features/LandingPage/LandingPage.tsx
+++ b/web/src/features/LandingPage/LandingPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { Navbar } from '../../components/Navbar/Navbar';
 import { Hero } from '../../components/Hero/Hero';
 import { StatsBar } from '../../components/StatsBar/StatsBar';

--- a/web/src/features/LandingPage/__tests__/LandingPage.test.tsx
+++ b/web/src/features/LandingPage/__tests__/LandingPage.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, within } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { AuthProvider } from '../../../auth/auth-context';
 import { SpyAuthPort } from '../../../auth/__tests__/spies/spy-auth-port';

--- a/web/src/features/Map/MapPage.tsx
+++ b/web/src/features/Map/MapPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { MapContainer, TileLayer, Marker, useMap, useMapEvents } from 'react-leaflet';
 import type { MapPort, MapBounds } from '../../domain/ports/map-port';
 import type { ApplicationStatus, ClusterMember, MapCluster, WatchZoneSummary } from '../../domain/types';

--- a/web/src/features/Map/__tests__/MapPage.test.tsx
+++ b/web/src/features/Map/__tests__/MapPage.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MapPage } from '../MapPage';
 import { SpyMapPort } from './spies/spy-map-port';

--- a/web/src/features/SavedApplications/__tests__/SavedApplicationsPage.test.tsx
+++ b/web/src/features/SavedApplications/__tests__/SavedApplicationsPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { describe, it, expect } from 'vitest';
 import { SavedApplicationsPage } from '../SavedApplicationsPage';
 import { SpySavedApplicationRepository } from '../../Applications/__tests__/spies/spy-saved-application-repository';

--- a/web/src/features/Settings/SettingsPage.tsx
+++ b/web/src/features/Settings/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useAuth } from '../../auth/auth-context';
 import { useTheme } from '../../hooks/useTheme';
 import { useUserProfile } from './useUserProfile';

--- a/web/src/features/Settings/__tests__/SettingsPage.test.tsx
+++ b/web/src/features/Settings/__tests__/SettingsPage.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { SettingsPage } from '../SettingsPage';
 import { SpySettingsRepository } from './spies/spy-settings-repository';
 import { freeUserProfile, proUserProfile } from './fixtures/user-profile.fixtures';

--- a/web/src/features/Settings/__tests__/SettingsPageRedeemOfferCode.test.tsx
+++ b/web/src/features/Settings/__tests__/SettingsPageRedeemOfferCode.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { SettingsPage } from '../SettingsPage';
 import { SpySettingsRepository } from './spies/spy-settings-repository';
 import { freeUserProfile, proUserProfile } from './fixtures/user-profile.fixtures';

--- a/web/src/features/WatchZones/ConnectedWatchZoneCreatePage.tsx
+++ b/web/src/features/WatchZones/ConnectedWatchZoneCreatePage.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useApiClient } from '../../api/useApiClient';
 import { geocodingApi } from '../../api/geocoding';
 import { ApiWatchZoneRepository } from './ApiWatchZoneRepository';

--- a/web/src/features/WatchZones/ConnectedWatchZoneEditPage.tsx
+++ b/web/src/features/WatchZones/ConnectedWatchZoneEditPage.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { useApiClient } from '../../api/useApiClient';
 import { useProfileRepository } from '../../auth/profile-context';
 import { useFetchData } from '../../hooks/useFetchData';

--- a/web/src/features/WatchZones/WatchZoneCreatePage.tsx
+++ b/web/src/features/WatchZones/WatchZoneCreatePage.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import type { WatchZoneRepository } from '../../domain/ports/watch-zone-repository';
 import type { GeocodingPort } from '../../domain/ports/geocoding-port';
 import { useCreateWatchZone } from './useCreateWatchZone';

--- a/web/src/features/WatchZones/WatchZoneEditPage.tsx
+++ b/web/src/features/WatchZones/WatchZoneEditPage.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import type { WatchZoneSummary, SubscriptionTier } from '../../domain/types';
 import type { WatchZoneRepository } from '../../domain/ports/watch-zone-repository';
 import { useZonePreferences } from './useZonePreferences';

--- a/web/src/features/WatchZones/WatchZoneListPage.tsx
+++ b/web/src/features/WatchZones/WatchZoneListPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import type { WatchZoneRepository } from '../../domain/ports/watch-zone-repository';
 import { useWatchZones } from './useWatchZones';
 import { EmptyState } from '../../components/EmptyState/EmptyState';

--- a/web/src/features/WatchZones/__tests__/WatchZoneCreatePage.test.tsx
+++ b/web/src/features/WatchZones/__tests__/WatchZoneCreatePage.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { WatchZoneCreatePage } from '../WatchZoneCreatePage';
 import { SpyWatchZoneRepository } from './spies/spy-watch-zone-repository';

--- a/web/src/features/WatchZones/__tests__/WatchZoneEditPage.test.tsx
+++ b/web/src/features/WatchZones/__tests__/WatchZoneEditPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { WatchZoneEditPage } from '../WatchZoneEditPage';
 import { SpyWatchZoneRepository } from './spies/spy-watch-zone-repository';

--- a/web/src/features/WatchZones/__tests__/WatchZoneListPage.test.tsx
+++ b/web/src/features/WatchZones/__tests__/WatchZoneListPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { WatchZoneListPage } from '../WatchZoneListPage';
 import { SpyWatchZoneRepository } from './spies/spy-watch-zone-repository';

--- a/web/src/features/legal/LegalPage.tsx
+++ b/web/src/features/legal/LegalPage.tsx
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import type { LegalDocumentPort } from '../../domain/ports/legal-document-port';
 import { useLegalDocument } from './useLegalDocument';
 import styles from './LegalPage.module.css';

--- a/web/src/features/legal/__tests__/ConnectedLegalPage.test.tsx
+++ b/web/src/features/legal/__tests__/ConnectedLegalPage.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { describe, it, expect } from 'vitest';
 import { ConnectedLegalPage } from '../ConnectedLegalPage';
 

--- a/web/src/features/legal/__tests__/LegalPage.test.tsx
+++ b/web/src/features/legal/__tests__/LegalPage.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { describe, it, expect } from 'vitest';
 import { LegalPage } from '../LegalPage';
 import { SpyLegalDocumentPort } from './spies/spy-legal-document-port';

--- a/web/src/features/onboarding/ConnectedOnboardingPage.tsx
+++ b/web/src/features/onboarding/ConnectedOnboardingPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
-import { Navigate } from 'react-router-dom';
+import { Navigate } from 'react-router';
 import { useApiClient } from '../../api/useApiClient';
 import { userProfileApi } from '../../api/userProfile';
 import { watchZonesApi } from '../../api/watchZones';

--- a/web/src/features/onboarding/OnboardingPage.tsx
+++ b/web/src/features/onboarding/OnboardingPage.tsx
@@ -1,4 +1,4 @@
-import { Navigate } from 'react-router-dom';
+import { Navigate } from 'react-router';
 import type { OnboardingPort } from '../../domain/ports/onboarding-port';
 import type { GeocodingPort } from '../../domain/ports/geocoding-port';
 import { ConfirmMap } from '../../components/ConfirmMap/ConfirmMap';

--- a/web/src/features/onboarding/__tests__/OnboardingPage.test.tsx
+++ b/web/src/features/onboarding/__tests__/OnboardingPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router';
 import { describe, it, expect, vi } from 'vitest';
 import { OnboardingPage } from '../OnboardingPage';
 import { SpyOnboardingPort } from './spies/spy-onboarding-port';


### PR DESCRIPTION
## Summary

- GitHub's Dependabot security-only updater has been failing daily on this repo: it can't auto-fix 5 open react-router vulnerability alerts (GHSA-qwww-vcr4-c8h2 high, GHSA-chx6-hx7r-mcp5 high, GHSA-wrjc-x8rr-h8h6 medium, GHSA-h8fp-f39c-q6mh medium, GHSA-337j-9hxr-rhxg medium) because the fix requires react-router 8.3.0+, which needs a major-version bump the security-only updater won't do automatically.
- **`react-router-dom` has no v8 release — it was removed entirely as a package in react-router v8.0.0.** The last version ever published on that name is `7.18.1`. Everything this app used from `react-router-dom` (`BrowserRouter`, `Routes`, `Route`, `Link`, `NavLink`, `Navigate`, `Outlet`, `useNavigate`, `useParams`, `useLocation`, `useSearchParams`) now lives directly in the `react-router` package — only `RouterProvider`/`HydratedRouter` (data-router / RSC APIs, unused here) moved to `react-router/dom`.
- Swapped `web/package.json`'s `react-router-dom: ^7.16.0` for `react-router: ^8.3.0`, and repointed all 45 `src/` files that imported from `react-router-dom` to import from `react-router` instead.
- `react`/`react-dom` auto-resolved `19.2.4 -> 19.2.8` via the existing `^19.2.4` caret range in `package-lock.json`, satisfying react-router v8's new `React >=19.2.7` peer floor — no `package.json` change needed there.
- Confirmed via grep before and after that this app only uses classic declarative-mode router APIs — no `createBrowserRouter`, no loaders/actions, no data router, no RSC-mode usage — so this is a straightforward import-path swap, not a behavioural migration.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` (eslint) — clean
- [x] `npx vitest run` — 1247/1247 pass
- [x] `npm run build` — succeeds
- [x] Manually verified live in a real browser (Vite dev server + `agent-browser`, not just jsdom):
  - Landing page renders with zero console/page errors
  - Client-side `Link` navigation (Privacy Policy → `/legal/privacy`) works
  - `useParams` route (`/legal/:type`) matched and rendered without error
  - Native browser back/forward navigation works
  - `useSearchParams` read (`?ref=`) and write (`signed_out` param stripped via `setSearchParams`) both work
  - `AuthGuard` on a protected nested route (`/dashboard`, chain: `AuthGuard` → `OnboardingGate` → `AppShell`) correctly redirects to Auth0 `/authorize` with the right `redirect_uri`
- [x] Should clear Dependabot alerts #50–#53, #55 on next scan once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cpb93zvudnJgfEw3CwwYui