### PR TITLE
fix(digest): drop boilerplate, front-load count+zone in subject (tc-o69z1)

### DIFF
--- a/api-go/internal/digest/email.go
+++ b/api-go/internal/digest/email.go
@@ -130,9 +130,38 @@ type watchZoneDigest struct {
 	notifications []notifications.DigestNotification
 }
 
-// buildDigestSubject renders the digest email subject line.
-func buildDigestSubject(totalCount int) string {
-	return fmt.Sprintf("Planning update: %d new applications near you", totalCount)
+// buildDigestSubject renders the digest email subject line: the count leads,
+// with no "Planning update:" boilerplate (the sender is already "Town
+// Crier", so the prefix is dead text in an inbox preview), followed by the
+// zone(s) the updates fall in. A single zone with no saved-only
+// notifications names it directly. Saved-only notifications with no zone at
+// all (WatchZoneID == nil) get their own fallback, since "near {zone}"
+// doesn't apply to them. Anything spanning more than one group — multiple
+// zones, or a zone plus a saved-only group — leads with the first zone name
+// and folds the remaining groups into "+K more" rather than trying to list
+// them all and risk truncation in a notification/inbox preview.
+func buildDigestSubject(totalCount int, sections []watchZoneDigest, saved []notifications.DigestNotification) string {
+	plural := "s"
+	if totalCount == 1 {
+		plural = ""
+	}
+
+	groups := len(sections)
+	if len(saved) > 0 {
+		groups++
+	}
+
+	switch {
+	case groups == 0:
+		return fmt.Sprintf("%d update%s near your zones", totalCount, plural)
+	case len(sections) == 1 && len(saved) == 0:
+		return fmt.Sprintf("%d update%s near %s", totalCount, plural, sections[0].name)
+	case len(sections) == 0:
+		return fmt.Sprintf("%d update%s on your saved applications", totalCount, plural)
+	default:
+		more := groups - 1
+		return fmt.Sprintf("%d update%s near %s +%d more", totalCount, plural, sections[0].name, more)
+	}
 }
 
 // buildDigestHTML renders the full digest email body as a Public Notice

--- a/api-go/internal/digest/email_test.go
+++ b/api-go/internal/digest/email_test.go
@@ -35,10 +35,67 @@ func testNotification(uid, zoneID, address, appType, desc string) notifications.
 
 func TestBuildDigestSubject(t *testing.T) {
 	t.Parallel()
-	got := buildDigestSubject(3)
-	want := "Planning update: 3 new applications near you"
-	if got != want {
-		t.Errorf("subject: got %q, want %q", got, want)
+
+	oneZone := []watchZoneDigest{{name: "Camden Zone"}}
+	twoZones := []watchZoneDigest{{name: "Camden Zone"}, {name: "Islington Zone"}}
+	oneSaved := []notifications.DigestNotification{testNotification("20/00045/FUL", "", "5 Mill Ln", "Full", "New dwelling")}
+	twoSaved := []notifications.DigestNotification{
+		testNotification("20/00045/FUL", "", "5 Mill Ln", "Full", "New dwelling"),
+		testNotification("20/00046/FUL", "", "7 Mill Ln", "Full", "Loft conversion"),
+	}
+
+	tests := []struct {
+		name       string
+		totalCount int
+		sections   []watchZoneDigest
+		saved      []notifications.DigestNotification
+		want       string
+	}{
+		{
+			name:       "single zone, no saved-only notifications",
+			totalCount: 3,
+			sections:   oneZone,
+			saved:      nil,
+			want:       "3 updates near Camden Zone",
+		},
+		{
+			name:       "singular count uses singular noun",
+			totalCount: 1,
+			sections:   oneZone,
+			saved:      nil,
+			want:       "1 update near Camden Zone",
+		},
+		{
+			name:       "multiple zones leads with the first and folds the rest",
+			totalCount: 5,
+			sections:   twoZones,
+			saved:      nil,
+			want:       "5 updates near Camden Zone +1 more",
+		},
+		{
+			name:       "zone plus saved-only notifications counts the saved group",
+			totalCount: 4,
+			sections:   oneZone,
+			saved:      oneSaved,
+			want:       "4 updates near Camden Zone +1 more",
+		},
+		{
+			name:       "saved-only notifications with no zone get their own fallback",
+			totalCount: 2,
+			sections:   nil,
+			saved:      twoSaved,
+			want:       "2 updates on your saved applications",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := buildDigestSubject(tc.totalCount, tc.sections, tc.saved)
+			if got != tc.want {
+				t.Errorf("subject: got %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/api-go/internal/digest/handler.go
+++ b/api-go/internal/digest/handler.go
@@ -385,7 +385,7 @@ func (h *Handler) sendDigestEmail(ctx context.Context, kind, userID, email strin
 	msg := acsemail.Message{
 		Sender:    senderAddress,
 		Recipient: email,
-		Subject:   buildDigestSubject(total),
+		Subject:   buildDigestSubject(total, sections, saved),
 		HTMLBody:  buildDigestHTML(sections, saved, total, showFreeTierNotice),
 	}
 	if err := h.email.Send(ctx, kind, msg); err != nil {

--- a/api-go/internal/digest/handler_test.go
+++ b/api-go/internal/digest/handler_test.go
@@ -710,7 +710,8 @@ func TestRunWeekly_DuplicateNewApplicationAndDecisionUpdate_RendersOnceWithUniqu
 	if got := strings.Count(msg.HTMLBody, "addr uid-A"); got != 1 {
 		t.Errorf("address should render exactly once, got %d occurrences in:\n%s", got, msg.HTMLBody)
 	}
-	if want := buildDigestSubject(1); msg.Subject != want {
+	wantSections := []watchZoneDigest{{name: "Home"}}
+	if want := buildDigestSubject(1, wantSections, nil); msg.Subject != want {
 		t.Errorf("subject should count unique applications: got %q, want %q", msg.Subject, want)
 	}
 	if !contains(msg.HTMLBody, "1 new application ") {


### PR DESCRIPTION
## Changes
- `buildDigestSubject` no longer returns a fixed "Planning update: N new applications near you" for every send — it drops the boilerplate prefix (dead text in an inbox preview since the sender is already "Town Crier") and front-loads the count and zone instead.
- Single zone, no saved-only notifications: `"{N} update(s) near {ZoneName}"`.
- Multiple zones, or a zone plus a saved-only group: lead zone name + `"+K more"`, avoiding a long zone list that risks truncation in a notification/inbox preview.
- Saved-only notifications with no zone: `"{N} updates on your saved applications"`.
- `sendDigestEmail` (handler.go) threads the already-computed `sections`/`saved` through — no new query.
- `TestBuildDigestSubject` rewritten table-driven, covering all of the above plus singular count.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Digest email subject lines now provide more context based on the included watch zones and saved notifications.
  * Subjects use singular or plural wording appropriately.
  * When multiple zones are included, the subject highlights the first zone and indicates additional zones.
  * Saved-only digest notifications are reflected in the subject when applicable.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->