### PR TITLE
seo: nearby-areas + neighbouring-councils cross-links (tc-gyw1q)

### DIFF
--- a/web/scripts/lib/__tests__/nearest.test.mjs
+++ b/web/scripts/lib/__tests__/nearest.test.mjs
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import { haversineDistanceKm, nearestK, centroidOf } from '../nearest.mjs';
+
+describe('haversineDistanceKm', () => {
+  it('matches a hand-computed value for a known one-degree-of-latitude pair', () => {
+    // At the same longitude, haversine reduces exactly to R * dLat(radians) —
+    // an analytically exact case, not just "looks about right". One degree of
+    // latitude at the mean Earth radius (6371 km) is
+    // 6371 * (Math.PI / 180) km ≈ 111.1949 km.
+    const a = { lat: 51.0, lng: -1.0 };
+    const b = { lat: 52.0, lng: -1.0 };
+    const expectedKm = 6371 * (Math.PI / 180);
+    expect(haversineDistanceKm(a, b)).toBeCloseTo(expectedKm, 6);
+    expect(haversineDistanceKm(a, b)).toBeCloseTo(111.1949, 3);
+  });
+
+  it('is zero for two identical points', () => {
+    const p = { lat: 50.2632, lng: -5.051 };
+    expect(haversineDistanceKm(p, p)).toBe(0);
+  });
+
+  it('is symmetric: distance(a, b) === distance(b, a)', () => {
+    const a = { lat: 50.2632, lng: -5.051 };
+    const b = { lat: 51.4545, lng: -2.5879 };
+    expect(haversineDistanceKm(a, b)).toBeCloseTo(haversineDistanceKm(b, a), 10);
+  });
+});
+
+describe('nearestK', () => {
+  const identity = (c) => c.slug;
+
+  it('returns the K nearest candidates in ascending distance order', () => {
+    const origin = { slug: 'origin', lat: 51.0, lng: -1.0 };
+    const near = { slug: 'near', lat: 51.01, lng: -1.0 };
+    const mid = { slug: 'mid', lat: 51.5, lng: -1.0 };
+    const far = { slug: 'far', lat: 55.0, lng: -1.0 };
+    const result = nearestK(origin, [far, mid, near], 2, { identity });
+    expect(result.map((r) => r.slug)).toEqual(['near', 'mid']);
+  });
+
+  it('excludes the origin from its own candidate pool by identity, not by bare slug alone', () => {
+    // Two towns with the SAME bare slug in different authorities (e.g. two
+    // "Richmond"s) must never wrongly exclude each other — only an exact
+    // identity match (here, authoritySlug/slug) is a genuine self-exclusion.
+    const origin = { slug: 'richmond', authoritySlug: 'yorkshire', lat: 54.4, lng: -1.7 };
+    const otherRichmond = {
+      slug: 'richmond',
+      authoritySlug: 'richmond-upon-thames',
+      lat: 51.46,
+      lng: -0.3,
+    };
+    const compositeIdentity = (c) => `${c.authoritySlug}/${c.slug}`;
+
+    const result = nearestK(origin, [otherRichmond], 8, { identity: compositeIdentity });
+
+    // The other Richmond is NOT excluded — it has a different composite identity.
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(otherRichmond);
+  });
+
+  it('excludes the origin itself when it appears in the candidate pool', () => {
+    const origin = { slug: 'truro', lat: 50.2632, lng: -5.051 };
+    const other = { slug: 'falmouth', lat: 50.1526, lng: -5.0745 };
+    const result = nearestK(origin, [origin, other], 8, { identity });
+    expect(result).toEqual([other]);
+  });
+
+  it('breaks exact distance ties by tieBreakKey (slug) ascending', () => {
+    const origin = { slug: 'origin', lat: 51.0, lng: -1.0 };
+    // Two candidates at an IDENTICAL distance from origin (symmetric offset).
+    const zebra = { slug: 'zebra', lat: 51.1, lng: -1.0 };
+    const alpha = { slug: 'alpha', lat: 50.9, lng: -1.0 };
+    const result = nearestK(origin, [zebra, alpha], 2, {
+      identity,
+      tieBreakKey: (c) => c.slug,
+    });
+    expect(
+      haversineDistanceKm(origin, zebra) === haversineDistanceKm(origin, alpha),
+    ).toBe(true);
+    expect(result.map((r) => r.slug)).toEqual(['alpha', 'zebra']);
+  });
+
+  it('never relies on Array.prototype.sort stability alone: reversing input order does not change tie-break output', () => {
+    const origin = { slug: 'origin', lat: 51.0, lng: -1.0 };
+    const zebra = { slug: 'zebra', lat: 51.1, lng: -1.0 };
+    const alpha = { slug: 'alpha', lat: 50.9, lng: -1.0 };
+    const forward = nearestK(origin, [zebra, alpha], 2, { identity });
+    const reversed = nearestK(origin, [alpha, zebra], 2, { identity });
+    expect(forward.map((r) => r.slug)).toEqual(reversed.map((r) => r.slug));
+    expect(forward.map((r) => r.slug)).toEqual(['alpha', 'zebra']);
+  });
+
+  it('never drops a valid candidate the caller supplied (does no filtering of its own beyond self-exclusion)', () => {
+    // The function must not silently exclude an "unpublished-looking" entry —
+    // filtering to only published/eligible candidates is the CALLER's job.
+    // Every distinct entry handed in (other than the origin) comes back.
+    const origin = { slug: 'origin', lat: 51.0, lng: -1.0 };
+    const candidates = Array.from({ length: 5 }, (_, i) => ({
+      slug: `c${i}`,
+      lat: 51.0 + i * 0.1,
+      lng: -1.0,
+    }));
+    const result = nearestK(origin, candidates, 10, { identity });
+    expect(result).toHaveLength(5);
+    expect(new Set(result.map((r) => r.slug))).toEqual(
+      new Set(candidates.map((c) => c.slug)),
+    );
+  });
+
+  it('returns every available candidate, unpadded, when K exceeds the candidate pool', () => {
+    const origin = { slug: 'origin', lat: 51.0, lng: -1.0 };
+    const a = { slug: 'a', lat: 51.1, lng: -1.0 };
+    const b = { slug: 'b', lat: 51.2, lng: -1.0 };
+    const result = nearestK(origin, [a, b], 6, { identity });
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.slug)).toEqual(['a', 'b']);
+  });
+
+  it('returns an empty array when there are no candidates other than the origin', () => {
+    const origin = { slug: 'origin', lat: 51.0, lng: -1.0 };
+    expect(nearestK(origin, [origin], 8, { identity })).toEqual([]);
+    expect(nearestK(origin, [], 8, { identity })).toEqual([]);
+  });
+});
+
+describe('centroidOf', () => {
+  it('is the arithmetic mean of the given points', () => {
+    const points = [
+      { lat: 50.0, lng: -5.0 },
+      { lat: 52.0, lng: -3.0 },
+    ];
+    expect(centroidOf(points)).toEqual({ lat: 51.0, lng: -4.0 });
+  });
+
+  it('returns the point itself for a single-point list', () => {
+    const point = { lat: 50.2632, lng: -5.051 };
+    expect(centroidOf([point])).toEqual({ lat: 50.2632, lng: -5.051 });
+  });
+
+  it('returns null for an empty list (no honest centroid to report)', () => {
+    expect(centroidOf([])).toBeNull();
+  });
+});

