### PR TITLE
fix(api): treat client-cancelled reads as non-errors, not 500s (tc-ftccw)

### DIFF
--- a/api-go/internal/applications/anonclusters_test.go
+++ b/api-go/internal/applications/anonclusters_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -397,5 +398,32 @@ func TestClustersHandler_StoreErrorIs500(t *testing.T) {
 	}
 	if rec.Body.Len() != 0 {
 		t.Errorf("body = %q, want empty (bodyless 500)", rec.Body.String())
+	}
+}
+
+// TestClustersHandler_ContextCanceled_NoServerErrorNoErrorLog proves a client
+// disconnect (context.Canceled from the store, wrapped as a real caller would
+// wrap it) is NOT treated as a server fault: no 500 is written and no
+// error-level log line is emitted (tc-ftccw). A disconnected caller is
+// already gone, so nothing meaningfully needs to be sent back.
+func TestClustersHandler_ContextCanceled_NoServerErrorNoErrorLog(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeClustersStore{err: fmt.Errorf("find clusters in zone near (51.5,-0.1): %w", context.Canceled)}
+	capture := &capturingHandler{}
+	mux := http.NewServeMux()
+	ClustersRoutes(mux, store, testResolver(), slog.New(capture))
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/applications/clusters"+validClustersQuery, nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusInternalServerError {
+		t.Fatalf("status = %d, want NOT 500 on a client-cancelled read", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("body = %q, want empty", rec.Body.String())
+	}
+	if _, ok := capture.find(slog.LevelError, "application request failed"); ok {
+		t.Error("expected no error-level log for a client-cancelled read")
 	}
 }

--- a/api-go/internal/applications/respond.go
+++ b/api-go/internal/applications/respond.go
@@ -2,6 +2,7 @@ package applications
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 
@@ -27,8 +28,15 @@ func writeJSON(w http.ResponseWriter, r *http.Request, logger *slog.Logger, v an
 }
 
 // serverError logs and emits a bodyless 500; the error envelope is backfilled by
-// middleware.ErrorBody.
+// middleware.ErrorBody. A context.Canceled error means the caller disconnected
+// before the response was ready (e.g. a rapid map pan cancelling an in-flight
+// fetch) rather than a genuine server fault — that case is deliberately not
+// logged at error level and not given a 500: the caller is already gone, so
+// nothing meaningfully needs to be written back (tc-ftccw).
 func serverError(w http.ResponseWriter, r *http.Request, logger *slog.Logger, op string, err error) {
+	if errors.Is(err, context.Canceled) {
+		return
+	}
 	logger.ErrorContext(r.Context(), "application request failed", "op", op, "error", err)
 	w.WriteHeader(http.StatusInternalServerError)
 }

