### PR TITLE
fix: per-session cloud init — dolt creds, repo fingerprint, beads hydration (tc-812ni)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -120,6 +120,12 @@
       {
         "hooks": [
           {
+            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/wf/cloud-session-init.sh",
+            "statusMessage": "Cloud session init (dolt creds, fingerprint, beads hydration)...",
+            "timeout": 600,
+            "type": "command"
+          },
+          {
             "command": "bd prime",
             "type": "command"
           }

--- a/scripts/wf/cloud-session-init.sh
+++ b/scripts/wf/cloud-session-init.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Per-session init for Claude Code cloud (web) sessions. Runs from the
+# SessionStart hook in .claude/settings.json; exits immediately on local
+# machines, so it is a committed no-op for Mac development.
+#
+# Why this exists (and why none of it can live in the environment setup
+# script): cloud environments snapshot the filesystem after the setup script
+# runs ONCE, and later sessions reuse the snapshot with setup skipped
+# entirely. Environment variables (including the DOLT_CLOUD_CREDS_* secrets)
+# are injected per-session and are NOT present while the setup script runs.
+# The git proxy port changes every session, so a remote rewrite done at
+# snapshot time would bake in a dead port. And a hydrated .beads/dolt in the
+# snapshot would serve week-stale backlog data. So the setup script installs
+# binaries only (bd, dolt), and everything session-specific happens here.
+#
+# Three jobs, all idempotent so resumed sessions re-run this safely:
+#   1. Install DoltHub credentials from DOLT_CLOUD_CREDS_ID/_B64. Without
+#      them, dolt pushes anonymously: reads succeed (the DB is public) but
+#      bd dolt push fails with rpc PermissionDenied. Must happen before the
+#      first bd command — the dolt sql-server reads ~/.dolt/creds at startup.
+#   2. Repo fingerprint: bd doctor hashes the configured origin URL against
+#      the repo_id stored in the shared (DoltHub-synced) metadata table
+#      (fb4ae834 = sha256 of "github.com-amyde/AmyDe/town-crier", minted
+#      from the Mac's SSH-alias remote). Set origin to that same URL string
+#      and route actual git traffic through the live session proxy with an
+#      insteadOf rewrite. Never "fix" this with bd migrate --update-repo-id
+#      from a cloud session — repo_id syncs via DoltHub and rewriting it
+#      would break the Mac on its next pull.
+#   3. Hydrate the Dolt-backed issue DB from the DoltHub remote (fresh
+#      clone), or pull to freshen one restored from the environment cache.
+
+[ "${CLAUDE_CODE_REMOTE:-}" = "true" ] || exit 0
+set -euo pipefail
+
+repo_root="${CLAUDE_PROJECT_DIR:-/home/user/town-crier}"
+
+# 1. DoltHub credentials
+if [ -z "${DOLT_CLOUD_CREDS_ID:-}" ] || [ -z "${DOLT_CLOUD_CREDS_B64:-}" ]; then
+  echo "cloud-session-init FATAL: DOLT_CLOUD_CREDS_ID/_B64 not set in this session." >&2
+  echo "bd dolt push will run anonymously and DoltHub will deny it (PermissionDenied)." >&2
+  echo "Check the cloud environment's variable configuration. Do NOT work around this" >&2
+  echo "by skipping pushes — unpushed bd mutations vanish with this container." >&2
+  exit 1
+fi
+if [ ! -f "$HOME/.dolt/creds/$DOLT_CLOUD_CREDS_ID.jwk" ]; then
+  mkdir -p "$HOME/.dolt/creds"
+  printf '%s' "$DOLT_CLOUD_CREDS_B64" | base64 -d > "$HOME/.dolt/creds/$DOLT_CLOUD_CREDS_ID.jwk"
+  chmod 600 "$HOME/.dolt/creds/$DOLT_CLOUD_CREDS_ID.jwk"
+  # dolt creds ls will show a key ID derived from the JWK contents, not
+  # $DOLT_CLOUD_CREDS_ID — that mismatch is normal.
+  dolt config --global --add user.creds "$DOLT_CLOUD_CREDS_ID"
+fi
+
+# 2. Repo fingerprint / origin rewrite
+canonical="git@github.com-amyde:AmyDe/town-crier.git"
+current_origin="$(git -C "$repo_root" remote get-url origin)"
+if [ "$current_origin" != "$canonical" ]; then
+  proxy_prefix="${current_origin%AmyDe/town-crier*}"
+  git -C "$repo_root" remote set-url origin "$canonical"
+  git -C "$repo_root" config url."$proxy_prefix".insteadOf "git@github.com-amyde:"
+fi
+
+# 3. Beads DB: hydrate or freshen
+chmod 700 "$repo_root/.beads"
+cd "$repo_root"
+if [ -d .beads/dolt/town_crier ]; then
+  bd dolt pull
+else
+  # bd bootstrap's metadata-reconcile step reads the server port file, which
+  # doesn't exist yet on a fresh clone — start the server first to write it.
+  bd dolt start
+  bd bootstrap
+fi
+
+echo "cloud-session-init: dolt creds installed, origin fingerprint set, beads DB ready"


### PR DESCRIPTION
Fixes the three failure modes that have blocked every scheduled cloud-runner firing of the backlog routine, diagnosed live across four failed runs.

## Problem

Cloud sessions run from an environment whose setup script executes **once per cache rebuild** (the filesystem is snapshotted and later sessions skip setup), and env-var secrets are **not injected during the setup phase**. That makes the setup script unusable for anything session-specific, which caused:

1. **`bd dolt push` → rpc `PermissionDenied`** — no DoltHub credential was ever installed (`~/.dolt/creds` empty), so pushes went out anonymously. Reads worked (the DoltHub DB is public), which repeatedly misdirected diagnosis toward credential scoping.
2. **`bd doctor` hard error: repo fingerprint mismatch** — bd hashes the configured origin URL; the cloud harness sets a per-session proxy URL (`http://local_proxy@127.0.0.1:<port>/...`), so the fingerprint never matched the stored `repo_id` (`fb4ae834` = sha256 of `github.com-amyde/AmyDe/town-crier`, minted from the Mac's SSH-alias remote). Routine runs abort on doctor errors.
3. **Hydration fragility** — once the environment cache stabilises, setup no longer runs per session, so `.beads/dolt` would be missing or week-stale snapshot data.

## Change

- **`scripts/wf/cloud-session-init.sh`** (new): per-session init, gated on `CLAUDE_CODE_REMOTE=true` so it exits immediately (status 0) on local machines. Installs the DoltHub credential from `DOLT_CLOUD_CREDS_ID`/`_B64` env vars, sets origin to the Mac-canonical URL string with a git `insteadOf` rewrite to the live session proxy (traffic unchanged, only the string bd hashes changes), and hydrates (`bd bootstrap`) or freshens (`bd dolt pull`) the beads DB. Idempotent for resumed sessions. Fails loudly with a diagnosis if the creds env vars are absent. Deliberately does **not** use `bd migrate --update-repo-id`, which would rewrite the DoltHub-synced `repo_id` and break local clones on their next pull.
- **`.claude/settings.json`**: run the init script from the SessionStart hook, ahead of `bd prime` so the DB is ready before prime reads it (600s timeout for the initial DoltHub clone).

Local development is unaffected: the only Mac-visible change is a sub-millisecond no-op exec before the existing `bd prime` hook.

## Verification (live cloud session)

- Credential install → `bd dolt push` succeeds (previously `PermissionDenied`); confirmed on DoltHub that `main` advanced.
- Origin rewrite → `git fetch` still routes through the session proxy; `bd doctor` reports `Repo Fingerprint Verified (fb4ae834)` and 0 errors overall.
- Claim-then-push flow (the routine's critical path) exercised end-to-end for bead tc-812ni itself.

Companion change (environment side, not in this repo): the cloud environment's setup script is reduced to binaries-only (bd 1.1.2 + prebuilt dolt 2.1.10 from GitHub releases, replacing the from-source build that died mid-setup on the 2026-07-28 09:00 run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DPuaSaVqzkmEuc24is1QHu

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPuaSaVqzkmEuc24is1QHu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic initialization for cloud development sessions.
  * Cloud sessions now configure required credentials, verify repository connectivity, and prepare the issue database automatically.
  * Existing local sessions remain unaffected.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->