--- a/web/scripts/lib/__tests__/prerender-nearest.test.mjs
+++ b/web/scripts/lib/__tests__/prerender-nearest.test.mjs
@@ -1,0 +1,323 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, readFile, writeFile, readdir, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runPrerender } from '../../prerender-planning.mjs';
+
+/**
+ * Two-pass restructuring coverage (tc-gyw1q, GH #990 slices 3+4): a page's
+ * neighbour links require knowing the FULL published set before any page can
+ * be written, so these tests exercise the whole `runPrerender` fixture-mode
+ * pipeline end to end rather than the individual decide/write helpers.
+ */
+
+const silentLogger = { log() {}, warn() {}, error() {} };
+
+let outDir;
+
+beforeEach(async () => {
+  outDir = await mkdtemp(join(tmpdir(), 'prerender-nearest-'));
+});
+
+afterEach(async () => {
+  await rm(outDir, { recursive: true, force: true });
+});
+
+const app = (uid) => ({
+  uid,
+  name: uid,
+  address: `${uid} address`,
+  description: 'desc',
+  appState: 'Permitted',
+  startDate: '2026-01-10',
+  lastDifferent: '2026-06-10T10:00:00+00:00',
+  link: null,
+  url: null,
+});
+
+/**
+ * A dense fixture: 9 qualifying authorities, 8 of which have published towns
+ * (giving each other 7 other centroid candidates so nearestK(6) has to
+ * TRUNCATE, not just return everything), plus one authority (Iardshire) with
+ * ZERO published towns of its own — no honest centroid, so it must be
+ * excluded both from having its own section AND from being a neighbour
+ * CANDIDATE for anyone else. Every town sits at the same longitude with
+ * strictly increasing latitude, so distance ordering is exact and easy to
+ * reason about by hand.
+ */
+const authorities = [
+  { id: 1, name: 'Aardshire', areaType: 'English District' },
+  { id: 2, name: 'Bardshire', areaType: 'English District' },
+  { id: 3, name: 'Cardshire', areaType: 'English District' },
+  { id: 4, name: 'Dardshire', areaType: 'English District' },
+  { id: 5, name: 'Eardshire', areaType: 'English District' },
+  { id: 6, name: 'Fardshire', areaType: 'English District' },
+  { id: 7, name: 'Gardshire', areaType: 'English District' },
+  { id: 8, name: 'Hardshire', areaType: 'English District' },
+  { id: 9, name: 'Iardshire', areaType: 'English District' },
+];
+
+function authorityFixtureEntries() {
+  return authorities.map((a) => ({
+    id: a.id,
+    name: a.name,
+    areaType: a.areaType,
+    areaName: a.name,
+    total: 15,
+    statusBreakdown: [{ appState: 'Permitted', count: 15 }],
+    applications: [app(`${a.name}-A1`)],
+  }));
+}
+
+/** slug -> lat, in strictly increasing order. */
+const townFixtureEntries = [
+  { slug: 'apton', name: 'Apton', lat: 51.0, lng: -1.0, authorityId: 1 },
+  { slug: 'bapton', name: 'Bapton', lat: 51.02, lng: -1.0, authorityId: 1 },
+  { slug: 'capton', name: 'Capton', lat: 51.05, lng: -1.0, authorityId: 2 },
+  { slug: 'japton', name: 'Japton', lat: 51.06, lng: -1.0, authorityId: 2 },
+  { slug: 'dapton', name: 'Dapton', lat: 51.1, lng: -1.0, authorityId: 3 },
+  { slug: 'eapton', name: 'Eapton', lat: 51.2, lng: -1.0, authorityId: 4 },
+  { slug: 'fapton', name: 'Fapton', lat: 51.4, lng: -1.0, authorityId: 5 },
+  { slug: 'gapton', name: 'Gapton', lat: 51.7, lng: -1.0, authorityId: 6 },
+  { slug: 'hapton', name: 'Hapton', lat: 52.1, lng: -1.0, authorityId: 7 },
+  { slug: 'iapton', name: 'Iapton', lat: 52.12, lng: -1.0, authorityId: 7 },
+  { slug: 'kapton', name: 'Kapton', lat: 52.5, lng: -1.0, authorityId: 8 },
+  // authorityId 9 (Iardshire) deliberately has NO town at all.
+].map((t) => ({
+  ...t,
+  total: 12,
+  statusBreakdown: [{ appState: 'Permitted', count: 12 }],
+  applications: [app(`${t.name}-T1`)],
+}));
+
+async function writeDenseFixtures(dir) {
+  const authorityFixture = join(dir, 'authorities.json');
+  const townFixture = join(dir, 'towns.json');
+  await writeFile(authorityFixture, JSON.stringify(authorityFixtureEntries()), 'utf-8');
+  await writeFile(townFixture, JSON.stringify(townFixtureEntries), 'utf-8');
+  return { authorityFixture, townFixture };
+}
+
+async function runDense(dir) {
+  const { authorityFixture, townFixture } = await writeDenseFixtures(dir);
+  return runPrerender({
+    outDir: dir,
+    fixturePath: authorityFixture,
+    townFixturePath: townFixture,
+    loadAuthorities: async () => authorities,
+    logger: silentLogger,
+  });
+}
+
+describe('runPrerender — nearby areas (town pages, tc-gyw1q GH #990 slice 3)', () => {
+  it('renders exactly 8 nearby-area links, truncating the two farthest candidates', async () => {
+    await runDense(outDir);
+
+    const html = await readFile(
+      join(outDir, 'planning', 'aardshire', 'apton', 'index.html'),
+      'utf-8',
+    );
+    expect(html).toContain('<section class="nearbyAreas">');
+    const section = html.match(/<section class="nearbyAreas">[\s\S]*?<\/section>/)[0];
+    const liCount = (section.match(/<li>/g) ?? []).length;
+    expect(liCount).toBe(8);
+
+    // The two FARTHEST towns from Apton (Iapton, Kapton) are truncated away.
+    expect(section).not.toContain('>Iapton');
+    expect(section).not.toContain('>Kapton');
+    // The nearest same-authority town is still included...
+    expect(section).toContain('Bapton, Aardshire');
+    // ...alongside a genuinely cross-authority neighbour (the border-town case).
+    expect(section).toContain('Capton, Bardshire');
+  });
+
+  it('links each nearby town to its own nested /planning/<authority>/<town> path', async () => {
+    await runDense(outDir);
+
+    const html = await readFile(
+      join(outDir, 'planning', 'aardshire', 'apton', 'index.html'),
+      'utf-8',
+    );
+    expect(html).toContain('<a href="/planning/bardshire/capton">Capton, Bardshire</a>');
+  });
+
+  it('renders fewer than 8 links when the published town pool is smaller', async () => {
+    // Only 3 towns published in total -> each gets at most 2 candidates.
+    const authorityFixture = join(outDir, 'authorities-small.json');
+    const townFixture = join(outDir, 'towns-small.json');
+    await writeFile(
+      authorityFixture,
+      JSON.stringify([
+        {
+          id: 1,
+          name: 'Aardshire',
+          areaType: 'English District',
+          areaName: 'Aardshire',
+          total: 15,
+          statusBreakdown: [{ appState: 'Permitted', count: 15 }],
+          applications: [app('A1')],
+        },
+      ]),
+      'utf-8',
+    );
+    await writeFile(
+      townFixture,
+      JSON.stringify(
+        [
+          { slug: 'apton', name: 'Apton', lat: 51.0, lng: -1.0, authorityId: 1 },
+          { slug: 'bapton', name: 'Bapton', lat: 51.02, lng: -1.0, authorityId: 1 },
+          { slug: 'capton', name: 'Capton', lat: 51.05, lng: -1.0, authorityId: 1 },
+        ].map((t) => ({
+          ...t,
+          total: 12,
+          statusBreakdown: [{ appState: 'Permitted', count: 12 }],
+          applications: [app(`${t.name}-T1`)],
+        })),
+      ),
+      'utf-8',
+    );
+
+    await runPrerender({
+      outDir,
+      fixturePath: authorityFixture,
+      townFixturePath: townFixture,
+      loadAuthorities: async () => [{ id: 1, name: 'Aardshire' }],
+      logger: silentLogger,
+    });
+
+    const html = await readFile(
+      join(outDir, 'planning', 'aardshire', 'apton', 'index.html'),
+      'utf-8',
+    );
+    const section = html.match(/<section class="nearbyAreas">[\s\S]*?<\/section>/)[0];
+    const liCount = (section.match(/<li>/g) ?? []).length;
+    expect(liCount).toBe(2);
+  });
+});
+
+describe('runPrerender — neighbouring councils (authority pages, tc-gyw1q GH #990 slice 4)', () => {
+  it('renders exactly 6 neighbouring-council links, truncating the farthest candidate', async () => {
+    await runDense(outDir);
+
+    const html = await readFile(
+      join(outDir, 'planning', 'aardshire', 'index.html'),
+      'utf-8',
+    );
+    expect(html).toContain('<section class="neighbouringCouncils">');
+    const section = html.match(
+      /<section class="neighbouringCouncils">[\s\S]*?<\/section>/,
+    )[0];
+    const liCount = (section.match(/<li>/g) ?? []).length;
+    expect(liCount).toBe(6);
+
+    // Aardshire's centroid is 51.01; Hardshire (52.50) is the FARTHEST of the
+    // 7 other authorities with a centroid, so it is truncated away...
+    expect(section).not.toContain('>Hardshire<');
+    // ...and Iardshire (zero published towns, no centroid) was never even a
+    // CANDIDATE, let alone a neighbour.
+    expect(section).not.toContain('Iardshire');
+    // The 6 nearest all appear.
+    for (const name of [
+      'Bardshire',
+      'Cardshire',
+      'Dardshire',
+      'Eardshire',
+      'Fardshire',
+      'Gardshire',
+    ]) {
+      expect(section).toContain(`>${name}<`);
+    }
+  });
+
+  it('links each neighbour to its own /planning/<slug> authority page', async () => {
+    await runDense(outDir);
+
+    const html = await readFile(
+      join(outDir, 'planning', 'aardshire', 'index.html'),
+      'utf-8',
+    );
+    expect(html).toContain('<a href="/planning/bardshire">Bardshire</a>');
+  });
+
+  it('renders no neighbours section for an authority with zero published towns, and does not error', async () => {
+    const result = await runDense(outDir);
+    expect(result.published).toContain('iardshire');
+
+    const html = await readFile(
+      join(outDir, 'planning', 'iardshire', 'index.html'),
+      'utf-8',
+    );
+    expect(html).not.toContain('<section class="neighbouringCouncils">');
+  });
+});
+
+describe('runPrerender — no generated /planning/* link ever points at an unpublished page (GH #990 acceptance)', () => {
+  it('every href="/planning/..." across every rendered page resolves to something actually published', async () => {
+    const result = await runDense(outDir);
+
+    const publishedPaths = new Set([
+      '/planning',
+      '/planning/towns',
+      ...result.published.map((slug) => `/planning/${slug}`),
+      ...result.publishedTowns.map((path) => `/planning/${path}`),
+    ]);
+
+    const files = await readAllFiles(join(outDir, 'planning'));
+    const pathPattern =
+      /(?:https:\/\/towncrierapp\.uk)?(\/planning(?:\/[a-z0-9][a-z0-9-]*){0,2})(?=["\s])/g;
+
+    let checked = 0;
+    for (const [, content] of files) {
+      for (const match of content.matchAll(pathPattern)) {
+        const path = match[1];
+        expect(publishedPaths.has(path), `unpublished link: ${path}`).toBe(true);
+        checked += 1;
+      }
+    }
+    // Sanity check the scan actually exercised a meaningful number of links —
+    // an empty scan would make every assertion above vacuously true.
+    expect(checked).toBeGreaterThan(20);
+  });
+});
+
+describe('runPrerender — two consecutive render passes are byte-identical (GH #990 acceptance)', () => {
+  it('produces identical HTML for every page across two independent renders of the same fixtures', async () => {
+    const outDirA = await mkdtemp(join(tmpdir(), 'prerender-nearest-a-'));
+    const outDirB = await mkdtemp(join(tmpdir(), 'prerender-nearest-b-'));
+    try {
+      await runDense(outDirA);
+      await runDense(outDirB);
+
+      const filesA = await readAllFiles(join(outDirA, 'planning'));
+      const filesB = await readAllFiles(join(outDirB, 'planning'));
+
+      expect([...filesA.keys()].sort()).toEqual([...filesB.keys()].sort());
+      for (const [relPath, contentA] of filesA) {
+        expect(contentA, relPath).toBe(filesB.get(relPath));
+      }
+    } finally {
+      await rm(outDirA, { recursive: true, force: true });
+      await rm(outDirB, { recursive: true, force: true });
+    }
+  });
+});
+
+/**
+ * Recursively read every FILE under `dir` into a `relativePath -> content`
+ * map (relative to `dir`), for structural/content comparison across renders.
+ *
+ * @param {string} dir
+ * @returns {Promise<Map<string, string>>}
+ */
+async function readAllFiles(dir) {
+  const relPaths = await readdir(dir, { recursive: true });
+  const files = new Map();
+  for (const rel of relPaths) {
+    const full = join(dir, rel);
+    const st = await stat(full);
+    if (st.isFile()) {
+      files.set(rel, await readFile(full, 'utf-8'));
+    }
+  }
+  return files;
+}

--- a/web/scripts/lib/__tests__/render-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-page.test.mjs
@@ -571,4 +571,75 @@ describe('renderPlanningPage', () => {
       expect(html).toContain('Stoke &amp; &lt;b&gt;Bramley&lt;/b&gt;');
     });
   });
