### PR TITLE
Redact device token from APNs push span url.full (tc-s5n7r)

### DIFF
--- a/api-go/internal/apns/client.go
+++ b/api-go/internal/apns/client.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
 	"golang.org/x/net/http2"
@@ -94,8 +95,19 @@ func NewClient(opts Options, logger *slog.Logger, now func() time.Time) (*Client
 	transport := &http2.Transport{
 		TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12},
 	}
+	httpClient := tracedPushClient(transport)
+	return newClientWithBaseURL(opts, opts.baseURL(), httpClient, logger, now)
+}
+
+// tracedPushClient wraps base with the same redaction-then-tracing chain
+// NewClient applies in production, so tests can exercise the real
+// construction seam against a stub transport instead of re-assembling it by
+// hand — a regression that drops either wrapper here is caught by both. opts
+// forwards to WrapHTTPClient; production passes none (global tracer
+// provider), tests pass otelhttp.WithTracerProvider for hermetic assertions.
+func tracedPushClient(base http.RoundTripper, opts ...otelhttp.Option) *http.Client {
 	httpClient := &http.Client{
-		Transport: transport,
+		Transport: base,
 		Timeout:   requestTimeout,
 	}
 	// Redact the device token from the request URL before otelhttp records it
@@ -104,13 +116,12 @@ func NewClient(opts Options, logger *slog.Logger, now func() time.Time) (*Client
 	// (applied next, by WrapHTTPClient) still starts the span first and calls
 	// this RoundTripper afterwards, letting it overwrite url.full before the
 	// request reaches transport for the real network call.
-	httpClient.Transport = &platform.RedactingTransport{Next: transport, Redact: redactPushURL}
+	httpClient.Transport = &platform.RedactingTransport{Next: base, Redact: redactPushURL}
 	// Wrap the transport so every APNs push emits an OTel client span
 	// (Type=HTTP in AppDependencies) named "APNs push". api.push.apple.com lands
 	// in server.address; the static span name keeps cardinality low (no per-device
 	// token in the name).
-	httpClient = platform.WrapHTTPClient(httpClient, func(string, *http.Request) string { return "APNs push" })
-	return newClientWithBaseURL(opts, opts.baseURL(), httpClient, logger, now)
+	return platform.WrapHTTPClient(httpClient, func(string, *http.Request) string { return "APNs push" }, opts...)
 }
 
 // newClientWithBaseURL is the constructor seam shared by NewClient and tests. It

--- a/api-go/internal/apns/client.go
+++ b/api-go/internal/apns/client.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -17,6 +18,11 @@ import (
 
 	"github.com/AmyDe/town-crier/api-go/internal/platform"
 )
+
+// devicePathPrefix is the APNs URL path segment do() places the raw device
+// token after; redactPushURL uses it to find and redact the token before the
+// URL is recorded into the "APNs push" client span's url.full attribute.
+const devicePathPrefix = "/3/device/"
 
 // tracerName labels the "APNs delivery" wrapper span this package emits,
 // distinct from the transport-level "APNs push" HTTP client spans
@@ -92,6 +98,13 @@ func NewClient(opts Options, logger *slog.Logger, now func() time.Time) (*Client
 		Transport: transport,
 		Timeout:   requestTimeout,
 	}
+	// Redact the device token from the request URL before otelhttp records it
+	// into the span's url.full attribute (see redactPushURL). This must sit
+	// INNERMOST — wrapping transport, not httpClient — so otelhttp.NewTransport
+	// (applied next, by WrapHTTPClient) still starts the span first and calls
+	// this RoundTripper afterwards, letting it overwrite url.full before the
+	// request reaches transport for the real network call.
+	httpClient.Transport = &platform.RedactingTransport{Next: transport, Redact: redactPushURL}
 	// Wrap the transport so every APNs push emits an OTel client span
 	// (Type=HTTP in AppDependencies) named "APNs push". api.push.apple.com lands
 	// in server.address; the static span name keeps cardinality low (no per-device
@@ -288,6 +301,24 @@ func redactToken(token string) string {
 		return "***"
 	}
 	return token[:8] + "..."
+}
+
+// redactPushURL rewrites an APNs request URL for telemetry so the device
+// token in the /3/device/<token> path (see do()) is reduced to the same
+// 8-char-prefix redaction the logging layer already uses, instead of shipping
+// the raw token into the "APNs push" client span's url.full attribute
+// (App Insights, 90d retention). Wired as a platform.URLRedactor via
+// platform.RedactingTransport in NewClient. If the expected path prefix isn't
+// present — defensive, since do() always builds the URL this way — the URL is
+// returned unchanged rather than guessing at a redaction.
+func redactPushURL(r *http.Request) string {
+	full := r.URL.String()
+	idx := strings.Index(full, devicePathPrefix)
+	if idx < 0 {
+		return full
+	}
+	tokenStart := idx + len(devicePathPrefix)
+	return full[:tokenStart] + redactToken(full[tokenStart:])
 }
 
 // compile-time assertions that both senders satisfy the consumer contract.

