### PR TITLE
test(api): assert empty body on client-cancelled reads (tc-6hhef)

### DIFF
--- a/api-go/internal/sharepage/handler_test.go
+++ b/api-go/internal/sharepage/handler_test.go
@@ -620,6 +620,9 @@ func TestServe_ContextCanceled_NoServerErrorNoErrorLog(t *testing.T) {
 	if rec.Code == http.StatusInternalServerError {
 		t.Fatalf("status = %d, want NOT 500 on a client-cancelled read", rec.Code)
 	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("body = %q, want empty", rec.Body.String())
+	}
 	if capture.find(slog.LevelError, "share page read failed") {
 		t.Error("expected no error-level log for a client-cancelled read")
 	}

--- a/api-go/internal/watchzones/nearby_test.go
+++ b/api-go/internal/watchzones/nearby_test.go
@@ -1650,6 +1650,9 @@ func TestClusters_ContextCanceled_NoServerErrorNoErrorLog(t *testing.T) {
 	if rec.Code == http.StatusInternalServerError {
 		t.Fatalf("status: got %d, want NOT 500 on a client-cancelled read", rec.Code)
 	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("body = %q, want empty", rec.Body.String())
+	}
 	if _, ok := capture.find(slog.LevelError, "watch-zone request failed"); ok {
 		t.Error("expected no error-level log for a client-cancelled read")
 	}


### PR DESCRIPTION
## Summary

Follow-up to #1016 (tc-ftccw). CodeRabbit's review on that PR (landed just after auto-merge) correctly noted that two of the three new `context.Canceled` regression tests only asserted the HTTP status wasn't 500 — not that the response body stayed empty. A future regression that returned some non-500 status *with* a body on cancellation would still have passed them.

This is test-only: adds a `rec.Body.Len() == 0` assertion to `TestServe_ContextCanceled_NoServerErrorNoErrorLog` (sharepage) and `TestClusters_ContextCanceled_NoServerErrorNoErrorLog` (watchzones), matching the wording already used in the equivalent `applications` package test. Both assertions pass immediately against the existing tc-ftccw fix — no production code changes.

## Test plan

- [x] `go vet ./...`, `gofmt -l .` clean
- [x] `go test ./...` green across all packages


---
_Generated by [Claude Code](https://claude.ai/code/session_012PmCpqhdf6e9KSP8nJmDF5)_