+
+  describe('neighbouring councils section (tc-gyw1q, GH #990 slice 4)', () => {
+    const sixNeighbours = [
+      { name: 'Adur', slug: 'adur' },
+      { name: 'Worthing', slug: 'worthing' },
+      { name: 'Horsham', slug: 'horsham' },
+      { name: 'Mid Sussex', slug: 'mid-sussex' },
+      { name: 'Crawley', slug: 'crawley' },
+      { name: 'Arun', slug: 'arun' },
+    ];
+
+    it('omits the section entirely when neighbours is undefined (an authority with zero published towns)', () => {
+      const html = renderPlanningPage(pageData());
+      expect(html).not.toContain('<section class="neighbouringCouncils">');
+    });
+
+    it('omits the section entirely when neighbours is an empty array, without erroring', () => {
+      const html = renderPlanningPage(pageData({ neighbours: [] }));
+      expect(html).not.toContain('<section class="neighbouringCouncils">');
+    });
+
+    it('renders exactly 6 neighbouring-authority links when 6 are supplied', () => {
+      const html = renderPlanningPage(pageData({ neighbours: sixNeighbours }));
+      expect(html).toContain('<section class="neighbouringCouncils">');
+      const section = html.match(
+        /<section class="neighbouringCouncils">[\s\S]*?<\/section>/,
+      )[0];
+      const liCount = (section.match(/<li>/g) ?? []).length;
+      expect(liCount).toBe(6);
+    });
+
+    it('renders fewer than 6 links when fewer are supplied', () => {
+      const html = renderPlanningPage(
+        pageData({ neighbours: sixNeighbours.slice(0, 2) }),
+      );
+      const section = html.match(
+        /<section class="neighbouringCouncils">[\s\S]*?<\/section>/,
+      )[0];
+      const liCount = (section.match(/<li>/g) ?? []).length;
+      expect(liCount).toBe(2);
+    });
+
+    it('links each neighbour to its own /planning/<slug> authority page', () => {
+      const html = renderPlanningPage(pageData({ neighbours: sixNeighbours }));
+      expect(html).toContain('<a href="/planning/adur">Adur</a>');
+      expect(html).toContain('<a href="/planning/mid-sussex">Mid Sussex</a>');
+    });
+
+    it('HTML-escapes neighbour names', () => {
+      const html = renderPlanningPage(
+        pageData({
+          neighbours: [{ name: 'Stoke & <b>Bramley</b>', slug: 'stoke-bramley' }],
+        }),
+      );
+      expect(html).not.toContain('<b>Bramley</b>');
+      expect(html).toContain('Stoke &amp; &lt;b&gt;Bramley&lt;/b&gt;');
+    });
+
+    it('renders the section before the bottom CTA banner', () => {
+      const html = renderPlanningPage(pageData({ neighbours: sixNeighbours }));
+      expect(html.indexOf('<section class="neighbouringCouncils">')).toBeLessThan(
+        html.indexOf('<section class="cta">'),
+      );
+    });
+
+    it('regression: still carries the /planning and /planning/towns cross-links from PR #991 alongside the new section', () => {
+      const html = renderPlanningPage(pageData({ neighbours: sixNeighbours }));
+      expect(html).toContain('href="/planning"');
+      expect(html).toContain('href="/planning/towns"');
+    });
+  });
 });