--- a/api-go/internal/apns/span_test.go
+++ b/api-go/internal/apns/span_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -87,5 +88,69 @@ func TestSendOne_EmitsClientSpan(t *testing.T) {
 	}
 	if _, ok := spanAttr(span.Attributes(), "server.address"); !ok {
 		t.Errorf("missing server.address attribute (Target source); attrs=%v", span.Attributes())
+	}
+}
+
+// TestSendOne_RedactsDeviceTokenFromSpanURL asserts the "APNs push" client
+// span's url.full attribute never carries the raw device token — otelhttp
+// records the real request URL (including /3/device/<token>) into url.full
+// before the request reaches the transport, so the client must wrap its base
+// transport with platform.RedactingTransport (as NewClient does) to overwrite
+// it with the same 8-char-prefix redaction the logging layer uses.
+func TestSendOne_RedactsDeviceTokenFromSpanURL(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	tp, rec := recorderProvider(t)
+
+	pemBytes, _ := newTestKeyPEM(t)
+	opts := Options{
+		Enabled:  true,
+		AuthKey:  string(pemBytes),
+		KeyID:    "L2J5PQASN5",
+		TeamID:   "4574VQ7N2X",
+		BundleID: "uk.towncrierapp.mobile",
+	}
+	traced := platform.WrapHTTPClient(
+		&http.Client{Transport: &platform.RedactingTransport{
+			Next:   srv.Client().Transport,
+			Redact: redactPushURL,
+		}},
+		func(string, *http.Request) string { return "APNs push" },
+		otelhttp.WithTracerProvider(tp),
+	)
+	client, err := newClientWithBaseURL(opts, srv.URL, traced, testLogger(), func() time.Time {
+		return time.Unix(1_700_000_000, 0).UTC()
+	})
+	if err != nil {
+		t.Fatalf("newClientWithBaseURL: %v", err)
+	}
+
+	const token = "device-token-abc123"
+	if _, err := client.Send(context.Background(), []string{token}, []byte(`{"aps":{}}`)); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	spans := rec.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 client span, got %d", len(spans))
+	}
+	span := spans[0]
+
+	got, ok := spanAttr(span.Attributes(), "url.full")
+	if !ok {
+		t.Fatalf("missing url.full attribute; attrs=%v", span.Attributes())
+	}
+	url := got.AsString()
+	if strings.Contains(url, token) {
+		t.Errorf("url.full leaked the raw device token: %q", url)
+	}
+	wantPrefix := redactToken(token)
+	if !strings.Contains(url, wantPrefix) {
+		t.Errorf("url.full %q does not contain redacted prefix %q", url, wantPrefix)
 	}
 }

