### PR TITLE
Web: mandatory location gate + map picker for /search (tc-rrv7i.2)

### DIFF
--- a/web/src/AppRoutes.tsx
+++ b/web/src/AppRoutes.tsx
@@ -3,11 +3,17 @@ import { Routes, Route } from 'react-router';
 import { LandingPage } from './features/LandingPage/LandingPage';
 import { CallbackPage } from './auth/CallbackPage';
 import { ConnectedLegalPage } from './features/legal/ConnectedLegalPage';
-import { ConnectedSearchPage } from './features/Search/ConnectedSearchPage';
 import { AuthGuard } from './auth/AuthGuard';
 import { OnboardingGate } from './auth/OnboardingGate';
 import { AppShell } from './components/AppShell/AppShell';
 
+// Lazy (GH#863, tc-rrv7i.2): the location gate's LocationPicker pulls in
+// react-leaflet/leaflet, same as the other map-carrying routes below. /search
+// used to be a light eager import, but now needs the same treatment — every
+// visitor to any page would otherwise pay for leaflet in the main bundle.
+const ConnectedSearchPage = lazy(() =>
+  import('./features/Search/ConnectedSearchPage').then((m) => ({ default: m.ConnectedSearchPage })),
+);
 const ConnectedOnboardingPage = lazy(() =>
   import('./features/onboarding/ConnectedOnboardingPage').then((m) => ({ default: m.ConnectedOnboardingPage })),
 );