--- a/api-go/internal/sharepage/handler.go
+++ b/api-go/internal/sharepage/handler.go
@@ -13,6 +13,7 @@ package sharepage
 import (
 	"bytes"
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -64,6 +65,14 @@ func (h *handler) serve(w http.ResponseWriter, r *http.Request) {
 
 	app, found, err := h.store.GetByAuthorityAndName(r.Context(), strconv.Itoa(areaID), ref)
 	if err != nil {
+		// A context.Canceled error means the caller disconnected before the
+		// response was ready (e.g. a rapid map pan cancelling an in-flight
+		// fetch) rather than a genuine server fault — deliberately not logged
+		// at error level and not given a 500: the caller is already gone, so
+		// nothing meaningfully needs to be written back (tc-ftccw).
+		if errors.Is(err, context.Canceled) {
+			return
+		}
 		h.logger.ErrorContext(r.Context(), "share page read failed", "op", "read application by slug", "slug", slug, "ref", ref, "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return

--- a/api-go/internal/sharepage/handler_test.go
+++ b/api-go/internal/sharepage/handler_test.go
@@ -4,15 +4,48 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/AmyDe/town-crier/api-go/internal/applications"
 )
+
+// capturingHandler is a hand-written slog.Handler that records emitted records so
+// a test can assert a specific log line (and its level) was, or was not, produced.
+type capturingHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *capturingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *capturingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r.Clone())
+	return nil
+}
+
+func (h *capturingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *capturingHandler) WithGroup(string) slog.Handler      { return h }
+
+// find reports whether a record at level matching msg was captured.
+func (h *capturingHandler) find(level slog.Level, msg string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, r := range h.records {
+		if r.Level == level && r.Message == msg {
+			return true
+		}
+	}
+	return false
+}
 
 // fakeStore is a hand-written double for the application point read. It records
 // how it was called so tests can assert the (authorityCode, ref) it received.
@@ -84,8 +117,15 @@ func fullApp(t *testing.T) applications.PlanningApplication {
 // token — the page is anonymous.
 func serve(t *testing.T, store appStore, resolver slugResolver, path string) *httptest.ResponseRecorder {
 	t.Helper()
+	return serveWithLogger(t, store, resolver, path, slog.New(slog.DiscardHandler))
+}
+
+// serveWithLogger is serve with an injectable logger, so a test can substitute
+// a capturingHandler to assert on (or the absence of) a particular log line.
+func serveWithLogger(t *testing.T, store appStore, resolver slugResolver, path string, logger *slog.Logger) *httptest.ResponseRecorder {
+	t.Helper()
 	mux := http.NewServeMux()
-	Routes(mux, store, resolver, slog.New(slog.DiscardHandler))
+	Routes(mux, store, resolver, logger)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, path, nil)
 	mux.ServeHTTP(rec, req)
@@ -561,6 +601,27 @@ func TestServe_StoreError_Returns500(t *testing.T) {
 
 	if rec.Code != http.StatusInternalServerError {
 		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+}
+
+// TestServe_ContextCanceled_NoServerErrorNoErrorLog proves a client disconnect
+// (context.Canceled from the store, wrapped as a real caller would wrap it) is
+// NOT treated as a server fault: no 500 is written and no error-level log line
+// is emitted (tc-ftccw). A disconnected caller is already gone, so nothing
+// meaningfully needs to be sent back.
+func TestServe_ContextCanceled_NoServerErrorNoErrorLog(t *testing.T) {
+	t.Parallel()
+	store := &fakeStore{err: fmt.Errorf(`read application "165"/"23/0001/FUL": %w`, context.Canceled)}
+	resolver := &fakeResolver{slugs: map[string]int{"croydon": 165}}
+	capture := &capturingHandler{}
+
+	rec := serveWithLogger(t, store, resolver, "/a/croydon/23/0001/FUL", slog.New(capture))
+
+	if rec.Code == http.StatusInternalServerError {
+		t.Fatalf("status = %d, want NOT 500 on a client-cancelled read", rec.Code)
+	}
+	if capture.find(slog.LevelError, "share page read failed") {
+		t.Error("expected no error-level log for a client-cancelled read")
 	}
 }
 

--- a/api-go/internal/watchzones/handler.go
+++ b/api-go/internal/watchzones/handler.go
@@ -441,8 +441,16 @@ func (h *handler) writeError(w http.ResponseWriter, r *http.Request, status int,
 }
 
 // serverError logs and emits a bodyless 500; the error envelope (with Detail) is
-// backfilled by middleware.ErrorBody, mirroring the rest of the API.
+// backfilled by middleware.ErrorBody, mirroring the rest of the API. A
+// context.Canceled error means the caller disconnected before the response was
+// ready (e.g. a rapid map pan cancelling an in-flight fetch) rather than a
+// genuine server fault — that case is deliberately not logged at error level
+// and not given a 500: the caller is already gone, so nothing meaningfully
+// needs to be written back (tc-ftccw).
 func (h *handler) serverError(w http.ResponseWriter, r *http.Request, op string, err error) {
+	if errors.Is(err, context.Canceled) {
+		return
+	}
 	h.logger.ErrorContext(r.Context(), "watch-zone request failed", "op", op, "error", err)
 	w.WriteHeader(http.StatusInternalServerError)
 }

--- a/api-go/internal/watchzones/handler_test.go
+++ b/api-go/internal/watchzones/handler_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -15,6 +16,43 @@ import (
 )
 
 const testUser = "auth0|user"
+
+// capturingHandler is a hand-written slog.Handler that records emitted records so
+// a test can assert a specific log line (and its attributes/level) was, or was
+// not, produced.
+type capturingHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *capturingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *capturingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r.Clone())
+	return nil
+}
+
+func (h *capturingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *capturingHandler) WithGroup(string) slog.Handler      { return h }
+
+// find returns the attributes of the first record matching level and message.
+func (h *capturingHandler) find(level slog.Level, msg string) (map[string]any, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, r := range h.records {
+		if r.Level == level && r.Message == msg {
+			attrs := map[string]any{}
+			r.Attrs(func(a slog.Attr) bool {
+				attrs[a.Key] = a.Value.Any()
+				return true
+			})
+			return attrs, true
+		}
+	}
+	return nil, false
+}
 
 // fakeZoneStore is a hand-written zoneStore. It holds zones in an ordered slice
 // so list order is deterministic, and exposes hooks for forced errors.

--- a/api-go/internal/watchzones/nearby_test.go
+++ b/api-go/internal/watchzones/nearby_test.go
@@ -128,6 +128,14 @@ type nearbyDeps struct {
 
 func newNearbyMux(t *testing.T, d nearbyDeps) *http.ServeMux {
 	t.Helper()
+	return newNearbyMuxWithLogger(t, d, slog.New(slog.DiscardHandler))
+}
+
+// newNearbyMuxWithLogger is newNearbyMux with an injectable logger, so a test
+// can substitute a capturingHandler to assert on (or the absence of) a
+// particular log line.
+func newNearbyMuxWithLogger(t *testing.T, d nearbyDeps, logger *slog.Logger) *http.ServeMux {
+	t.Helper()
 	mux := http.NewServeMux()
 	// The CAS gate is the only create path, so every create test wires a CAS
 	// fake seeded from the same profile the reader returns. With a legacy (nil
@@ -137,7 +145,7 @@ func newNearbyMux(t *testing.T, d nearbyDeps) *http.ServeMux {
 	cas := newFakeProfileCAS(d.profiles.profile)
 	NearbyRoutes(mux, d.store, d.profiles, d.resolver, d.apps, d.unread,
 		func() string { return "zone-123" }, func() time.Time { return nearbyNow },
-		slog.New(slog.DiscardHandler), WithProfileCAS(cas))
+		logger, WithProfileCAS(cas))
 	return mux
 }
 
@@ -1624,5 +1632,25 @@ func TestClusters_StoreErrorIs500(t *testing.T) {
 	rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications/clusters"+validClusterQuery, "")
 	if rec.Code != http.StatusInternalServerError {
 		t.Fatalf("status: got %d, want 500", rec.Code)
+	}
+}
+
+// TestClusters_ContextCanceled_NoServerErrorNoErrorLog proves a client
+// disconnect (context.Canceled from the store, wrapped as a real caller would
+// wrap it) is NOT treated as a server fault: no 500 is written and no
+// error-level log line is emitted (tc-ftccw). A disconnected caller is
+// already gone, so nothing meaningfully needs to be sent back.
+func TestClusters_ContextCanceled_NoServerErrorNoErrorLog(t *testing.T) {
+	t.Parallel()
+	apps := &fakeAppFinder{clusterErr: fmt.Errorf("find clusters in zone near (51.5,-0.12): %w", context.Canceled)}
+	capture := &capturingHandler{}
+	mux := newNearbyMuxWithLogger(t, clusterDeps(t, apps), slog.New(capture))
+	rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications/clusters"+validClusterQuery, "")
+
+	if rec.Code == http.StatusInternalServerError {
+		t.Fatalf("status: got %d, want NOT 500 on a client-cancelled read", rec.Code)
+	}
+	if _, ok := capture.find(slog.LevelError, "watch-zone request failed"); ok {
+		t.Error("expected no error-level log for a client-cancelled read")
 	}
 }


### PR DESCRIPTION
## Summary

Prod telemetry (tc-ftccw) showed that 27/27 error-level traces in a 24h window, and 25/30 5xx in 7 days, were actually `context.Canceled` from clients disconnecting mid-request (e.g. a user rapidly panning the map, cancelling in-flight fetches) — not real server failures. The affected handlers logged these at error level and returned HTTP 500 indistinguishably from genuine faults, polluting the 5xx error budget and drowning out real signal.

This adds an `errors.Is(err, context.Canceled)` short-circuit before the 500 response and before the error-level log call in the three read paths named in the bug report:

- `internal/applications/respond.go` — shared `serverError()` helper (covers `anonclusters.go`'s "find clusters near point", plus other callers of the same helper)
- `internal/watchzones/handler.go` — shared `(h *handler) serverError()` (covers `nearby.go`'s "find clusters in zone", plus other callers)
- `internal/sharepage/handler.go` — inline fix in the share-page slug read handler ("read application by slug")

On a canceled context the handler now returns without logging or writing a response — the client is already gone, so nothing meaningful needs to be sent back.

Out of scope, filed as a follow-up (`tc-gez3y`, `discovered-from` tc-ftccw): `internal/sharepage/ogimage.go` has the same pattern for the OG-image share card endpoint, but wasn't named in the bug report.

## Test plan

- [x] New handler tests for all three call sites assert no 500 is written and no error-level log line is emitted when the store returns a wrapped `context.Canceled`
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `go test ./...` green across all packages


---
_Generated by [Claude Code](https://claude.ai/code/session_012PmCpqhdf6e9KSP8nJmDF5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Client disconnects and canceled requests are no longer treated as server errors.
  * Affected endpoints no longer return HTTP 500 responses or emit error logs when the client has already disconnected.
  * Other server-side failures continue to return HTTP 500 responses and be logged normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->