--- a/api-go/internal/apns/span_test.go
+++ b/api-go/internal/apns/span_test.go
@@ -95,8 +95,11 @@ func TestSendOne_EmitsClientSpan(t *testing.T) {
 // span's url.full attribute never carries the raw device token — otelhttp
 // records the real request URL (including /3/device/<token>) into url.full
 // before the request reaches the transport, so the client must wrap its base
-// transport with platform.RedactingTransport (as NewClient does) to overwrite
-// it with the same 8-char-prefix redaction the logging layer uses.
+// transport with platform.RedactingTransport to overwrite it with the same
+// 8-char-prefix redaction the logging layer uses. It builds the client
+// through tracedPushClient, the same construction seam NewClient uses in
+// production, so a regression that drops either wrapper from NewClient fails
+// this test too.
 func TestSendOne_RedactsDeviceTokenFromSpanURL(t *testing.T) {
 	t.Parallel()
 
@@ -115,14 +118,7 @@ func TestSendOne_RedactsDeviceTokenFromSpanURL(t *testing.T) {
 		TeamID:   "4574VQ7N2X",
 		BundleID: "uk.towncrierapp.mobile",
 	}
-	traced := platform.WrapHTTPClient(
-		&http.Client{Transport: &platform.RedactingTransport{
-			Next:   srv.Client().Transport,
-			Redact: redactPushURL,
-		}},
-		func(string, *http.Request) string { return "APNs push" },
-		otelhttp.WithTracerProvider(tp),
-	)
+	traced := tracedPushClient(srv.Client().Transport, otelhttp.WithTracerProvider(tp))
 	client, err := newClientWithBaseURL(opts, srv.URL, traced, testLogger(), func() time.Time {
 		return time.Unix(1_700_000_000, 0).UTC()
 	})

--- a/api-go/internal/fcm/client_test.go
+++ b/api-go/internal/fcm/client_test.go
@@ -43,7 +43,7 @@ func newTestClient(t *testing.T, fcmSrv, tokenSrv *httptest.Server) *Client {
 		ProjectID:          "town-crier-test",
 		ServiceAccountJSON: newTestServiceAccountJSON(t, tokenSrv.URL, pemBytes),
 	}
-	client, err := newClientWithBaseURL(opts, fcmSrv.URL, &http.Client{}, testLogger(), fixedClock(1_700_000_000))
+	client, err := newClientWithBaseURL(opts, fcmSrv.URL, &http.Client{}, testLogger(), fixedClock())
 	if err != nil {
 		t.Fatalf("newClientWithBaseURL: %v", err)
 	}

--- a/api-go/internal/fcm/span_test.go
+++ b/api-go/internal/fcm/span_test.go
@@ -77,7 +77,7 @@ func TestSendOne_EmitsClientSpan(t *testing.T) {
 		func(string, *http.Request) string { return "FCM push" },
 		otelhttp.WithTracerProvider(tp),
 	)
-	client, err := newClientWithBaseURL(opts, fcmSrv.URL, traced, testLogger(), fixedClock(1_700_000_000))
+	client, err := newClientWithBaseURL(opts, fcmSrv.URL, traced, testLogger(), fixedClock())
 	if err != nil {
 		t.Fatalf("newClientWithBaseURL: %v", err)
 	}
@@ -129,7 +129,7 @@ func TestSendOne_SpanURLDoesNotCarryDeviceToken(t *testing.T) {
 		func(string, *http.Request) string { return "FCM push" },
 		otelhttp.WithTracerProvider(tp),
 	)
-	client, err := newClientWithBaseURL(opts, fcmSrv.URL, traced, testLogger(), fixedClock(1_700_000_000))
+	client, err := newClientWithBaseURL(opts, fcmSrv.URL, traced, testLogger(), fixedClock())
 	if err != nil {
 		t.Fatalf("newClientWithBaseURL: %v", err)
 	}

--- a/api-go/internal/fcm/span_test.go
+++ b/api-go/internal/fcm/span_test.go
@@ -1,0 +1,156 @@
+package fcm
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	oteltrace "go.opentelemetry.io/otel/trace"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
+)
+
+// recorderProvider returns an in-memory SDK TracerProvider for hermetic span
+// assertions; the wrapped transport emits into the recorder, not the global.
+func recorderProvider(t *testing.T) (*sdktrace.TracerProvider, *tracetest.SpanRecorder) {
+	t.Helper()
+	rec := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	return tp, rec
+}
+
+func spanAttr(attrs []attribute.KeyValue, key string) (attribute.Value, bool) {
+	for _, a := range attrs {
+		if string(a.Key) == key {
+			return a.Value, true
+		}
+	}
+	return attribute.Value{}, false
+}
+
+// sendSpan picks out the FCM send span (as opposed to the OAuth token-exchange
+// span, which shares the same "FCM push" formatter name since both requests
+// go through the same traced httpClient) by its url.full containing the FCM
+// v1 messages:send path.
+func sendSpan(t *testing.T, spans []sdktrace.ReadOnlySpan) sdktrace.ReadOnlySpan {
+	t.Helper()
+	for _, s := range spans {
+		if v, ok := spanAttr(s.Attributes(), "url.full"); ok && strings.Contains(v.AsString(), "messages:send") {
+			return s
+		}
+	}
+	t.Fatalf("no FCM send span found among %d spans", len(spans))
+	return nil
+}
+
+// TestSendOne_EmitsClientSpan asserts an FCM push produces a client span named
+// "FCM push" carrying the upstream host as server.address, mirroring
+// internal/apns's span coverage. Two client spans are emitted per Send — the
+// OAuth token exchange and the FCM send itself — since both share the traced
+// httpClient; this test asserts on the FCM send span.
+func TestSendOne_EmitsClientSpan(t *testing.T) {
+	t.Parallel()
+
+	fcmSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(fcmSrv.Close)
+	tokenSrv, _ := tokenServer(t)
+
+	tp, rec := recorderProvider(t)
+
+	pemBytes, _ := newTestKeyPEM(t)
+	opts := Options{
+		Enabled:            true,
+		ProjectID:          "town-crier-test",
+		ServiceAccountJSON: newTestServiceAccountJSON(t, tokenSrv.URL, pemBytes),
+	}
+	traced := platform.WrapHTTPClient(
+		&http.Client{},
+		func(string, *http.Request) string { return "FCM push" },
+		otelhttp.WithTracerProvider(tp),
+	)
+	client, err := newClientWithBaseURL(opts, fcmSrv.URL, traced, testLogger(), fixedClock(1_700_000_000))
+	if err != nil {
+		t.Fatalf("newClientWithBaseURL: %v", err)
+	}
+
+	payload := []byte(`{"notification":{"title":"hi","body":"there"}}`)
+	if _, err := client.Send(context.Background(), []string{"device-token-abc123"}, payload); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	span := sendSpan(t, rec.Ended())
+
+	if span.Name() != "FCM push" {
+		t.Errorf("span name: got %q, want %q", span.Name(), "FCM push")
+	}
+	if span.SpanKind() != oteltrace.SpanKindClient {
+		t.Errorf("span kind: got %v, want client", span.SpanKind())
+	}
+	if _, ok := spanAttr(span.Attributes(), "server.address"); !ok {
+		t.Errorf("missing server.address attribute (Target source); attrs=%v", span.Attributes())
+	}
+}
+
+// TestSendOne_SpanURLDoesNotCarryDeviceToken is a regression guard: the FCM v1
+// send URL is /v1/projects/<projectID>/messages:send — the device token only
+// ever goes into the JSON body (see withToken), never the URL path — so no
+// client span's url.full attribute (FCM send or OAuth token exchange) should
+// ever carry it. Unlike APNs, no platform.RedactingTransport wiring is needed
+// here because there is nothing in the URL to redact; this test exists to
+// catch a future regression if the URL shape ever changes to embed the token.
+func TestSendOne_SpanURLDoesNotCarryDeviceToken(t *testing.T) {
+	t.Parallel()
+
+	fcmSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(fcmSrv.Close)
+	tokenSrv, _ := tokenServer(t)
+
+	tp, rec := recorderProvider(t)
+
+	pemBytes, _ := newTestKeyPEM(t)
+	opts := Options{
+		Enabled:            true,
+		ProjectID:          "town-crier-test",
+		ServiceAccountJSON: newTestServiceAccountJSON(t, tokenSrv.URL, pemBytes),
+	}
+	traced := platform.WrapHTTPClient(
+		&http.Client{},
+		func(string, *http.Request) string { return "FCM push" },
+		otelhttp.WithTracerProvider(tp),
+	)
+	client, err := newClientWithBaseURL(opts, fcmSrv.URL, traced, testLogger(), fixedClock(1_700_000_000))
+	if err != nil {
+		t.Fatalf("newClientWithBaseURL: %v", err)
+	}
+
+	const token = "device-token-abc123"
+	payload := []byte(`{"notification":{"title":"hi","body":"there"}}`)
+	if _, err := client.Send(context.Background(), []string{token}, payload); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	spans := rec.Ended()
+	if len(spans) == 0 {
+		t.Fatalf("expected at least 1 client span, got 0")
+	}
+	for _, span := range spans {
+		got, ok := spanAttr(span.Attributes(), "url.full")
+		if !ok {
+			t.Fatalf("missing url.full attribute on span %q; attrs=%v", span.Name(), span.Attributes())
+		}
+		if strings.Contains(got.AsString(), token) {
+			t.Errorf("span %q url.full leaked the raw device token: %q", span.Name(), got.AsString())
+		}
+	}
+}

--- a/api-go/internal/fcm/token_test.go
+++ b/api-go/internal/fcm/token_test.go
@@ -54,8 +54,8 @@ func newTestServiceAccountJSON(t *testing.T, tokenURI string, pemBytes []byte) s
 	return string(raw)
 }
 
