### PR TITLE
fix(wf): only override HOME for bd worktree create when checkout mismatches HOME (tc-sqf8n)

### DIFF
--- a/scripts/wf/worktree-setup.sh
+++ b/scripts/wf/worktree-setup.sh
@@ -21,6 +21,16 @@
 #
 # Prints the worktree path as the final line. Remove steps 3-4 when the upstream
 # bd fixes ship. Anchored to the repo root, so a drifted CWD can't misfire it.
+#
+# bd's SEC-003 safety check rejects a BEADS_DIR under /home/* or /Users/* that
+# doesn't have $HOME as a prefix. A normal local checkout is always under the
+# real $HOME, so this never fires there. It does fire in sandboxes that run as
+# root with HOME=/root while the repo is checked out under /home/<user>/... —
+# there, bd worktree create fails with "BEADS_DIR points to unsafe location"
+# even though the path is perfectly safe. Only override HOME for that one
+# subprocess, and only when $root isn't already under $HOME, so a real local
+# dev setup (where git/ssh/credential lookups must keep using the real $HOME)
+# is untouched.
 set -eo pipefail
 
 name="${1:?usage: worktree-setup.sh <name> [--branch <branch>]}"
@@ -48,10 +58,16 @@ git -C "$root" fetch origin --quiet
 # on stdout, which would corrupt `wt=$(worktree-setup.sh <name>)`.
 git -C "$root" branch -f main origin/main >/dev/null 2>&1 || true
 
+bd_home="$HOME"
+case "$root" in
+  "$HOME"/*|"$HOME") ;;                             # already safe — leave $HOME alone
+  /home/*|/Users/*) bd_home=$(dirname "$root") ;;   # HOME/checkout mismatch — fall back
+esac
+
 if [ -n "$branch" ]; then
-  (cd "$root" && bd worktree create "$rel" --branch "$branch" >/dev/null)
+  (cd "$root" && HOME="$bd_home" bd worktree create "$rel" --branch "$branch" >/dev/null)
 else
-  (cd "$root" && bd worktree create "$rel" >/dev/null)
+  (cd "$root" && HOME="$bd_home" bd worktree create "$rel" >/dev/null)
 fi
 
 # Confirm git registered it where we asked — EnterWorktree requires both the


### PR DESCRIPTION
## Summary

`bd worktree create` (called from `scripts/wf/worktree-setup.sh`) fails with `Error: BEADS_DIR points to unsafe location` in remote/cloud sandbox sessions that run as root with `$HOME=/root` while the repo is checked out under `/home/user/...`. This is bd's SEC-003 safety check (`isPathInSafeBoundary` in gastownhall/beads), which rejects any `BEADS_DIR` under `/home/*` or `/Users/*` that doesn't have `$HOME` as a prefix — a reasonable check in general, but a false positive here since the checkout path is perfectly safe, just not under this particular process's `$HOME`.

A normal local dev checkout never trips this (you clone under your own home directory, so `$HOME` always prefixes it), so the fix is scoped to only kick in on the actual mismatch: `HOME` is overridden **only for the one `bd worktree create` subprocess**, and **only when** the repo root isn't already under `$HOME`, falling back to the repo's parent directory in that case. A real local setup takes the `"$HOME"/*` branch and is completely unaffected — git/ssh/credential-helper lookups for that subprocess keep using the real `$HOME`.

Confirmed `bd worktree remove` doesn't hit this check at all (tested directly), so it needed no change.

## Test plan

- [x] `bash -n scripts/wf/worktree-setup.sh` — syntax clean
- [x] Ran the script live in a sandbox with the `HOME=/root` vs `/home/user/town-crier` mismatch: worktree created successfully with no manual `HOME=` workaround needed (previously failed with "unsafe location")
- [x] Confirmed the case pattern correctly no-ops when `$root` is already under `$HOME` (the normal local-dev case)


---
_Generated by [Claude Code](https://claude.ai/code/session_012PmCpqhdf6e9KSP8nJmDF5)_