### PR TITLE
fix(cloud): reclone beads DB each session instead of merging cache (tc-vmh1z)

### DIFF
--- a/scripts/wf/cloud-session-init.sh
+++ b/scripts/wf/cloud-session-init.sh
@@ -26,8 +26,9 @@
 #      insteadOf rewrite. Never "fix" this with bd migrate --update-repo-id
 #      from a cloud session — repo_id syncs via DoltHub and rewriting it
 #      would break the Mac on its next pull.
-#   3. Hydrate the Dolt-backed issue DB from the DoltHub remote (fresh
-#      clone), or pull to freshen one restored from the environment cache.
+#   3. Hydrate the Dolt-backed issue DB as a fresh clone from the DoltHub
+#      remote, discarding any clone restored from the environment cache.
+#      Never merge with a cached clone — see the long note at step 3.
 
 [ "${CLAUDE_CODE_REMOTE:-}" = "true" ] || exit 0
 set -euo pipefail
@@ -60,16 +61,41 @@ if [ "$current_origin" != "$canonical" ]; then
   git -C "$repo_root" config url."$proxy_prefix".insteadOf "git@github.com-amyde:"
 fi
 
-# 3. Beads DB: hydrate or freshen
+# 3. Beads DB: always a fresh clone of the DoltHub remote.
+#
+# This deliberately discards any .beads/dolt restored from the environment
+# cache rather than merging with it. The cache can carry a clone from an
+# earlier session holding Dolt commits that never reached DoltHub — a run
+# whose push failed, or one killed mid-flight. `bd dolt pull` on such a clone
+# is a three-way merge: it hits per-row conflicts on the issues table, aborts
+# with "merge conflicts in issues require operator resolution", and restores
+# the working set. Nothing changes, so the next session repeats the same
+# failed merge. The clone can never self-heal and every scheduled run dies in
+# preflight. Observed 2026-07-29 against a clone cached on 2026-07-28 that
+# held 16 unpushed commits (tc-812ni's own, made while creds were still
+# broken — the session fixing the push bug stranded its own history).
+#
+# Local-only history is never worth preserving here. The routines push after
+# every bd mutation and abort if the push fails, so anything of value is
+# already on the remote by construction; whatever is local-only is the
+# residue of a failed run. Re-cloning is ~1 minute against this DB and is the
+# only path, so it stays exercised and cannot rot.
 chmod 700 "$repo_root/.beads"
 cd "$repo_root"
-if [ -d .beads/dolt/town_crier ]; then
-  bd dolt pull
-else
-  # bd bootstrap's metadata-reconcile step reads the server port file, which
-  # doesn't exist yet on a fresh clone — start the server first to write it.
-  bd dolt start
-  bd bootstrap
+bd dolt stop >/dev/null 2>&1 || true
+rm -rf "$repo_root/.beads/dolt"
+# bd bootstrap's metadata-reconcile step reads the server port file, which
+# doesn't exist yet on a fresh clone — start the server first to write it.
+bd dolt start
+bd bootstrap
+
+# Fail loudly rather than hand a routine a DB that isn't actually current:
+# a clean clone must pull as a no-op.
+if ! bd dolt pull; then
+  echo "cloud-session-init FATAL: freshly cloned beads DB still cannot pull" >&2
+  echo "from origin. Do NOT work around this by skipping preflight — the" >&2
+  echo "backlog would be stale or diverged and bead decisions unsafe." >&2
+  exit 1
 fi
 
 echo "cloud-session-init: dolt creds installed, origin fingerprint set, beads DB ready"


### PR DESCRIPTION
## Problem

Every scheduled cloud routine (`Work through bead backlog`, `Open PR Triage`) has been dying in preflight with:

```
bd dolt pull -> merge conflicts in issues require operator resolution; merge aborted and working set restored
```

It reproduced on every run, including a manual re-trigger, while `bd dolt pull` from the Mac succeeded cleanly — so origin itself was healthy. Diagnosed live in the cloud environment on 2026-07-29.

## Root cause

The cloud environment's filesystem snapshot **persists across sessions** — it is not a fresh clone each time. The `.beads/dolt` directory in `env_01BTqwBPrXvQs2dWWb29Reow` had a birth timestamp of **2026-07-28 09:48**, over a day before the run that inspected it.

`scripts/wf/cloud-session-init.sh` step 3 handled that cached-clone case with `bd dolt pull`. That is a **three-way merge**, and it cannot recover a clone whose local history has diverged.

The cached clone had diverged badly. It held **16 local commits that never reached DoltHub** — `bd: create/claim/update/close tc-812ni` plus the ADR 0046 schema migrations. Those are tc-812ni's *own* commits: the session that fixed the DoltHub `PermissionDenied` push bug made them while credentials were still broken, so it stranded its own history in the snapshot.

Origin moved on independently. `dolt_diff('origin/main', 'main', 'issues')` showed **17 diverged rows**: 7 modified on both sides (`tc-oekir`, `tc-moku`, `tc-ninlp`, `tc-oydv8`, `tc-97k35`, `tc-rrv7i.1`, `tc-rrv7i.2` — local still `open`/`in_progress`, origin since `closed`) and 10 present only on origin (`tc-qtko0`, `tc-ubquc`, `tc-vealu`, `tc-aj2pn`, `tc-kg77x`, `tc-qi7ae*`, `tc-u4t85`).

Two real histories over the same primary keys, neither an ancestor of the other. So: cached dir present -> `pull` -> per-row conflicts -> merge aborts and restores the working set -> **nothing mutates** -> next session repeats it identically. Self-perpetuating; it can never self-heal.

This also explains why `bd doctor` reported `Clean working set` / `Sync is up to date` and `dolt_conflicts_issues` came back empty — the merge auto-rolls back, so the conflict only exists transiently mid-merge and post-hoc inspection always looks clean.

## Change

Always re-clone the beads DB instead of merging with whatever the cache restored.

Local-only history is never worth preserving in this environment: the routines push after every bd mutation and abort if the push fails, so anything of value is already on the remote by construction, and whatever is local-only is the residue of a failed run.

Re-cloning costs ~1 minute against this DB (the 07-28 log shows 145,486 chunks landing in well under a minute; the SessionStart hook's timeout is 600s). Chosen over a reset-with-reclone-fallback deliberately: one code path, exercised every session, so it cannot rot the way a rarely-taken fallback branch does.

Also added a post-clone `bd dolt pull` assertion that fails loudly, rather than handing a routine a DB that is silently stale.

## Why not the environment setup script

`setup.sh` runs **once per cache rebuild** and is skipped by later sessions, and env-var secrets are absent while it runs. It is correctly binaries-only. Per-session work belongs here, which is exactly what #1022 established.

## Verification

- `bash -n` clean, `shellcheck` clean (exit 0).
- With `CLAUDE_CODE_REMOTE` unset the script still exits 0 at the guard on line 32, **before** the new `rm -rf` — confirmed by running it on the Mac and checking `.beads/` was untouched. It remains a committed no-op for local development.
- Full-path behaviour is verified by the next cloud session: the fix lands on main, the cloud git checkout is refreshed per session (the diagnostic run was on 07-29 commits), so the next scheduled firing picks it up and self-heals.

Closes tc-vmh1z. Follow-up to #1022 (tc-812ni).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session initialization for the Dolt-backed issue database by always starting from a fresh clone.
  * Prevented stale cached data from causing repeated initialization failures.
  * Added validation to detect synchronization problems early and stop with a clear error when the fresh clone cannot be verified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->