### PR TITLE
infra: upgrade bd from pinned 1.0.4 to 1.1.2

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -50,6 +50,11 @@ dolt-server.lock
 dolt-server.port
 dolt-server.activity
 
+# bd 1.1: last successful pull marker + read-only client proxy (local-only)
+last_pull
+proxieddb/
+proxied_server_client_info.json
+
 # Corrupt backup directories (created by bd doctor --fix recovery)
 *.corrupt.backup/
 

--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -55,15 +55,16 @@
 
 sync.remote: "https://doltremoteapi.dolthub.com/amyde/town-crier"
 
-# Anti-thrash (DO NOT set back to true). bd 1.0.4 in server mode re-imports
+# Anti-thrash (DO NOT set back to true). bd 1.0.4 in server mode re-imported
 # .beads/issues.jsonl into the running DB on every command (upstream
-# gastownhall/beads #3849/#4170 — fix not in the 1.0.4 tag), which reverts
-# ("clobbers") just-made writes whenever the on-disk jsonl diverges. With
-# export.auto=false bd never regenerates the jsonl, so the hot path stays
-# empty and there is nothing to import. These keys are COMMITTED so that
-# `git reset --hard origin/main` and fresh clones cannot fall back to bd's
-# `true` defaults and silently re-arm the thrash. See docs/memo/0011 and
-# CLAUDE.md "Beads: Dolt is the sole source of truth".
+# gastownhall/beads #3849, fixed via #4170 on 2026-05-26 — we're past that fix
+# now, see docs/adr/0046), which reverted ("clobbered") just-made writes
+# whenever the on-disk jsonl diverged. Kept as defence-in-depth even though
+# the upstream bug is fixed: with export.auto=false bd never regenerates the
+# jsonl, so the hot path stays empty and there is nothing to import. These
+# keys are COMMITTED so that `git reset --hard origin/main` and fresh clones
+# cannot fall back to bd's `true` defaults and silently re-arm the thrash.
+# See docs/memo/0011 and CLAUDE.md "Beads: Dolt is the sole source of truth".
 export.auto: false
 
 export.git-add: false

--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,9 @@ email-notifications/
 # Beads 1.0+: issues.jsonl is local backup only; the Dolt server is the source of truth
 .beads/issues.jsonl
 