@@ -52,7 +58,7 @@ export function AppRoutes() {
       <Route path="/" element={<LandingPage />} />
       <Route path="/callback" element={<CallbackPage />} />
       <Route path="/legal/:type" element={<ConnectedLegalPage />} />
-      <Route path="/search" element={<ConnectedSearchPage />} />
+      <Route path="/search" element={<Suspense fallback={null}><ConnectedSearchPage /></Suspense>} />
 
       {/* Authenticated routes */}
       <Route element={<AuthGuard />}>

--- a/web/src/components/osmTiles.ts
+++ b/web/src/components/osmTiles.ts
@@ -1,0 +1,9 @@
+/**
+ * Shared OpenStreetMap tile constants. Hoisted out of `features/Map/MapPage.tsx`
+ * (tc-rrv7i.2 / GH#863) so `features/Search`'s location-picker map can reuse the
+ * same tile source and attribution without a forbidden cross-feature import —
+ * both features depend on this shared module instead of on each other.
+ */
+export const OSM_TILE_URL = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+export const OSM_ATTRIBUTION =
+  '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';

--- a/web/src/domain/ports/postcode-lookup-port.ts
+++ b/web/src/domain/ports/postcode-lookup-port.ts
@@ -1,0 +1,18 @@
+import type { SearchLocation } from './search-port';
+
+/**
+ * Client-side postcode -> lat/lon resolution for the `/search` location
+ * picker (GH#863, tc-rrv7i.2). Deliberately never routed through our own
+ * `ApiClient`/base URL — the concrete adapter must call postcodes.io
+ * directly from the browser (see `PostcodesIoLookupPort`), so a spike in
+ * lookups is spread across every visitor's own IP rather than funnelled
+ * through our single server IP.
+ */
+export interface PostcodeLookupPort {
+  /**
+   * @param postcode raw user input; the adapter trims/encodes it.
+   * @throws when the postcode does not resolve (distinct message from a
+   *   network failure) or the lookup itself could not be made.
+   */
+  lookup(postcode: string): Promise<SearchLocation>;
+}

--- a/web/src/domain/ports/search-port.ts
+++ b/web/src/domain/ports/search-port.ts
@@ -11,10 +11,20 @@ export interface SearchOutcome {
 }
 
 /**
- * Anonymous application search (#821 Phase 3/4) —
- * `GET /v1/applications/search`. Public and unauthenticated: no auth token is
- * ever attached to this call, so it must keep working for a fully logged-out
- * visitor.
+ * A resolved query point — the browser-supplied `lat`/`lon` the API's KNN
+ * nearest-first search ranks results from (GH#863, tc-rrv7i). Field names
+ * match the API's query-string parameters exactly.
+ */
+export interface SearchLocation {
+  readonly lat: number;
+  readonly lon: number;
+}
+
+/**
+ * Anonymous application search (#821 Phase 3/4, mandatory location as of
+ * GH#863) — `GET /v1/applications/search`. Public and unauthenticated: no
+ * auth token is ever attached to this call, so it must keep working for a
+ * fully logged-out visitor.
  */
 export interface SearchPort {
   /**
@@ -22,6 +32,10 @@ export interface SearchPort {
    *   description keywords).
    * @param authority optional authority id-or-slug filter; `null` searches
    *   across all authorities.
+   * @param location mandatory query point — the API 400s without it, and
+   *   results are nearest-first from this point. Never optional: a location
+   *   must be resolved (postcode, "use my location", or a map tap) before a
+   *   search can run at all (see `useSearch`'s gating).
    */
-  search(query: string, authority: string | null): Promise<SearchOutcome>;
+  search(query: string, authority: string | null, location: SearchLocation): Promise<SearchOutcome>;
 }

--- a/web/src/features/Map/MapPage.tsx
+++ b/web/src/features/Map/MapPage.tsx
@@ -6,13 +6,10 @@ import type { ApplicationStatus, ClusterMember, MapCluster, WatchZoneSummary } f
 import { clusterMemberStatus } from '../../domain/types';
 import { useMapData } from './useMapData';
 import { countBubbleIcon, statusPinIcon } from './markerIcons';
+import { OSM_TILE_URL, OSM_ATTRIBUTION } from '../../components/osmTiles';
 import styles from './MapPage.module.css';
 import 'leaflet/dist/leaflet.css';
 import './leaflet-overrides.css';
-
-const OSM_TILE_URL = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
-const OSM_ATTRIBUTION =
-  '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
 
 const UK_CENTER: [number, number] = [54.5, -2.5];
 const ZONE_ZOOM = 13;

--- a/web/src/features/Search/ApiSearchPort.ts
+++ b/web/src/features/Search/ApiSearchPort.ts
@@ -1,4 +1,4 @@
-import type { SearchOutcome, SearchPort } from '../../domain/ports/search-port';
+import type { SearchLocation, SearchOutcome, SearchPort } from '../../domain/ports/search-port';
 import type { SearchResult } from '../../domain/types';
 
 interface SearchResultDto {
@@ -46,8 +46,16 @@ export class ApiSearchPort implements SearchPort {
     this.fetchFn = fetchFn;
   }
 
-  async search(query: string, authority: string | null): Promise<SearchOutcome> {
-    const params = new URLSearchParams({ q: query });
+  async search(
+    query: string,
+    authority: string | null,
+    location: SearchLocation,
+  ): Promise<SearchOutcome> {
+    const params = new URLSearchParams({
+      q: query,
+      lat: String(location.lat),
+      lon: String(location.lon),
+    });
     if (authority !== null && authority !== '') {
       params.set('authority', authority);
     }

--- a/web/src/features/Search/ConnectedSearchPage.tsx
+++ b/web/src/features/Search/ConnectedSearchPage.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { ApiSearchPort } from './ApiSearchPort';
+import { PostcodesIoLookupPort } from './PostcodesIoLookupPort';
 import { SearchPage } from './SearchPage';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL as string || 'http://localhost:5000';
@@ -7,10 +8,15 @@ const API_BASE_URL = import.meta.env.VITE_API_BASE_URL as string || 'http://loca
 /**
  * Composition root for the public `/search` route (#821 Phase 4). Wires the
  * anonymous `ApiSearchPort` directly — never the token-bearing `ApiClient` —
- * so this page keeps working for a visitor who has never signed in.
+ * so this page keeps working for a visitor who has never signed in. Also
+ * wires `PostcodesIoLookupPort` (GH#863, tc-rrv7i.2), which talks to
+ * `api.postcodes.io` directly from the browser rather than through
+ * `API_BASE_URL` — postcode lookups must never be proxied through our own
+ * server (see the port's own doc comment for why).
  */
 export function ConnectedSearchPage() {
   const port = useMemo(() => new ApiSearchPort(API_BASE_URL), []);
+  const postcodePort = useMemo(() => new PostcodesIoLookupPort(), []);
 
-  return <SearchPage port={port} />;
+  return <SearchPage port={port} postcodePort={postcodePort} />;
 }

--- a/web/src/features/Search/PostcodesIoLookupPort.ts
+++ b/web/src/features/Search/PostcodesIoLookupPort.ts
@@ -1,0 +1,59 @@
+import type { PostcodeLookupPort } from '../../domain/ports/postcode-lookup-port';
+import type { SearchLocation } from '../../domain/ports/search-port';
+
+const POSTCODES_IO_BASE_URL = 'https://api.postcodes.io';
+
+interface PostcodesIoResult {
+  readonly latitude: number;
+  readonly longitude: number;
+}
+
+interface PostcodesIoResponse {
+  readonly status: number;
+  readonly result: PostcodesIoResult | null;
+}
+
+/**
+ * Client-side adapter for postcodes.io (GH#863, tc-rrv7i.2). Calls
+ * `https://api.postcodes.io` directly from the browser using its own
+ * `fetch` — this is a hard constraint, not a style choice: postcodes.io is a
+ * free public service, and proxying every user's lookup through our own
+ * server would put all of them behind one server IP, risking
+ * rate-limiting/blacklisting for every user at once. Never wire this through
+ * the app's own `ApiClient`/base URL.
+ */
+export class PostcodesIoLookupPort implements PostcodeLookupPort {
+  private readonly fetchFn: typeof globalThis.fetch;
+
+  constructor(fetchFn: typeof globalThis.fetch = globalThis.fetch.bind(globalThis)) {
+    this.fetchFn = fetchFn;
+  }
+
+  async lookup(postcode: string): Promise<SearchLocation> {
+    const normalised = postcode.trim();
+
+    let response: Response;
+    try {
+      response = await this.fetchFn(
+        `${POSTCODES_IO_BASE_URL}/postcodes/${encodeURIComponent(normalised)}`,
+      );
+    } catch {
+      // fetch() itself rejecting (offline, DNS failure, CORS, etc.) throws an
+      // engine-specific, unfriendly message — never surface that verbatim.
+      throw new Error('Could not look up that postcode. Check your connection and try again.');
+    }
+
+    if (response.status === 404) {
+      throw new Error('Postcode not found');
+    }
+    if (!response.ok) {
+      throw new Error('Could not look up that postcode. Check your connection and try again.');
+    }
+
+    const dto = (await response.json()) as PostcodesIoResponse;
+    if (!dto.result) {
+      throw new Error('Postcode not found');
+    }
+    return { lat: dto.result.latitude, lon: dto.result.longitude };
+  }
+}

--- a/web/src/features/Search/SearchPage.module.css
+++ b/web/src/features/Search/SearchPage.module.css
@@ -4,6 +4,76 @@
   padding: var(--tc-space-xl) var(--tc-space-md);
 }
 
+/* ---------- Location gate: disabled bar + inline gate (never a modal/full page) ---------- */
+
+.locationBar {
+  margin-bottom: var(--tc-space-md);
+}
+
+.locationPrompt {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--tc-space-xs);
+  min-height: 44px;
+  padding: var(--tc-space-sm) var(--tc-space-md);
+  border: 1.5px dashed var(--tc-border);
+  border-radius: var(--tc-radius-md);
+  background: transparent;
+  color: var(--tc-text-secondary);
+  font-size: var(--tc-text-body);
+  cursor: pointer;
+}
+
+.locationPrompt:hover {
+  border-color: var(--tc-amber);
+  color: var(--tc-text-primary);
+}
+
+.locationChipRow {
+  display: flex;
+  align-items: center;
+  gap: var(--tc-space-sm);
+}
+
+/* Stamp language (Public Notice component vocabulary): outlined, uppercase,
+   letter-spaced — matches ApplicationCard's status stamp. */
+.locationChip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--tc-space-xs);
+  padding: var(--tc-space-xs) var(--tc-space-sm);
+  border: 1.5px solid var(--tc-border-focused);
+  border-radius: var(--tc-radius-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: var(--tc-text-caption);
+  font-weight: var(--tc-weight-semibold);
+  color: var(--tc-text-primary);
+}
+
+.changeButton {
+  min-height: 44px;
+  padding: var(--tc-space-xs) var(--tc-space-md);
+  border: 1px solid var(--tc-border);
+  border-radius: var(--tc-radius-md);
+  background: var(--tc-surface);
+  color: var(--tc-text-primary);
+  font-size: var(--tc-text-caption);
+  cursor: pointer;
+}
+
+.cancelPickerButton {
+  align-self: flex-start;
+  border: none;
+  background: transparent;
+  color: var(--tc-text-secondary);
+  font-size: var(--tc-text-caption);
+  text-decoration: underline;
+  cursor: pointer;
+  padding: var(--tc-space-xs) 0;
+  margin-top: var(--tc-space-xs);
+}
+
 .heading {
   font-size: var(--tc-text-display-small);
   font-weight: var(--tc-weight-semibold);
@@ -49,6 +119,11 @@
 .input:focus-visible {
   outline: 2px solid var(--tc-border-focused);
   outline-offset: 2px;
+}
+
+.input:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 .status {

--- a/web/src/features/Search/SearchPage.tsx
+++ b/web/src/features/Search/SearchPage.tsx
@@ -1,11 +1,14 @@
 import { useEffect } from 'react';
 import type { SearchPort } from '../../domain/ports/search-port';
+import type { PostcodeLookupPort } from '../../domain/ports/postcode-lookup-port';
 import { useSearch } from './useSearch';
 import { SearchResultCard } from './components/SearchResultCard';
+import { LocationPicker } from './components/LocationPicker';
 import styles from './SearchPage.module.css';
 
 interface Props {
   port: SearchPort;
+  postcodePort: PostcodeLookupPort;
 }
 
 const PAGE_TITLE = 'Search UK planning applications | Town Crier';
@@ -17,13 +20,25 @@ const PAGE_DESCRIPTION =
  * fully logged out. Sets its own `<title>`/meta description on mount so the
  * page is indexable in its own right, distinct from the landing page; results
  * are client-rendered and deliberately never added to `sitemap.xml`.
+ *
+ * A location is mandatory before a search can run (GH#863, tc-rrv7i.2): the
+ * search input carries a real `disabled` attribute until one is confirmed.
+ * This is the "disabled bar + inline gate" pattern — a prompt expands an
+ * inline `LocationPicker` in place, never a full-page picker or a blocking
+ * modal. Once confirmed, the prompt becomes a location chip with a "Change"
+ * action that reopens the picker, prefilled with the current selection.
  */
-export function SearchPage({ port }: Props) {
+export function SearchPage({ port, postcodePort }: Props) {
   const {
     query,
     setQuery,
     authority,
     setAuthority,
+    location,
+    locationLabel,
+    isLocationPickerOpen,
+    changeLocation,
+    confirmLocation,
     results,
     isLoading,
     error,
@@ -57,6 +72,27 @@ export function SearchPage({ port }: Props) {
         link to share it.
       </p>
 
+      <div className={styles.locationBar}>
+        {isLocationPickerOpen ? (
+          <LocationPicker
+            postcodePort={postcodePort}
+            initialLocation={location}
+            onConfirm={confirmLocation}
+          />
+        ) : location !== null ? (
+          <div className={styles.locationChipRow}>
+            <span className={styles.locationChip}>📍 Near {locationLabel}</span>
+            <button type="button" className={styles.changeButton} onClick={changeLocation}>
+              Change
+            </button>
+          </div>
+        ) : (
+          <button type="button" className={styles.locationPrompt} onClick={changeLocation}>
+            📍 Set a location to search
+          </button>
+        )}
+      </div>
+
       <form className={styles.form} onSubmit={(event) => event.preventDefault()}>
         <div className={styles.field}>
           <label className={styles.label} htmlFor="search-query">
@@ -69,6 +105,7 @@ export function SearchPage({ port }: Props) {
             placeholder="Reference, address, or description"
             value={query}
             onChange={(event) => setQuery(event.target.value)}
+            disabled={location === null}
           />
         </div>
 

--- a/web/src/features/Search/SearchPage.tsx
+++ b/web/src/features/Search/SearchPage.tsx
@@ -38,6 +38,7 @@ export function SearchPage({ port, postcodePort }: Props) {
     locationLabel,
     isLocationPickerOpen,
     changeLocation,
+    closeLocationPicker,
     confirmLocation,
     results,
     isLoading,
@@ -74,11 +75,22 @@ export function SearchPage({ port, postcodePort }: Props) {
 
       <div className={styles.locationBar}>
         {isLocationPickerOpen ? (
-          <LocationPicker
-            postcodePort={postcodePort}
-            initialLocation={location}
-            onConfirm={confirmLocation}
-          />
+          <>
+            <LocationPicker
+              postcodePort={postcodePort}
+              initialLocation={location}
+              onConfirm={confirmLocation}
+            />
+            {location !== null && (
+              <button
+                type="button"
+                className={styles.cancelPickerButton}
+                onClick={closeLocationPicker}
+              >
+                Cancel
+              </button>
+            )}
+          </>
         ) : location !== null ? (
           <div className={styles.locationChipRow}>
             <span className={styles.locationChip}>📍 Near {locationLabel}</span>

--- a/web/src/features/Search/__tests__/ApiSearchPort.test.ts
+++ b/web/src/features/Search/__tests__/ApiSearchPort.test.ts
@@ -26,6 +26,8 @@ class StubFetch {
   };
 }
 
+const aLocation = { lat: 51.5074, lon: -0.1278 };
+
 describe('ApiSearchPort', () => {
   let stub: StubFetch;
   let port: ApiSearchPort;
@@ -36,22 +38,28 @@ describe('ApiSearchPort', () => {
     port = new ApiSearchPort(baseUrl, stub.fetch);
   });
 
-  it('fetches from the search endpoint with the query string', async () => {
-    await port.search('mill road', null);
+  it('fetches from the search endpoint with the query string and location', async () => {
+    await port.search('mill road', null, aLocation);
 
-    expect(stub.lastUrl).toBe('https://api.example.com/v1/applications/search?q=mill+road');
+    const url = new URL(stub.lastUrl!);
+    expect(url.pathname).toBe('/v1/applications/search');
+    expect(url.searchParams.get('q')).toBe('mill road');
+    expect(url.searchParams.get('lat')).toBe('51.5074');
+    expect(url.searchParams.get('lon')).toBe('-0.1278');
   });
 
-  it('adds the authority filter when provided', async () => {
-    await port.search('mill road', 'cambridge');
+  it('sends lat/lon on every call, including when an authority filter is set', async () => {
+    await port.search('mill road', 'cambridge', aLocation);
 
     const url = new URL(stub.lastUrl!);
     expect(url.searchParams.get('q')).toBe('mill road');
     expect(url.searchParams.get('authority')).toBe('cambridge');
+    expect(url.searchParams.get('lat')).toBe('51.5074');
+    expect(url.searchParams.get('lon')).toBe('-0.1278');
   });
 
   it('never attaches an Authorization header — this endpoint is anonymous', async () => {
-    await port.search('mill road', null);
+    await port.search('mill road', null, aLocation);
 
     const headers = stub.lastInit?.headers;
     expect(headers).toBeUndefined();
@@ -74,7 +82,7 @@ describe('ApiSearchPort', () => {
       refineQuery: true,
     };
 
-    const outcome = await port.search('mill road', null);
+    const outcome = await port.search('mill road', null, aLocation);
 
     expect(outcome.refineQuery).toBe(true);
     expect(outcome.results).toEqual([
@@ -107,7 +115,7 @@ describe('ApiSearchPort', () => {
       refineQuery: false,
     };
 
-    const outcome = await port.search('ref', null);
+    const outcome = await port.search('ref', null, aLocation);
 
     expect(outcome.results[0]).toEqual({
       reference: '24/0001/FUL',
@@ -123,7 +131,7 @@ describe('ApiSearchPort', () => {
   it('throws when the API returns a non-ok status', async () => {
     stub.responseStatus = 400;
 
-    await expect(port.search('a', null)).rejects.toThrow('Failed to search applications');
+    await expect(port.search('a', null, aLocation)).rejects.toThrow('Failed to search applications');
   });
 
   it('throws a friendly message when fetch itself fails (offline, DNS, CORS, etc.)', async () => {
@@ -134,7 +142,7 @@ describe('ApiSearchPort', () => {
     stub.shouldReject = true;
     stub.rejectError = new TypeError('Failed to fetch');
 
-    await expect(port.search('mill road', null)).rejects.toThrow(
+    await expect(port.search('mill road', null, aLocation)).rejects.toThrow(
       'Could not reach the search service. Check your connection and try again.',
     );
   });

--- a/web/src/features/Search/__tests__/PostcodesIoLookupPort.test.ts
+++ b/web/src/features/Search/__tests__/PostcodesIoLookupPort.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { PostcodesIoLookupPort } from '../PostcodesIoLookupPort';
+
+class StubFetch {
+  lastUrl: string | null = null;
+  responseBody: unknown = { status: 200, result: { latitude: 51.5, longitude: -0.1 } };
+  responseStatus = 200;
+  shouldReject = false;
+  rejectError: Error = new Error('Network failure');
+
+  readonly fetch: typeof globalThis.fetch = async (input: RequestInfo | URL) => {
+    this.lastUrl = String(input);
+    if (this.shouldReject) {
+      throw this.rejectError;
+    }
+    return {
+      ok: this.responseStatus >= 200 && this.responseStatus < 300,
+      status: this.responseStatus,
+      json: async () => this.responseBody,
+    } as Response;
+  };
+}
+
+describe('PostcodesIoLookupPort', () => {
+  let stub: StubFetch;
+  let port: PostcodesIoLookupPort;
+
+  beforeEach(() => {
+    stub = new StubFetch();
+    port = new PostcodesIoLookupPort(stub.fetch);
+  });
+
+  it('calls api.postcodes.io directly — never our own API baseUrl', async () => {
+    await port.lookup('SW1A 1AA');
+
+    expect(stub.lastUrl).toBe('https://api.postcodes.io/postcodes/SW1A%201AA');
+  });
+
+  it('resolves lat/lon from a successful lookup', async () => {
+    stub.responseBody = {
+      status: 200,
+      result: { latitude: 51.501, longitude: -0.1415 },
+    };
+
+    const location = await port.lookup('SW1A 1AA');
+
+    expect(location).toEqual({ lat: 51.501, lon: -0.1415 });
+  });
+
+  it('trims whitespace from the postcode before encoding it', async () => {
+    await port.lookup('  SW1A 1AA  ');
+
+    expect(stub.lastUrl).toBe('https://api.postcodes.io/postcodes/SW1A%201AA');
+  });
+
+  it('throws a distinct "not found" message on a 404', async () => {
+    stub.responseStatus = 404;
+    stub.responseBody = { status: 404, error: 'Postcode not found' };
+
+    await expect(port.lookup('ZZ9 9ZZ')).rejects.toThrow('Postcode not found');
+  });
+
+  it('throws a generic message on a non-404 non-ok response', async () => {
+    stub.responseStatus = 500;
+
+    await expect(port.lookup('SW1A 1AA')).rejects.toThrow(
+      'Could not look up that postcode. Check your connection and try again.',
+    );
+  });
+
+  it('throws a friendly message when fetch itself fails (offline, DNS, CORS, etc.)', async () => {
+    stub.shouldReject = true;
+    stub.rejectError = new TypeError('Failed to fetch');
+
+    await expect(port.lookup('SW1A 1AA')).rejects.toThrow(
+      'Could not look up that postcode. Check your connection and try again.',
+    );
+  });
+});

--- a/web/src/features/Search/__tests__/SearchPage.test.tsx
+++ b/web/src/features/Search/__tests__/SearchPage.test.tsx
@@ -119,6 +119,20 @@ describe('SearchPage', () => {
     expect(marker.getAttribute('data-lon')).toBe('-0.1');
   });
 
+  it('cancels a reopened picker via Change without discarding the confirmed location', () => {
+    renderPage(new SpySearchPort());
+    confirmALocationViaMap();
+
+    fireEvent.click(screen.getByRole('button', { name: /change/i }));
+    expect(screen.getByTestId('map-container')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(screen.queryByTestId('map-container')).not.toBeInTheDocument();
+    expect(screen.getByText(/near custom pin/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/search/i)).not.toBeDisabled();
+  });
+
   it('re-confirming after Change updates the chip label', () => {
     renderPage(new SpySearchPort());
     confirmALocationViaMap();

--- a/web/src/features/Search/__tests__/SearchPage.test.tsx
+++ b/web/src/features/Search/__tests__/SearchPage.test.tsx
@@ -1,8 +1,47 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { SearchPage } from '../SearchPage';
 import { SpySearchPort } from './spies/spy-search-port';
+import { SpyPostcodeLookupPort } from './spies/spy-postcode-lookup-port';
 import { aSearchResult, anotherSearchResult } from './fixtures/search-result.fixtures';
+
+const h = vi.hoisted(() => {
+  let capturedClickHandler: ((event: { latlng: { lat: number; lng: number } }) => void) | null = null;
+  return {
+    setClickHandler: (fn: typeof capturedClickHandler) => {
+      capturedClickHandler = fn;
+    },
+    fireMapClick: (lat: number, lng: number) => {
+      capturedClickHandler?.({ latlng: { lat, lng } });
+    },
+  };
+});
+
+vi.mock('react-leaflet', () => ({
+  MapContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="map-container">{children}</div>
+  ),
+  TileLayer: () => <div data-testid="tile-layer" />,
+  Marker: ({ position }: { position: [number, number] }) => (
+    <div data-testid="marker" data-lat={position[0]} data-lon={position[1]} />
+  ),
+  useMapEvents: (handlers: { click: (event: { latlng: { lat: number; lng: number } }) => void }) => {
+    h.setClickHandler(handlers.click);
+    return null;
+  },
+}));
+
+/** Confirms a location the fastest way available in a test: a direct map tap. */
+function confirmALocationViaMap() {
+  fireEvent.click(screen.getByRole('button', { name: /set a location to search/i }));
+  act(() => {
+    h.fireMapClick(51.5, -0.1);
+  });
+}
+
+function renderPage(searchPort: SpySearchPort, postcodePort = new SpyPostcodeLookupPort()) {
+  return render(<SearchPage port={searchPort} postcodePort={postcodePort} />);
+}
 
 describe('SearchPage', () => {
   afterEach(() => {
@@ -10,7 +49,7 @@ describe('SearchPage', () => {
   });
 
   it('renders a heading and a search input', () => {
-    render(<SearchPage port={new SpySearchPort()} />);
+    renderPage(new SpySearchPort());
 
     expect(screen.getByRole('heading', { name: /search planning applications/i })).toBeInTheDocument();
     expect(screen.getByLabelText(/search/i)).toBeInTheDocument();
@@ -22,7 +61,7 @@ describe('SearchPage', () => {
     originalDescription.setAttribute('content', 'Town Crier home');
     document.head.appendChild(originalDescription);
 
-    const { unmount } = render(<SearchPage port={new SpySearchPort()} />);
+    const { unmount } = renderPage(new SpySearchPort());
 
     expect(document.title).toMatch(/search/i);
     expect(document.title).toMatch(/town crier/i);
@@ -33,10 +72,79 @@ describe('SearchPage', () => {
     document.head.removeChild(originalDescription);
   });
 
+  it('disables the search input while no location is set, regardless of query text', () => {
+    renderPage(new SpySearchPort());
+
+    const input = screen.getByLabelText(/search/i);
+    expect(input).toBeDisabled();
+  });
+
+  it('shows a "Set a location" prompt before any location is confirmed', () => {
+    renderPage(new SpySearchPort());
+
+    expect(screen.getByRole('button', { name: /set a location to search/i })).toBeInTheDocument();
+    expect(screen.queryByTestId('map-container')).not.toBeInTheDocument();
+  });
+
+  it('expands the inline picker when the prompt is clicked, never a full-page picker or modal', () => {
+    renderPage(new SpySearchPort());
+
+    fireEvent.click(screen.getByRole('button', { name: /set a location to search/i }));
+
+    expect(screen.getByTestId('map-container')).toBeInTheDocument();
+    // Still on the same page — the heading and search input are still present,
+    // proving this is an inline expansion, not a route change or a dialog.
+    expect(screen.getByRole('heading', { name: /search planning applications/i })).toBeInTheDocument();
+  });
+
+  it('enables the search input and shows a location chip once a location is confirmed', () => {
+    renderPage(new SpySearchPort());
+
+    confirmALocationViaMap();
+
+    expect(screen.getByLabelText(/search/i)).not.toBeDisabled();
+    expect(screen.getByText(/near custom pin/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /set a location to search/i })).not.toBeInTheDocument();
+  });
+
+  it('reopens the picker, prefilled with the current selection, via Change', () => {
+    renderPage(new SpySearchPort());
+    confirmALocationViaMap();
+
+    fireEvent.click(screen.getByRole('button', { name: /change/i }));
+
+    expect(screen.getByTestId('map-container')).toBeInTheDocument();
+    const marker = screen.getByTestId('marker');
+    expect(marker.getAttribute('data-lat')).toBe('51.5');
+    expect(marker.getAttribute('data-lon')).toBe('-0.1');
+  });
+
+  it('re-confirming after Change updates the chip label', () => {
+    renderPage(new SpySearchPort());
+    confirmALocationViaMap();
+
+    fireEvent.click(screen.getByRole('button', { name: /change/i }));
+    act(() => {
+      h.fireMapClick(52.2, 0.1);
+    });
+
+    expect(screen.getByText(/near custom pin/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('map-container')).not.toBeInTheDocument();
+  });
+
+  it('never renders any radius slider or radius UI', () => {
+    renderPage(new SpySearchPort());
+    confirmALocationViaMap();
+
+    expect(screen.queryByRole('slider')).not.toBeInTheDocument();
+    expect(screen.queryByText(/radius/i)).not.toBeInTheDocument();
+  });
+
   it('shows results after the debounced search resolves', async () => {
     const spy = new SpySearchPort();
     spy.searchResult = { results: [aSearchResult(), anotherSearchResult()], refineQuery: false };
-    render(<SearchPage port={spy} />);
+    renderPage(spy);
+    confirmALocationViaMap();
 
     fireEvent.change(screen.getByLabelText(/search/i), { target: { value: 'mill road' } });
 
@@ -52,7 +160,8 @@ describe('SearchPage', () => {
   it('shows a refine-your-search notice when the match set was truncated', async () => {
     const spy = new SpySearchPort();
     spy.searchResult = { results: [aSearchResult()], refineQuery: true };
-    render(<SearchPage port={spy} />);
+    renderPage(spy);
+    confirmALocationViaMap();
 
     fireEvent.change(screen.getByLabelText(/search/i), { target: { value: 'road' } });
 
@@ -67,7 +176,8 @@ describe('SearchPage', () => {
   it('shows an empty-results message when the search returns nothing', async () => {
     const spy = new SpySearchPort();
     spy.searchResult = { results: [], refineQuery: false };
-    render(<SearchPage port={spy} />);
+    renderPage(spy);
+    confirmALocationViaMap();
 
     fireEvent.change(screen.getByLabelText(/search/i), { target: { value: 'nonexistent' } });
 
@@ -82,7 +192,8 @@ describe('SearchPage', () => {
   it('shows an error message when the search fails', async () => {
     const spy = new SpySearchPort();
     spy.searchError = new Error('Request failed with status 500');
-    render(<SearchPage port={spy} />);
+    renderPage(spy);
+    confirmALocationViaMap();
 
     fireEvent.change(screen.getByLabelText(/search/i), { target: { value: 'mill road' } });
 
@@ -94,9 +205,10 @@ describe('SearchPage', () => {
     );
   });
 
-  it('passes the authority filter through to the port', async () => {
+  it('passes the authority filter and the confirmed location through to the port', async () => {
     const spy = new SpySearchPort();
-    render(<SearchPage port={spy} />);
+    renderPage(spy);
+    confirmALocationViaMap();
 
     fireEvent.change(screen.getByLabelText(/council/i), { target: { value: 'cambridge' } });
     fireEvent.change(screen.getByLabelText(/search/i), { target: { value: 'mill road' } });
@@ -107,12 +219,25 @@ describe('SearchPage', () => {
       },
       { timeout: 2000 },
     );
-    expect(spy.searchCalls[0]).toEqual({ query: 'mill road', authority: 'cambridge' });
+    expect(spy.searchCalls[0]).toEqual({
+      query: 'mill road',
+      authority: 'cambridge',
+      location: { lat: 51.5, lon: -0.1 },
+    });
   });
 
   it('does not search on mount, before the user has typed anything', async () => {
     const spy = new SpySearchPort();
-    render(<SearchPage port={spy} />);
+    renderPage(spy);
+    confirmALocationViaMap();
+
+    await new Promise((r) => setTimeout(r, 600));
+    expect(spy.searchCalls).toHaveLength(0);
+  });
+
+  it('never calls the port while location is unset, even if a query were somehow present', async () => {
+    const spy = new SpySearchPort();
+    renderPage(spy);
 
     await new Promise((r) => setTimeout(r, 600));
     expect(spy.searchCalls).toHaveLength(0);

--- a/web/src/features/Search/__tests__/spies/spy-postcode-lookup-port.ts
+++ b/web/src/features/Search/__tests__/spies/spy-postcode-lookup-port.ts
@@ -1,0 +1,16 @@
+import type { PostcodeLookupPort } from '../../../../domain/ports/postcode-lookup-port';
+import type { SearchLocation } from '../../../../domain/ports/search-port';
+
+export class SpyPostcodeLookupPort implements PostcodeLookupPort {
+  lookupCalls: string[] = [];
+  lookupResult: SearchLocation = { lat: 51.5, lon: -0.1 };
+  lookupError: Error | null = null;
+
+  async lookup(postcode: string): Promise<SearchLocation> {
+    this.lookupCalls.push(postcode);
+    if (this.lookupError) {
+      throw this.lookupError;
+    }
+    return this.lookupResult;
+  }
+}

--- a/web/src/features/Search/__tests__/spies/spy-search-port.ts
+++ b/web/src/features/Search/__tests__/spies/spy-search-port.ts
@@ -1,8 +1,9 @@
-import type { SearchOutcome, SearchPort } from '../../../../domain/ports/search-port';
+import type { SearchLocation, SearchOutcome, SearchPort } from '../../../../domain/ports/search-port';
 
 interface SearchCall {
   readonly query: string;
   readonly authority: string | null;
+  readonly location: SearchLocation;
 }
 
 export class SpySearchPort implements SearchPort {
@@ -10,8 +11,12 @@ export class SpySearchPort implements SearchPort {
   searchResult: SearchOutcome = { results: [], refineQuery: false };
   searchError: Error | null = null;
 
-  async search(query: string, authority: string | null): Promise<SearchOutcome> {
-    this.searchCalls.push({ query, authority });
+  async search(
+    query: string,
+    authority: string | null,
+    location: SearchLocation,
+  ): Promise<SearchOutcome> {
+    this.searchCalls.push({ query, authority, location });
     if (this.searchError) {
       throw this.searchError;
     }

--- a/web/src/features/Search/__tests__/useSearch.test.ts
+++ b/web/src/features/Search/__tests__/useSearch.test.ts
@@ -4,7 +4,18 @@ import { useSearch } from '../useSearch';
 import { SpySearchPort } from './spies/spy-search-port';
 import { aSearchResult, anotherSearchResult } from './fixtures/search-result.fixtures';
 
+const aLocation = { lat: 51.5074, lon: -0.1278 };
+
 describe('useSearch', () => {
+  it('starts with no location set and the picker closed', () => {
+    const spy = new SpySearchPort();
+    const { result } = renderHook(() => useSearch(spy));
+
+    expect(result.current.location).toBeNull();
+    expect(result.current.locationLabel).toBeNull();
+    expect(result.current.isLocationPickerOpen).toBe(false);
+  });
+
   it('does not call the port while the query is empty', async () => {
     const spy = new SpySearchPort();
 
@@ -18,9 +29,102 @@ describe('useSearch', () => {
     expect(result.current.hasSearched).toBe(false);
   });
 
+  it('never calls the port while location is null, regardless of query text', async () => {
+    const spy = new SpySearchPort();
+    const { result } = renderHook(() => useSearch(spy));
+
+    act(() => {
+      result.current.setQuery('mill road');
+    });
+
+    // Give the debounce window time to elapse — it must not fire without a location.
+    await new Promise((r) => setTimeout(r, 600));
+    expect(spy.searchCalls).toHaveLength(0);
+    expect(result.current.hasSearched).toBe(false);
+  });
+
+  it('changeLocation opens the picker', () => {
+    const spy = new SpySearchPort();
+    const { result } = renderHook(() => useSearch(spy));
+
+    act(() => {
+      result.current.changeLocation();
+    });
+
+    expect(result.current.isLocationPickerOpen).toBe(true);
+  });
+
+  it('confirmLocation sets the location, label, and closes the picker', () => {
+    const spy = new SpySearchPort();
+    const { result } = renderHook(() => useSearch(spy));
+
+    act(() => {
+      result.current.changeLocation();
+    });
+    act(() => {
+      result.current.confirmLocation(aLocation, 'SW1A 1AA');
+    });
+
+    expect(result.current.location).toEqual(aLocation);
+    expect(result.current.locationLabel).toBe('SW1A 1AA');
+    expect(result.current.isLocationPickerOpen).toBe(false);
+  });
+
+  it('confirming a location triggers the first search using the already-typed query', async () => {
+    const spy = new SpySearchPort();
+    const { result } = renderHook(() => useSearch(spy));
+
+    act(() => {
+      result.current.setQuery('mill road');
+    });
+    act(() => {
+      result.current.confirmLocation(aLocation, 'SW1A 1AA');
+    });
+
+    await waitFor(
+      () => {
+        expect(spy.searchCalls).toHaveLength(1);
+      },
+      { timeout: 2000 },
+    );
+    expect(spy.searchCalls[0]).toEqual({ query: 'mill road', authority: null, location: aLocation });
+  });
+
+  it('re-runs the search with the new location when the location is changed mid-session', async () => {
+    const spy = new SpySearchPort();
+    const { result } = renderHook(() => useSearch(spy));
+
+    act(() => {
+      result.current.setQuery('mill road');
+      result.current.confirmLocation(aLocation, 'SW1A 1AA');
+    });
+
+    await waitFor(() => {
+      expect(spy.searchCalls).toHaveLength(1);
+    });
+
+    const secondLocation = { lat: 52.2, lon: 0.1 };
+    act(() => {
+      result.current.confirmLocation(secondLocation, 'CB1 2AD');
+    });
+
+    await waitFor(() => {
+      expect(spy.searchCalls).toHaveLength(2);
+    });
+    expect(spy.searchCalls[1]).toEqual({
+      query: 'mill road',
+      authority: null,
+      location: secondLocation,
+    });
+  });
+
   it('debounces rapid typing into a single search call with the final query', async () => {
     const spy = new SpySearchPort();
     const { result } = renderHook(() => useSearch(spy));
+
+    act(() => {
+      result.current.confirmLocation(aLocation, 'SW1A 1AA');
+    });
 
     act(() => {
       result.current.setQuery('m');
@@ -38,7 +142,7 @@ describe('useSearch', () => {
       },
       { timeout: 2000 },
     );
-    expect(spy.searchCalls[0]).toEqual({ query: 'mill road', authority: null });
+    expect(spy.searchCalls[0]).toEqual({ query: 'mill road', authority: null, location: aLocation });
   });
 
   it('populates results after a successful search', async () => {
@@ -47,6 +151,7 @@ describe('useSearch', () => {
     const { result } = renderHook(() => useSearch(spy));
 
     act(() => {
+      result.current.confirmLocation(aLocation, 'SW1A 1AA');
       result.current.setQuery('mill road');
     });
 
@@ -68,6 +173,7 @@ describe('useSearch', () => {
     const { result } = renderHook(() => useSearch(spy));
 
     act(() => {
+      result.current.confirmLocation(aLocation, 'SW1A 1AA');
       result.current.setQuery('a common word');
     });
 
@@ -85,6 +191,7 @@ describe('useSearch', () => {
     const { result } = renderHook(() => useSearch(spy));
 
     act(() => {
+      result.current.confirmLocation(aLocation, 'SW1A 1AA');
       result.current.setQuery('zz');
     });
 
@@ -104,6 +211,7 @@ describe('useSearch', () => {
     const { result } = renderHook(() => useSearch(spy));
 
     act(() => {
+      result.current.confirmLocation(aLocation, 'SW1A 1AA');
       result.current.setAuthority('  cambridge  ');
       result.current.setQuery('mill road');
     });
@@ -114,7 +222,11 @@ describe('useSearch', () => {
       },
       { timeout: 2000 },
     );
-    expect(spy.searchCalls[0]).toEqual({ query: 'mill road', authority: 'cambridge' });
+    expect(spy.searchCalls[0]).toEqual({
+      query: 'mill road',
+      authority: 'cambridge',
+      location: aLocation,
+    });
 
     act(() => {
       result.current.setAuthority('');
@@ -127,14 +239,18 @@ describe('useSearch', () => {
       },
       { timeout: 2000 },
     );
-    expect(spy.searchCalls[1]).toEqual({ query: 'mill road again', authority: null });
+    expect(spy.searchCalls[1]).toEqual({
+      query: 'mill road again',
+      authority: null,
+      location: aLocation,
+    });
   });
 
   it('resets to idle and ignores a stale in-flight response when the query is cleared', async () => {
     let resolveSearch: ((outcome: { results: never[]; refineQuery: boolean }) => void) | null = null;
     const spy = new SpySearchPort();
-    spy.search = (query: string, authority: string | null) => {
-      spy.searchCalls.push({ query, authority });
+    spy.search = (query: string, authority: string | null, location) => {
+      spy.searchCalls.push({ query, authority, location });
       return new Promise((resolve) => {
         resolveSearch = resolve;
       });
@@ -143,6 +259,7 @@ describe('useSearch', () => {
     const { result } = renderHook(() => useSearch(spy));
 
     act(() => {
+      result.current.confirmLocation(aLocation, 'SW1A 1AA');
       result.current.setQuery('mill road');
     });
 

--- a/web/src/features/Search/__tests__/useSearch.test.ts
+++ b/web/src/features/Search/__tests__/useSearch.test.ts
@@ -54,6 +54,25 @@ describe('useSearch', () => {
     expect(result.current.isLocationPickerOpen).toBe(true);
   });
 
+  it('closeLocationPicker closes the picker without touching the confirmed location', () => {
+    const spy = new SpySearchPort();
+    const { result } = renderHook(() => useSearch(spy));
+
+    act(() => {
+      result.current.confirmLocation(aLocation, 'SW1A 1AA');
+    });
+    act(() => {
+      result.current.changeLocation();
+    });
+    act(() => {
+      result.current.closeLocationPicker();
+    });
+
+    expect(result.current.isLocationPickerOpen).toBe(false);
+    expect(result.current.location).toEqual(aLocation);
+    expect(result.current.locationLabel).toBe('SW1A 1AA');
+  });
+
   it('confirmLocation sets the location, label, and closes the picker', () => {
     const spy = new SpySearchPort();
     const { result } = renderHook(() => useSearch(spy));

--- a/web/src/features/Search/components/LocationPicker.module.css
+++ b/web/src/features/Search/components/LocationPicker.module.css
@@ -1,0 +1,79 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--tc-space-sm);
+  padding: var(--tc-space-md);
+  border: 1px solid var(--tc-border);
+  border-radius: var(--tc-radius-md);
+  background: var(--tc-surface);
+  margin-bottom: var(--tc-space-md);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--tc-space-xs);
+}
+
+.label {
+  font-size: var(--tc-text-caption);
+  font-weight: var(--tc-weight-medium);
+  color: var(--tc-text-secondary);
+}
+
+.input {
+  min-height: 44px;
+  padding: var(--tc-space-sm) var(--tc-space-md);
+  border: 1px solid var(--tc-border);
+  border-radius: var(--tc-radius-md);
+  background: var(--tc-surface);
+  color: var(--tc-text-primary);
+  font-size: var(--tc-text-body);
+}
+
+.input:focus-visible {
+  outline: 2px solid var(--tc-border-focused);
+  outline-offset: 2px;
+}
+
+.status {
+  font-size: var(--tc-text-caption);
+  color: var(--tc-text-secondary);
+  margin: 0;
+}
+
+.error {
+  font-size: var(--tc-text-caption);
+  color: var(--tc-status-rejected);
+  margin: 0;
+}
+
+.locateButton {
+  align-self: flex-start;
+  min-height: 44px;
+  padding: var(--tc-space-sm) var(--tc-space-md);
+  border: 1px solid var(--tc-border);
+  border-radius: var(--tc-radius-md);
+  background: var(--tc-surface);
+  color: var(--tc-text-primary);
+  font-size: var(--tc-text-body);
+  cursor: pointer;
+}
+
+.locateButton:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.hint {
+  font-size: var(--tc-text-caption);
+  color: var(--tc-text-secondary);
+  margin: 0;
+}
+
+.mapWrapper {
+  height: 240px;
+  border-radius: var(--tc-radius-md);
+  overflow: hidden;
+  border: 1px solid var(--tc-border);
+}

--- a/web/src/features/Search/components/LocationPicker.tsx
+++ b/web/src/features/Search/components/LocationPicker.tsx
@@ -1,0 +1,108 @@
+import { MapContainer, TileLayer, Marker, useMapEvents } from 'react-leaflet';
+import type { PostcodeLookupPort } from '../../../domain/ports/postcode-lookup-port';
+import type { SearchLocation } from '../../../domain/ports/search-port';
+import { OSM_TILE_URL, OSM_ATTRIBUTION } from '../../../components/osmTiles';
+import { useLocationPicker } from './useLocationPicker';
+import styles from './LocationPicker.module.css';
+import 'leaflet/dist/leaflet.css';
+
+const UK_CENTER: [number, number] = [54.5, -2.5];
+const DEFAULT_ZOOM = 6;
+const PICKED_ZOOM = 15;
+
+interface MapClickEvent {
+  readonly latlng: { readonly lat: number; readonly lng: number };
+}
+
+interface TapToPlaceProps {
+  readonly onSelect: (lat: number, lon: number) => void;
+}
+
+/** Lives inside `MapContainer` so a plain tap anywhere drops a pin there. */
+function TapToPlace({ onSelect }: TapToPlaceProps) {
+  useMapEvents({
+    click: (event: MapClickEvent) => onSelect(event.latlng.lat, event.latlng.lng),
+  });
+  return null;
+}
+
+interface Props {
+  readonly postcodePort: PostcodeLookupPort;
+  /** Prefills the map centre/marker when reopened via "Change". */
+  readonly initialLocation: SearchLocation | null;
+  readonly onConfirm: (location: SearchLocation, label: string) => void;
+}
+
+/**
+ * Inline location picker for the mandatory `/search` location gate (GH#863,
+ * tc-rrv7i.2) — the "disabled bar + inline gate" pattern, never a full-page
+ * picker or a blocking modal. Offers three equally-valid ways to resolve a
+ * location, each confirming immediately on success: a debounced client-side
+ * postcode lookup (`useLocationPicker` — never routed through our own API),
+ * "use my location" via `navigator.geolocation`, and a tap anywhere on the
+ * map. No radius UI: this component only ever resolves a point.
+ */
+export function LocationPicker({ postcodePort, initialLocation, onConfirm }: Props) {
+  const {
+    postcode,
+    setPostcode,
+    postcodeError,
+    isLookingUp,
+    geolocationError,
+    isLocating,
+    useMyLocation,
+    selectMapPoint,
+  } = useLocationPicker(postcodePort, onConfirm);
+
+  const center: [number, number] = initialLocation
+    ? [initialLocation.lat, initialLocation.lon]
+    : UK_CENTER;
+  const zoom = initialLocation ? PICKED_ZOOM : DEFAULT_ZOOM;
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.field}>
+        <label className={styles.label} htmlFor="location-picker-postcode">
+          Postcode
+        </label>
+        <input
+          id="location-picker-postcode"
+          type="text"
+          className={styles.input}
+          placeholder="e.g. SW1A 1AA"
+          value={postcode}
+          onChange={(event) => setPostcode(event.target.value)}
+        />
+        {isLookingUp && <p className={styles.status}>Looking up…</p>}
+        {postcodeError !== null && (
+          <p className={styles.error} role="alert">
+            {postcodeError}
+          </p>
+        )}
+      </div>
+
+      <button
+        type="button"
+        className={styles.locateButton}
+        onClick={useMyLocation}
+        disabled={isLocating}
+      >
+        {isLocating ? 'Locating…' : 'Use my location'}
+      </button>
+      {geolocationError !== null && (
+        <p className={styles.error} role="alert">
+          {geolocationError}
+        </p>
+      )}
+
+      <p className={styles.hint}>Or tap the map to drop a pin</p>
+      <div className={styles.mapWrapper}>
+        <MapContainer center={center} zoom={zoom} style={{ height: '100%', width: '100%' }}>
+          <TileLayer url={OSM_TILE_URL} attribution={OSM_ATTRIBUTION} />
+          {initialLocation && <Marker position={[initialLocation.lat, initialLocation.lon]} />}
+          <TapToPlace onSelect={selectMapPoint} />
+        </MapContainer>
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/Search/components/__tests__/LocationPicker.test.tsx
+++ b/web/src/features/Search/components/__tests__/LocationPicker.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { LocationPicker } from '../LocationPicker';
+import { SpyPostcodeLookupPort } from '../../__tests__/spies/spy-postcode-lookup-port';
+
+const h = vi.hoisted(() => {
+  let capturedClickHandler: ((event: { latlng: { lat: number; lng: number } }) => void) | null = null;
+  return {
+    setClickHandler: (fn: typeof capturedClickHandler) => {
+      capturedClickHandler = fn;
+    },
+    fireMapClick: (lat: number, lng: number) => {
+      capturedClickHandler?.({ latlng: { lat, lng } });
+    },
+  };
+});
+
+vi.mock('react-leaflet', () => ({
+  MapContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="map-container">{children}</div>
+  ),
+  TileLayer: () => <div data-testid="tile-layer" />,
+  Marker: ({ position }: { position: [number, number] }) => (
+    <div data-testid="marker" data-lat={position[0]} data-lon={position[1]} />
+  ),
+  useMapEvents: (handlers: { click: (event: { latlng: { lat: number; lng: number } }) => void }) => {
+    h.setClickHandler(handlers.click);
+    return null;
+  },
+}));
+
+describe('LocationPicker', () => {
+  let port: SpyPostcodeLookupPort;
+  let onConfirm: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    port = new SpyPostcodeLookupPort();
+    onConfirm = vi.fn();
+  });
+
+  it('renders a postcode input, a "use my location" button, and a map', () => {
+    render(<LocationPicker postcodePort={port} initialLocation={null} onConfirm={onConfirm} />);
+
+    expect(screen.getByLabelText(/postcode/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /use my location/i })).toBeInTheDocument();
+    expect(screen.getByTestId('map-container')).toBeInTheDocument();
+  });
+
+  it('confirms the resolved location after a debounced postcode lookup', async () => {
+    port.lookupResult = { lat: 51.501, lon: -0.1415 };
+    render(<LocationPicker postcodePort={port} initialLocation={null} onConfirm={onConfirm} />);
+
+    fireEvent.change(screen.getByLabelText(/postcode/i), { target: { value: 'SW1A 1AA' } });
+
+    await waitFor(
+      () => {
+        expect(onConfirm).toHaveBeenCalledWith({ lat: 51.501, lon: -0.1415 }, 'SW1A 1AA');
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  it('shows a distinct message when the postcode is not found', async () => {
+    port.lookupError = new Error('Postcode not found');
+    render(<LocationPicker postcodePort={port} initialLocation={null} onConfirm={onConfirm} />);
+
+    fireEvent.change(screen.getByLabelText(/postcode/i), { target: { value: 'ZZ9 9ZZ' } });
+
+    await waitFor(
+      () => {
+        expect(screen.getByText('Postcode not found')).toBeInTheDocument();
+      },
+      { timeout: 2000 },
+    );
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('confirms a "custom pin" when the map is tapped', () => {
+    render(<LocationPicker postcodePort={port} initialLocation={null} onConfirm={onConfirm} />);
+
+    h.fireMapClick(52.2053, 0.1218);
+
+    expect(onConfirm).toHaveBeenCalledWith({ lat: 52.2053, lon: 0.1218 }, 'custom pin');
+  });
+
+  it('renders a marker prefilled at the current selection when reopened via Change', () => {
+    render(
+      <LocationPicker
+        postcodePort={port}
+        initialLocation={{ lat: 51.5, lon: -0.1 }}
+        onConfirm={onConfirm}
+      />,
+    );
+
+    const marker = screen.getByTestId('marker');
+    expect(marker.getAttribute('data-lat')).toBe('51.5');
+    expect(marker.getAttribute('data-lon')).toBe('-0.1');
+  });
+
+  it('never sends the postcode lookup through anything other than the injected port', async () => {
+    render(<LocationPicker postcodePort={port} initialLocation={null} onConfirm={onConfirm} />);
+
+    fireEvent.change(screen.getByLabelText(/postcode/i), { target: { value: 'SW1A 1AA' } });
+
+    await waitFor(() => {
+      expect(port.lookupCalls).toEqual(['SW1A 1AA']);
+    });
+  });
+});

--- a/web/src/features/Search/components/__tests__/useLocationPicker.test.ts
+++ b/web/src/features/Search/components/__tests__/useLocationPicker.test.ts
@@ -1,0 +1,163 @@
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { useLocationPicker } from '../useLocationPicker';
+import { SpyPostcodeLookupPort } from '../../__tests__/spies/spy-postcode-lookup-port';
+
+interface StubGeolocation {
+  getCurrentPosition: (
+    success: (position: GeolocationPosition) => void,
+    error?: (error: GeolocationPositionError) => void,
+  ) => void;
+}
+
+function stubGeolocationSuccess(lat: number, lon: number): StubGeolocation {
+  return {
+    getCurrentPosition: (success) => {
+      success({ coords: { latitude: lat, longitude: lon } } as GeolocationPosition);
+    },
+  };
+}
+
+function stubGeolocationDenied(): StubGeolocation {
+  return {
+    getCurrentPosition: (_success, error) => {
+      error?.({ code: 1, message: 'User denied Geolocation' } as GeolocationPositionError);
+    },
+  };
+}
+
+describe('useLocationPicker', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('does not look up while the postcode is too short', async () => {
+    const port = new SpyPostcodeLookupPort();
+    const onConfirm = vi.fn();
+    const { result } = renderHook(() => useLocationPicker(port, onConfirm));
+
+    act(() => {
+      result.current.setPostcode('SW1');
+    });
+
+    await new Promise((r) => setTimeout(r, 600));
+    expect(port.lookupCalls).toHaveLength(0);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('debounces postcode entry into a single lookup, then confirms with the postcode as the label', async () => {
+    const port = new SpyPostcodeLookupPort();
+    port.lookupResult = { lat: 51.501, lon: -0.1415 };
+    const onConfirm = vi.fn();
+    const { result } = renderHook(() => useLocationPicker(port, onConfirm));
+
+    act(() => {
+      result.current.setPostcode('S');
+    });
+    act(() => {
+      result.current.setPostcode('SW');
+    });
+    act(() => {
+      result.current.setPostcode('sw1a 1aa');
+    });
+
+    await waitFor(
+      () => {
+        expect(port.lookupCalls).toHaveLength(1);
+      },
+      { timeout: 2000 },
+    );
+    expect(port.lookupCalls[0]).toBe('sw1a 1aa');
+
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalledWith({ lat: 51.501, lon: -0.1415 }, 'SW1A 1AA');
+    });
+  });
+
+  it('surfaces a distinct error and does not confirm when the postcode is not found', async () => {
+    const port = new SpyPostcodeLookupPort();
+    port.lookupError = new Error('Postcode not found');
+    const onConfirm = vi.fn();
+    const { result } = renderHook(() => useLocationPicker(port, onConfirm));
+
+    act(() => {
+      result.current.setPostcode('zz9 9zz');
+    });
+
+    await waitFor(() => {
+      expect(result.current.postcodeError).toBe('Postcode not found');
+    });
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a network-failure error distinctly from not-found', async () => {
+    const port = new SpyPostcodeLookupPort();
+    port.lookupError = new Error('Could not look up that postcode. Check your connection and try again.');
+    const onConfirm = vi.fn();
+    const { result } = renderHook(() => useLocationPicker(port, onConfirm));
+
+    act(() => {
+      result.current.setPostcode('sw1a 1aa');
+    });
+
+    await waitFor(() => {
+      expect(result.current.postcodeError).toBe(
+        'Could not look up that postcode. Check your connection and try again.',
+      );
+    });
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('confirms with "your location" on a successful geolocation request', async () => {
+    vi.stubGlobal('navigator', { geolocation: stubGeolocationSuccess(51.5, -0.12) });
+    const port = new SpyPostcodeLookupPort();
+    const onConfirm = vi.fn();
+    const { result } = renderHook(() => useLocationPicker(port, onConfirm));
+
+    act(() => {
+      result.current.useMyLocation();
+    });
+
+    expect(onConfirm).toHaveBeenCalledWith({ lat: 51.5, lon: -0.12 }, 'your location');
+  });
+
+  it('surfaces an error and does not confirm when geolocation is denied', () => {
+    vi.stubGlobal('navigator', { geolocation: stubGeolocationDenied() });
+    const port = new SpyPostcodeLookupPort();
+    const onConfirm = vi.fn();
+    const { result } = renderHook(() => useLocationPicker(port, onConfirm));
+
+    act(() => {
+      result.current.useMyLocation();
+    });
+
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(result.current.geolocationError).not.toBeNull();
+  });
+
+  it('surfaces an error when the browser has no geolocation support', () => {
+    vi.stubGlobal('navigator', {});
+    const port = new SpyPostcodeLookupPort();
+    const onConfirm = vi.fn();
+    const { result } = renderHook(() => useLocationPicker(port, onConfirm));
+
+    act(() => {
+      result.current.useMyLocation();
+    });
+
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(result.current.geolocationError).not.toBeNull();
+  });
+
+  it('confirms a map tap with a "custom pin" label', () => {
+    const port = new SpyPostcodeLookupPort();
+    const onConfirm = vi.fn();
+    const { result } = renderHook(() => useLocationPicker(port, onConfirm));
+
+    act(() => {
+      result.current.selectMapPoint(52.2053, 0.1218);
+    });
+
+    expect(onConfirm).toHaveBeenCalledWith({ lat: 52.2053, lon: 0.1218 }, 'custom pin');
+  });
+});

--- a/web/src/features/Search/components/useLocationPicker.ts
+++ b/web/src/features/Search/components/useLocationPicker.ts
@@ -1,0 +1,114 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
+import type { PostcodeLookupPort } from '../../../domain/ports/postcode-lookup-port';
+import type { SearchLocation } from '../../../domain/ports/search-port';
+import { extractErrorMessage } from '../../../utils/extractErrorMessage';
+
+/** Debounce window between the last postcode keystroke and the client-side lookup. */
+const POSTCODE_DEBOUNCE_MS = 400;
+/** Shortest valid UK postcode ("M1 1AE" without its space) — avoids firing on every keystroke. */
+const MIN_POSTCODE_LENGTH = 5;
+
+const GEOLOCATION_UNAVAILABLE_MESSAGE = 'Geolocation is not supported by this browser.';
+const GEOLOCATION_DENIED_MESSAGE =
+  'Could not get your location. Check your browser permissions and try again.';
+
+/**
+ * ViewModel for the inline location picker (GH#863, tc-rrv7i.2). Owns the
+ * three resolution paths — a debounced client-side postcode lookup (never
+ * routed through our own API, see `PostcodeLookupPort`), "use my location"
+ * via `navigator.geolocation`, and a direct map tap — and calls `onConfirm`
+ * the moment any of them resolves a location. There is no separate "confirm"
+ * step: picking a postcode, tapping the map, or a successful geolocation
+ * request each immediately confirm.
+ */
+export function useLocationPicker(
+  port: PostcodeLookupPort,
+  onConfirm: (location: SearchLocation, label: string) => void,
+) {
+  const [postcode, setPostcodeRaw] = useState('');
+  const [postcodeError, setPostcodeError] = useState<string | null>(null);
+  const [isLookingUp, setIsLookingUp] = useState(false);
+  const [geolocationError, setGeolocationError] = useState<string | null>(null);
+  const [isLocating, setIsLocating] = useState(false);
+
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const requestIdRef = useRef(0);
+
+  const setPostcode = useCallback((value: string) => {
+    setPostcodeRaw(value);
+    setPostcodeError(null);
+  }, []);
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+
+    const trimmed = postcode.trim();
+    if (trimmed.length < MIN_POSTCODE_LENGTH) {
+      return;
+    }
+
+    debounceRef.current = setTimeout(() => {
+      const requestId = ++requestIdRef.current;
+      setIsLookingUp(true);
+      setPostcodeError(null);
+      void port
+        .lookup(trimmed)
+        .then((location) => {
+          if (requestIdRef.current !== requestId) return;
+          setIsLookingUp(false);
+          onConfirm(location, trimmed.toUpperCase());
+        })
+        .catch((err: unknown) => {
+          if (requestIdRef.current !== requestId) return;
+          setIsLookingUp(false);
+          setPostcodeError(extractErrorMessage(err, 'Could not look up that postcode.'));
+        });
+    }, POSTCODE_DEBOUNCE_MS);
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [postcode, port, onConfirm]);
+
+  const useMyLocation = useCallback(() => {
+    setGeolocationError(null);
+
+    if (!navigator.geolocation) {
+      setGeolocationError(GEOLOCATION_UNAVAILABLE_MESSAGE);
+      return;
+    }
+
+    setIsLocating(true);
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        setIsLocating(false);
+        onConfirm(
+          { lat: position.coords.latitude, lon: position.coords.longitude },
+          'your location',
+        );
+      },
+      () => {
+        setIsLocating(false);
+        setGeolocationError(GEOLOCATION_DENIED_MESSAGE);
+      },
+    );
+  }, [onConfirm]);
+
+  const selectMapPoint = useCallback(
+    (lat: number, lon: number) => {
+      onConfirm({ lat, lon }, 'custom pin');
+    },
+    [onConfirm],
+  );
+
+  return {
+    postcode,
+    setPostcode,
+    postcodeError,
+    isLookingUp,
+    geolocationError,
+    isLocating,
+    useMyLocation,
+    selectMapPoint,
+  };
+}

--- a/web/src/features/Search/useSearch.ts
+++ b/web/src/features/Search/useSearch.ts
@@ -94,6 +94,13 @@ export function useSearch(port: SearchPort) {
     setIsLocationPickerOpen(true);
   }, []);
 
+  // Abandons a reopened picker (the "Change" flow) without touching the
+  // already-confirmed location. Only ever exposed once a location exists —
+  // there is no way to back out of the mandatory first-time gate.
+  const closeLocationPicker = useCallback(() => {
+    setIsLocationPickerOpen(false);
+  }, []);
+
   const confirmLocation = useCallback((newLocation: SearchLocation, label: string) => {
     setLocation(newLocation);
     setLocationLabel(label);
@@ -127,6 +134,7 @@ export function useSearch(port: SearchPort) {
     locationLabel,
     isLocationPickerOpen,
     changeLocation,
+    closeLocationPicker,
     confirmLocation,
     ...state,
   };

--- a/web/src/features/Search/useSearch.ts
+++ b/web/src/features/Search/useSearch.ts
@@ -1,5 +1,5 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
-import type { SearchPort } from '../../domain/ports/search-port';
+import type { SearchLocation, SearchPort } from '../../domain/ports/search-port';
 import type { SearchResult } from '../../domain/types';
 import { extractErrorMessage } from '../../utils/extractErrorMessage';
 
@@ -24,15 +24,26 @@ const IDLE_STATE: SearchState = {
 };
 
 /**
- * ViewModel for the public `/search` page (#821 Phase 4). Debounces the query
- * box (and authority filter) before calling the anonymous `SearchPort`, and
- * guards against out-of-order responses — a slow response for a query the
- * user has since changed or cleared must never clobber newer state.
+ * ViewModel for the public `/search` page (#821 Phase 4; mandatory location
+ * gate GH#863 / tc-rrv7i). Debounces the query box (and authority filter)
+ * before calling the anonymous `SearchPort`, and guards against out-of-order
+ * responses — a slow response for a query the user has since changed or
+ * cleared must never clobber newer state.
+ *
+ * A location must be resolved (postcode, "use my location", or a map tap —
+ * `confirmLocation`) before the debounced effect is ever allowed to fire,
+ * regardless of query text: the API 400s without `lat`/`lon`, and results are
+ * ranked nearest-first from this point. `changeLocation` opens (or reopens)
+ * the inline picker without clearing the previously confirmed location, so
+ * `SearchPage` can prefill it for a "Change" flow.
  */
 export function useSearch(port: SearchPort) {
   const [query, setQueryState] = useState('');
   const [authority, setAuthority] = useState('');
   const [state, setState] = useState<SearchState>(IDLE_STATE);
+  const [location, setLocation] = useState<SearchLocation | null>(null);
+  const [locationLabel, setLocationLabel] = useState<string | null>(null);
+  const [isLocationPickerOpen, setIsLocationPickerOpen] = useState(false);
 
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Incremented on every new search attempt (including a reset-to-idle);
@@ -40,11 +51,11 @@ export function useSearch(port: SearchPort) {
   const requestIdRef = useRef(0);
 
   const runSearch = useCallback(
-    async (trimmedQuery: string, authorityFilter: string | null) => {
+    async (trimmedQuery: string, authorityFilter: string | null, searchLocation: SearchLocation) => {
       const requestId = ++requestIdRef.current;
       setState((prev) => ({ ...prev, isLoading: true, error: null }));
       try {
-        const outcome = await port.search(trimmedQuery, authorityFilter);
+        const outcome = await port.search(trimmedQuery, authorityFilter, searchLocation);
         if (requestIdRef.current !== requestId) return;
         setState({
           results: outcome.results,
@@ -79,29 +90,44 @@ export function useSearch(port: SearchPort) {
     }
   }, []);
 
+  const changeLocation = useCallback(() => {
+    setIsLocationPickerOpen(true);
+  }, []);
+
+  const confirmLocation = useCallback((newLocation: SearchLocation, label: string) => {
+    setLocation(newLocation);
+    setLocationLabel(label);
+    setIsLocationPickerOpen(false);
+  }, []);
+
   useEffect(() => {
     if (debounceRef.current) clearTimeout(debounceRef.current);
 
     const trimmedQuery = query.trim();
-    if (trimmedQuery === '') {
+    if (trimmedQuery === '' || location === null) {
       return;
     }
 
     const trimmedAuthority = authority.trim();
     debounceRef.current = setTimeout(() => {
-      void runSearch(trimmedQuery, trimmedAuthority === '' ? null : trimmedAuthority);
+      void runSearch(trimmedQuery, trimmedAuthority === '' ? null : trimmedAuthority, location);
     }, SEARCH_DEBOUNCE_MS);
 
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, [query, authority, runSearch]);
+  }, [query, authority, location, runSearch]);
 
   return {
     query,
     setQuery,
     authority,
     setAuthority,
+    location,
+    locationLabel,
+    isLocationPickerOpen,
+    changeLocation,
+    confirmLocation,
     ...state,
   };
 }


### PR DESCRIPTION
## Summary

- Redesigns the public `/search` page so a location must be resolved before a search can run, matching the API's mandatory `lat`/`lon` requirement shipped in tc-rrv7i.1 (#1025).
- Adds an inline `LocationPicker` (disabled-bar + inline-gate pattern, no modal/full-page takeover): a debounced client-side postcode lookup against `api.postcodes.io`, a "Use my location" geolocation button, and a tap-to-place Leaflet map (reusing `MapPage`'s OSM tile constants, now hoisted to `web/src/components/osmTiles.ts`). Any of the three confirms immediately — no separate confirm step.
- Once confirmed, the prompt becomes a "📍 Near `<label>`" stamp-styled chip with a "Change" action that reopens the picker prefilled with the current pin.
- No radius UI anywhere (slider/circle) — matches the KNN nearest-first design; there's no bound to visualize.
- Postcode lookups are made directly from the browser to `api.postcodes.io` — never proxied through our own API/`baseUrl` (hard constraint, see the port's doc comment).
- `/search` is now lazy-loaded (it pulls in `react-leaflet`/`leaflet`), keeping the main bundle small for visitors who never hit the map picker.

Design-language note: the issue's original text mentioned a Fraunces display treatment from the Public Notice rebrand, but that was reverted repo-wide in GH#912 (single-typeface decision, per the `design-language` skill) before this landed — the new UI follows the *current* tokens (Inter, `--tc-font-display`) and reuses the existing stamp/chip visual language instead.

## Test plan

- [x] `npx vitest run` — 137 files / 1321 tests, all green
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint .` — clean
- [x] Visual verification (subagent-driven headless browser, per CLAUDE.md UI verification policy): gated/disabled search input, inline picker expand, tap-to-place pin confirms immediately, chip + Change flow, no radius UI anywhere, dark mode rendering — all pass, no defects found. Postcode/tile network calls were blocked by this sandbox's outbound proxy (`api.postcodes.io` / OSM tiles unreachable), so that specific network path reads as a sandbox limitation rather than a verified pass — worth a quick manual smoke-test of the postcode field against a real network before/after merge.
- [ ] Live backend/Postgres search call itself was not exercised (no credentials in this environment) — the API side already shipped and tested in tc-rrv7i.1.

Closes tc-rrv7i.2.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AABdLpz9M1odXxcp1gc7UL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search now requires a confirmed location before displaying results.
  * Set a location by entering a postcode, using device location, or selecting a point on the map.
  * Reopen, change, or cancel location selection while preserving the current location.
  * Search results are sorted based on distance from the selected location.
* **Performance**
  * Search functionality is loaded only when visitors open the search page, improving initial load performance.
* **Bug Fixes**
  * Added clearer handling for invalid postcodes, unavailable location services, and connection errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->