--- a/web/scripts/lib/__tests__/render-shared.test.mjs
+++ b/web/scripts/lib/__tests__/render-shared.test.mjs
@@ -548,7 +548,11 @@ describe('pageStyles townLinks', () => {
     expect(css).toContain('.townLinks__list');
     expect(css).toContain('.townLinks__list a');
     // Uses design tokens (var(--tc-*)), never hard-coded colours/spacing.
-    expect(css).toMatch(/\.townLinks__list a \{[^}]*var\(--tc-/);
+    // tc-gyw1q: the rule's selector may now be grouped with the sibling
+    // nearby-areas/neighbouring-councils pill lists (`.townLinks__list a,
+    // .nearbyAreas__list a { ... }`), so match anything up to the opening
+    // brace rather than requiring it immediately after this one selector.
+    expect(css).toMatch(/\.townLinks__list a[^{]*\{[^}]*var\(--tc-/);
   });
 });
 

--- a/web/scripts/lib/__tests__/render-town-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-town-page.test.mjs
@@ -495,4 +495,86 @@ describe('renderTownPage', () => {
     expect(html).not.toContain('<script>alert(1)</script>');
     expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
   });
+
+  describe('nearby areas section (tc-gyw1q, GH #990 slice 3)', () => {
+    const eightNearby = [
+      { name: 'Falmouth', slug: 'falmouth', authoritySlug: 'cornwall', authorityName: 'Cornwall' },
+      { name: 'Penryn', slug: 'penryn', authoritySlug: 'cornwall', authorityName: 'Cornwall' },
+      { name: 'Redruth', slug: 'redruth', authoritySlug: 'cornwall', authorityName: 'Cornwall' },
+      { name: 'Camborne', slug: 'camborne', authoritySlug: 'cornwall', authorityName: 'Cornwall' },
+      { name: 'St Austell', slug: 'st-austell', authoritySlug: 'cornwall', authorityName: 'Cornwall' },
+      { name: 'Newquay', slug: 'newquay', authoritySlug: 'cornwall', authorityName: 'Cornwall' },
+      { name: 'Saltash', slug: 'saltash', authoritySlug: 'cornwall', authorityName: 'Cornwall' },
+      // The cross-authority entry (GH #990's explicit border-town requirement):
+      // a neighbour in a DIFFERENT authority from the page's own (Cornwall).
+      { name: 'Plymouth', slug: 'plymouth', authoritySlug: 'plymouth', authorityName: 'Plymouth' },
+    ];
+
+    it('omits the section entirely when nearby is undefined (backwards compatible)', () => {
+      const html = renderTownPage(townData());
+      expect(html).not.toContain('<section class="nearbyAreas">');
+    });
+
+    it('omits the section entirely when nearby is an empty array', () => {
+      const html = renderTownPage(townData({ nearby: [] }));
+      expect(html).not.toContain('<section class="nearbyAreas">');
+    });
+
+    it('renders exactly 8 nearby-area links when 8 are supplied', () => {
+      const html = renderTownPage(townData({ nearby: eightNearby }));
+      expect(html).toContain('<section class="nearbyAreas">');
+      const section = html.match(/<section class="nearbyAreas">[\s\S]*?<\/section>/)[0];
+      const liCount = (section.match(/<li>/g) ?? []).length;
+      expect(liCount).toBe(8);
+    });
+
+    it('renders fewer than 8 links when fewer are supplied', () => {
+      const html = renderTownPage(
+        townData({ nearby: eightNearby.slice(0, 3) }),
+      );
+      const section = html.match(/<section class="nearbyAreas">[\s\S]*?<\/section>/)[0];
+      const liCount = (section.match(/<li>/g) ?? []).length;
+      expect(liCount).toBe(3);
+    });
+
+    it('links each nearby town to its own nested /planning/<authority>/<town> path', () => {
+      const html = renderTownPage(townData({ nearby: eightNearby }));
+      expect(html).toContain('<a href="/planning/cornwall/falmouth">Falmouth, Cornwall</a>');
+      expect(html).toContain('<a href="/planning/plymouth/plymouth">Plymouth, Plymouth</a>');
+    });
+
+    it('includes a cross-authority neighbour, labelled with ITS OWN authority (a border-town case)', () => {
+      const html = renderTownPage(townData({ nearby: eightNearby }));
+      // Truro's own authority is Cornwall; Plymouth is a DIFFERENT authority —
+      // the label must read "Plymouth, Plymouth", never "Plymouth, Cornwall".
+      expect(html).toContain('Plymouth, Plymouth');
+      expect(html).not.toContain('Plymouth, Cornwall');
+    });
+
+    it('HTML-escapes the town and authority names', () => {
+      const html = renderTownPage(
+        townData({
+          nearby: [
+            {
+              name: 'Stoke & <b>Bramley</b>',
+              slug: 'stoke-bramley',
+              authoritySlug: 'somewhere',
+              authorityName: 'Some & <i>Council</i>',
+            },
+          ],
+        }),
+      );
+      expect(html).not.toContain('<b>Bramley</b>');
+      expect(html).not.toContain('<i>Council</i>');
+      expect(html).toContain('Stoke &amp; &lt;b&gt;Bramley&lt;/b&gt;');
+      expect(html).toContain('Some &amp; &lt;i&gt;Council&lt;/i&gt;');
+    });
+
+    it('renders the section before the bottom CTA banner', () => {
+      const html = renderTownPage(townData({ nearby: eightNearby }));
+      expect(html.indexOf('<section class="nearbyAreas">')).toBeLessThan(
+        html.indexOf('<section class="cta">'),
+      );
+    });
+  });
 });