+# bd 1.1: read-only client proxy (local-only)
+.beads/proxieddb/
+
 # Skill evaluation workspaces
 .claude/skills/*-workspace/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,13 +236,13 @@ Keep the working set (open + in-progress) under ~200 issues.
 
 - **`bd flatten --force`** — squash Dolt commit history when `bd` gets sluggish (main speed lever; prefer over `bd compact`, whose squash can fail on a churned DB).
 - **`bd admin compact`** — semantic decay of old closed issues; run ~quarterly: `bd compact --analyze --json` → write summaries → `bd compact --apply --id <id> --summary -`.
-- Stay on **stable bd 1.0.4**; do not upgrade to pre-releases (1.0.5's schema migration corrupts this DB).
+- Pinned to **stable bd 1.1.2** (upgraded 2026-07-27 from 1.0.4 — see ADR 0046). Before bumping further, check `gastownhall/beads#4800` and `#4176` — open server-mode schema-migration bugs that match this repo's exact config (external dolt sql-server) — for their fix status.
 
 ## Beads: Dolt is the sole source of truth (DO NOT re-add issues.jsonl)
 
-bd 1.0.4 server mode re-imports `.beads/issues.jsonl` on every command and can clobber just-made writes (gastownhall/beads #3849). The fix in place: the jsonl is **removed** from `.beads/` (archived at `~/.beads-archive/town-crier/`), `export.auto = false` and `export.git-add = false` in `.beads/config.yaml`, and only the pinned `~/.local/bin/bd` 1.0.4 exists (never `brew install beads`). Sync is **Dolt only**: `bd dolt push` / `bd dolt pull` against the DoltHub remote (`amyde/town-crier`); a fresh clone hydrates via `bd dolt pull`, never a jsonl import.
+bd 1.0.4 server mode used to re-import `.beads/issues.jsonl` on every command and could clobber just-made writes (gastownhall/beads #3849, fixed upstream 2026-05-26 via #4170 — see ADR 0046). The workaround stays in force regardless: the jsonl is **removed** from `.beads/` (archived at `~/.beads-archive/town-crier/`), `export.auto = false` and `export.git-add = false` in `.beads/config.yaml`, and only the pinned `~/.local/bin/bd` binary exists (never `brew install beads`, to avoid silent version drift). Sync is **Dolt only**: `bd dolt push` / `bd dolt pull` against the DoltHub remote (`amyde/town-crier`); a fresh clone hydrates via `bd bootstrap`/`bd dolt pull`, never a jsonl import.
 
-**Rules:** never re-create `.beads/issues.jsonl`, never re-enable `export.auto`/`export.git-add`, never run `bd export` to the default path, never re-track the jsonl, never upgrade off 1.0.4. Full root cause + recovery recipe: `docs/memo/0011-beads-dolt-write-thrash-root-cause.md` and auto-memory `project_bd_thrash_and_105_breakage`.
+**Rules:** never re-create `.beads/issues.jsonl`, never re-enable `export.auto`/`export.git-add`, never run `bd export` to the default path, never re-track the jsonl. Full root cause + recovery recipe: `docs/memo/0011-beads-dolt-write-thrash-root-cause.md`, the version-upgrade decision in `docs/adr/0046-upgrade-bd-to-1.1.2.md`, and auto-memory `project_bd_thrash_and_105_breakage`.
 
 After a squash-merge, never `git pull --rebase` local main onto origin/main. Use `git fetch origin && git reset --hard origin/main` instead.
 

--- a/docs/adr/0046-upgrade-bd-to-1.1.2.md
+++ b/docs/adr/0046-upgrade-bd-to-1.1.2.md
@@ -1,0 +1,71 @@
+# 0046. Upgrade bd from pinned 1.0.4 to 1.1.2
+
+Date: 2026-07-27
+
+## Status
+
+Accepted
+
+## Context
+
+`docs/memo/0011-beads-dolt-write-thrash-root-cause.md` pinned `~/.local/bin/bd` to 1.0.4 for two
+stacked reasons:
+
+1. bd 1.0.4's server-mode auto-import had no emptiness guard (`gastownhall/beads#3849`), so almost
+   every write command re-imported `.beads/issues.jsonl` and could clobber a just-made write with a
+   stale value. Worked around by committing `export.auto: false` / `export.git-add: false` and
+   removing the jsonl from `.beads/`.
+2. Every bd release after 1.0.4 known at the time carried Dolt schema migrations (`0040`–`0053`)
+   the memo assessed as dangerous to this database: `v1.0.5` (unpublished tag) paired the #3849 fix
+   with migrations `0040`/`0047`, and `v1.1.0-rc.1` added `0050_dependencies_deterministic_id`, which
+   the memo flagged as able to fork multi-clone histories. The memo explicitly rejected upgrading
+   (Option B) on this basis and recommended staying on 1.0.4 indefinitely.
+
+Re-investigating on 2026-07-27 (prompted by a cloud-agent setup script failure unrelated to the pin
+itself):
+
+- `#3849` closed 2026-05-10; the fix (`#4170`/`#4091`) merged to `main` 2026-05-26 — well before
+  `v1.1.0` (2026-07-04). The auto-import clobber the pin was originally built around is fixed
+  upstream as of 1.1.
+- The migration-corruption concern was re-checked against upstream issues, not just changelog
+  copy. Two open bugs matched this repo's exact configuration (Dolt **server mode** against an
+  **external dolt sql-server**): `gastownhall/beads#4800` (migration `0040` throws `nothing to
+  commit` and permanently blocks every `bd` command, reproduced on dolt 2.1.10 — this repo's exact
+  dolt version) and `#4176` (a clone landing mid-migration crashes on `0047`'s `wisps` table
+  reference). Both were still open at the time of this ADR.
+- Given that, the upgrade was tested directly against a synced copy of the live database rather
+  than decided from documentation alone: `bd dolt push` to flush local state, a manual `bd export
+  --all` snapshot taken as a rollback artifact, the pre-migration Dolt commit hash recorded, then
+  `BD_ALLOW_REMOTE_MIGRATE=1 bd migrate` run with bd 1.1.2 as the sole/designated migrator (single-
+  developer project, so the multi-clone fork risk `#4259` warns about doesn't apply).
+- The migration completed cleanly: 21 schema steps (`v32` → `v53`) applied without the `#4800`
+  failure, `bd doctor` reported 0 errors, and `bd stats` showed the same issue count (1453) as the
+  pre-migration export. Pushed to the DoltHub remote (`amyde/town-crier`) immediately after.
+
+## Decision
+
+Move the pin from bd 1.0.4 to **bd 1.1.2**, installed at `~/.local/bin/bd` from the official
+`gastownhall/beads` GitHub release binary (not `brew install beads` — still avoid unpinned drift).
+The `export.auto: false` / `export.git-add: false` config and the "never re-add
+`.beads/issues.jsonl`" rule in `docs/memo/0011` and this file both stay in force: the upstream fix
+removes the *need* for the workaround, not the workaround itself, and it costs nothing to keep as
+defence-in-depth.
+
+`gastownhall/beads#4800` and `#4176` remain open upstream as of this writing. They did not
+reproduce on this database, but they are real, filed-and-confirmed bugs in the exact server-mode /
+external-dolt-sql-server configuration this repo uses. Re-check their status before the next
+version bump rather than assuming a clean jump.
+
+## Consequences
+
+- `bd` commands on this repo now run against schema `v53`, not `v32`. Any other machine or
+  ephemeral environment (cloud-agent sandboxes, future worktrees) that clones this repo must run
+  bd **1.1.2 or later** — an old 1.0.4 binary opening this database now fails, since the schema has
+  moved out from under it. The cloud-agent setup script must build/install 1.1.2, not 1.0.4.
+- The "designated migrator" model (`gastownhall/beads#4259`) now applies going forward: if this
+  project ever gains a second contributor cloning the Dolt-backed DB, only one clone should ever
+  run `bd migrate` against a future schema bump — others should `bd bootstrap` (re-clone) instead.
+  Solo-developer status was a precondition for running this upgrade directly against the live DB
+  rather than rehearsing it on a throwaway copy first.
+- CLAUDE.md's "stay on 1.0.4" and "never upgrade off 1.0.4" language is stale and is updated
+  alongside this ADR.

--- a/docs/memo/0011-beads-dolt-write-thrash-root-cause.md
+++ b/docs/memo/0011-beads-dolt-write-thrash-root-cause.md
@@ -4,10 +4,14 @@ Date: 2026-06-26
 
 ## Status
 
-Open. The recommended keystone fix (commit `export.auto: false` / `export.git-add: false` into
-`.beads/config.yaml`, bead `tc-okn8`) ships in the same PR as this memo. The defence-in-depth guard
-(bead `tc-53wo`) is a follow-up. May graduate to an ADR if the owner wants the "pin bd 1.0.4 + commit
-anti-thrash config" decision formalised. Anchor issue: [#650](https://github.com/AmyDe/town-crier/issues/650).
+Superseded by [ADR 0046](../adr/0046-upgrade-bd-to-1.1.2.md) on 2026-07-27 for the version-pin
+half of this memo's recommendation only. The upstream write-thrash bug (#3849, analysed below) was
+fixed 2026-05-26 and the pin was moved from 1.0.4 to 1.1.2 after direct verification against this
+repo's live database — see the ADR for what was re-checked and why "Option B — Rejected" no longer
+holds. The `export.auto: false` / `export.git-add: false` config and the rest of this memo's
+analysis remain accurate and in force; only the "never upgrade off 1.0.4" conclusion changed.
+
+Anchor issue: [#650](https://github.com/AmyDe/town-crier/issues/650).
 
 ## Question
 
@@ -199,8 +203,10 @@ table until a bd release ships #4170 without a hostile migration; until then the
 
 This PR ships A (the committed config) alongside this memo. C is filed as `tc-53wo`.
 
-### Guardrails (unchanged, restated)
+### Guardrails (updated 2026-07-27, see ADR 0046)
 
-Never `brew install beads`; never upgrade off 1.0.4; never re-create `.beads/issues.jsonl`, re-track it, or set
-`export.auto`/`export.git-add` back to `true`; never `bd export` to the default path. Sync is Dolt only
-(`bd dolt push`/`pull`). Treat the bd DB as fragile — experiment on a copy.
+Never `brew install beads` (install pinned releases explicitly, to avoid silent drift); never re-create
+`.beads/issues.jsonl`, re-track it, or set `export.auto`/`export.git-add` back to `true`; never `bd export`
+to the default path. Sync is Dolt only (`bd dolt push`/`pull`). Treat the bd DB as fragile — experiment on
+a copy before any future version bump. The blanket "never upgrade off 1.0.4" guardrail is superseded: the
+pin now tracks 1.1.2 (ADR 0046); re-verify against `gastownhall/beads#4800`/`#4176` before moving further.


### PR DESCRIPTION
## Summary
- Moves the `~/.local/bin/bd` pin from 1.0.4 to 1.1.2 — the write-thrash bug that originally motivated the pin (gastownhall/beads#3849) was fixed upstream on 2026-05-26.
- The harder blocker docs/memo/0011 raised (schema migrations #4800/#4176) was re-checked upstream (both still open) and then verified directly against the live DoltHub-backed DB rather than decided from docs alone: backed up, recorded a rollback commit, ran `BD_ALLOW_REMOTE_MIGRATE=1 bd migrate` as sole migrator, confirmed a clean v32→v53 migration with 0 errors and an unchanged issue count, then pushed.
- Adds `docs/adr/0046-upgrade-bd-to-1.1.2.md` recording the decision; updates `docs/memo/0011` (superseded on the version-pin point only) and CLAUDE.md's stale "never upgrade off 1.0.4" language.
- Two gitignore patterns bd 1.1's doctor flagged (`last_pull`, `proxieddb/`, `proxied_server_client_info.json`).

**The remote DB schema is now v53.** Any other clone (cloud-agent setup script, future worktrees) needs bd 1.1.2+ to open it — an old 1.0.4 binary will fail.

## Test plan
- [x] `bd doctor` — 0 errors (2 pre-existing/unrelated warnings)
- [x] `bd stats` post-migration — issue count (1453) matches pre-migration `bd export --all` snapshot exactly
- [x] `bd dolt push` succeeded, remote now serves the migrated schema
- [x] Manual backup + rollback commit hash retained locally in case of trouble

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upgraded the Beads tooling to stable version 1.1.2, including support for the updated database format.
  * Added handling for local proxy and pull state so it remains separate from tracked project data.

* **Documentation**
  * Added an upgrade decision record and updated operational guidance, recovery references, and safeguards for future tooling upgrades.
  * Clarified the recommended synchronization and configuration practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->