### PR TITLE
fix(polling): clamp Lane C cursor to never regress on hydration-cap stall (tc-6u4da)

### DIFF
--- a/api-go/internal/polling/lanec.go
+++ b/api-go/internal/polling/lanec.go
@@ -290,7 +290,27 @@ func (h *InverseMaskLaneHandler) RunOnePage(ctx context.Context) laneOutcome {
 		// exact-instant skips above — so both the cursor and last_poll_time
 		// advance even on a mid-page bail, and the next pass resumes past
 		// what this one already handled instead of re-walking it forever.
-		newCursor := &PollCursor{DifferentStart: epochLower, NextIndex: startIndex + i, KnownTotal: res.Total}
+		nextIndex := startIndex + i
+		// tc-6u4da: a cluster of permanently-unhydratable rows (FetchByUID
+		// genuinely has no matching record for them, forever) never dedupes
+		// via GetByUID/inverseMaskDiffers, so every one of them burns a
+		// hydration-cap slot on every single pass. Because
+		// resumeOverlapRecords (100) is much bigger than maxHydrationsPerPass
+		// (25), a resume that lands near such a cluster can hit the cap
+		// after attempting only maxHydrationsPerPass hydrations — i banked
+		// well short of the overlap this resume already subtracted — so the
+		// raw startIndex+i checkpoint can land BELOW the cursor this call
+		// loaded. Left alone that retreats the persisted cursor, and since
+		// the same cluster is still there next pass, it retreats again,
+		// spiralling the epoch drain backward indefinitely instead of
+		// stalling in place. Clamp to the loaded cursor's own NextIndex (only
+		// meaningful when a cursor was actually loaded — a freshly-anchored
+		// epoch has no prior checkpoint to protect) so a stuck cluster can at
+		// worst flatline the checkpoint, never walk it backward.
+		if cursor != nil && nextIndex < cursor.NextIndex {
+			nextIndex = cursor.NextIndex
+		}
+		newCursor := &PollCursor{DifferentStart: epochLower, NextIndex: nextIndex, KnownTotal: res.Total}
 		if serr := h.watermark.save(ctx, now, epochUpper, newCursor); serr != nil && out.err == nil {
 			out.err = serr
 		}
@@ -311,6 +331,16 @@ func (h *InverseMaskLaneHandler) RunOnePage(ctx context.Context) laneOutcome {
 			out.err = serr
 		}
 	} else {
+		// tc-6u4da: same clamp as the stoppedEarly branch above, applied here
+		// for consistency/defense-in-depth. In practice a fully-consumed
+		// page's nextIndex is normally well past the prior checkpoint
+		// already, so this branch is unlikely to ever need it — but nothing
+		// stops a caller from getting here with a small page and a large
+		// loaded cursor, and monotonic advance should hold everywhere this
+		// lane persists NextIndex, not just on the hydration-cap path.
+		if cursor != nil && nextIndex < cursor.NextIndex {
+			nextIndex = cursor.NextIndex
+		}
 		newCursor := &PollCursor{DifferentStart: epochLower, NextIndex: nextIndex, KnownTotal: res.Total}
 		if serr := h.watermark.save(ctx, now, epochUpper, newCursor); serr != nil && out.err == nil {
 			out.err = serr

--- a/api-go/internal/polling/lanec_test.go
+++ b/api-go/internal/polling/lanec_test.go
@@ -771,6 +771,128 @@ func TestInverseMaskLane_HydrationCapStopsPassAndCheckpoints(t *testing.T) {
 	}
 }
 
+// TestInverseMaskLane_HydrationCapNeverRegressesCursor is tc-6u4da: a cluster
+// of PERMANENTLY-unhydratable rows (FetchByUID genuinely has no matching
+// record for them, forever — a historical areaId-198 cluster in prod) never
+// dedupes via GetByUID/inverseMaskDiffers (Postgres has no row for them
+// either), so every one of them consumes a hydration-cap slot on every single
+// pass, and the resume overlap (100) dwarfs the cap (25): a resume can hit
+// the cap after attempting only maxHydrationsPerPass hydrations, i banked
+// well short of the 100-record overlap the resume subtracted. Left alone,
+// startIndex+i checkpoints BELOW the cursor's own prior NextIndex — the
+// checkpoint retreats, and since the same cluster is still there next pass,
+// it retreats again, and again, potentially spiralling all the way back to
+// index 0. This proves the fix: the persisted cursor must never fall below
+// the NextIndex already loaded at the top of this call.
+func TestInverseMaskLane_HydrationCapNeverRegressesCursor(t *testing.T) {
+	t.Parallel()
+	epochLower := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	epochUpper := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+	ld := epochLower.Add(time.Hour)
+
+	const priorNextIndex = 500
+	const startIndex = priorNextIndex - resumeOverlapRecords // 400
+
+	// A run of unhydratable rows, one more than the cap: the fake fetcher's
+	// hydrated map has NO entry for any of these uids, so FetchByUID returns
+	// zero matching applications every time -- exactly "200 OK, no matching
+	// record", never wired into fetcher.hydrateErr.
+	const rowCount = maxHydrationsPerPass + 1
+	fetcher := newFakeInverseMaskFetcher()
+	lightRows := make([]applications.PlanningApplication, 0, rowCount)
+	for i := range rowCount {
+		uid := fmt.Sprintf("phantom-%02d/HSE", i)
+		lightRows = append(lightRows, lightApp(uid, 198, "Permitted", ld))
+	}
+	fetcher.pages[startIndex] = planit.FetchPageResult{From: startIndex, Applications: lightRows, HasMorePages: false}
+
+	apps := newFakeApps() // nothing hydrated ever lands here either
+	state := newFakeStateStore()
+	state.states[sentinelLaneC] = PollState{
+		HighWaterMark: epochUpper,
+		Cursor:        &PollCursor{DifferentStart: epochLower, NextIndex: priorNextIndex},
+	}
+
+	h := newLaneCHandler(t, fetcher, apps, state, defaultInverseMaskOpts())
+	out := h.RunOnePage(context.Background())
+
+	if out.err != nil {
+		t.Fatalf("RunOnePage: %v (the hydration cap is a clean early stop, not an error)", out.err)
+	}
+	if len(fetcher.hydrateCalls) != maxHydrationsPerPass {
+		t.Fatalf("hydrateCalls: got %d, want %d (the per-pass cap)", len(fetcher.hydrateCalls), maxHydrationsPerPass)
+	}
+	got := state.states[sentinelLaneC].Cursor
+	if got == nil {
+		t.Fatal("cursor: got nil, want a checkpoint")
+	}
+	if rawCheckpoint := startIndex + maxHydrationsPerPass; got.NextIndex < priorNextIndex {
+		t.Errorf("cursor.NextIndex regressed: got %d (raw startIndex+i would have been %d), want >= the prior checkpoint %d", got.NextIndex, rawCheckpoint, priorNextIndex)
+	}
+}
+
+// TestInverseMaskLane_HydrationCapFlatlinesAcrossRepeatedPasses extends the
+// above across two consecutive RunOnePage calls with the SAME permanently-
+// unhydratable cluster still sitting at the resumed offset (nothing about it
+// ever changes in Postgres or PlanIt, so nothing about the situation changes
+// between passes either). Proves the failure mode this bead converts a
+// backward spiral into a bounded flatline: the second call's persisted
+// cursor is never LOWER than the first call's, even though both calls hit
+// the identical cap-stop arithmetic that would otherwise retreat it every
+// single time.
+func TestInverseMaskLane_HydrationCapFlatlinesAcrossRepeatedPasses(t *testing.T) {
+	t.Parallel()
+	epochLower := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	epochUpper := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+	ld := epochLower.Add(time.Hour)
+
+	const priorNextIndex = 500
+	const startIndex = priorNextIndex - resumeOverlapRecords // 400
+
+	const rowCount = maxHydrationsPerPass + 1
+	fetcher := newFakeInverseMaskFetcher()
+	lightRows := make([]applications.PlanningApplication, 0, rowCount)
+	for i := range rowCount {
+		uid := fmt.Sprintf("phantom-%02d/HSE", i)
+		lightRows = append(lightRows, lightApp(uid, 198, "Permitted", ld))
+	}
+	fetcher.pages[startIndex] = planit.FetchPageResult{From: startIndex, Applications: lightRows, HasMorePages: false}
+
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	state.states[sentinelLaneC] = PollState{
+		HighWaterMark: epochUpper,
+		Cursor:        &PollCursor{DifferentStart: epochLower, NextIndex: priorNextIndex},
+	}
+
+	h := newLaneCHandler(t, fetcher, apps, state, defaultInverseMaskOpts())
+
+	firstOut := h.RunOnePage(context.Background())
+	if firstOut.err != nil {
+		t.Fatalf("first RunOnePage: %v", firstOut.err)
+	}
+	firstCursor := state.states[sentinelLaneC].Cursor
+	if firstCursor == nil {
+		t.Fatal("first pass cursor: got nil, want a checkpoint")
+	}
+
+	// The cluster is still exactly there: the fake fetcher's page/hydrated
+	// maps are untouched, so a second call resumes at the same overlap-
+	// adjusted offset and hits the identical cap-stop.
+	secondOut := h.RunOnePage(context.Background())
+	if secondOut.err != nil {
+		t.Fatalf("second RunOnePage: %v", secondOut.err)
+	}
+	secondCursor := state.states[sentinelLaneC].Cursor
+	if secondCursor == nil {
+		t.Fatal("second pass cursor: got nil, want a checkpoint")
+	}
+
+	if secondCursor.NextIndex < firstCursor.NextIndex {
+		t.Errorf("cursor regressed on the second pass: got %d, want >= the first pass's %d", secondCursor.NextIndex, firstCursor.NextIndex)
+	}
+}
+
 // TestInverseMaskLane_IngestErrorIsAHardStop proves a hydrated Ingest
 // failure checkpoints at the failing record's offset (GH#986) exactly like a
 // mid-page hydration 429 does, and advances last_poll_time, even though the

--- a/api-go/internal/polling/lanec_test.go
+++ b/api-go/internal/polling/lanec_test.go
@@ -826,8 +826,8 @@ func TestInverseMaskLane_HydrationCapNeverRegressesCursor(t *testing.T) {
 	if got == nil {
 		t.Fatal("cursor: got nil, want a checkpoint")
 	}
-	if rawCheckpoint := startIndex + maxHydrationsPerPass; got.NextIndex < priorNextIndex {
-		t.Errorf("cursor.NextIndex regressed: got %d (raw startIndex+i would have been %d), want >= the prior checkpoint %d", got.NextIndex, rawCheckpoint, priorNextIndex)
+	if got.NextIndex != priorNextIndex {
+		t.Errorf("cursor.NextIndex: got %d, want exactly the prior checkpoint %d (raw startIndex+i would have been %d)", got.NextIndex, priorNextIndex, startIndex+maxHydrationsPerPass)
 	}
 }
 
@@ -888,8 +888,8 @@ func TestInverseMaskLane_HydrationCapFlatlinesAcrossRepeatedPasses(t *testing.T)
 		t.Fatal("second pass cursor: got nil, want a checkpoint")
 	}
 
-	if secondCursor.NextIndex < firstCursor.NextIndex {
-		t.Errorf("cursor regressed on the second pass: got %d, want >= the first pass's %d", secondCursor.NextIndex, firstCursor.NextIndex)
+	if secondCursor.NextIndex != firstCursor.NextIndex {
+		t.Errorf("cursor changed on the second pass: got %d, want exactly the first pass's %d", secondCursor.NextIndex, firstCursor.NextIndex)
 	}
 }
 


### PR DESCRIPTION
## Summary

Bead: `tc-6u4da` (follow-up from tc-9tp49 / GH#986, which fixed Lane C's original livelock — see PR #987).

Lane C (the national inverse-mask reconciliation lane, ADR 0044) can hit a cluster of rows that are **permanently unhydratable**: `FetchByUID` genuinely returns "no matching record" for them, forever (prod evidence: a historical 2021-era cluster in areaId 198). These rows never dedupe via `GetByUID`/`inverseMaskDiffers`, so they burn a `maxHydrationsPerPass` (25) slot on every single pass.

Because `resumeOverlapRecords` (100) is much larger than `maxHydrationsPerPass` (25), a resume landing near such a cluster can hit the hydration cap after attempting only 25 hydrations — well short of the 100-record overlap the resume already subtracted. The raw `startIndex + i` checkpoint then lands **below** the cursor already loaded, and since the same cluster never clears, this repeats every pass: the persisted cursor can spiral backward indefinitely (in the worst case all the way to index 0), and Lane C's own epoch drain never reaches its ceiling — a reconciliation-lag stall, not a PlanIt-hammering issue (Lanes A/B are unaffected, and PlanIt call volume per pass stays bounded).

## Fix

Clamp both places `RunOnePage` persists a new `PollCursor.NextIndex` (the hydration-cap/mid-page-bail branch, and the epoch-not-drained normal-page-boundary branch) to never fall below the `NextIndex` already loaded at entry — but only when a cursor was actually loaded (a freshly-anchored epoch has no prior checkpoint to protect). This converts the failure mode from an unbounded backward spiral into a bounded flatline: a truly stuck cluster can stop the checkpoint from advancing, but it can never walk it backward.

Deliberately **out of scope**: the bead's other named fix option (cap-exempting or persistently marking "no matching record" uids as handled) is a distinct, larger design question left undecided in the bead's own notes — not attempted here.

## Changes

- `api-go/internal/polling/lanec.go` — clamp `NextIndex` to `max(computed, cursor.NextIndex)` at both cursor-persist sites in `RunOnePage`, when `cursor != nil`.
- `api-go/internal/polling/lanec_test.go` — two new tests:
  - `TestInverseMaskLane_HydrationCapNeverRegressesCursor` — single-pass reproduction of the retreat (confirmed RED before the clamp, GREEN after).
  - `TestInverseMaskLane_HydrationCapFlatlinesAcrossRepeatedPasses` — two consecutive passes against the same stuck cluster never regress the cursor.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (full suite, all packages green)
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- No live PlanIt calls made — driven entirely against the existing hand-written fakes in `internal/polling`.
- No DB/store/SQL changes, so `make test-integration` isn't applicable here.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015Er7Adg5tcnZckLf1XBktc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved polling progress tracking to prevent pagination checkpoints from moving backward.
  * Prevented repeated processing of unhydrated records from causing cursor regression or stalled progress.

* **Tests**
  * Added coverage for hydration-limit scenarios, including repeated polling passes, to verify stable checkpoint advancement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->