### PR TITLE
feat(infra): route ACS email delivery logs to shared Log Analytics (tc-p6af)

### DIFF
--- a/infra/shared.go
+++ b/infra/shared.go
@@ -593,6 +593,35 @@ func runSharedStack(ctx *pulumi.Context, conf *config.Config, tags pulumi.String
 		return err
 	}
 
+	// Diagnostic Setting routes ACS email logs to the shared Log Analytics workspace, giving
+	// us an independent send/delivery audit trail — during the tc-wr7r investigation ACS
+	// metrics (ApiRequests/DeliveryStatusUpdate) read 0 even when real email was delivered, so
+	// they can't be trusted as a send signal on their own. Only two named categories, not the
+	// "allLogs" group: EmailSendMailOperational (aggregate send-volume metadata, no PII) and
+	// EmailStatusUpdateOperational (per-recipient delivery status — Delivered/Bounced/Failed/
+	// etc). The latter includes the recipient's email address in a RecipientId field; that is
+	// an accepted, deliberate tradeoff already discussed, not an oversight — no scrubbing or
+	// extra config gating here. No RetentionPolicy override — inherits the workspace's
+	// existing 30-day default, same as every other table there. See tc-p6af.
+	_, err = monitor.NewDiagnosticSetting(ctx, "diag-acs-town-crier-uk", &monitor.DiagnosticSettingArgs{
+		Name:        pulumi.String("diag-acs-town-crier-uk"),
+		ResourceUri: communicationServiceUk.ID(),
+		WorkspaceId: logAnalytics.ID(),
+		Logs: monitor.LogSettingsArray{
+			&monitor.LogSettingsArgs{
+				Category: pulumi.String("EmailSendMailOperational"),
+				Enabled:  pulumi.Bool(true),
+			},
+			&monitor.LogSettingsArgs{
+				Category: pulumi.String("EmailStatusUpdateOperational"),
+				Enabled:  pulumi.Bool(true),
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+
 	// Authorises the local-part `hello` for sends from towncrierapp.uk. See tc-6tak.
 	_, err = communication.NewSenderUsername(ctx, "sender-hello-towncrier-uk", &communication.SenderUsernameArgs{
 		SenderUsername:    pulumi.String("hello"),


### PR DESCRIPTION
## Changes
- Add a Pulumi diagnostic setting on `acs-town-crier-uk` routing two named log categories to the shared Log Analytics workspace (`log-town-crier-shared`): `EmailSendMailOperational` (aggregate send-volume metadata, no PII) and `EmailStatusUpdateOperational` (per-recipient delivery status — Delivered/Bounced/Failed/etc).
- Gives an independent send/delivery audit trail for the weekly/hourly digest emails — during the tc-wr7r investigation, ACS-side metrics (`ApiRequests`/`DeliveryStatusUpdate`) read 0 even when real email was delivered, so they weren't trustworthy as a health signal on their own.
- Only the two named categories are enabled (not the `allLogs` category group). No `RetentionPolicy` override — inherits the workspace's existing 30-day default, same as every other table there.
- `EmailStatusUpdateOperational` includes the recipient's email address in a `RecipientId` field. This was reviewed against the published privacy policy (`api-go/internal/legal/resources/privacy.json`), which already discloses that Communication Services/App Insights process "email delivery" and that the address is stored to send alerts/digests — logging delivery status of an already-disclosed send is compatible processing under the existing legitimate-interest basis, not a new undisclosed use. No policy change needed.

Closes tc-p6af.

---
*Auto-shipped via ship skill*