### PR TITLE
feat(api): emit push delivery failure telemetry (tc-97k35.4)

### DIFF
--- a/api-go/cmd/worker/devseed_wiring_test.go
+++ b/api-go/cmd/worker/devseed_wiring_test.go
@@ -27,7 +27,7 @@ func TestBuildDevSeeder_UnconfiguredReturnsNil(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			runner := buildDevSeeder(tc.cfg, &stores{}, discardLogger())
+			runner := buildDevSeeder(tc.cfg, nil, &stores{}, discardLogger())
 			if runner != nil {
 				t.Fatalf("buildDevSeeder: got non-nil runner, want nil (job unconfigured)")
 			}
@@ -57,7 +57,7 @@ func TestBuildDevSeeder_ConfiguredReturnsNonNilSeeder(t *testing.T) {
 		zone: watchzones.NewPostgresStore(nil),
 	}
 
-	runner := buildDevSeeder(cfg, st, discardLogger())
+	runner := buildDevSeeder(cfg, nil, st, discardLogger())
 
 	if runner == nil {
 		t.Fatal("buildDevSeeder: got nil runner, want a configured Seeder")

--- a/api-go/cmd/worker/main.go
+++ b/api-go/cmd/worker/main.go
@@ -181,7 +181,7 @@ func run() int {
 	// unconditionally now Postgres is always present. The email and push senders
 	// fall back to NoOp when their credentials are absent, so a job without
 	// ACS/APNs config still boots cleanly.
-	digester := buildDigester(cfg, st, logger)
+	digester := buildDigester(cfg, registry, st, logger)
 	dormantRunner := buildDormant(cfg, st, logger)
 	sweepRunner := buildSweep(cfg, st, logger)
 
@@ -218,7 +218,7 @@ func run() int {
 	// and any dev job before that infra bead deploys) leaves devSeeder a
 	// genuinely nil interface; dev-seed then refuses to run rather than
 	// crashing.
-	devSeeder := buildDevSeeder(cfg, st, logger)
+	devSeeder := buildDevSeeder(cfg, registry, st, logger)
 
 	return worker.Run(context.Background(), mode, bootstrapper, digester, dormantRunner, poller, sweepRunner, purger, devSeeder, logger)
 }
@@ -443,7 +443,7 @@ func buildPollOrchestrator(cfg platform.Config, sbClient *servicebus.Client, reg
 // fields are extracted under a nil guard so the fan-out wires with no other
 // store dependency.
 func wirePollFanOut(cfg platform.Config, laneA, laneB *polling.NationalLaneHandler, laneC *polling.InverseMaskLaneHandler, handler *polling.NationalPollHandler, zoneStore watchzones.Store, registry *metrics.Registry, st *stores, logger *slog.Logger) {
-	dispatcher, enqueuer, coalescer := buildNotifyFanOut(cfg, zoneStore, st, logger)
+	dispatcher, enqueuer, coalescer := buildNotifyFanOut(cfg, registry, zoneStore, st, logger)
 
 	// Record towncrier.notifications.created on each dispatcher (tc-21np). Only
 	// the real poll-sb path is on this KPI surface, so metrics wiring is this
@@ -478,14 +478,20 @@ func wirePollFanOut(cfg platform.Config, laneA, laneB *polling.NationalLaneHandl
 // dev-seed job, dev-only, tc-grvu.5/GH#808) so both feed applications through
 // byte-for-byte the same notification pipeline, whatever their application
 // source (PlanIt poll vs. the read-only prod mirror). Metrics wiring
-// (WithMetrics) is left to the caller: dev-seed is a QA aid, not part of the
-// towncrier.notifications.* KPI surface poll-sb's real cycle feeds, so it
-// deliberately skips it.
+// (WithMetrics) on the enqueuer/dispatcher themselves is left to the caller:
+// dev-seed is a QA aid, not part of the towncrier.notifications.* KPI surface
+// poll-sb's real cycle feeds, so it deliberately skips that.
+//
+// registry is, however, always wired onto the underlying APNs/FCM push
+// senders (towncrier.push.delivery_failed, tc-97k35.4): dev-seed still sends
+// real pushes to real device tokens, so a delivery failure there is as
+// genuine an operational signal as one from the poll-sb path — unlike
+// notifications.created, it isn't a KPI reserved to the real cycle.
 //
 // st may be nil in tests that only exercise the zone-containment path; the
 // store fields are extracted under a nil guard so the fan-out wires with no
 // other store dependency.
-func buildNotifyFanOut(cfg platform.Config, zoneStore watchzones.Store, st *stores, logger *slog.Logger) (*notifydispatch.DecisionDispatcher, *notifydispatch.Enqueuer, *notifydispatch.PushCoalescer) {
+func buildNotifyFanOut(cfg platform.Config, registry *metrics.Registry, zoneStore watchzones.Store, st *stores, logger *slog.Logger) (*notifydispatch.DecisionDispatcher, *notifydispatch.Enqueuer, *notifydispatch.PushCoalescer) {
 	var (
 		notifStore     *notifications.PostgresStore
 		profileStore   *profiles.PostgresStore
@@ -501,7 +507,7 @@ func buildNotifyFanOut(cfg platform.Config, zoneStore watchzones.Store, st *stor
 		savedStore = st.savedApp
 	}
 
-	pushDispatcher := buildPlatformDispatcher(cfg, logger)
+	pushDispatcher := buildPlatformDispatcher(cfg, registry, logger)
 	coalescer := notifydispatch.NewPushCoalescer(deviceStore, statePushStore, pushDispatcher, zoneStore, logger)
 	enqueuer := notifydispatch.NewEnqueuer(
 		notifStore, zoneStore, profileStore, coalescer,
@@ -534,7 +540,7 @@ func buildNotifyFanOut(cfg platform.Config, zoneStore watchzones.Store, st *stor
 // unconfigured (logged, nil returned) rather than fatal, since a malformed
 // managed-identity/DSN input at boot must not crash the OTHER modes this same
 // binary dispatches (digest, dormant-cleanup, etc.) when they share a process.
-func buildDevSeeder(cfg platform.Config, st *stores, logger *slog.Logger) worker.DevSeedRunner {
+func buildDevSeeder(cfg platform.Config, registry *metrics.Registry, st *stores, logger *slog.Logger) worker.DevSeedRunner {
 	if cfg.DevSeedProdAzureClientID == "" || cfg.DevSeedProdPostgresUser == "" {
 		logger.Info("dev-seed unconfigured (DEV_SEED_PROD_AZURE_CLIENT_ID / DEV_SEED_PROD_POSTGRES_USER unset); dev-seed mode will refuse to run")
 		return nil
@@ -561,10 +567,11 @@ func buildDevSeeder(cfg platform.Config, st *stores, logger *slog.Logger) worker
 
 	prodApps := applications.NewPostgresStore(prodPool)
 
-	// registry is deliberately nil here: buildNotifyFanOut's metrics wiring is
-	// wirePollFanOut's job (the poll-sb KPI surface); dev-seed's ingestion is a
-	// QA aid and skips it.
-	decision, enqueuer, coalescer := buildNotifyFanOut(cfg, st.zone, st, logger)
+	// registry is threaded through for the push-sender delivery-failure metrics
+	// only (tc-97k35.4) — the towncrier.notifications.created KPI wiring on
+	// enqueuer/decision below is still skipped: that's wirePollFanOut's job (the
+	// poll-sb KPI surface), and dev-seed's ingestion is a QA aid, not part of it.
+	decision, enqueuer, coalescer := buildNotifyFanOut(cfg, registry, st.zone, st, logger)
 	ingester := polling.NewIngester(st.app, decision, enqueuer)
 
 	return devseed.NewSeeder(st.zone, prodApps, ingester, coalescer, cfg.DevSeedLimit, logger)
@@ -629,7 +636,7 @@ func maxInt(a, b int) int {
 // buildDigester constructs the digest handler, wiring the per-feature Postgres
 // stores and the email/push senders (real when their credentials are present,
 // NoOp otherwise so a job without ACS/APNs boots cleanly).
-func buildDigester(cfg platform.Config, st *stores, logger *slog.Logger) *digest.Handler {
+func buildDigester(cfg platform.Config, registry *metrics.Registry, st *stores, logger *slog.Logger) *digest.Handler {
 	// digestProfiles combines the cross-user admin selector (ByDigestDay) and the
 	// point-read store (Get).
 	profileStore := digestProfiles{
@@ -641,7 +648,7 @@ func buildDigester(cfg platform.Config, st *stores, logger *slog.Logger) *digest
 	// "Email send" span (tagged email.kind) distinct from the underlying "ACS
 	// email send" HTTP client spans (tc-3jx8d).
 	emailSender := acsemail.NewInstrumentedSender(buildEmailSender(cfg, logger))
-	dispatcher := buildPlatformDispatcher(cfg, logger)
+	dispatcher := buildPlatformDispatcher(cfg, registry, logger)
 
 	return digest.NewHandler(
 		profileStore,
@@ -775,8 +782,10 @@ func buildEmailSender(cfg platform.Config, logger *slog.Logger) acsemail.EmailSe
 }
 
 // buildPushSender returns the real APNs sender when APNs is enabled, else a NoOp
-// so a job without a .p8 auth key boots cleanly.
-func buildPushSender(cfg platform.Config, logger *slog.Logger) apns.PushSender {
+// so a job without a .p8 auth key boots cleanly. registry wires
+// towncrier.push.delivery_failed (tc-97k35.4) onto the real client; a nil
+// registry is a safe no-op (matches every other WithMetrics call site).
+func buildPushSender(cfg platform.Config, registry *metrics.Registry, logger *slog.Logger) apns.PushSender {
 	if !cfg.APNsEnabled {
 		logger.Info("apns disabled; digest pushes disabled (NoOp sender)")
 		return apns.NewNoOpSender()
@@ -793,13 +802,14 @@ func buildPushSender(cfg platform.Config, logger *slog.Logger) apns.PushSender {
 		logger.Error("build apns client; falling back to NoOp sender", "error", err)
 		return apns.NewNoOpSender()
 	}
-	return client
+	return client.WithMetrics(registry)
 }
 
 // buildFCMSender returns the real FCM sender when FCM is enabled, else a NoOp so
 // a job without a service-account key boots cleanly (the mirror of
-// buildPushSender for Android delivery).
-func buildFCMSender(cfg platform.Config, logger *slog.Logger) fcm.PushSender {
+// buildPushSender for Android delivery). registry wires
+// towncrier.push.delivery_failed (tc-97k35.4) onto the real client.
+func buildFCMSender(cfg platform.Config, registry *metrics.Registry, logger *slog.Logger) fcm.PushSender {
 	if !cfg.FCMEnabled {
 		logger.Info("fcm disabled; android pushes disabled (NoOp sender)")
 		return fcm.NewNoOpSender()
@@ -814,7 +824,7 @@ func buildFCMSender(cfg platform.Config, logger *slog.Logger) fcm.PushSender {
 		return fcm.NewNoOpSender()
 	}
 	logger.Info("fcm enabled", "projectId", cfg.FCMProjectID)
-	return client
+	return client.WithMetrics(registry)
 }
 
 // buildPlatformDispatcher wires the platform-aware push dispatcher over the APNs
@@ -822,10 +832,10 @@ func buildFCMSender(cfg platform.Config, logger *slog.Logger) fcm.PushSender {
 // and the weekly-digest handler — swap their single push sender for this one
 // dispatcher, which splits a recipient's tokens by platform and prunes the union
 // of tokens either sender reports invalid.
-func buildPlatformDispatcher(cfg platform.Config, logger *slog.Logger) *notifydispatch.PlatformDispatcher {
+func buildPlatformDispatcher(cfg platform.Config, registry *metrics.Registry, logger *slog.Logger) *notifydispatch.PlatformDispatcher {
 	return notifydispatch.NewPlatformDispatcher(
-		buildPushSender(cfg, logger),
-		buildFCMSender(cfg, logger),
+		buildPushSender(cfg, registry, logger),
+		buildFCMSender(cfg, registry, logger),
 		logger,
 	)
 }

--- a/api-go/internal/apns/client.go
+++ b/api-go/internal/apns/client.go
@@ -11,10 +11,17 @@ import (
 	"net/http"
 	"time"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
 	"golang.org/x/net/http2"
 
 	"github.com/AmyDe/town-crier/api-go/internal/platform"
 )
+
+// tracerName labels the "APNs delivery" wrapper span this package emits,
+// distinct from the transport-level "APNs push" HTTP client spans
+// platform.WrapHTTPClient attaches to each individual request/retry.
+const tracerName = "github.com/AmyDe/town-crier/api-go/internal/apns"
 
 const (
 	// maxAttempts bounds retries per device on transient (5xx / transport)
@@ -46,6 +53,24 @@ type Client struct {
 	bundleID string
 	logger   *slog.Logger
 	now      func() time.Time
+	metrics  pushMetricsRecorder
+}
+
+// pushMetricsRecorder is the consumer-side slice of the metrics registry the
+// client records towncrier.push.delivery_failed on. *metrics.Registry
+// satisfies it; nil (the default) leaves the counter dark, matching the
+// notifydispatch.Enqueuer.WithMetrics convention.
+type pushMetricsRecorder interface {
+	PushDeliveryFailed(ctx context.Context, platform string)
+}
+
+// WithMetrics wires the recorder Send calls PushDeliveryFailed on for a
+// genuine per-device delivery failure (never for a routine invalid-token
+// rejection). Returns c for chaining; the default nil recorder leaves the
+// counter dark.
+func (c *Client) WithMetrics(rec pushMetricsRecorder) *Client {
+	c.metrics = rec
+	return c
 }
 
 // NewClient builds a production APNs client from validated options. The HTTP
@@ -105,7 +130,7 @@ func (c *Client) Send(ctx context.Context, tokens []string, payload json.RawMess
 
 	invalid := make([]string, 0, len(tokens))
 	for _, token := range tokens {
-		rejected, err := c.sendOne(ctx, token, payload)
+		rejected, err := c.sendOneTraced(ctx, token, payload)
 		if err != nil {
 			c.logger.ErrorContext(ctx, "apns send failed", "token", redactToken(token), "error", err)
 			continue
@@ -118,6 +143,33 @@ func (c *Client) Send(ctx context.Context, tokens []string, payload json.RawMess
 		return nil, nil
 	}
 	return invalid, nil
+}
+
+// sendOneTraced wraps sendOne in an "APNs delivery" span — distinct from the
+// transport-level "APNs push" HTTP client spans platform.WrapHTTPClient
+// attaches to each individual request/retry — so a genuine per-device
+// delivery failure is visible as a single dependency with Error status even
+// when the failure happened before any HTTP request was made (e.g. a JWT
+// signing failure). On failure it also records
+// towncrier.push.delivery_failed (platform=apns) so the same failure is
+// queryable/alertable through AppMetrics, not just the "apns send failed"
+// slog line Send still emits. A routine permanently-invalid-token rejection
+// (rejected=true, err=nil) is expected churn the caller prunes, not a
+// failure — it is deliberately left off both the span's error status and the
+// counter.
+func (c *Client) sendOneTraced(ctx context.Context, token string, payload json.RawMessage) (rejected bool, err error) {
+	ctx, span := otel.Tracer(tracerName).Start(ctx, "APNs delivery")
+	defer span.End()
+
+	rejected, err = c.sendOne(ctx, token, payload)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		if c.metrics != nil {
+			c.metrics.PushDeliveryFailed(ctx, "apns")
+		}
+	}
+	return rejected, err
 }
 
 // sendOne posts payload to a single device token, returning rejected=true when

--- a/api-go/internal/apns/delivery_test.go
+++ b/api-go/internal/apns/delivery_test.go
@@ -1,0 +1,139 @@
+package apns
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// fakePushMetrics is a hand-written double for pushMetricsRecorder, recording
+// every platform tag the client reports a delivery failure for.
+type fakePushMetrics struct {
+	platforms []string
+}
+
+func (f *fakePushMetrics) PushDeliveryFailed(_ context.Context, platform string) {
+	f.platforms = append(f.platforms, platform)
+}
+
+// recordDeliverySpans swaps in an in-memory SDK TracerProvider for the
+// duration of run, restoring the previous global provider on cleanup, and
+// returns every span recorded. Deliberately not t.Parallel(): mutating the
+// global TracerProvider is safe only while no sibling test's body is
+// concurrently executing (matches internal/acsemail/instrumented_test.go and
+// this package's own span_test.go, which use a locally-scoped provider
+// instead since the HTTP-transport span is wired explicitly per test).
+func recordDeliverySpans(t *testing.T, run func()) []sdktrace.ReadOnlySpan {
+	t.Helper()
+
+	prev := otel.GetTracerProvider()
+	rec := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+		otel.SetTracerProvider(prev)
+	})
+
+	run()
+
+	return rec.Ended()
+}
+
+// TestClient_Send_RecordsDeliveryFailureSpanAndMetric pins tc-97k35.4: a
+// genuine per-device delivery failure (here, the APNs host is unreachable, so
+// sendOne exhausts its retries before ever getting a response) must produce
+// an "APNs delivery" span with Error status plus a
+// towncrier.push.delivery_failed(platform=apns) count — not just the
+// "apns send failed" slog line, which is all today's code emits.
+func TestClient_Send_RecordsDeliveryFailureSpanAndMetric(t *testing.T) {
+	pemBytes, _ := newTestKeyPEM(t)
+	opts := Options{
+		Enabled:  true,
+		AuthKey:  string(pemBytes),
+		KeyID:    "L2J5PQASN5",
+		TeamID:   "4574VQ7N2X",
+		BundleID: "uk.towncrierapp.mobile",
+	}
+	// 127.0.0.1:1 is a privileged, unlistened port: every connection attempt
+	// fails immediately with "connection refused", exercising sendOne's
+	// error path (exhausted transport retries) without needing to race an
+	// httptest server's shutdown.
+	client, err := newClientWithBaseURL(opts, "http://127.0.0.1:1", &http.Client{}, testLogger(), func() time.Time {
+		return time.Unix(1_700_000_000, 0).UTC()
+	})
+	if err != nil {
+		t.Fatalf("newClientWithBaseURL: %v", err)
+	}
+	metricsRec := &fakePushMetrics{}
+	client.WithMetrics(metricsRec)
+
+	spans := recordDeliverySpans(t, func() {
+		invalid, sendErr := client.Send(context.Background(), []string{"tok"}, json.RawMessage(`{}`))
+		if sendErr != nil {
+			t.Fatalf("Send: %v", sendErr)
+		}
+		if len(invalid) != 0 {
+			t.Fatalf("invalid = %v, want none (a transport failure is not an invalid token)", invalid)
+		}
+	})
+
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 delivery span, got %d", len(spans))
+	}
+	span := spans[0]
+	if span.Name() != "APNs delivery" {
+		t.Errorf("span name = %q, want %q", span.Name(), "APNs delivery")
+	}
+	if span.Status().Code != codes.Error {
+		t.Errorf("span status = %v, want Error", span.Status().Code)
+	}
+
+	if len(metricsRec.platforms) != 1 || metricsRec.platforms[0] != "apns" {
+		t.Errorf("PushDeliveryFailed calls = %v, want [apns]", metricsRec.platforms)
+	}
+}
+
+// TestClient_Send_RejectedTokenIsNotADeliveryFailure pins the churn-vs-failure
+// distinction: a permanently invalid token (410 Unregistered) is expected
+// churn the caller prunes, not a delivery failure — it must not mark the
+// "APNs delivery" span as Error nor increment towncrier.push.delivery_failed.
+func TestClient_Send_RejectedTokenIsNotADeliveryFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusGone)
+		_, _ = w.Write([]byte(`{"reason":"Unregistered"}`))
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	metricsRec := &fakePushMetrics{}
+	client.WithMetrics(metricsRec)
+
+	spans := recordDeliverySpans(t, func() {
+		invalid, sendErr := client.Send(context.Background(), []string{"deadtoken"}, json.RawMessage(`{}`))
+		if sendErr != nil {
+			t.Fatalf("Send: %v", sendErr)
+		}
+		if len(invalid) != 1 || invalid[0] != "deadtoken" {
+			t.Fatalf("invalid = %v, want [deadtoken]", invalid)
+		}
+	})
+
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 delivery span, got %d", len(spans))
+	}
+	if spans[0].Status().Code == codes.Error {
+		t.Error("span status = Error, want unset for a routine token rejection")
+	}
+	if len(metricsRec.platforms) != 0 {
+		t.Errorf("PushDeliveryFailed calls = %v, want none", metricsRec.platforms)
+	}
+}

--- a/api-go/internal/fcm/client.go
+++ b/api-go/internal/fcm/client.go
@@ -10,8 +10,17 @@ import (
 	"net/http"
 	"time"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
+
 	"github.com/AmyDe/town-crier/api-go/internal/platform"
 )
+
+// tracerName labels the "FCM delivery" wrapper span this package emits,
+// distinct from the transport-level "FCM push" HTTP client spans
+// platform.WrapHTTPClient attaches to each individual request (both the
+// token exchange and the actual send).
+const tracerName = "github.com/AmyDe/town-crier/api-go/internal/fcm"
 
 const (
 	// maxRespBytes bounds the FCM error body read. FCM error bodies are a few
@@ -48,6 +57,24 @@ type Client struct {
 	baseURL   string
 	logger    *slog.Logger
 	now       func() time.Time
+	metrics   pushMetricsRecorder
+}
+
+// pushMetricsRecorder is the consumer-side slice of the metrics registry the
+// client records towncrier.push.delivery_failed on. *metrics.Registry
+// satisfies it; nil (the default) leaves the counter dark, mirroring
+// internal/apns.Client's WithMetrics convention.
+type pushMetricsRecorder interface {
+	PushDeliveryFailed(ctx context.Context, platform string)
+}
+
+// WithMetrics wires the recorder Send calls PushDeliveryFailed on for a
+// genuine per-device delivery failure (never for a routine invalid-token
+// rejection). Returns c for chaining; the default nil recorder leaves the
+// counter dark.
+func (c *Client) WithMetrics(rec pushMetricsRecorder) *Client {
+	c.metrics = rec
+	return c
 }
 
 // NewClient builds a production FCM client from validated options. The caller
@@ -95,7 +122,7 @@ func (c *Client) Send(ctx context.Context, tokens []string, payload json.RawMess
 
 	invalid := make([]string, 0, len(tokens))
 	for _, token := range tokens {
-		rejected, err := c.sendOne(ctx, token, payload)
+		rejected, err := c.sendOneTraced(ctx, token, payload)
 		if err != nil {
 			c.logger.ErrorContext(ctx, "fcm send failed", "token", redactToken(token), "error", err)
 			continue
@@ -108,6 +135,32 @@ func (c *Client) Send(ctx context.Context, tokens []string, payload json.RawMess
 		return nil, nil
 	}
 	return invalid, nil
+}
+
+// sendOneTraced wraps sendOne in an "FCM delivery" span — distinct from the
+// transport-level "FCM push" HTTP client spans platform.WrapHTTPClient
+// attaches to each individual request — so a genuine per-device delivery
+// failure is visible as a single dependency with Error status even when the
+// failure happened before the FCM send itself (e.g. the OAuth token
+// exchange). On failure it also records towncrier.push.delivery_failed
+// (platform=fcm) so the same failure is queryable/alertable through
+// AppMetrics, not just the "fcm send failed" slog line Send still emits. A
+// routine permanently-invalid-token rejection (rejected=true, err=nil) is
+// expected churn the caller prunes, not a failure — it is deliberately left
+// off both the span's error status and the counter.
+func (c *Client) sendOneTraced(ctx context.Context, token string, payload json.RawMessage) (rejected bool, err error) {
+	ctx, span := otel.Tracer(tracerName).Start(ctx, "FCM delivery")
+	defer span.End()
+
+	rejected, err = c.sendOne(ctx, token, payload)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		if c.metrics != nil {
+			c.metrics.PushDeliveryFailed(ctx, "fcm")
+		}
+	}
+	return rejected, err
 }
 
 // sendOne posts payload to a single device token, returning rejected=true when

--- a/api-go/internal/fcm/delivery_test.go
+++ b/api-go/internal/fcm/delivery_test.go
@@ -1,0 +1,128 @@
+package fcm
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// fakePushMetrics is a hand-written double for pushMetricsRecorder, recording
+// every platform tag the client reports a delivery failure for.
+type fakePushMetrics struct {
+	platforms []string
+}
+
+func (f *fakePushMetrics) PushDeliveryFailed(_ context.Context, platform string) {
+	f.platforms = append(f.platforms, platform)
+}
+
+// recordDeliverySpans swaps in an in-memory SDK TracerProvider for the
+// duration of run, restoring the previous global provider on cleanup, and
+// returns every span recorded. Deliberately not t.Parallel(): mutating the
+// global TracerProvider is safe only while no sibling test's body is
+// concurrently executing (matches internal/acsemail/instrumented_test.go and
+// the mirror helper in internal/apns/delivery_test.go).
+func recordDeliverySpans(t *testing.T, run func()) []sdktrace.ReadOnlySpan {
+	t.Helper()
+
+	prev := otel.GetTracerProvider()
+	rec := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+		otel.SetTracerProvider(prev)
+	})
+
+	run()
+
+	return rec.Ended()
+}
+
+// TestClient_Send_RecordsDeliveryFailureSpanAndMetric pins tc-97k35.4: a
+// genuine per-device delivery failure (here, the OAuth token endpoint is
+// unreachable, so sendOne never even gets to send the FCM request) must
+// produce an "FCM delivery" span with Error status plus a
+// towncrier.push.delivery_failed(platform=fcm) count — not just the
+// "fcm send failed" slog line, which is all today's code emits.
+func TestClient_Send_RecordsDeliveryFailureSpanAndMetric(t *testing.T) {
+	fcmSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer fcmSrv.Close()
+	tokenSrv, _ := tokenServer(t)
+	tokenSrv.Close() // force the OAuth token exchange to fail immediately
+
+	client := newTestClient(t, fcmSrv, tokenSrv)
+	metricsRec := &fakePushMetrics{}
+	client.WithMetrics(metricsRec)
+
+	spans := recordDeliverySpans(t, func() {
+		invalid, err := client.Send(context.Background(), []string{"tok"}, json.RawMessage(`{"data":{}}`))
+		if err != nil {
+			t.Fatalf("Send: %v", err)
+		}
+		if len(invalid) != 0 {
+			t.Fatalf("invalid = %v, want none (a transport failure is not an invalid token)", invalid)
+		}
+	})
+
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 delivery span, got %d", len(spans))
+	}
+	span := spans[0]
+	if span.Name() != "FCM delivery" {
+		t.Errorf("span name = %q, want %q", span.Name(), "FCM delivery")
+	}
+	if span.Status().Code != codes.Error {
+		t.Errorf("span status = %v, want Error", span.Status().Code)
+	}
+
+	if len(metricsRec.platforms) != 1 || metricsRec.platforms[0] != "fcm" {
+		t.Errorf("PushDeliveryFailed calls = %v, want [fcm]", metricsRec.platforms)
+	}
+}
+
+// TestClient_Send_RejectedTokenIsNotADeliveryFailure pins the churn-vs-failure
+// distinction: a permanently invalid token (UNREGISTERED) is expected churn
+// the caller prunes, not a delivery failure — it must not mark the "FCM
+// delivery" span as Error nor increment towncrier.push.delivery_failed.
+func TestClient_Send_RejectedTokenIsNotADeliveryFailure(t *testing.T) {
+	fcmSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":{"code":404,"status":"NOT_FOUND","message":"Requested entity was not found.","details":[{"@type":"type.googleapis.com/google.firebase.fcm.v1.FcmError","errorCode":"UNREGISTERED"}]}}`))
+	}))
+	defer fcmSrv.Close()
+	tokenSrv, _ := tokenServer(t)
+
+	client := newTestClient(t, fcmSrv, tokenSrv)
+	metricsRec := &fakePushMetrics{}
+	client.WithMetrics(metricsRec)
+
+	spans := recordDeliverySpans(t, func() {
+		invalid, err := client.Send(context.Background(), []string{"deadtoken"}, json.RawMessage(`{"data":{}}`))
+		if err != nil {
+			t.Fatalf("Send: %v", err)
+		}
+		if len(invalid) != 1 || invalid[0] != "deadtoken" {
+			t.Fatalf("invalid = %v, want [deadtoken]", invalid)
+		}
+	})
+
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 delivery span, got %d", len(spans))
+	}
+	if spans[0].Status().Code == codes.Error {
+		t.Error("span status = Error, want unset for a routine token rejection")
+	}
+	if len(metricsRec.platforms) != 0 {
+		t.Errorf("PushDeliveryFailed calls = %v, want none", metricsRec.platforms)
+	}
+}

--- a/api-go/internal/metrics/registry.go
+++ b/api-go/internal/metrics/registry.go
@@ -58,6 +58,8 @@ type Registry struct {
 	watchZonesCreated metric.Int64Counter
 	watchZonesUpdated metric.Int64Counter
 	watchZonesDeleted metric.Int64Counter
+
+	pushDeliveryFailed metric.Int64Counter
 }
 
 // New builds the registry from a meter. Construction errors are deliberately
@@ -156,6 +158,11 @@ func New(meter metric.Meter) *Registry {
 	r.watchZonesCreated = counter("towncrier.watchzones.created")
 	r.watchZonesUpdated = counter("towncrier.watchzones.updated")
 	r.watchZonesDeleted = counter("towncrier.watchzones.deleted")
+
+	r.pushDeliveryFailed = counter(
+		"towncrier.push.delivery_failed",
+		metric.WithDescription("Per-device push send delivery failures (APNs or FCM), tagged by platform. Excludes routine invalid-token rejections (410/BadDeviceToken/UNREGISTERED etc.), which are expected churn the caller prunes, not a failure."),
+	)
 
 	return r
 }
@@ -339,6 +346,18 @@ func (r *Registry) WatchZoneDeleted(ctx context.Context) {
 		return
 	}
 	r.watchZonesDeleted.Add(ctx, 1)
+}
+
+// PushDeliveryFailed counts a per-device push send delivery failure (JWT/token
+// mint failure, transport error, or exhausted retries) for the given platform
+// ("apns" | "fcm"). Deliberately excludes a routine invalid-token rejection
+// (410 Unregistered, 400 BadDeviceToken, UNREGISTERED, ...) — that is expected
+// token churn the caller prunes, not a failure worth alerting on.
+func (r *Registry) PushDeliveryFailed(ctx context.Context, platform string) {
+	if r == nil || r.pushDeliveryFailed == nil {
+		return
+	}
+	r.pushDeliveryFailed.Add(ctx, 1, metric.WithAttributes(attribute.String("platform", platform)))
 }
 
 // boolStr renders a bool as the lowercase "true"/"false" string used in App

--- a/api-go/internal/metrics/registry_test.go
+++ b/api-go/internal/metrics/registry_test.go
@@ -65,6 +65,7 @@ func TestRegistry_RecordsAllInstrumentNames(t *testing.T) {
 	reg.WatchZoneCreated(ctx)
 	reg.WatchZoneUpdated(ctx)
 	reg.WatchZoneDeleted(ctx)
+	reg.PushDeliveryFailed(ctx, "apns")
 
 	got := metricNames(collect())
 
@@ -87,6 +88,7 @@ func TestRegistry_RecordsAllInstrumentNames(t *testing.T) {
 		"towncrier.watchzones.created",
 		"towncrier.watchzones.updated",
 		"towncrier.watchzones.deleted",
+		"towncrier.push.delivery_failed",
 	}
 	for _, name := range want {
 		if _, ok := got[name]; !ok {
@@ -120,6 +122,7 @@ func TestRegistry_NilIsNoOp(t *testing.T) {
 	reg.WatchZoneCreated(ctx)
 	reg.WatchZoneUpdated(ctx)
 	reg.WatchZoneDeleted(ctx)
+	reg.PushDeliveryFailed(ctx, "apns")
 }
 
 func TestRegistry_RetryAfterTagsHeaderPresence(t *testing.T) {
@@ -152,5 +155,41 @@ func TestRegistry_RetryAfterTagsHeaderPresence(t *testing.T) {
 	}
 	if !foundHeaderPresent {
 		t.Error("retry_after_seconds missing header_present tag")
+	}
+}
+
+// TestRegistry_PushDeliveryFailedTagsPlatform pins tc-97k35.4: the counter must
+// carry the platform tag ("apns" | "fcm") so a dashboard/alert can distinguish
+// which sender is failing, mirroring PlanItHTTPError's status-code tag.
+func TestRegistry_PushDeliveryFailedTagsPlatform(t *testing.T) {
+	t.Parallel()
+	reg, collect := newTestRegistry(t)
+	ctx := context.Background()
+
+	reg.PushDeliveryFailed(ctx, "fcm")
+
+	rm := collect()
+	var foundPlatform bool
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "towncrier.push.delivery_failed" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			if !ok {
+				t.Fatalf("push.delivery_failed is not an int64 sum: %T", m.Data)
+			}
+			for _, dp := range sum.DataPoints {
+				if v, ok := dp.Attributes.Value("platform"); ok {
+					foundPlatform = true
+					if v.AsString() != "fcm" {
+						t.Errorf("platform = %q, want fcm", v.AsString())
+					}
+				}
+			}
+		}
+	}
+	if !foundPlatform {
+		t.Error("push.delivery_failed missing platform tag")
 	}
 }

--- a/api-go/internal/notifications/digest.go
+++ b/api-go/internal/notifications/digest.go
@@ -29,12 +29,19 @@ type DigestNotification struct {
 	Decision               *string
 	EventType              EventType
 	Sources                string
-	// PushSent records whether an instant push was queued (optimistically —
-	// set once the user was determined push-eligible, not once APNs actually
-	// delivered) for this notification during its poll cycle. The poll-cycle
-	// coalescer (GH#784) flushes queued pushes as at most one per (user, watch
-	// zone) after this record is written, so a device-less or later-failed send
-	// still reads true here. Audit-only: no business logic reads this field.
+	// PushSent means "a push was queued for this notification", never
+	// "delivered" — it is set true the moment the user is determined
+	// push-eligible, before the poll-cycle coalescer (GH#784) has attempted
+	// any send. The coalescer flushes queued pushes as at most one per
+	// (user, watch zone) after this record is written, so a device-less
+	// send, an APNs/FCM delivery failure, or a partial multi-device/
+	// multi-platform failure all still leave this true. This is a
+	// deliberate, permanent choice (tc-97k35.4): reconciling it against the
+	// coalescer's batched, per-platform delivery outcome is materially more
+	// complex than the field's one audience — a user's own data export
+	// (profiles.ExportedNotification, "pushSent") — justifies. No business
+	// logic reads this field; treat every "true" as "queued", not "confirmed
+	// delivered".
 	PushSent  bool
 	EmailSent bool
 	CreatedAt time.Time

--- a/api-go/internal/notifydispatch/decision.go
+++ b/api-go/internal/notifydispatch/decision.go
@@ -165,8 +165,10 @@ func (d *DecisionDispatcher) dispatchForUser(ctx context.Context, app applicatio
 		now:         d.now().UTC(),
 	})
 
-	// PushSent is set optimistically (queued, not delivered) the moment the user
-	// is push-eligible; the coalescer flushes the actual send at cycle end.
+	// PushSent means "queued", not "delivered": it is set true here, before the
+	// coalescer has attempted any send, and is never reconciled against the
+	// actual delivery outcome (a deliberate choice, tc-97k35.4 — see
+	// notifications.DigestNotification.PushSent's doc comment).
 	if d.canPush(profile, m) {
 		n.PushSent = true
 		d.push.Add(userID, n)

--- a/api-go/internal/notifydispatch/enqueuer.go
+++ b/api-go/internal/notifydispatch/enqueuer.go
@@ -209,8 +209,10 @@ func (e *Enqueuer) Enqueue(ctx context.Context, app applications.PlanningApplica
 	// Instant push is a paid-tier entitlement. Free-tier users — including a paid
 	// tier whose subscription has lapsed (EffectiveTier) — still get the
 	// notification record (picked up by the weekly digest) but no push. PushSent
-	// is set optimistically (queued, not delivered) the moment the user is
-	// push-eligible; the coalescer flushes the actual send at cycle end.
+	// means "queued", not "delivered": it is set true here, before the coalescer
+	// has attempted any send, and is never reconciled against the actual
+	// delivery outcome (a deliberate choice, tc-97k35.4 — see
+	// notifications.DigestNotification.PushSent's doc comment).
 	if profile.EffectiveTier(e.now()).IsPaid() && profile.Preferences.PushEnabled {
 		n.PushSent = true
 		e.push.Add(zone.UserID, n)

--- a/api-go/internal/profiles/export.go
+++ b/api-go/internal/profiles/export.go
@@ -69,17 +69,21 @@ type ExportedWatchZone struct {
 }
 
 type ExportedNotification struct {
-	ID                     string              `json:"id"`
-	ApplicationName        string              `json:"applicationName"`
-	WatchZoneID            *string             `json:"watchZoneId"`
-	ApplicationAddress     string              `json:"applicationAddress"`
-	ApplicationDescription string              `json:"applicationDescription"`
-	ApplicationType        *string             `json:"applicationType"`
-	AuthorityID            int                 `json:"authorityId"`
-	Decision               *string             `json:"decision"`
-	PushSent               bool                `json:"pushSent"`
-	EmailSent              bool                `json:"emailSent"`
-	CreatedAt              platform.DotNetTime `json:"createdAt"`
+	ID                     string  `json:"id"`
+	ApplicationName        string  `json:"applicationName"`
+	WatchZoneID            *string `json:"watchZoneId"`
+	ApplicationAddress     string  `json:"applicationAddress"`
+	ApplicationDescription string  `json:"applicationDescription"`
+	ApplicationType        *string `json:"applicationType"`
+	AuthorityID            int     `json:"authorityId"`
+	Decision               *string `json:"decision"`
+	// PushSent mirrors notifications.DigestNotification.PushSent: it means "a
+	// push was queued for this notification", not "confirmed delivered" (a
+	// deliberate choice, tc-97k35.4). A user reading their own data export
+	// should not take "true" here as proof a push reached their device.
+	PushSent  bool                `json:"pushSent"`
+	EmailSent bool                `json:"emailSent"`
+	CreatedAt platform.DotNetTime `json:"createdAt"`
 }
 
 type ExportedSavedApplication struct {


### PR DESCRIPTION
## Summary
- APNs/FCM per-user push-delivery failures were slog-only, invisible to alerting/dashboards (AppTraces is Basic-tier).
- Adds `metrics.Registry.PushDeliveryFailed(ctx, platform)` plus manual "APNs delivery"/"FCM delivery" spans wrapping each per-device send, distinct from the existing transport-level "APNs push"/"FCM push" HTTP client spans — covers failure paths those never see (e.g. APNs JWT mint failure never reaches the HTTP client). Routine invalid-token rejections (410/BadDeviceToken/UNREGISTERED) are left untouched as expected churn, not failures.
- Wired `WithMetrics(registry)` into `cmd/worker/main.go`'s real APNs/FCM client construction.
- `notifications.PushSent` reconciliation was scoped and explicitly declined (see bead notes): the field is optimistic-at-enqueue and audit-only, only ever surfaced in a user's own GDPR data export; real reconciliation would need new plumbing through the coalescer's multi-notification/multi-platform batching for a field nothing functional reads. Doc comments on `DigestNotification.PushSent`, `profiles.ExportedNotification.PushSent`, and the enqueue call sites were tightened instead to make clear it means "queued", not "delivered".

## Test plan
- [x] TDD: red/green pairs for `Registry.PushDeliveryFailed`, `apns.Client`, `fcm.Client`
- [x] `go build ./...`, `go vet ./...`, `golangci-lint`, `gofmt -l .` clean
- [x] `go test -race ./...` (2026 tests, 49 packages) clean

Part of epic tc-97k35 (alert posture audit gaps).