### PR TITLE
fix(polling): restore other_fields in ingest select projection (tc-vealu)

### DIFF
--- a/api-go/internal/applications/store_postgres_test.go
+++ b/api-go/internal/applications/store_postgres_test.go
@@ -423,6 +423,14 @@ func TestPostgresStore_Upsert_NilOtherFields_OverwritesPreviousValue(t *testing.
 		t.Fatalf("Upsert first: %v", err)
 	}
 
+	gotFirst, found, err := store.GetByUID(ctx, "nil-overwrite-uid", "100")
+	if err != nil || !found {
+		t.Fatalf("GetByUID after first upsert: found=%v err=%v", found, err)
+	}
+	if gotFirst.OtherFields["comment_url"] != "https://example.test/comment" {
+		t.Fatalf("first OtherFields was not persisted: %+v", gotFirst.OtherFields)
+	}
+
 	second := first
 	second.OtherFields = nil
 	if err := store.Upsert(ctx, second); err != nil {

--- a/api-go/internal/applications/store_postgres_test.go
+++ b/api-go/internal/applications/store_postgres_test.go
@@ -405,6 +405,39 @@ func TestPostgresStore_Upsert_OverwritesOtherFieldsOnSecondUpsert(t *testing.T) 
 	}
 }
 
+// TestPostgresStore_Upsert_NilOtherFields_OverwritesPreviousValue is a
+// characterization test for GH#1027 / tc-vealu: upserting a record whose
+// incoming OtherFields is nil (e.g. because the caller's select projection
+// didn't request it) NULLs a previously-stored non-nil value. This is
+// intentional, not a bug — see GH#1027's "open question" for the rationale —
+// and is deliberately NOT mitigated with a COALESCE in upsertQuery, so this
+// test exists to catch anyone changing that decision silently.
+func TestPostgresStore_Upsert_NilOtherFields_OverwritesPreviousValue(t *testing.T) {
+	ctx := context.Background()
+	store := newAppPGStore(t)
+
+	first := pgApp("24/0009/FUL", 100)
+	first.UID = "nil-overwrite-uid"
+	first.OtherFields = map[string]any{"comment_url": "https://example.test/comment"}
+	if err := store.Upsert(ctx, first); err != nil {
+		t.Fatalf("Upsert first: %v", err)
+	}
+
+	second := first
+	second.OtherFields = nil
+	if err := store.Upsert(ctx, second); err != nil {
+		t.Fatalf("Upsert second: %v", err)
+	}
+
+	got, found, err := store.GetByUID(ctx, "nil-overwrite-uid", "100")
+	if err != nil || !found {
+		t.Fatalf("GetByUID: found=%v err=%v", found, err)
+	}
+	if got.OtherFields != nil {
+		t.Errorf("OtherFields: got %v, want nil (a nil incoming value must overwrite the previously-stored one)", got.OtherFields)
+	}
+}
+
 // TestPostgresStore_Upsert_FullFieldsNullRoundTripAsNil proves an application
 // with none of the seven new fields set stores and reads back all of them as
 // nil/empty, not the JSON literal "null" or an empty (non-nil) map.

--- a/api-go/internal/planit/backfill_test.go
+++ b/api-go/internal/planit/backfill_test.go
@@ -58,6 +58,9 @@ func TestBuildBackfillPath(t *testing.T) {
 	if !containsString(fields, "reference") || !containsString(fields, "last_scraped") {
 		t.Errorf("select must be the full ingest projection (GH#935 fields included): got %v", fields)
 	}
+	if !containsString(fields, "other_fields") {
+		t.Errorf("select must contain other_fields (GH#1027 regression: an absent select field nulls the stored value on every re-poll): got %v", fields)
+	}
 }
 
 // TestFetchBackfillPage_SendsExpectedQueryAndParsesResponse drives the client

--- a/api-go/internal/planit/national.go
+++ b/api-go/internal/planit/national.go
@@ -2,9 +2,8 @@
 // query shapes the old per-authority drain (client.go) never needed: a
 // national (no-auth) query masked by start_date or decided_start so the
 // re-index churn that dominates the raw last_different axis is filtered out
-// upstream, a select projection (mandatory on every one of these requests —
-// PlanIt's other_fields is ~60% of a record's bytes and nothing here reads it
-// back), and compress=on. FetchApplicationsPage (client.go) is unchanged and
+// upstream, a select projection (mandatory on every one of these requests),
+// and compress=on. FetchApplicationsPage (client.go) is unchanged and
 // untouched by this file.
 package planit
 
@@ -37,7 +36,7 @@ var ingestSelectFields = []string{
 	"name", "uid", "area_name", "area_id", "address", "postcode", "description",
 	"app_type", "app_state", "app_size", "start_date", "decided_date", "consulted_date",
 	"location_x", "location_y", "url", "link", "last_different", "reference", "altid",
-	"associated_id", "last_changed", "last_scraped", "scraper_name",
+	"associated_id", "last_changed", "last_scraped", "scraper_name", "other_fields",
 }
 
 // inverseMaskSelectFields is ADR 0044 Lane C's light national projection:

