### PR TITLE
Log subscription verify outcomes at info level (tc-mqa4)

### DIFF
--- a/api-go/internal/subscriptions/handler.go
+++ b/api-go/internal/subscriptions/handler.go
@@ -216,6 +216,7 @@ func (h *handler) runVerify(ctx context.Context, userID string, signedTransactio
 		}
 		return verifyResponse{}, fmt.Errorf("load profile %q: %w", userID, err)
 	}
+	tierBefore := profile.Tier
 
 	now := h.now()
 	highestTier := profiles.TierFree
@@ -285,6 +286,17 @@ func (h *handler) runVerify(ctx context.Context, userID string, signedTransactio
 	// it through EffectiveTier keeps the contract that no entitlement read trusts
 	// the raw stored Tier.
 	effective := profile.EffectiveTier(now)
+
+	// tc-mqa4: log the verify outcome at info so we can confirm from server logs
+	// alone whether a verify call arrived and what it resolved to, without
+	// logging anything user-identifying (no userID, no JWS/transaction content,
+	// no Apple original transaction id).
+	h.logger.InfoContext(ctx, "subscription verify completed",
+		"tier", effective.String(),
+		"transactionCount", len(signedTransactions),
+		"tierChanged", profile.Tier != tierBefore,
+	)
+
 	return verifyResponse{
 		Tier:               effective.String(),
 		SubscriptionExpiry: platform.DotNetTimePtr(profile.SubscriptionExpiry),

--- a/api-go/internal/subscriptions/handler_test.go
+++ b/api-go/internal/subscriptions/handler_test.go
@@ -1,6 +1,7 @@
 package subscriptions
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -138,6 +139,13 @@ func newTestDeps() *testDeps {
 }
 
 func newTestDepsWithEnvs(allowedEnvs []string) *testDeps {
+	return newTestDepsWithEnvsAndLogger(allowedEnvs, slog.New(slog.DiscardHandler))
+}
+
+// newTestDepsWithEnvsAndLogger wires the handler exactly like
+// newTestDepsWithEnvs but with a caller-supplied logger, so tests can assert
+// on emitted log lines.
+func newTestDepsWithEnvsAndLogger(allowedEnvs []string, logger *slog.Logger) *testDeps {
 	d := &testDeps{
 		verifier:    &fakeVerifier{results: map[string]string{}, errs: map[string]error{}},
 		byUser:      &fakeProfileByUser{},
@@ -147,7 +155,7 @@ func newTestDepsWithEnvs(allowedEnvs []string) *testDeps {
 		mux:         http.NewServeMux(),
 	}
 	Routes(d.mux, d.verifier, d.byUser, d.byTxn, d.auth0, d.idempotency, testBundleID, allowedEnvs,
-		func() time.Time { return testNow }, slog.New(slog.DiscardHandler))
+		func() time.Time { return testNow }, logger)
 	return d
 }
 
@@ -890,6 +898,142 @@ func TestWebhook_RejectsOversizedPayloadBeforeVerify(t *testing.T) {
 	}
 	if d.verifier.callCount != 0 {
 		t.Errorf("verifier called %d time(s), want 0 — expensive crypto must not run on oversized input", d.verifier.callCount)
+	}
+}
+
+// --- observability tests (tc-mqa4) ---
+
+// decodeJSONLogLines splits newline-delimited JSON log output into decoded
+// records, skipping blank lines.
+func decodeJSONLogLines(t *testing.T, raw []byte) []map[string]any {
+	t.Helper()
+	var lines []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(string(raw)), "\n") {
+		if line == "" {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			t.Fatalf("decode log line %q: %v", line, err)
+		}
+		lines = append(lines, m)
+	}
+	return lines
+}
+
+// findLogLine returns the first decoded log record whose "msg" field matches
+// msg, and whether one was found.
+func findLogLine(lines []map[string]any, msg string) (map[string]any, bool) {
+	for _, l := range lines {
+		if l["msg"] == msg {
+			return l, true
+		}
+	}
+	return nil, false
+}
+
+// TestVerify_LogsOutcomeOnSuccess pins the tc-mqa4 observability requirement:
+// a successful verify must emit a single info-level "subscription verify
+// completed" log line reporting the resulting tier, how many signed
+// transactions were submitted, and whether the call changed the stored tier
+// — with no userID, JWS/transaction content, or Apple original transaction id
+// anywhere in the record.
+func TestVerify_LogsOutcomeOnSuccess(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	d := newTestDepsWithEnvsAndLogger(testAllowedEnvs, logger)
+	d.byUser.profile = freshProfile(t) // starts Free
+	d.verifier.results["JWS_PRO"] = txnJSON(ProductProMonthly, testBundleID, "orig-1", futureExpiryMs())
+
+	rec := d.serve(t, "/v1/subscriptions/verify", `{"signedTransaction":"JWS_PRO"}`, true)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+
+	line, ok := findLogLine(decodeJSONLogLines(t, buf.Bytes()), "subscription verify completed")
+	if !ok {
+		t.Fatalf("expected info log %q not found in log output: %s", "subscription verify completed", buf.String())
+	}
+	if line["tier"] != "Pro" {
+		t.Errorf("tier = %v, want %q", line["tier"], "Pro")
+	}
+	if line["transactionCount"] != float64(1) {
+		t.Errorf("transactionCount = %v, want 1", line["transactionCount"])
+	}
+	if line["tierChanged"] != true {
+		t.Errorf("tierChanged = %v, want true (Free -> Pro)", line["tierChanged"])
+	}
+	for _, forbidden := range []string{"userID", "user", "signedTransaction", "originalTransactionId", "jws"} {
+		if _, present := line[forbidden]; present {
+			t.Errorf("log line must not contain %q, got %v", forbidden, line[forbidden])
+		}
+	}
+	if strings.Contains(buf.String(), testUserID) {
+		t.Errorf("log output must not contain the userID %q: %s", testUserID, buf.String())
+	}
+	if strings.Contains(buf.String(), "orig-1") {
+		t.Errorf("log output must not contain the Apple original transaction id: %s", buf.String())
+	}
+}
+
+// TestVerify_LogsNoChangeOnIdempotentReVerify pins tierChanged=false for a
+// re-verify that resolves to the same tier the profile already had.
+func TestVerify_LogsNoChangeOnIdempotentReVerify(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	d := newTestDepsWithEnvsAndLogger(testAllowedEnvs, logger)
+	p := freshProfile(t) // UserID = testUserID
+	d.byUser.profile = p
+	d.byTxn.profilesByTxnID = map[string]*profiles.UserProfile{"orig-1": p}
+	d.verifier.results["JWS_REVERIFY"] = txnJSON(ProductProMonthly, testBundleID, "orig-1", futureExpiryMs())
+
+	// First verify: Free -> Pro.
+	rec := d.serve(t, "/v1/subscriptions/verify", `{"signedTransaction":"JWS_REVERIFY"}`, true)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("first verify status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	buf.Reset()
+
+	// Second verify with the same already-active transaction: Pro -> Pro, a no-op.
+	rec = d.serve(t, "/v1/subscriptions/verify", `{"signedTransaction":"JWS_REVERIFY"}`, true)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("second verify status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+
+	line, ok := findLogLine(decodeJSONLogLines(t, buf.Bytes()), "subscription verify completed")
+	if !ok {
+		t.Fatalf("expected info log not found in log output: %s", buf.String())
+	}
+	if line["tier"] != "Pro" {
+		t.Errorf("tier = %v, want %q", line["tier"], "Pro")
+	}
+	if line["tierChanged"] != false {
+		t.Errorf("tierChanged = %v, want false (Pro -> Pro re-verify)", line["tierChanged"])
+	}
+}
+
+// TestVerify_LogsOnly_NoInfoLogOnFailure asserts that a verify request that
+// fails before reaching the success path (e.g. JWS verification failure)
+// does not emit the "subscription verify completed" info log — only the
+// existing error-path logging behaviour is preserved.
+func TestVerify_LogsOnly_NoInfoLogOnFailure(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	d := newTestDepsWithEnvsAndLogger(testAllowedEnvs, logger)
+	d.byUser.profile = freshProfile(t)
+	d.verifier.errs["BAD"] = &JWSVerificationError{Message: "tampered"}
+
+	rec := d.serve(t, "/v1/subscriptions/verify", `{"signedTransaction":"BAD"}`, true)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if _, ok := findLogLine(decodeJSONLogLines(t, buf.Bytes()), "subscription verify completed"); ok {
+		t.Errorf("success log must not be emitted on a failed verify: %s", buf.String())
 	}
 }
 

--- a/api-go/internal/subscriptions/handler_test.go
+++ b/api-go/internal/subscriptions/handler_test.go
@@ -956,6 +956,9 @@ func TestVerify_LogsOutcomeOnSuccess(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected info log %q not found in log output: %s", "subscription verify completed", buf.String())
 	}
+	if line["level"] != "INFO" {
+		t.Errorf("level = %v, want %q", line["level"], "INFO")
+	}
 	if line["tier"] != "Pro" {
 		t.Errorf("tier = %v, want %q", line["tier"], "Pro")
 	}
@@ -975,6 +978,9 @@ func TestVerify_LogsOutcomeOnSuccess(t *testing.T) {
 	}
 	if strings.Contains(buf.String(), "orig-1") {
 		t.Errorf("log output must not contain the Apple original transaction id: %s", buf.String())
+	}
+	if strings.Contains(buf.String(), "JWS_PRO") {
+		t.Errorf("log output must not contain the raw signed transaction: %s", buf.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

Bead [tc-mqa4](https://github.com/AmyDe/town-crier/issues) ("Personal→Pro upgrade not persisting") is a device-reported bug where a StoreKit Personal→Pro upgrade never reached the stored server tier. The bead's own investigation concluded this is not a Go server bug, and full root-cause diagnosis requires device-side reproduction (real iPhone + sandbox purchase) that an unattended session can't perform.

This PR implements exactly one of the bead's own explicitly-listed next steps — the part that's pure server-side code and unblocks future diagnosis:

> "Improve Go subscription observability (route-templated request telemetry + log verify outcomes at info) so server-side confirms whether a Pro verify arrived."

`runVerify` in `api-go/internal/subscriptions/handler.go` previously logged nothing on its success path — only error paths logged. This adds a single info-level log line at the end of a successful verify, so a future investigation can confirm from server logs alone whether a verify request arrived and what it resolved to:

```go
h.logger.InfoContext(ctx, "subscription verify completed",
    "tier", effective.String(),
    "transactionCount", len(signedTransactions),
    "tierChanged", profile.Tier != tierBefore,
)
```

Deliberately omitted: userID, JWS/signed-transaction content, Apple original transaction ID — per the active GDPR-minimisation concern tracked in tc-s5n7r. A test asserts the log line and buffer contain none of those.

**tc-mqa4 stays open** — this only adds observability; the actual upgrade-persistence bug still needs device-side reproduction, which is out of scope for this change and for an unattended session.

## Test plan

- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./...` — full suite green, including 3 new tests (`TestVerify_LogsOutcomeOnSuccess`, `TestVerify_LogsNoChangeOnIdempotentReVerify`, `TestVerify_LogsOnly_NoInfoLogOnFailure`)
- [ ] Not applicable: backend-only logging change, no UI/device verification needed

---
Generated by an autonomous backlog-runner session. Bead: tc-mqa4.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FgRYPfmHK9P7pa3tR4kaKj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Monitoring & Observability**
  * Added structured completion logs for subscription verification, including the effective tier, processed transaction count, and whether the tier changed.
  * Verification attempts that fail before completion no longer produce misleading completion events.
  * Repeated verification of an unchanged subscription is clearly recorded as having no tier change.
  * Logs exclude sensitive transaction and user-identifying details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->