### PR TITLE
fix: use real design tokens in WatchZones CSS modules (tc-hzqej)

### DIFF
--- a/web/src/features/WatchZones/WatchZoneCreatePage.module.css
+++ b/web/src/features/WatchZones/WatchZoneCreatePage.module.css
@@ -12,8 +12,8 @@
 }
 
 .title {
-  font-size: var(--tc-text-h2);
-  font-weight: var(--tc-font-bold);
+  font-size: var(--tc-text-display-large);
+  font-weight: var(--tc-weight-bold);
   color: var(--tc-text-primary);
   margin: 0;
 }
@@ -46,7 +46,7 @@
 
 .label {
   display: block;
-  font-weight: var(--tc-font-semibold);
+  font-weight: var(--tc-weight-semibold);
   color: var(--tc-text-primary);
   margin-bottom: var(--tc-space-xs);
   font-size: var(--tc-text-body);
@@ -87,7 +87,7 @@
   color: var(--tc-text-on-accent);
   border: none;
   border-radius: var(--tc-radius-md);
-  font-weight: var(--tc-font-semibold);
+  font-weight: var(--tc-weight-semibold);
   font-size: var(--tc-text-body);
   cursor: pointer;
   transition: background var(--tc-duration-fast);
@@ -122,6 +122,6 @@
 
 .confirmValue {
   font-size: var(--tc-text-body);
-  font-weight: var(--tc-font-semibold);
+  font-weight: var(--tc-weight-semibold);
   color: var(--tc-text-primary);
 }

--- a/web/src/features/WatchZones/WatchZoneEditPage.module.css
+++ b/web/src/features/WatchZones/WatchZoneEditPage.module.css
@@ -11,7 +11,7 @@
 .backLink {
   color: var(--tc-text-primary);
   text-decoration: none;
-  font-weight: var(--tc-font-semibold);
+  font-weight: var(--tc-weight-semibold);
   font-size: var(--tc-text-caption);
 }
 
@@ -34,7 +34,7 @@
 .fieldLabel {
   display: block;
   font-size: var(--tc-text-caption);
-  font-weight: var(--tc-font-semibold);
+  font-weight: var(--tc-weight-semibold);
   color: var(--tc-text-secondary);
   margin-bottom: var(--tc-space-xs);
 }
@@ -69,7 +69,7 @@
   padding: var(--tc-space-sm) var(--tc-space-md);
   margin-top: var(--tc-space-md);
   font-size: var(--tc-text-body);
-  font-weight: var(--tc-font-semibold);
+  font-weight: var(--tc-weight-semibold);
   color: var(--tc-text-on-accent);
   background: var(--tc-amber);
   border: none;
@@ -104,14 +104,14 @@
 
 .sectionTitle {
   font-size: var(--tc-text-body);
-  font-weight: var(--tc-font-semibold);
+  font-weight: var(--tc-weight-semibold);
   color: var(--tc-text-primary);
   margin: 0 0 var(--tc-space-md) 0;
 }
 
 .preferencesGroupTitle {
   font-size: var(--tc-text-caption);
-  font-weight: var(--tc-font-semibold);
+  font-weight: var(--tc-weight-semibold);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: var(--tc-text-secondary);

--- a/web/src/features/WatchZones/WatchZoneListPage.module.css
+++ b/web/src/features/WatchZones/WatchZoneListPage.module.css
@@ -12,8 +12,8 @@
 }
 
 .title {
-  font-size: var(--tc-text-h2);
-  font-weight: var(--tc-font-bold);
+  font-size: var(--tc-text-display-large);
+  font-weight: var(--tc-weight-bold);
   color: var(--tc-text-primary);
   margin: 0;
 }
@@ -25,7 +25,7 @@
   background: var(--tc-amber);
   color: var(--tc-text-on-accent);
   border-radius: var(--tc-radius-md);
-  font-weight: var(--tc-font-semibold);
+  font-weight: var(--tc-weight-semibold);
   text-decoration: none;
   transition: background var(--tc-duration-fast);
 }
@@ -67,7 +67,7 @@
 
 .zoneName {
   font-size: var(--tc-text-body);
-  font-weight: var(--tc-font-semibold);
+  font-weight: var(--tc-weight-semibold);
   color: var(--tc-text-primary);
   margin: 0;
 }
@@ -111,7 +111,7 @@
 .editLink {
   padding: var(--tc-space-xs) var(--tc-space-sm);
   color: var(--tc-text-primary);
-  font-weight: var(--tc-font-semibold);
+  font-weight: var(--tc-weight-semibold);
   font-size: var(--tc-text-caption);
   text-decoration: none;
   border-radius: var(--tc-radius-sm);
@@ -125,7 +125,7 @@
 .deleteButton {
   padding: var(--tc-space-xs) var(--tc-space-sm);
   color: var(--tc-status-rejected);
-  font-weight: var(--tc-font-semibold);
+  font-weight: var(--tc-weight-semibold);
   font-size: var(--tc-text-caption);
   background: none;
   border: none;
@@ -156,7 +156,7 @@
   background: var(--tc-amber);
   color: var(--tc-text-on-accent);
   border-radius: var(--tc-radius-md);
-  font-weight: var(--tc-font-semibold);
+  font-weight: var(--tc-weight-semibold);
   text-decoration: none;
   transition: background var(--tc-duration-fast);
 }


### PR DESCRIPTION
## Summary

- `WatchZoneListPage.module.css`, `WatchZoneEditPage.module.css`, and `WatchZoneCreatePage.module.css` referenced CSS custom properties (`--tc-font-bold`, `--tc-font-semibold`, `--tc-text-h2`) that don't exist in `web/src/styles/tokens.css`. Undefined custom properties silently fall back to the browser default (normal weight, inherited size), so these pages rendered without their intended weight/size styling in all three theme modes.
- Replaced with the real tokens: `--tc-font-bold` → `--tc-weight-bold`, `--tc-font-semibold` → `--tc-weight-semibold`, `--tc-text-h2` → `--tc-text-display-large` (only where it sized an `<h1>` page title in `WatchZoneListPage`/`WatchZoneCreatePage`).
- Token mapping for the page-title size was chosen to match every other top-level feature page (Dashboard, Applications, Map, SavedApplications, onboarding, Settings, legal), which all use `--tc-text-display-large` + `--tc-weight-bold` for their `<h1>`.
- `WatchZoneEditPage`'s `<h2>` section titles never actually referenced the undefined size token (only the weight token was broken there), so no size change was needed in that file.

Closes bead tc-hzqej (discovered as a side-quest during tc-6c3md, GH #889).

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npx vitest run` — 137 test files, 1321 tests, all passing
- [x] `npx eslint src/features/WatchZones/` — clean
- [x] `npm run build` — production build succeeds
- [x] Confirmed no other undefined-token references remain in `web/src/features/WatchZones/*.module.css`
- [ ] Visual verification in browser — not performed in this unattended run; recommend a quick look at the WatchZones list/edit/create pages in light/dark/OLED-dark before merge

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NX9y2DJMwS2BsALzHnKvt5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Watch Zones page typography to use the current design tokens.
  * Improved consistency of font weights and display text across creation, editing, and list views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->