--- a/web/scripts/lib/nearest.mjs
+++ b/web/scripts/lib/nearest.mjs
@@ -1,10 +1,143 @@
-// stub for red phase (tc-gyw1q)
-export function haversineDistanceKm() {
-  throw new Error('not implemented');
+/**
+ * Pure geographic helpers for the `/planning` cross-link mesh (GH #990 slices
+ * 3+4, tc-gyw1q): haversine distance between two WGS84 points, deterministic
+ * nearest-K selection, and an authority centroid (the arithmetic mean of its
+ * own published towns). No I/O, no framework code, no committed data of its
+ * own — every caller (`prerender-planning.mjs`) owns the published-set
+ * filtering, gating, and page writes; these functions only ever see the exact
+ * candidate pool they are handed.
+ */
+
+/**
+ * Mean Earth radius in kilometres. The exact constant only affects the
+ * absolute distance value, never the RANKING — every candidate in a given
+ * call is measured with the same radius, so nearest-K ordering is unaffected
+ * by which reasonable value is chosen here.
+ * @type {number}
+ */
+const EARTH_RADIUS_KM = 6371;
+
+/**
+ * @typedef {Object} GeoPoint
+ * @property {number} lat WGS84 latitude, degrees
+ * @property {number} lng WGS84 longitude, degrees
+ */
+
+/**
+ * @param {number} degrees
+ * @returns {number} radians
+ */
+function toRadians(degrees) {
+  return (degrees * Math.PI) / 180;
 }
-export function nearestK() {
-  throw new Error('not implemented');
+
+/**
+ * Great-circle distance between two WGS84 points, in kilometres (the
+ * standard haversine formula over the mean Earth radius).
+ *
+ * @param {GeoPoint} a
+ * @param {GeoPoint} b
+ * @returns {number}
+ */
+export function haversineDistanceKm(a, b) {
+  const dLat = toRadians(b.lat - a.lat);
+  const dLng = toRadians(b.lng - a.lng);
+  const lat1 = toRadians(a.lat);
+  const lat2 = toRadians(b.lat);
+  const sinDLat = Math.sin(dLat / 2);
+  const sinDLng = Math.sin(dLng / 2);
+  const h = sinDLat * sinDLat + Math.cos(lat1) * Math.cos(lat2) * sinDLng * sinDLng;
+  // Clamp to 1 before asin: floating-point error can push h fractionally over 1
+  // for two near-identical points, which would otherwise make asin return NaN.
+  return 2 * EARTH_RADIUS_KM * Math.asin(Math.min(1, Math.sqrt(h)));
 }
-export function centroidOf() {
-  throw new Error('not implemented');
+
+/**
+ * Select the K nearest candidates to `origin`, deterministically.
+ *
+ * Self-exclusion never relies on a bare `slug` alone: two different towns in
+ * different authorities can legitimately share one (e.g. two "Richmond"s —
+ * Yorkshire and Richmond-upon-Thames), so the caller supplies
+ * `options.identity`, a key unique across the WHOLE candidate pool (a town's
+ * full page path, an authority's slug), and any candidate whose identity
+ * matches the origin's is excluded from its own neighbour list.
+ *
+ * Ties in distance break by `options.tieBreakKey` ascending (the town/
+ * authority slug, per GH #990's decision), then by `identity` ascending as a
+ * final, fully-deterministic fallback for the rare case two candidates share
+ * even that key (e.g. same-slug towns in different authorities, equidistant)
+ * — never left to `Array.prototype.sort`'s stability alone.
+ *
+ * Returns every available candidate, unpadded, when fewer than `k` remain
+ * after self-exclusion — never pads or fabricates entries. Does no filtering
+ * of its own beyond self-exclusion: the candidate pool the caller passes in is
+ * exactly the pool considered (a below-threshold/unpublished/gated-out entry
+ * must never appear in `candidates` in the first place — that is the
+ * caller's job, not this function's).
+ *
+ * @template {GeoPoint} T
+ * @param {T} origin
+ * @param {ReadonlyArray<T>} candidates the full candidate pool, already
+ *   restricted by the caller to published/eligible entries
+ * @param {number} k
+ * @param {Object} options
+ * @param {(candidate: T) => string} options.identity unique key across the
+ *   whole pool, used for self-exclusion and the final tie-break
+ * @param {(candidate: T) => string} [options.tieBreakKey] primary tie-break
+ *   key on an exact distance tie; defaults to `identity`
+ * @returns {T[]}
+ */
+export function nearestK(origin, candidates, k, options) {
+  const { identity, tieBreakKey = identity } = options;
+  const originIdentity = identity(origin);
+
+  const scored = [];
+  for (const candidate of candidates) {
+    if (identity(candidate) === originIdentity) {
+      continue;
+    }
+    scored.push({ candidate, distanceKm: haversineDistanceKm(origin, candidate) });
+  }
+
+  scored.sort((x, y) => {
+    if (x.distanceKm !== y.distanceKm) {
+      return x.distanceKm - y.distanceKm;
+    }
+    const xKey = tieBreakKey(x.candidate);
+    const yKey = tieBreakKey(y.candidate);
+    if (xKey !== yKey) {
+      return xKey < yKey ? -1 : 1;
+    }
+    const xId = identity(x.candidate);
+    const yId = identity(y.candidate);
+    if (xId === yId) {
+      return 0;
+    }
+    return xId < yId ? -1 : 1;
+  });
+
+  return scored.slice(0, k).map((s) => s.candidate);
+}
+
+/**
+ * Arithmetic mean of a set of points — an authority's centroid, derived ONLY
+ * from its own published towns (the caller filters; this does no filtering of
+ * its own). Returns `null` for an empty list: an authority with zero
+ * published towns has no honest centroid to report (GH #990 decision — the
+ * caller omits the neighbours section rather than guessing one).
+ *
+ * @param {ReadonlyArray<GeoPoint>} points
+ * @returns {GeoPoint | null}
+ */
+export function centroidOf(points) {
+  if (points.length === 0) {
+    return null;
+  }
+  let sumLat = 0;
+  let sumLng = 0;
+  for (const point of points) {
+    sumLat += point.lat;
+    sumLng += point.lng;
+  }
+  return { lat: sumLat / points.length, lng: sumLng / points.length };
 }

--- a/web/scripts/lib/nearest.mjs
+++ b/web/scripts/lib/nearest.mjs
@@ -1,0 +1,10 @@
+// stub for red phase (tc-gyw1q)
+export function haversineDistanceKm() {
+  throw new Error('not implemented');
+}
+export function nearestK() {
+  throw new Error('not implemented');
+}
+export function centroidOf() {
+  throw new Error('not implemented');
+}

--- a/web/scripts/lib/render-page.mjs
+++ b/web/scripts/lib/render-page.mjs
@@ -10,6 +10,7 @@ import {
   renderQrBlock,
   renderAttributionList,
   renderPlanningCrossLinks,
+  renderNeighbouringCouncils,
 } from './render-shared.mjs';
 
 /**
@@ -23,6 +24,12 @@ import {
  */
 
 /**
+ * @typedef {Object} NeighbourAuthority
+ * @property {string} name display name of the neighbouring authority
+ * @property {string} slug the neighbouring authority's own URL slug
+ */
+
+/**
  * @typedef {Object} PlanningPageData
  * @property {string} slug
  * @property {string} areaName
@@ -32,6 +39,10 @@ import {
  * @property {PlanningApplicationItem[]} applications
  * @property {TownLink[]} [towns] published town children, for the internal link
  *   list. Omitted/empty for authorities with no published towns.
+ * @property {NeighbourAuthority[]} [neighbours] up to 6 nearest published
+ *   authorities (tc-gyw1q, GH #990 slice 4), by centroid distance. Omitted/
+ *   empty for an authority with no published towns of its own (no honest
+ *   centroid to measure from) — renders no "Neighbouring councils" section.
  */
 
 /**
@@ -218,7 +229,7 @@ ${townLinks}
             and the place to submit formal comments.
           </p>
         </section>
-
+${renderNeighbouringCouncils(data.neighbours)}
         <section class="cta">
           <h2 class="cta__heading">Get push alerts for ${area}</h2>
           <p>

--- a/web/scripts/lib/render-shared.mjs
+++ b/web/scripts/lib/render-shared.mjs
@@ -360,6 +360,75 @@ export function renderPlanningCrossLinks() {
 }
 
 /**
+ * Render the "Nearby areas" section on a town page (tc-gyw1q, GH #990 slice
+ * 3): up to 8 links to the nearest published town pages by great-circle
+ * distance, crossing authority boundaries where geography puts a neighbour in
+ * a different council area. Each link is labelled with the neighbour's OWN
+ * parent authority ("Saltash, Cornwall") so a cross-council entry reads
+ * sensibly to a reader on, say, a Plymouth page. Returns `''` (renders
+ * nothing) when there are no nearby towns to show, so the section is omitted
+ * rather than rendered empty — the caller (`prerender-planning.mjs`) has
+ * already resolved this list from the full published set, so every href here
+ * points at a real page.
+ *
+ * @param {ReadonlyArray<{ name: string, slug: string, authoritySlug: string, authorityName: string }>} [nearby]
+ * @returns {string}
+ */
+export function renderNearbyAreas(nearby) {
+  if (!Array.isArray(nearby) || nearby.length === 0) {
+    return '';
+  }
+  const items = nearby
+    .map(
+      (town) =>
+        `          <li><a href="/planning/${town.authoritySlug}/${town.slug}">${escapeHtml(town.name)}, ${escapeHtml(town.authorityName)}</a></li>`,
+    )
+    .join('\n');
+  return `
+        <section class="nearbyAreas">
+          <h2>Nearby areas</h2>
+          <p>Planning applications in the towns nearest here, including neighbouring council areas.</p>
+          <ul class="nearbyAreas__list">
+${items}
+          </ul>
+        </section>
+`;
+}
+
+/**
+ * Render the "Neighbouring councils" section on an authority page (tc-gyw1q,
+ * GH #990 slice 4): up to 6 links to the nearest published authorities, by
+ * the great-circle distance between each authority's own centroid (the mean
+ * of its published towns). Returns `''` (renders nothing, no error) when this
+ * authority has no neighbours to show — either it has zero published towns of
+ * its own (no honest centroid to measure from) or the published set is too
+ * thin to have any other authority with a centroid to measure to.
+ *
+ * @param {ReadonlyArray<{ name: string, slug: string }>} [neighbours]
+ * @returns {string}
+ */
+export function renderNeighbouringCouncils(neighbours) {
+  if (!Array.isArray(neighbours) || neighbours.length === 0) {
+    return '';
+  }
+  const items = neighbours
+    .map(
+      (authority) =>
+        `          <li><a href="/planning/${authority.slug}">${escapeHtml(authority.name)}</a></li>`,
+    )
+    .join('\n');
+  return `
+        <section class="neighbouringCouncils">
+          <h2>Neighbouring councils</h2>
+          <p>Planning applications in the councils nearest here.</p>
+          <ul class="neighbouringCouncils__list">
+${items}
+          </ul>
+        </section>
+`;
+}
+
+/**
  * Render the QR block for the bottom CTA banner (tc-fgoyj). Hidden on touch
  * devices by the stylesheet (see `.cta__qr`) and shown only where the primary
  * pointer is a mouse/trackpad: a desktop visitor who clicks the App Store link
@@ -573,8 +642,13 @@ export function pageStyles() {
     .statusSummary__otherList { list-style: none; margin: var(--tc-space-sm) 0 0; padding: 0; display: grid; gap: var(--tc-space-sm); }
     .statusSummary__otherList li { display: flex; justify-content: space-between; gap: var(--tc-space-md); }
     .statusSummary__otherCount { font-weight: 700; }
-    .townLinks__list { list-style: none; margin: 0; padding: 0; display: flex; flex-wrap: wrap; gap: var(--tc-space-sm); }
-    .townLinks__list a {
+    /* Nearby-area / neighbouring-council links (tc-gyw1q, GH #990 slices 3+4)
+       share the exact same pill vocabulary as the town-links list above — one
+       grouped rule rather than a near-duplicate per section. */
+    .townLinks__list, .nearbyAreas__list, .neighbouringCouncils__list {
+      list-style: none; margin: 0; padding: 0; display: flex; flex-wrap: wrap; gap: var(--tc-space-sm);
+    }
+    .townLinks__list a, .nearbyAreas__list a, .neighbouringCouncils__list a {
       display: inline-block;
       padding: var(--tc-space-sm) var(--tc-space-md);
       background: var(--tc-surface);
@@ -584,7 +658,9 @@ export function pageStyles() {
       text-decoration: none;
       font-weight: 600;
     }
-    .townLinks__list a:hover { color: var(--tc-amber-hover); border-color: var(--tc-amber); }
+    .townLinks__list a:hover, .nearbyAreas__list a:hover, .neighbouringCouncils__list a:hover {
+      color: var(--tc-amber-hover); border-color: var(--tc-amber);
+    }
     /* /planning/ authority hub (tc-geq7h.1): an A-Z jump nav plus one
        <section> per letter, each holding a flat list of authority links with
        a small mono metadata line (application/town counts) — the same

--- a/web/scripts/lib/render-town-page.mjs
+++ b/web/scripts/lib/render-town-page.mjs
@@ -29,7 +29,18 @@ import {
   renderInlineCta,
   renderQrBlock,
   renderAttributionList,
+  renderNearbyAreas,
 } from './render-shared.mjs';
+
+/**
+ * @typedef {Object} NearbyTown
+ * @property {string} name           display name, e.g. "Saltash"
+ * @property {string} slug           lowercase-hyphenated town slug
+ * @property {string} authoritySlug  the NEIGHBOUR's own parent authority slug
+ *   (may differ from this page's own authoritySlug — nearest-neighbour
+ *   selection crosses authority boundaries, GH #990 decision)
+ * @property {string} authorityName  the neighbour's own parent authority name
+ */
 
 /**
  * @typedef {Object} TownPageData
@@ -41,6 +52,9 @@ import {
  * @property {number} total
  * @property {Array<{ appState: string | null, count: number }>} statusBreakdown
  * @property {import('./render-shared.mjs').PlanningApplicationItem[]} applications
+ * @property {NearbyTown[]} [nearby]  up to 8 nearest published town pages
+ *   (tc-gyw1q, GH #990 slice 3), crossing authority boundaries; omitted/empty
+ *   renders no "Nearby areas" section.
  */
 
 /**
@@ -218,7 +232,7 @@ ${applicationsList}
             authoritative source and the place to submit formal comments.
           </p>
         </section>
-
+${renderNearbyAreas(data.nearby)}
         <section class="cta">
           <h2 class="cta__heading">Get push alerts for ${town}</h2>
           <p>

--- a/web/scripts/prerender-planning.mjs
+++ b/web/scripts/prerender-planning.mjs
@@ -50,6 +50,7 @@ import { resolveAuthority, townPagePath } from './lib/town-path.mjs';
 import { renderSitemap } from './lib/render-sitemap.mjs';
 import { isSameNameAsAuthority } from './lib/same-name.mjs';
 import { mergeRedirects } from './lib/redirect-config.mjs';
+import { nearestK, centroidOf } from './lib/nearest.mjs';
 import {
   renderTownsIndexPage,
   assertNoTownsSlugCollision,
@@ -78,6 +79,21 @@ const DEFAULT_NEAR_RADIUS_METERS = 5000;
  * @type {number}
  */
 const SNAPSHOT_VERSION = 1;
+
+/**
+ * How many nearest published town pages a town's "Nearby areas" section links
+ * to (GH #990 slice 3, tc-gyw1q's Pre-Resolved Design Decisions).
+ * @type {number}
+ */
+const NEARBY_TOWNS_COUNT = 8;
+
+/**
+ * How many nearest published authorities an authority's "Neighbouring
+ * councils" section links to (GH #990 slice 4, tc-gyw1q's Pre-Resolved Design
+ * Decisions).
+ * @type {number}
+ */
+const NEIGHBOUR_AUTHORITIES_COUNT = 6;
 
 /**
  * Derive a page's content `lastmod` from the applications it actually shows: the
@@ -479,14 +495,28 @@ async function writeRedirectConfig({ outDir, redirects, baseConfigPath }) {
 }
 
 /**
- * Render and write a page if the authority qualifies and clears the gate.
- * Mutates `published`/`excluded`/`seenSlugs` and returns nothing.
+ * @typedef {Object} PublishedAuthorityRecord
+ * @property {string} slug
+ * @property {string} areaName
+ * @property {number} authorityId
+ * @property {number} total
+ * @property {object[]} statusBreakdown
+ * @property {object[]} applications
+ * @property {Array<{ name: string, slug: string }>} towns
+ */
+
+/**
+ * DECIDE an authority: gate (coverage, slug dedup), resolve its published town
+ * children, and — if it qualifies — collect a full page-data record. Mutates
+ * `published`/`excluded`/`seenSlugs`/`hubEntries`/`publishedAuthorityRecords`;
+ * writes NOTHING (GH #990 slice 4, tc-gyw1q two-pass split). A page can only
+ * be written once every OTHER authority has also been decided, so its nearest
+ * neighbours can be resolved from the complete published set — see
+ * {@link writeAuthorityPagesWithNeighbours}, the second pass.
  *
  * @param {Object} args
- * @param {string} args.outDir
  * @param {number} args.authorityId
  * @param {string} args.name
- * @param {string} args.areaType
  * @param {string} args.areaName
  * @param {number} args.total
  * @param {object[]} args.statusBreakdown
@@ -503,12 +533,14 @@ async function writeRedirectConfig({ outDir, redirects, baseConfigPath }) {
  *   accumulates one entry per PUBLISHED authority for the `/planning/` hub
  *   page (tc-geq7h.1) — never a non-qualifying or coverage-gated-out one, so
  *   the hub can never link to a 404.
+ * @param {PublishedAuthorityRecord[]} [args.publishedAuthorityRecords]
+ *   accumulates one full page-data record per published authority, consumed
+ *   by the second (write) pass once every authority has been decided.
  * @param {{ warn: (msg: string) => void }} args.logger
  * @returns {Promise<void>}
  */
 async function considerAuthority(args) {
   const {
-    outDir,
     authorityId,
     name,
     total,
@@ -522,6 +554,7 @@ async function considerAuthority(args) {
     seenSlugs,
     townsByAuthority,
     hubEntries,
+    publishedAuthorityRecords,
     logger,
   } = args;
 
@@ -546,19 +579,11 @@ async function considerAuthority(args) {
   const towns = [...(townsByAuthority?.get(authorityId) ?? [])].sort((a, b) =>
     a.name.localeCompare(b.name),
   );
-  await writePage(outDir, {
-    slug,
-    areaName: areaName || name,
-    authorityId,
-    total,
-    statusBreakdown,
-    applications: shown,
-    towns,
-  });
+  const displayName = areaName || name;
+
   published.push(slug);
   sitemapEntries.push({ path: slug, lastmod: maxLastmod(shown) });
   if (hubEntries) {
-    const displayName = areaName || name;
     hubEntries.push({
       name: displayName,
       slug,
@@ -566,6 +591,168 @@ async function considerAuthority(args) {
       townCount: towns.length,
     });
   }
+  if (publishedAuthorityRecords) {
+    publishedAuthorityRecords.push({
+      slug,
+      areaName: displayName,
+      authorityId,
+      total,
+      statusBreakdown,
+      applications: shown,
+      towns,
+    });
+  }
+}
+
+/**
+ * Derive each authority's centroid — the arithmetic mean lat/lng of ONLY its
+ * own PUBLISHED town records (GH #990 slice 4) — computed once, after the
+ * town decide-loop, from every {@link PublishedTownRecord}. An authority with
+ * no entries here (zero published towns) simply has no key in the returned
+ * map: a missing centroid means "no honest centroid", never a guessed one.
+ *
+ * @param {ReadonlyArray<{ authorityId: number, lat: number, lng: number }>} records
+ * @returns {Map<number, import('./lib/nearest.mjs').GeoPoint>}
+ */
+function authorityCentroidsFromTowns(records) {
+  /** @type {Map<number, import('./lib/nearest.mjs').GeoPoint[]>} */
+  const byAuthority = new Map();
+  for (const record of records) {
+    const group = byAuthority.get(record.authorityId);
+    if (group) {
+      group.push(record);
+    } else {
+      byAuthority.set(record.authorityId, [record]);
+    }
+  }
+  /** @type {Map<number, import('./lib/nearest.mjs').GeoPoint>} */
+  const centroids = new Map();
+  for (const [authorityId, points] of byAuthority) {
+    const centroid = centroidOf(points);
+    if (centroid) {
+      centroids.set(authorityId, centroid);
+    }
+  }
+  return centroids;
+}
+
+/**
+ * WRITE every decided authority page (the second pass, GH #990 slice 4): for
+ * each record that has a centroid, resolve its up-to-
+ * {@link NEIGHBOUR_AUTHORITIES_COUNT} nearest neighbouring authorities from
+ * every OTHER published authority that ALSO has a centroid — an authority
+ * with zero published towns has no honest centroid and is excluded not just
+ * from having its own section, but from being a neighbour CANDIDATE for
+ * anyone else. Ties break by authority slug ascending (deterministic,
+ * reproducible builds).
+ *
+ * @param {string} outDir
+ * @param {ReadonlyArray<PublishedAuthorityRecord>} records
+ * @param {Map<number, import('./lib/nearest.mjs').GeoPoint>} authorityCentroids
+ * @returns {Promise<void>}
+ */
+async function writeAuthorityPagesWithNeighbours(outDir, records, authorityCentroids) {
+  // Only authorities with an honest centroid are valid neighbour CANDIDATES —
+  // never merely omitted from having their own section (GH #990 decision).
+  const candidates = [];
+  for (const record of records) {
+    const centroid = authorityCentroids.get(record.authorityId);
+    if (centroid) {
+      candidates.push({
+        slug: record.slug,
+        name: record.areaName,
+        lat: centroid.lat,
+        lng: centroid.lng,
+      });
+    }
+  }
+
+  for (const record of records) {
+    const centroid = authorityCentroids.get(record.authorityId);
+    let neighbours = [];
+    if (centroid) {
+      const origin = { slug: record.slug, lat: centroid.lat, lng: centroid.lng };
+      neighbours = nearestK(origin, candidates, NEIGHBOUR_AUTHORITIES_COUNT, {
+        identity: (c) => c.slug,
+      }).map((c) => ({ name: c.name, slug: c.slug }));
+    }
+    await writePage(outDir, { ...record, neighbours });
+  }
+}
+
+/**
+ * Render every authority that qualifies (areaType) and clears the coverage
+ * gate, across the two-pass split (GH #990 slices 3+4, tc-gyw1q): decide
+ * every candidate first (gate, slug/dedup, resolve its published town
+ * children), THEN write every page once each authority's up-to-
+ * {@link NEIGHBOUR_AUTHORITIES_COUNT} nearest NEIGHBOURING authorities can be
+ * resolved from the complete published set (`authorityCentroids`, computed by
+ * the earlier town pass, {@link renderTownPages}). Both `renderEntries` and
+ * `runLiveMode` share this — only `getApplications` (how one authority's
+ * bounded recent-applications projection is resolved: an inline lookup vs. a
+ * live fetch) differs between them.
+ *
+ * @param {Object} args
+ * @param {string} args.outDir
+ * @param {ReadonlyArray<{ id: number, name: string, areaType: string, areaName?: string }>} args.authorityEntries
+ * @param {(entry: { id: number, name: string, areaType: string, areaName?: string }) => Promise<{ areaName?: string, total: number, statusBreakdown?: object[], applications?: object[] }>} args.getApplications
+ * @param {number} args.limit
+ * @param {Map<number, Array<{ name: string, slug: string }>>} args.townsByAuthority
+ * @param {Map<number, import('./lib/nearest.mjs').GeoPoint>} args.authorityCentroids
+ * @param {import('./lib/render-planning-index.mjs').PlanningIndexEntry[]} [args.hubEntries]
+ * @param {{ warn: (msg: string) => void }} args.logger
+ * @returns {Promise<{ published: string[], sitemapEntries: SitemapEntry[], excluded: Array<{ name: string, reason: string }> }>}
+ */
+async function renderAuthorityPages(args) {
+  const {
+    outDir,
+    authorityEntries,
+    getApplications,
+    limit,
+    townsByAuthority,
+    authorityCentroids,
+    hubEntries,
+    logger,
+  } = args;
+
+  /** @type {string[]} */
+  const published = [];
+  /** @type {SitemapEntry[]} */
+  const sitemapEntries = [];
+  /** @type {Array<{ name: string, reason: string }>} */
+  const excluded = [];
+  const seenSlugs = new Set();
+  /** @type {PublishedAuthorityRecord[]} */
+  const publishedAuthorityRecords = [];
+
+  for (const entry of authorityEntries) {
+    if (!isQualifyingAreaType(entry.areaType)) {
+      excluded.push({ name: entry.name, reason: 'areaType' });
+      continue;
+    }
+    const data = await getApplications(entry);
+    await considerAuthority({
+      authorityId: entry.id,
+      name: entry.name,
+      areaName: data.areaName || entry.name,
+      total: data.total,
+      statusBreakdown: Array.isArray(data.statusBreakdown) ? data.statusBreakdown : [],
+      applications: Array.isArray(data.applications) ? data.applications : [],
+      limit,
+      published,
+      sitemapEntries,
+      excluded,
+      seenSlugs,
+      townsByAuthority,
+      hubEntries,
+      publishedAuthorityRecords,
+      logger,
+    });
+  }
+
+  await writeAuthorityPagesWithNeighbours(outDir, publishedAuthorityRecords, authorityCentroids);
+
+  return { published, sitemapEntries, excluded };
 }
 
 /**
@@ -668,11 +855,31 @@ function townsIndexLastmod(townSitemapEntries) {
 }
 
 /**
- * Render and write a town page if it clears the coverage gate, after resolving
- * its parent authority slug. Mutates `publishedTowns`/`excludedTowns`/`seenPaths`.
+ * @typedef {Object} PublishedTownRecord
+ * @property {string} townName
+ * @property {string} townSlug
+ * @property {string} authorityName
+ * @property {string} authoritySlug
+ * @property {number} authorityId
+ * @property {number} lat
+ * @property {number} lng
+ * @property {number} total
+ * @property {object[]} statusBreakdown
+ * @property {object[]} applications
+ */
+
+/**
+ * DECIDE a town: gate (coverage, same-name dedup, duplicate-path dedup),
+ * resolve its parent authority, and — if it qualifies — collect a full
+ * page-data record (including its centroid `lat`/`lng`). Mutates
+ * `publishedTowns`/`excludedTowns`/`redirects`/`seenPaths`/`townsByAuthority`/
+ * `townIndexEntries`/`publishedTownRecords`; writes NOTHING (GH #990 slice 3,
+ * tc-gyw1q two-pass split). A page can only be written once every OTHER town
+ * has also been decided, so its nearest neighbours (crossing authority
+ * boundaries) can be resolved from the complete published set — see
+ * {@link writeTownPagesWithNeighbours}, the second pass.
  *
  * @param {Object} args
- * @param {string} args.outDir
  * @param {Town} args.town
  * @param {ReadonlyArray<{ id: number, name: string }>} args.authorities
  * @param {number} args.total
@@ -692,12 +899,14 @@ function townsIndexLastmod(townSitemapEntries) {
  *   accumulates one entry per published town, in whatever order towns are
  *   considered — the town INDEX page (`/planning/towns`, GH #821 Phase 2)
  *   sorts and groups this flat list itself.
+ * @param {PublishedTownRecord[]} [args.publishedTownRecords]
+ *   accumulates one full page-data record per published town, consumed by
+ *   the second (write) pass once every town has been decided.
  * @param {{ warn: (msg: string) => void }} args.logger
  * @returns {Promise<void>}
  */
 async function considerTown(args) {
   const {
-    outDir,
     town,
     authorities,
     total,
@@ -711,6 +920,7 @@ async function considerTown(args) {
     seenPaths,
     townsByAuthority,
     townIndexEntries,
+    publishedTownRecords,
     logger,
   } = args;
 
@@ -750,16 +960,7 @@ async function considerTown(args) {
   // ordered by GREATEST(decidedDate, startDate) DESC (tc-s0yf) — like the
   // authority read (considerAuthority, above), so no re-sort here.
   const shown = applications.slice(0, limit);
-  await writeTownPage(outDir, {
-    townName: town.name,
-    townSlug: town.slug,
-    authorityName,
-    authoritySlug,
-    authorityId: town.authorityId,
-    total,
-    statusBreakdown,
-    applications: shown,
-  });
+
   publishedTowns.push(path);
   sitemapEntries.push({ path, lastmod: maxLastmod(shown) });
   // Record this published town for the town INDEX page (GH #821 Phase 2) —
@@ -786,11 +987,63 @@ async function considerTown(args) {
       ]);
     }
   }
+  if (publishedTownRecords) {
+    publishedTownRecords.push({
+      townName: town.name,
+      townSlug: town.slug,
+      authorityName,
+      authoritySlug,
+      authorityId: town.authorityId,
+      lat: town.lat,
+      lng: town.lng,
+      total,
+      statusBreakdown,
+      applications: shown,
+    });
+  }
 }
 
 /**
- * Render every town that clears the coverage gate. `getGeo` resolves a town to
- * its bounded recent-nearby projection (a live geo fetch, or inline fixture
+ * WRITE every decided town page (the second pass, GH #990 slice 3): for each
+ * record, resolve its up-to-{@link NEARBY_TOWNS_COUNT} nearest neighbouring
+ * town pages from every OTHER published town record — crossing authority
+ * boundaries where geography puts a neighbour in a different council area
+ * (GH #990 decision). Self-exclusion compares the FULL nested page path
+ * (`<authoritySlug>/<townSlug>`), never a bare slug alone, so two towns that
+ * merely SHARE a bare slug in different authorities (e.g. two "Richmond"s)
+ * never wrongly exclude each other. Ties break by town slug ascending
+ * (deterministic, reproducible builds).
+ *
+ * @param {string} outDir
+ * @param {ReadonlyArray<PublishedTownRecord>} records
+ * @returns {Promise<void>}
+ */
+async function writeTownPagesWithNeighbours(outDir, records) {
+  for (const record of records) {
+    const nearby = nearestK(record, records, NEARBY_TOWNS_COUNT, {
+      identity: (r) => townPagePath(r.authoritySlug, r.townSlug),
+      tieBreakKey: (r) => r.townSlug,
+    }).map((r) => ({
+      name: r.townName,
+      slug: r.townSlug,
+      authoritySlug: r.authoritySlug,
+      authorityName: r.authorityName,
+    }));
+
+    await writeTownPage(outDir, { ...record, nearby });
+  }
+}
+
+/**
+ * Render every town that clears the coverage gate, across the two-pass split
+ * (GH #990 slices 3+4, tc-gyw1q): decide every candidate first ({@link
+ * considerTown}), THEN write every page once each town's up-to-
+ * {@link NEARBY_TOWNS_COUNT} nearest neighbours can be resolved from the
+ * complete published set ({@link writeTownPagesWithNeighbours}). Also derives
+ * `authorityCentroids` — each authority's centroid, the arithmetic mean of
+ * ONLY its own published towns — for the (later) authority pass to resolve
+ * ITS neighbours from (GH #990 slice 4). `getGeo` resolves a town to its
+ * bounded recent-nearby projection (a live geo fetch, or inline fixture
  * data). The parent authority slug is resolved from `authorities`.
  *
  * @param {Object} args
@@ -800,7 +1053,7 @@ async function considerTown(args) {
  * @param {(town: Town) => Promise<{ applications: object[], total: number, statusBreakdown: object[] }>} args.getGeo
  * @param {number} args.limit
  * @param {{ warn: (msg: string) => void }} args.logger
- * @returns {Promise<{ publishedTowns: string[], townSitemapEntries: SitemapEntry[], excludedTowns: Array<{ name: string, reason: string }>, townsByAuthority: Map<number, Array<{ name: string, slug: string }>>, redirects: string[], townIndexEntries: import('./lib/render-towns-index.mjs').TownIndexEntry[] }>}
+ * @returns {Promise<{ publishedTowns: string[], townSitemapEntries: SitemapEntry[], excludedTowns: Array<{ name: string, reason: string }>, townsByAuthority: Map<number, Array<{ name: string, slug: string }>>, redirects: string[], townIndexEntries: import('./lib/render-towns-index.mjs').TownIndexEntry[], authorityCentroids: Map<number, import('./lib/nearest.mjs').GeoPoint> }>}
  */
 async function renderTownPages(args) {
   const { outDir, towns, authorities, getGeo, limit, logger } = args;
@@ -824,11 +1077,15 @@ async function renderTownPages(args) {
   // exact same gates (coverage, same-name dedup, duplicate-path).
   /** @type {import('./lib/render-towns-index.mjs').TownIndexEntry[]} */
   const townIndexEntries = [];
+  // Every decided-published town's full page-data record, incl. its centroid
+  // (lat/lng) — the candidate pool for the second (write) pass below, and the
+  // raw material for each authority's own centroid (GH #990 slices 3+4).
+  /** @type {PublishedTownRecord[]} */
+  const publishedTownRecords = [];
 
   for (const town of towns) {
     const geo = await getGeo(town);
     await considerTown({
-      outDir,
       town,
       authorities,
       total: geo.total,
@@ -844,9 +1101,17 @@ async function renderTownPages(args) {
       seenPaths,
       townsByAuthority,
       townIndexEntries,
+      publishedTownRecords,
       logger,
     });
   }
+
+  const authorityCentroids = authorityCentroidsFromTowns(publishedTownRecords);
+
+  // Second pass: every town has been decided, so each record's nearest
+  // neighbours (crossing authority boundaries) can be safely resolved before
+  // any town page is actually written (GH #990 slice 3).
+  await writeTownPagesWithNeighbours(outDir, publishedTownRecords);
 
   return {
     publishedTowns,
@@ -855,6 +1120,7 @@ async function renderTownPages(args) {
     excludedTowns,
     townsByAuthority,
     redirects,
+    authorityCentroids,
   };
 }
 
@@ -907,6 +1173,7 @@ async function renderEntries(args) {
     excludedTowns,
     townsByAuthority,
     redirects,
+    authorityCentroids,
   } = await renderTownPages({
     outDir,
     towns: townEntries,
@@ -922,42 +1189,28 @@ async function renderEntries(args) {
     logger,
   });
 
-  /** @type {string[]} */
-  const published = [];
-  /** @type {SitemapEntry[]} */
-  const authoritySitemapEntries = [];
-  /** @type {Array<{ name: string, reason: string }>} */
-  const excluded = [];
-  const seenSlugs = new Set();
   /** @type {import('./lib/render-planning-index.mjs').PlanningIndexEntry[]} */
   const hubEntries = [];
 
-  for (const entry of authorityEntries) {
-    if (!isQualifyingAreaType(entry.areaType)) {
-      excluded.push({ name: entry.name, reason: 'areaType' });
-      continue;
-    }
-    await considerAuthority({
-      outDir,
-      authorityId: entry.id,
-      name: entry.name,
-      areaType: entry.areaType,
+  const {
+    published,
+    sitemapEntries: authoritySitemapEntries,
+    excluded,
+  } = await renderAuthorityPages({
+    outDir,
+    authorityEntries,
+    getApplications: async (entry) => ({
       areaName: entry.areaName ?? entry.name,
       total: entry.total,
-      statusBreakdown: Array.isArray(entry.statusBreakdown)
-        ? entry.statusBreakdown
-        : [],
-      applications: Array.isArray(entry.applications) ? entry.applications : [],
-      limit,
-      published,
-      sitemapEntries: authoritySitemapEntries,
-      excluded,
-      seenSlugs,
-      townsByAuthority,
-      hubEntries,
-      logger,
-    });
-  }
+      statusBreakdown: entry.statusBreakdown,
+      applications: entry.applications,
+    }),
+    limit,
+    townsByAuthority,
+    authorityCentroids,
+    hubEntries,
+    logger,
+  });
 
   // Town INDEX page (GH #821 Phase 2) — always written, even with zero
   // entries, so /planning/towns is never a soft-404 (see writeTownsIndexPage).
@@ -1132,6 +1385,7 @@ async function runLiveMode(args) {
     excludedTowns,
     townsByAuthority,
     redirects,
+    authorityCentroids,
   } = await renderTownPages({
     outDir,
     towns: eligibleTowns,
@@ -1150,44 +1404,23 @@ async function runLiveMode(args) {
   });
   excludedTowns.push(...populationExcludedTowns);
 
-  /** @type {string[]} */
-  const published = [];
-  /** @type {SitemapEntry[]} */
-  const authoritySitemapEntries = [];
-  /** @type {Array<{ name: string, reason: string }>} */
-  const excluded = [];
-  const seenSlugs = new Set();
-
-  for (const authority of authorities) {
-    if (!isQualifyingAreaType(authority.areaType)) {
-      excluded.push({ name: authority.name, reason: 'areaType' });
-      continue;
-    }
-    const recent = await fetchRecentApplications(
-      apiBase,
-      authority.id,
-      buildKey,
-      limit,
-      fetchImpl,
-    );
-    await considerAuthority({
-      outDir,
-      authorityId: authority.id,
-      name: authority.name,
-      areaType: authority.areaType,
-      areaName: recent.areaName || authority.name,
-      total: recent.total,
-      statusBreakdown: recent.statusBreakdown,
-      applications: recent.applications,
-      limit,
-      published,
-      sitemapEntries: authoritySitemapEntries,
-      excluded,
-      seenSlugs,
-      townsByAuthority,
-      logger,
-    });
-  }
+  // NOTE: no `hubEntries` here — live mode has never written the `/planning/`
+  // hub page (a pre-existing asymmetry against the fixture/`--render` pipeline
+  // below, predating this bead; tracked separately, out of scope for tc-gyw1q).
+  const {
+    published,
+    sitemapEntries: authoritySitemapEntries,
+    excluded,
+  } = await renderAuthorityPages({
+    outDir,
+    authorityEntries: authorities,
+    getApplications: (authority) =>
+      fetchRecentApplications(apiBase, authority.id, buildKey, limit, fetchImpl),
+    limit,
+    townsByAuthority,
+    authorityCentroids,
+    logger,
+  });
 
   // Town INDEX page (GH #821 Phase 2) — always written, even with zero
   // entries, so /planning/towns is never a soft-404 (see writeTownsIndexPage).


### PR DESCRIPTION
## Changes

Slices 3+4 of #990 (bead tc-gyw1q), completing the cross-linking work started in #991 (slices 1+2).

- **`web/scripts/lib/nearest.mjs`** (new): pure haversine distance, deterministic nearest-K selection (self-exclusion by full `authoritySlug`/`townSlug` identity, not bare slug — two different towns can share a slug across authorities), and authority-centroid derivation (mean lat/lng of an authority's own published towns).
- **Town pages** (`render-town-page.mjs`): new "Nearby areas" section — up to 8 nearest published town pages by great-circle distance, crossing authority boundaries, each showing its parent authority for context. Rendered just before the bottom CTA banner.
- **Authority pages** (`render-page.mjs`): new "Neighbouring councils" section — up to 6 nearest published authorities by centroid distance. Authorities with zero published towns of their own (29 of them) have no honest centroid, so they get no section AND are excluded as neighbour candidates for everyone else.
- **`prerender-planning.mjs`**: the core change — both the town render loop and the authority render loop are now two-pass (decide + collect the full published set first, THEN resolve each page's neighbour list and write), because computing an accurate neighbour list requires knowing every other page that will actually publish, not just the ones considered so far. Shared between `renderEntries` (fixture/`--render`) and `runLiveMode` (the live default path) via an extracted `renderAuthorityPages()` helper.
- No maximum distance cap, no padding when the candidate pool is smaller than 8/6, deterministic slug tie-break — all per the issue's pre-resolved decisions.

Side quest found but **not** fixed here (kept out of scope, filed separately): `tc-aarmd` — `runLiveMode`'s flagless live path never writes `/planning/index.html` (pre-existing, unrelated to this diff).

## Verification

- `npx vitest run`: 1285/1285 pass, including new `nearest.test.mjs` (known-distance pair, tie-break, self-exclusion incl. same-slug-different-authority, K-larger-than-pool) and a pipeline-level test asserting every emitted `/planning/*` href resolves into the actual published set.
- Two consecutive render passes over an identical snapshot verified byte-identical.
- `npx tsc --noEmit` and `npm run build` clean.
- Verified live in a browser (dispatched UI-verification subagent driving `agent-browser` against a dense, hand-built fixture with deterministic geographic ordering): 8-link nearby-areas section including a confirmed cross-authority neighbour, 6-link neighbouring-councils section, a zero-town authority correctly showing no section at all (not an empty one), real link click-throughs (no 404s), and no visual regressions.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added nearby-area links to town pages, including cross-authority locations.
  * Added neighbouring-council links to authority pages.
  * Nearby links are limited, deterministic, correctly labeled, and point to published pages.
  * Added geographic distance and nearest-location calculations to support these links.

* **Bug Fixes**
  * Escaped location and authority names safely in generated HTML.
  * Preserved consistent styling and page navigation around the new sections.

* **Tests**
  * Added comprehensive coverage for distance calculations, rendering, link validity, ordering, and deterministic prerendered output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->