--- a/api-go/internal/planit/national_test.go
+++ b/api-go/internal/planit/national_test.go
@@ -67,6 +67,9 @@ func TestBuildNationalDeltaPath(t *testing.T) {
 			if !containsString(fields, "last_different") {
 				t.Errorf("select must contain the sort field last_different: got %v", fields)
 			}
+			if !containsString(fields, "other_fields") {
+				t.Errorf("select must contain other_fields (GH#1027 regression: an absent select field nulls the stored value on every re-poll): got %v", fields)
+			}
 		})
 	}
 }
@@ -214,6 +217,9 @@ func TestBuildUIDPath(t *testing.T) {
 	fields := strings.Split(got.Get("select"), ",")
 	if !containsString(fields, "area_id") {
 		t.Errorf("uid hydration must request the full ingest set (area_id needed for authority partitioning): got %v", fields)
+	}
+	if !containsString(fields, "other_fields") {
+		t.Errorf("select must contain other_fields (GH#1027 regression: an absent select field nulls the stored value on every re-poll): got %v", fields)
 	}
 }
 


### PR DESCRIPTION
## Problem

Since 2026-07-15 (regression in `1b80a190`), `ingestSelectFields` in `api-go/internal/planit/national.go` omitted `other_fields` from PlanIt's `select=` query parameter. Because the field was never requested, the parser correctly mapped it to `nil`, and the Postgres upsert (`other_fields = EXCLUDED.other_fields`) then overwrote any previously-stored value with `NULL` on every re-poll — destroying ~47,000 rows' worth of data a few thousand at a time. This slice is shared by `buildNationalDeltaPath`, `buildBackfillPath`, and `buildUIDPath`, so Lanes A, B and D were all affected.

Closes #1027.

## Changes

- Add `"other_fields"` to `ingestSelectFields` (`national.go`) — the entire functional fix, repairing all three lanes at once. Removed the now-stale doc comment that used to justify the exclusion ("nothing here reads it back").
- Regression tests: `TestBuildNationalDeltaPath`, `TestBuildUIDPath` (national_test.go) and `TestBuildBackfillPath` (backfill_test.go) now assert `other_fields` is present in `select=`, so a future edit to this slice can't silently drop it again.
- Characterization test `TestPostgresStore_Upsert_NilOtherFields_OverwritesPreviousValue` (store_postgres_test.go, integration-tagged) — see open question below.

## Open question from #1027, answered

**Should the upsert stop nulling `other_fields` on nil incoming input, e.g. `COALESCE(EXCLUDED.other_fields, applications.other_fields)`?**

**Decision: no — kept the existing destructive-overwrite behavior.**

- The actual defect was the missing select field, not the upsert semantics. It's fixed directly here and now locked behind a regression test, so this exact failure mode can't recur silently.
- COALESCE would permanently change upsert semantics for this column on *every* ingest, including cases where PlanIt legitimately shrinks or empties `other_fields` (e.g. after a decision is made). Silently keeping stale data in that case would violate the "a stored row mirrors PlanIt's current state" invariant that other code (Lane C staleness detection) relies on.
- Per #1027's own scope note, this isn't extended to other columns — a bespoke merge semantic for one column, introduced at the same time its root cause is closed off, isn't justified by the evidence here.

This is intentional and documented behavior, not an oversight — the new characterization test exists specifically to catch anyone changing it without a conscious decision.

## Truncation-guard confirmation (no code change)

Adding `other_fields` roughly doubles per-record payload, moving a `pg_sz=300` page from ~230 KB to ~570 KB. Confirmed safe:

- The client's own read guard (`maxResponseBytes`, 10 MiB) is far above this and isn't the relevant limit.
- The actual concern — PlanIt's own alleged ~1 MB server-side truncation (GH#955) — is already mitigated architecturally: every affected builder resumes by record `index=` rather than `page=`, so a truncated page can't be misread as end-of-results, and `fetchPage`'s zero-progress guard (`ErrZeroProgress`) hard-errors instead of silently treating a truncated/empty page as "done" when PlanIt's own `total` says more records remain.
- ~570 KB stays comfortably under the ~1 MB ceiling. No change to `nationalPageSize` or `maxResponseBytes`.

## Out of scope

- No backfill of historically-nulled rows — this fix only stops further data loss; coverage rebuilds as records are naturally re-polled.
- No change to Lane C's `inverseMaskSelectFields` (ADR 0044, detection-only).
- No new product features consuming `other_fields`.

## Testing

- `go build ./...`, `go vet ./...`, `gofmt -l .`, `go test -race ./...` — all green.
- `make test-integration` (real Postgres+PostGIS via Docker) — all green, including `internal/applications` (characterization test) and `internal/planit` (select-param regression tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved application “other fields” data during updates and national data refreshes.
  * Explicitly clearing these fields now correctly removes previously stored values.

* **Tests**
  * Added coverage to verify field preservation, clearing behavior, and refresh projections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->