-func fixedClock(unix int64) func() time.Time {
-	return func() time.Time { return time.Unix(unix, 0).UTC() }
+func fixedClock() func() time.Time {
+	return func() time.Time { return time.Unix(1_700_000_000, 0).UTC() }
 }
 
 func TestTokenProvider_MintsValidRS256Assertion(t *testing.T) {
@@ -139,7 +139,7 @@ func TestTokenProvider_ExchangesAssertionForAccessToken(t *testing.T) {
 	defer srv.Close()
 
 	saJSON := newTestServiceAccountJSON(t, srv.URL, pemBytes)
-	provider, err := newTokenProvider([]byte(saJSON), srv.Client(), fixedClock(1_700_000_000))
+	provider, err := newTokenProvider([]byte(saJSON), srv.Client(), fixedClock())
 	if err != nil {
 		t.Fatalf("newTokenProvider: %v", err)
 	}

--- a/api-go/internal/platform/otelhttp_redact.go
+++ b/api-go/internal/platform/otelhttp_redact.go
@@ -1,0 +1,44 @@
+package platform
+
+import (
+	"net/http"
+
+	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// URLRedactor rewrites a request's URL for telemetry only — the real request
+// sent over the wire is never touched. Implementations should return
+// r.URL.String() unchanged unless the URL carries something sensitive.
+type URLRedactor func(r *http.Request) string
+
+// RedactingTransport wraps Next and, if the request carries a recording span
+// (placed there by an outer otelhttp.Transport via WrapHTTPClient),
+// overwrites that span's url.full attribute with Redact's result before the
+// request reaches Next. otelhttp records the real URL into url.full when it
+// starts the span, before calling the wrapped RoundTripper — there is no
+// otelhttp Option to intercept that. The OTel SDK keeps the LAST value
+// written for a duplicate attribute key (see recordingSpan.Attributes'
+// dedupe-on-read in go.opentelemetry.io/otel/sdk/trace), so calling
+// SetAttributes again here overwrites the exported value while leaving the
+// outbound request and its URL completely unmodified.
+//
+// RedactingTransport is generic — it is not APNs-specific — so any outbound
+// client whose URL embeds a per-user secret (a device token, a signed query
+// parameter) can wrap its base transport with one before handing it to
+// WrapHTTPClient.
+type RedactingTransport struct {
+	// Next performs the actual network round trip. Required.
+	Next http.RoundTripper
+	// Redact returns the telemetry-safe URL string for r. Required.
+	Redact URLRedactor
+}
+
+// RoundTrip overwrites the current span's url.full attribute (if any) with
+// Redact(r), then delegates to Next unchanged.
+func (t *RedactingTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	if span := trace.SpanFromContext(r.Context()); span.IsRecording() {
+		span.SetAttributes(semconv.URLFull(t.Redact(r)))
+	}
+	return t.Next.RoundTrip(r)
+}

--- a/api-go/internal/platform/otelhttp_redact_test.go
+++ b/api-go/internal/platform/otelhttp_redact_test.go
@@ -18,9 +18,9 @@ import (
 func TestRedactingTransport_OverwritesURLFullWithoutTouchingRequest(t *testing.T) {
 	t.Parallel()
 
-	var gotPath string
+	pathCh := make(chan string, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotPath = r.URL.Path
+		pathCh <- r.URL.Path
 		w.WriteHeader(http.StatusOK)
 	}))
 	t.Cleanup(srv.Close)
@@ -48,7 +48,7 @@ func TestRedactingTransport_OverwritesURLFullWithoutTouchingRequest(t *testing.T
 	_ = resp.Body.Close()
 
 	// The real network request must be untouched by the redaction.
-	if gotPath != "/3/device/super-secret-token" {
+	if gotPath := <-pathCh; gotPath != "/3/device/super-secret-token" {
 		t.Fatalf("server saw path %q, want unredacted /3/device/super-secret-token", gotPath)
 	}
 

--- a/api-go/internal/platform/otelhttp_redact_test.go
+++ b/api-go/internal/platform/otelhttp_redact_test.go
@@ -1,0 +1,71 @@
+package platform
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+)
+
+// TestRedactingTransport_OverwritesURLFullWithoutTouchingRequest asserts that
+// wrapping the innermost transport with RedactingTransport rewrites the
+// recorded span's url.full attribute using Redact's return value, while the
+// request that actually reaches the server (via Next) still carries the
+// original, unredacted URL.
+func TestRedactingTransport_OverwritesURLFullWithoutTouchingRequest(t *testing.T) {
+	t.Parallel()
+
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	tp, rec := newRecorderProvider(t)
+
+	base := &http.Client{
+		Transport: &RedactingTransport{
+			Next: http.DefaultTransport,
+			Redact: func(r *http.Request) string {
+				return "https://example.invalid/redacted"
+			},
+		},
+	}
+	wrapped := WrapHTTPClient(base, func(string, *http.Request) string { return "Test push" }, otelhttp.WithTracerProvider(tp))
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/3/device/super-secret-token", http.NoBody)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	resp, err := wrapped.Do(req)
+	if err != nil {
+		t.Fatalf("wrapped.Do: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	// The real network request must be untouched by the redaction.
+	if gotPath != "/3/device/super-secret-token" {
+		t.Fatalf("server saw path %q, want unredacted /3/device/super-secret-token", gotPath)
+	}
+
+	spans := rec.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 client span, got %d", len(spans))
+	}
+	span := spans[0]
+
+	got, ok := attrLookupKV(span.Attributes(), "url.full")
+	if !ok {
+		t.Fatalf("missing url.full attribute; attrs=%v", span.Attributes())
+	}
+	if got.AsString() != "https://example.invalid/redacted" {
+		t.Errorf("url.full: got %q, want redacted value", got.AsString())
+	}
+	if strings.Contains(got.AsString(), "super-secret-token") {
+		t.Errorf("url.full leaked the raw token: %q", got.AsString())
+	}
+}


### PR DESCRIPTION
## Summary

- `platform.WrapHTTPClient`'s otelhttp transport records the real request URL into every client span's `url.full` attribute before handing the request to the wrapped `RoundTripper` — with no otelhttp `Option` to intercept it. For APNs pushes that meant the full device token (`https://api.push.apple.com/3/device/<64-hex-token>`) shipped into App Insights (90d retention) on every "APNs push" span, even though the logging layer already redacts tokens to an 8-char prefix. Device tokens identify a user's device, so this is GDPR-minimisation drift (bead tc-s5n7r, demonstrably joinable back to a named user in a 2026-07-13 investigation).
- Added `platform.RedactingTransport` (`api-go/internal/platform/otelhttp_redact.go`), a generic innermost `RoundTripper`. It overwrites the already-recorded `url.full` span attribute via `span.SetAttributes(semconv.URLFull(...))` — the OTel SDK keeps the *last* value written for a duplicate attribute key on read — without ever touching the outbound request itself.
- Wired it into `apns.NewClient`: the h2 transport is now wrapped by `RedactingTransport` (with a new `redactPushURL` helper reusing the existing `redactToken` 8-char-prefix logic) *before* `platform.WrapHTTPClient` applies the otelhttp layer on top.
- Checked FCM per the bead's ask: the FCM v1 send URL (`/v1/projects/<projectID>/messages:send`) never carries the device token — only the JSON body does — so no production fix was needed there. Added a regression-guard test (`internal/fcm/span_test.go`) asserting this stays true.
- `platform.WrapHTTPClient`'s exported signature is unchanged, so the other callers (`acsemail`, `fcm`, `planit`) are unaffected.

## Test plan

- [x] `gofmt -l .` — empty
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `go test -count=1 ./...` — all packages green, including new/extended tests in `internal/platform`, `internal/apns`, `internal/fcm`
- Backend-only observability/privacy fix; no user-visible behaviour change, no `Release-Note:` trailer needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_014FyPvd9pwdiALsRFNTkg77)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Privacy & Security**
  * Sensitive device tokens are now redacted from telemetry URLs while remaining unchanged in outbound requests.

* **Bug Fixes**
  * Improved protection against accidental exposure of device tokens in APNs tracing data.

* **Tests**
  * Added coverage verifying URL redaction and confirming requests continue to reach servers with their original paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->