### PR TITLE
feat(api): App Store Server API reconciliation for missed ASSN webhooks

### DIFF
--- a/api-go/cmd/worker/appstorereconcile_wiring_test.go
+++ b/api-go/cmd/worker/appstorereconcile_wiring_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
+)
+
+// validAppStoreServerAPIKeyPEM is a syntactically valid PKCS8 EC private key,
+// generated once for this test file — not a real Apple-issued key. It only
+// needs to parse; appstorereconcile's Handler never dials Apple in this test.
+const validAppStoreServerAPIKeyPEM = `-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg1KGB5FBmTOozZK3o
+7Q7VYVZEeCB6iF6dO1e3q9pS0PmhRANCAATeZWc+Mrg+K5c5g8Qk3P5Q4uNTBP1B
+xNJnfnRc+/L0iAaJ/rMYuI9O+M8fJ2WRPBQIxHUXMz9WjZ54zVIYD4RH
+-----END PRIVATE KEY-----`
+
+// TestBuildAppStoreReconcile_UnconfiguredReturnsNil proves buildAppStoreReconcile
+// returns a genuine nil *appstorereconcile.Handler — not just a nil-checked
+// error — whenever APPSTORE_RECONCILE_ENABLED is unset, mirroring the
+// "unconfigured optional job" posture buildDevSeeder/buildPollOrchestrator
+// already use.
+func TestBuildAppStoreReconcile_UnconfiguredReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	handler := buildAppStoreReconcile(platform.Config{}, &stores{}, discardLogger())
+
+	if handler != nil {
+		t.Fatalf("buildAppStoreReconcile: got non-nil handler, want nil (APPSTORE_RECONCILE_ENABLED unset)")
+	}
+}
+
+// TestBuildAppStoreReconcile_MalformedKeyReturnsNil proves an enabled job with
+// key material that fails to parse also returns nil rather than panicking or
+// propagating a fatal error — a malformed .p8 must not crash-loop the other
+// modes (digest, dormant-cleanup, etc.) this same binary dispatches.
+func TestBuildAppStoreReconcile_MalformedKeyReturnsNil(t *testing.T) {
+	t.Parallel()
+	cfg := platform.Config{
+		AppStoreReconcileEnabled:     true,
+		AppStoreServerAPIKey:         platform.NewSecret("not a pem"),
+		AppStoreServerAPIKeyID:       "ABCDE12345",
+		AppStoreServerAPIIssuerID:    "57246542-96fe-1a63-e053-0824d011072a",
+		AppStoreServerAPIEnvironment: "Sandbox",
+		AppleBundleID:                "uk.towncrierapp.mobile",
+		AppleEnvironments:            []string{"Production"},
+	}
+
+	handler := buildAppStoreReconcile(cfg, &stores{}, discardLogger())
+
+	if handler != nil {
+		t.Fatalf("buildAppStoreReconcile: got non-nil handler, want nil (malformed signing key)")
+	}
+}
+
+// TestBuildAppStoreReconcile_ConfiguredReturnsNonNilHandler proves
+// buildAppStoreReconcile builds a real Handler once enabled with valid key
+// material. It needs no live Apple/Postgres access: appstoreserverapi.NewClient
+// and subscriptions.NewJWSVerifier both construct lazily — no network call
+// happens until Handler.Run is invoked.
+func TestBuildAppStoreReconcile_ConfiguredReturnsNonNilHandler(t *testing.T) {
+	t.Parallel()
+	cfg := platform.Config{
+		AppStoreReconcileEnabled:       true,
+		AppStoreServerAPIKey:           platform.NewSecret(validAppStoreServerAPIKeyPEM),
+		AppStoreServerAPIKeyID:         "ABCDE12345",
+		AppStoreServerAPIIssuerID:      "57246542-96fe-1a63-e053-0824d011072a",
+		AppStoreServerAPIEnvironment:   "Sandbox",
+		AppStoreReconcileApplyEnabled:  false,
+		AppStoreReconcileLookbackHours: 30,
+		AppleBundleID:                  "uk.towncrierapp.mobile",
+		AppleEnvironments:              []string{"Production"},
+	}
+
+	handler := buildAppStoreReconcile(cfg, &stores{}, discardLogger())
+
+	if handler == nil {
+		t.Fatal("buildAppStoreReconcile: got nil handler, want a configured Handler")
+	}
+}

--- a/api-go/cmd/worker/main.go
+++ b/api-go/cmd/worker/main.go
@@ -24,6 +24,8 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/acsemail"
 	"github.com/AmyDe/town-crier/api-go/internal/apns"
 	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/appstorereconcile"
+	"github.com/AmyDe/town-crier/api-go/internal/appstoreserverapi"
 	"github.com/AmyDe/town-crier/api-go/internal/devicetokens"
 	"github.com/AmyDe/town-crier/api-go/internal/devseed"
 	"github.com/AmyDe/town-crier/api-go/internal/digest"
@@ -43,6 +45,7 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
 	"github.com/AmyDe/town-crier/api-go/internal/savedapplications"
 	"github.com/AmyDe/town-crier/api-go/internal/servicebus"
+	"github.com/AmyDe/town-crier/api-go/internal/subscriptions"
 	"github.com/AmyDe/town-crier/api-go/internal/subscriptionsweep"
 	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
 	"github.com/AmyDe/town-crier/api-go/internal/worker"
@@ -65,6 +68,7 @@ type stores struct {
 	pollState    *polling.PostgresPollStateStore
 	lease        *polling.PostgresLeaseStore
 	backfill     *polling.PostgresBackfillStateStore
+	appleNotif   *subscriptions.PostgresNotificationStore
 }
 
 func main() {
@@ -144,6 +148,7 @@ func run() int {
 		pollState:    polling.NewPostgresPollStateStore(pool),
 		lease:        polling.NewPostgresLeaseStore(pool, time.Now),
 		backfill:     polling.NewPostgresBackfillStateStore(pool),
+		appleNotif:   subscriptions.NewPostgresNotificationStore(pool, time.Now),
 	}
 
 	// The Service Bus client (and thus the bootstrapper and the poll-sb
@@ -220,7 +225,17 @@ func run() int {
 	// crashing.
 	devSeeder := buildDevSeeder(cfg, registry, st, logger)
 
-	return worker.Run(context.Background(), mode, bootstrapper, digester, dormantRunner, poller, sweepRunner, purger, devSeeder, logger)
+	// The appstore-reconcile runner is built only when APPSTORE_RECONCILE_ENABLED
+	// is set and its App Store Server API key material parses. A job missing
+	// either leaves reconciler a genuinely nil interface; appstore-reconcile then
+	// logs and exits 0 rather than crash-looping — this feature is genuinely
+	// optional during rollout (tc-97k35.6, GH#1011).
+	var reconciler worker.AppStoreReconcileRunner
+	if r := buildAppStoreReconcile(cfg, st, logger); r != nil {
+		reconciler = r
+	}
+
+	return worker.Run(context.Background(), mode, bootstrapper, digester, dormantRunner, poller, sweepRunner, purger, devSeeder, reconciler, logger)
 }
 
 // buildPollOrchestrator wires the poll-sb orchestrator: the PlanIt client,
@@ -763,6 +778,65 @@ func buildAuth0Syncer(cfg platform.Config, logger *slog.Logger) subscriptionswee
 		cfg.Auth0M2MClientID,
 		cfg.Auth0M2MClientSecret,
 	)
+}
+
+// buildAppStoreReconcile constructs the appstore-reconcile handler: the App
+// Store Server API client (JWT-authed via the .p8 signing key), the same
+// subscriptions.JWSVerifier and subscriptions.NotificationProcessor the live
+// POST /v1/webhooks/appstore handler uses (so a recovered notification can
+// never double-apply against a concurrent live delivery), and the Postgres
+// idempotency store built into st.appleNotif.
+//
+// It returns nil — logged, not fatal — when APPSTORE_RECONCILE_ENABLED is
+// unset or the key material fails to parse, following the same
+// "unconfigured optional job" template as buildDevSeeder: this feature is
+// genuinely optional during rollout (tc-97k35.6, GH#1011), so a malformed or
+// absent key must not crash-loop the job's OTHER modes (digest,
+// dormant-cleanup, etc.) that share this process.
+func buildAppStoreReconcile(cfg platform.Config, st *stores, logger *slog.Logger) *appstorereconcile.Handler {
+	if !cfg.AppStoreReconcileEnabled {
+		logger.Info("appstore-reconcile unconfigured (APPSTORE_RECONCILE_ENABLED unset); appstore-reconcile mode will refuse to run")
+		return nil
+	}
+
+	appleRoots, err := subscriptions.LoadAppleRootCertificates()
+	if err != nil {
+		logger.Error("appstore-reconcile: load apple root certificates; appstore-reconcile mode will refuse to run", "error", err)
+		return nil
+	}
+	jwsVerifier, err := subscriptions.NewJWSVerifier(appleRoots, time.Now)
+	if err != nil {
+		logger.Error("appstore-reconcile: build jws verifier; appstore-reconcile mode will refuse to run", "error", err)
+		return nil
+	}
+
+	apiClient, err := appstoreserverapi.NewClient(appstoreserverapi.Options{
+		SigningKey:  cfg.AppStoreServerAPIKey.Expose(),
+		KeyID:       cfg.AppStoreServerAPIKeyID,
+		IssuerID:    cfg.AppStoreServerAPIIssuerID,
+		BundleID:    cfg.AppleBundleID,
+		Environment: cfg.AppStoreServerAPIEnvironment,
+	}, time.Now)
+	if err != nil {
+		logger.Error("appstore-reconcile: build app store server api client; appstore-reconcile mode will refuse to run", "error", err)
+		return nil
+	}
+
+	// adminStore backs profileByTxn (GetByOriginalTransactionID + Save), the
+	// same store the live webhook path uses to locate a subscriber
+	// cross-partition.
+	adminStore := st.profileAdmin
+	processor := subscriptions.NewNotificationProcessor(
+		jwsVerifier,
+		adminStore,
+		buildAuth0Syncer(cfg, logger),
+		st.appleNotif,
+		cfg.AppleEnvironments,
+		logger,
+	)
+
+	lookback := time.Duration(cfg.AppStoreReconcileLookbackHours) * time.Hour
+	return appstorereconcile.New(apiClient, jwsVerifier, st.appleNotif, processor, lookback, cfg.AppStoreReconcileApplyEnabled, logger, time.Now)
 }
 
 // buildEmailSender returns the real ACS email sender when a connection string is

--- a/api-go/internal/appstorereconcile/handler.go
+++ b/api-go/internal/appstorereconcile/handler.go
@@ -1,0 +1,171 @@
+// Package appstorereconcile holds the App Store Server API reconciliation
+// worker mode (WORKER_MODE=appstore-reconcile): periodically polls Apple's
+// Get Notification History API for a lookback window and detects any
+// notificationUUID Apple sent that never reached our idempotency table —
+// evidence of a missed ASSN webhook delivery (GH #1011). It mirrors
+// internal/subscriptionsweep in spirit: consumer-side interfaces declared
+// here, concrete collaborators injected from main(), hand-written test
+// fakes, an injected now for a pinned clock, and per-item failure isolation
+// so one malformed history entry never aborts the cycle.
+//
+// Rollout is observe-only: a detected gap is always logged and counted, but
+// only actually re-applied through Applier.Process when applyEnabled is
+// true. In observe mode nothing here ever marks a gap processed — the same
+// gap is re-detected and re-alerted on every subsequent cycle until either
+// apply mode is turned on or someone investigates.
+package appstorereconcile
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/appstoreserverapi"
+	"github.com/AmyDe/town-crier/api-go/internal/subscriptions"
+)
+
+// HistoryFetcher is the consumer-side slice of the App Store Server API
+// client the handler polls. *appstoreserverapi.Client satisfies it.
+type HistoryFetcher interface {
+	FetchNotificationHistory(ctx context.Context, start, end time.Time) ([]appstoreserverapi.NotificationHistoryItem, error)
+}
+
+// Verifier verifies and decodes an Apple StoreKit JWS without trusting that
+// Apple's history API response is itself trustworthy transport — a
+// malformed or unexpected entry must not crash the cycle.
+// *subscriptions.JWSVerifier satisfies it.
+type Verifier interface {
+	VerifyAndDecode(signedPayload string) (string, error)
+}
+
+// IdempotencyChecker reports whether a notificationUUID has already been
+// recorded as processed. *subscriptions.PostgresNotificationStore satisfies
+// it. Deliberately narrower than the webhook path's idempotencyStore: this
+// package only ever reads the table, never marks it — see the package doc.
+type IdempotencyChecker interface {
+	IsProcessed(ctx context.Context, notificationUUID string) (bool, error)
+}
+
+// Applier applies one already-fetched, not-yet-verified notification JWS —
+// the same choke point the live webhook uses. *subscriptions.NotificationProcessor
+// satisfies it. Process re-verifies and re-checks idempotency internally, so
+// calling it here can never double-apply a notification a concurrent live
+// webhook delivery is also handling.
+type Applier interface {
+	Process(ctx context.Context, signedPayload string) (wasNew bool, err error)
+}
+
+// Handler runs one reconciliation cycle.
+type Handler struct {
+	fetcher      HistoryFetcher
+	verifier     Verifier
+	idempotency  IdempotencyChecker
+	applier      Applier
+	lookback     time.Duration
+	applyEnabled bool
+	logger       *slog.Logger
+	now          func() time.Time
+}
+
+// New builds a reconciliation handler. now is injected so tests pin the
+// scan window; production passes time.Now.
+func New(fetcher HistoryFetcher, verifier Verifier, idempotency IdempotencyChecker, applier Applier, lookback time.Duration, applyEnabled bool, logger *slog.Logger, now func() time.Time) *Handler {
+	return &Handler{
+		fetcher:      fetcher,
+		verifier:     verifier,
+		idempotency:  idempotency,
+		applier:      applier,
+		lookback:     lookback,
+		applyEnabled: applyEnabled,
+		logger:       logger,
+		now:          now,
+	}
+}
+
+// Run computes the window [now()-lookback, now()), fetches every notification
+// history item Apple recorded in it, and for each: verifies+decodes the outer
+// JWS (defensive re-verification, never trusting transport), extracts the
+// notificationUUID, and checks whether it is already in our idempotency
+// table. Any UUID not yet recorded is a gap — logged and counted regardless
+// of whether applying it would actually change anything. When applyEnabled,
+// a detected gap is also replayed through the Applier (which performs its own
+// second, harmless idempotency check, closing any TOCTOU race against a
+// concurrent live webhook delivery for the same UUID); the observe-only
+// default never marks a gap processed, so it is re-detected every cycle until
+// apply mode is turned on or someone investigates.
+//
+// A per-item verify/decode/idempotency-check failure is logged and skipped —
+// it does not fail the whole cycle. A HistoryFetcher error (Apple unreachable,
+// retries exhausted) is fatal to the cycle and is returned.
+func (h *Handler) Run(ctx context.Context) (scanned, gaps, applied int, err error) {
+	end := h.now()
+	start := end.Add(-h.lookback)
+
+	items, err := h.fetcher.FetchNotificationHistory(ctx, start, end)
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("fetch notification history: %w", err)
+	}
+	scanned = len(items)
+
+	for _, item := range items {
+		gap, wasApplied := h.processOne(ctx, item)
+		if gap {
+			gaps++
+		}
+		if wasApplied {
+			applied++
+		}
+	}
+
+	h.logger.InfoContext(ctx, "app store reconcile cycle complete",
+		"scanned", scanned, "gaps", gaps, "applied", applied, "applyEnabled", h.applyEnabled)
+	return scanned, gaps, applied, nil
+}
+
+// processOne handles a single history item in isolation: a verify/decode/
+// idempotency-check failure is logged and reported as no gap / not applied
+// rather than propagated, so one bad entry never aborts the cycle.
+func (h *Handler) processOne(ctx context.Context, item appstoreserverapi.NotificationHistoryItem) (gap, applied bool) {
+	outerJSON, err := h.verifier.VerifyAndDecode(item.SignedPayload)
+	if err != nil {
+		h.logger.WarnContext(ctx, "app store reconcile: skipping unverifiable history item", "error", err)
+		return false, false
+	}
+	notification, err := subscriptions.DecodeNotification(outerJSON)
+	if err != nil {
+		h.logger.WarnContext(ctx, "app store reconcile: skipping malformed history item", "error", err)
+		return false, false
+	}
+
+	processed, err := h.idempotency.IsProcessed(ctx, notification.NotificationUUID)
+	if err != nil {
+		h.logger.WarnContext(ctx, "app store reconcile: skipping item; idempotency check failed",
+			"notificationUUID", notification.NotificationUUID, "error", err)
+		return false, false
+	}
+	if processed {
+		return false, false
+	}
+
+	// A gap: Apple sent this notificationUUID and it is not yet in our
+	// idempotency table, full stop — regardless of whether applying it would
+	// actually change anything.
+	h.logger.WarnContext(ctx, "app store reconcile: gap detected",
+		"notificationUUID", notification.NotificationUUID,
+		"notificationType", notification.NotificationType,
+		"subtype", notification.Subtype,
+	)
+
+	if !h.applyEnabled {
+		return true, false
+	}
+
+	wasNew, err := h.applier.Process(ctx, item.SignedPayload)
+	if err != nil {
+		h.logger.WarnContext(ctx, "app store reconcile: apply failed for detected gap",
+			"notificationUUID", notification.NotificationUUID, "error", err)
+		return true, false
+	}
+	return true, wasNew
+}

--- a/api-go/internal/appstorereconcile/handler.go
+++ b/api-go/internal/appstorereconcile/handler.go
@@ -141,7 +141,7 @@ func (h *Handler) processOne(ctx context.Context, item appstoreserverapi.Notific
 	processed, err := h.idempotency.IsProcessed(ctx, notification.NotificationUUID)
 	if err != nil {
 		h.logger.WarnContext(ctx, "app store reconcile: skipping item; idempotency check failed",
-			"notificationUUID", notification.NotificationUUID, "error", err)
+			"notificationUuid", notification.NotificationUUID, "error", err)
 		return false, false
 	}
 	if processed {
@@ -152,7 +152,7 @@ func (h *Handler) processOne(ctx context.Context, item appstoreserverapi.Notific
 	// idempotency table, full stop — regardless of whether applying it would
 	// actually change anything.
 	h.logger.WarnContext(ctx, "app store reconcile: gap detected",
-		"notificationUUID", notification.NotificationUUID,
+		"notificationUuid", notification.NotificationUUID,
 		"notificationType", notification.NotificationType,
 		"subtype", notification.Subtype,
 	)
@@ -164,7 +164,7 @@ func (h *Handler) processOne(ctx context.Context, item appstoreserverapi.Notific
 	wasNew, err := h.applier.Process(ctx, item.SignedPayload)
 	if err != nil {
 		h.logger.WarnContext(ctx, "app store reconcile: apply failed for detected gap",
-			"notificationUUID", notification.NotificationUUID, "error", err)
+			"notificationUuid", notification.NotificationUUID, "error", err)
 		return true, false
 	}
 	return true, wasNew

--- a/api-go/internal/appstorereconcile/handler_test.go
+++ b/api-go/internal/appstorereconcile/handler_test.go
@@ -1,0 +1,422 @@
+package appstorereconcile
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/appstoreserverapi"
+)
+
+// --- fakes ---
+
+type fakeHistoryFetcher struct {
+	items        []appstoreserverapi.NotificationHistoryItem
+	err          error
+	calls        int
+	capturedFrom time.Time
+	capturedTo   time.Time
+}
+
+func (f *fakeHistoryFetcher) FetchNotificationHistory(_ context.Context, start, end time.Time) ([]appstoreserverapi.NotificationHistoryItem, error) {
+	f.calls++
+	f.capturedFrom = start
+	f.capturedTo = end
+	return f.items, f.err
+}
+
+type fakeVerifier struct {
+	results map[string]string
+	errs    map[string]error
+}
+
+func newFakeVerifier() *fakeVerifier {
+	return &fakeVerifier{results: map[string]string{}, errs: map[string]error{}}
+}
+
+func (f *fakeVerifier) VerifyAndDecode(signed string) (string, error) {
+	if e, ok := f.errs[signed]; ok {
+		return "", e
+	}
+	if j, ok := f.results[signed]; ok {
+		return j, nil
+	}
+	return "", fmt.Errorf("unmapped test jws %q", signed)
+}
+
+type fakeIdempotencyChecker struct {
+	processed map[string]bool
+	err       error
+}
+
+func newFakeIdempotencyChecker() *fakeIdempotencyChecker {
+	return &fakeIdempotencyChecker{processed: map[string]bool{}}
+}
+
+func (f *fakeIdempotencyChecker) IsProcessed(_ context.Context, uuid string) (bool, error) {
+	if f.err != nil {
+		return false, f.err
+	}
+	return f.processed[uuid], nil
+}
+
+// fakeApplier is a spy: it records every call so a test can assert it was
+// never invoked in observe mode, and can be primed per-signedPayload with an
+// error or a wasNew value.
+type fakeApplier struct {
+	calls  []string
+	wasNew map[string]bool
+	errs   map[string]error
+}
+
+func newFakeApplier() *fakeApplier {
+	return &fakeApplier{wasNew: map[string]bool{}, errs: map[string]error{}}
+}
+
+func (f *fakeApplier) Process(_ context.Context, signedPayload string) (bool, error) {
+	f.calls = append(f.calls, signedPayload)
+	if e, ok := f.errs[signedPayload]; ok {
+		return false, e
+	}
+	return f.wasNew[signedPayload], nil
+}
+
+// --- test helpers ---
+
+func notificationJSON(notifType, subtype, uuid string) string {
+	if subtype == "" {
+		return fmt.Sprintf(`{"notificationType":%q,"notificationUUID":%q,"data":{"signedTransactionInfo":"INNER"}}`, notifType, uuid)
+	}
+	return fmt.Sprintf(`{"notificationType":%q,"subtype":%q,"notificationUUID":%q,"data":{"signedTransactionInfo":"INNER"}}`, notifType, subtype, uuid)
+}
+
+var testNow = time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+
+const testLookback = 24 * time.Hour
+
+type testDeps struct {
+	fetcher     *fakeHistoryFetcher
+	verifier    *fakeVerifier
+	idempotency *fakeIdempotencyChecker
+	applier     *fakeApplier
+}
+
+func newTestHandler(applyEnabled bool) (*Handler, *testDeps) {
+	d := &testDeps{
+		fetcher:     &fakeHistoryFetcher{},
+		verifier:    newFakeVerifier(),
+		idempotency: newFakeIdempotencyChecker(),
+		applier:     newFakeApplier(),
+	}
+	h := New(d.fetcher, d.verifier, d.idempotency, d.applier, testLookback, applyEnabled,
+		slog.New(slog.DiscardHandler), func() time.Time { return testNow })
+	return h, d
+}
+
+// --- tests ---
+
+func TestRun_ZeroItemsCycle(t *testing.T) {
+	t.Parallel()
+	h, d := newTestHandler(false)
+	d.fetcher.items = nil
+
+	scanned, gaps, applied, err := h.Run(context.Background())
+
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if scanned != 0 || gaps != 0 || applied != 0 {
+		t.Errorf("scanned=%d gaps=%d applied=%d, want 0/0/0", scanned, gaps, applied)
+	}
+}
+
+func TestRun_AllGapsInObserveModeNeverCallsApplier(t *testing.T) {
+	t.Parallel()
+	h, d := newTestHandler(false)
+	d.fetcher.items = []appstoreserverapi.NotificationHistoryItem{
+		{SignedPayload: "jws-1"},
+		{SignedPayload: "jws-2"},
+	}
+	d.verifier.results["jws-1"] = notificationJSON("SUBSCRIBED", "", "uuid-1")
+	d.verifier.results["jws-2"] = notificationJSON("DID_RENEW", "", "uuid-2")
+
+	scanned, gaps, applied, err := h.Run(context.Background())
+
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if scanned != 2 {
+		t.Errorf("scanned = %d, want 2", scanned)
+	}
+	if gaps != 2 {
+		t.Errorf("gaps = %d, want 2", gaps)
+	}
+	if applied != 0 {
+		t.Errorf("applied = %d, want 0 in observe mode", applied)
+	}
+	if len(d.applier.calls) != 0 {
+		t.Fatalf("applier.calls = %v, want none called in observe mode", d.applier.calls)
+	}
+}
+
+func TestRun_AllGapsInApplyModeCallsApplierOncePerGap(t *testing.T) {
+	t.Parallel()
+	h, d := newTestHandler(true)
+	d.fetcher.items = []appstoreserverapi.NotificationHistoryItem{
+		{SignedPayload: "jws-1"},
+		{SignedPayload: "jws-2"},
+	}
+	d.verifier.results["jws-1"] = notificationJSON("SUBSCRIBED", "", "uuid-1")
+	d.verifier.results["jws-2"] = notificationJSON("DID_RENEW", "", "uuid-2")
+	d.applier.wasNew["jws-1"] = true
+	d.applier.wasNew["jws-2"] = true
+
+	scanned, gaps, applied, err := h.Run(context.Background())
+
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if scanned != 2 || gaps != 2 {
+		t.Errorf("scanned=%d gaps=%d, want 2/2", scanned, gaps)
+	}
+	if applied != 2 {
+		t.Errorf("applied = %d, want 2", applied)
+	}
+	if len(d.applier.calls) != 2 {
+		t.Fatalf("applier.calls = %v, want exactly 2 calls (one per gap)", d.applier.calls)
+	}
+}
+
+func TestRun_ApplyModeCountsAppliedOnlyWhenApplierReportsWasNew(t *testing.T) {
+	t.Parallel()
+	h, d := newTestHandler(true)
+	d.fetcher.items = []appstoreserverapi.NotificationHistoryItem{
+		{SignedPayload: "jws-1"},
+	}
+	d.verifier.results["jws-1"] = notificationJSON("DID_CHANGE_RENEWAL_PREF", "DOWNGRADE", "uuid-1")
+	d.applier.wasNew["jws-1"] = false // e.g. a no-op downgrade event
+
+	scanned, gaps, applied, err := h.Run(context.Background())
+
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if scanned != 1 || gaps != 1 {
+		t.Errorf("scanned=%d gaps=%d, want 1/1", scanned, gaps)
+	}
+	if applied != 0 {
+		t.Errorf("applied = %d, want 0 (applier reported wasNew=false)", applied)
+	}
+	if len(d.applier.calls) != 1 {
+		t.Errorf("applier.calls = %v, want exactly 1 call", d.applier.calls)
+	}
+}
+
+func TestRun_AllAlreadyProcessedIsZeroGapsRegardlessOfMode(t *testing.T) {
+	t.Parallel()
+	for _, applyEnabled := range []bool{false, true} {
+		applyEnabled := applyEnabled
+		t.Run(fmt.Sprintf("applyEnabled=%v", applyEnabled), func(t *testing.T) {
+			t.Parallel()
+			h, d := newTestHandler(applyEnabled)
+			d.fetcher.items = []appstoreserverapi.NotificationHistoryItem{
+				{SignedPayload: "jws-1"},
+				{SignedPayload: "jws-2"},
+			}
+			d.verifier.results["jws-1"] = notificationJSON("SUBSCRIBED", "", "uuid-1")
+			d.verifier.results["jws-2"] = notificationJSON("DID_RENEW", "", "uuid-2")
+			d.idempotency.processed["uuid-1"] = true
+			d.idempotency.processed["uuid-2"] = true
+
+			scanned, gaps, applied, err := h.Run(context.Background())
+
+			if err != nil {
+				t.Fatalf("Run: %v", err)
+			}
+			if scanned != 2 {
+				t.Errorf("scanned = %d, want 2", scanned)
+			}
+			if gaps != 0 {
+				t.Errorf("gaps = %d, want 0 (already processed)", gaps)
+			}
+			if applied != 0 {
+				t.Errorf("applied = %d, want 0", applied)
+			}
+			if len(d.applier.calls) != 0 {
+				t.Errorf("applier.calls = %v, want none (no gaps to apply)", d.applier.calls)
+			}
+		})
+	}
+}
+
+func TestRun_MixedProcessedAndUnprocessed(t *testing.T) {
+	t.Parallel()
+	h, d := newTestHandler(true)
+	d.fetcher.items = []appstoreserverapi.NotificationHistoryItem{
+		{SignedPayload: "jws-processed"},
+		{SignedPayload: "jws-gap"},
+	}
+	d.verifier.results["jws-processed"] = notificationJSON("SUBSCRIBED", "", "uuid-processed")
+	d.verifier.results["jws-gap"] = notificationJSON("DID_RENEW", "", "uuid-gap")
+	d.idempotency.processed["uuid-processed"] = true
+	d.applier.wasNew["jws-gap"] = true
+
+	scanned, gaps, applied, err := h.Run(context.Background())
+
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if scanned != 2 {
+		t.Errorf("scanned = %d, want 2", scanned)
+	}
+	if gaps != 1 {
+		t.Errorf("gaps = %d, want 1", gaps)
+	}
+	if applied != 1 {
+		t.Errorf("applied = %d, want 1", applied)
+	}
+	if len(d.applier.calls) != 1 || d.applier.calls[0] != "jws-gap" {
+		t.Errorf("applier.calls = %v, want [jws-gap]", d.applier.calls)
+	}
+}
+
+func TestRun_HistoryFetcherErrorPropagates(t *testing.T) {
+	t.Parallel()
+	h, d := newTestHandler(false)
+	d.fetcher.err = errors.New("apple unreachable")
+
+	scanned, gaps, applied, err := h.Run(context.Background())
+
+	if err == nil {
+		t.Fatal("Run: want error when HistoryFetcher fails, got nil")
+	}
+	if scanned != 0 || gaps != 0 || applied != 0 {
+		t.Errorf("scanned=%d gaps=%d applied=%d, want 0/0/0 on fatal fetch error", scanned, gaps, applied)
+	}
+}
+
+func TestRun_OneBadItemVerifyFailureIsSkippedWithoutFailingCycle(t *testing.T) {
+	t.Parallel()
+	h, d := newTestHandler(false)
+	d.fetcher.items = []appstoreserverapi.NotificationHistoryItem{
+		{SignedPayload: "jws-good-1"},
+		{SignedPayload: "jws-bad"},
+		{SignedPayload: "jws-good-2"},
+	}
+	d.verifier.results["jws-good-1"] = notificationJSON("SUBSCRIBED", "", "uuid-good-1")
+	d.verifier.errs["jws-bad"] = errors.New("tampered jws")
+	d.verifier.results["jws-good-2"] = notificationJSON("DID_RENEW", "", "uuid-good-2")
+
+	scanned, gaps, applied, err := h.Run(context.Background())
+
+	if err != nil {
+		t.Fatalf("Run: want no error (bad item isolated), got %v", err)
+	}
+	if scanned != 3 {
+		t.Errorf("scanned = %d, want 3", scanned)
+	}
+	if gaps != 2 {
+		t.Errorf("gaps = %d, want 2 (bad item excluded, both good items are gaps)", gaps)
+	}
+	if applied != 0 {
+		t.Errorf("applied = %d, want 0 in observe mode", applied)
+	}
+}
+
+func TestRun_OneBadItemDecodeFailureIsSkippedWithoutFailingCycle(t *testing.T) {
+	t.Parallel()
+	h, d := newTestHandler(false)
+	d.fetcher.items = []appstoreserverapi.NotificationHistoryItem{
+		{SignedPayload: "jws-malformed"},
+		{SignedPayload: "jws-good"},
+	}
+	// Missing the required notificationUUID field -> DecodeNotification fails.
+	d.verifier.results["jws-malformed"] = `{"notificationType":"SUBSCRIBED","data":{"signedTransactionInfo":"INNER"}}`
+	d.verifier.results["jws-good"] = notificationJSON("SUBSCRIBED", "", "uuid-good")
+
+	scanned, gaps, applied, err := h.Run(context.Background())
+
+	if err != nil {
+		t.Fatalf("Run: want no error (malformed item isolated), got %v", err)
+	}
+	if scanned != 2 {
+		t.Errorf("scanned = %d, want 2", scanned)
+	}
+	if gaps != 1 {
+		t.Errorf("gaps = %d, want 1 (malformed item excluded)", gaps)
+	}
+	if applied != 0 {
+		t.Errorf("applied = %d, want 0", applied)
+	}
+}
+
+func TestRun_ApplierErrorIsSkippedWithoutFailingCycle(t *testing.T) {
+	t.Parallel()
+	h, d := newTestHandler(true)
+	d.fetcher.items = []appstoreserverapi.NotificationHistoryItem{
+		{SignedPayload: "jws-1"},
+	}
+	d.verifier.results["jws-1"] = notificationJSON("SUBSCRIBED", "", "uuid-1")
+	d.applier.errs["jws-1"] = errors.New("save profile failed")
+
+	scanned, gaps, applied, err := h.Run(context.Background())
+
+	if err != nil {
+		t.Fatalf("Run: want no error (applier failure isolated), got %v", err)
+	}
+	if scanned != 1 || gaps != 1 {
+		t.Errorf("scanned=%d gaps=%d, want 1/1", scanned, gaps)
+	}
+	if applied != 0 {
+		t.Errorf("applied = %d, want 0 (applier errored)", applied)
+	}
+}
+
+func TestRun_WindowMatchesNowMinusLookback(t *testing.T) {
+	t.Parallel()
+	h, d := newTestHandler(false)
+
+	if _, _, _, err := h.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	wantEnd := testNow
+	wantStart := testNow.Add(-testLookback)
+	if !d.fetcher.capturedTo.Equal(wantEnd) {
+		t.Errorf("end = %v, want %v", d.fetcher.capturedTo, wantEnd)
+	}
+	if !d.fetcher.capturedFrom.Equal(wantStart) {
+		t.Errorf("start = %v, want %v", d.fetcher.capturedFrom, wantStart)
+	}
+	if d.fetcher.calls != 1 {
+		t.Errorf("fetcher calls = %d, want 1", d.fetcher.calls)
+	}
+}
+
+func TestRun_IdempotencyCheckErrorIsSkippedWithoutFailingCycle(t *testing.T) {
+	t.Parallel()
+	h, d := newTestHandler(false)
+	d.fetcher.items = []appstoreserverapi.NotificationHistoryItem{
+		{SignedPayload: "jws-1"},
+	}
+	d.verifier.results["jws-1"] = notificationJSON("SUBSCRIBED", "", "uuid-1")
+	d.idempotency.err = errors.New("postgres down")
+
+	scanned, gaps, applied, err := h.Run(context.Background())
+
+	if err != nil {
+		t.Fatalf("Run: want no error (idempotency check failure isolated), got %v", err)
+	}
+	if scanned != 1 {
+		t.Errorf("scanned = %d, want 1", scanned)
+	}
+	if gaps != 0 {
+		t.Errorf("gaps = %d, want 0 (could not determine gap status)", gaps)
+	}
+	if applied != 0 {
+		t.Errorf("applied = %d, want 0", applied)
+	}
+}

--- a/api-go/internal/appstorereconcile/handler_test.go
+++ b/api-go/internal/appstorereconcile/handler_test.go
@@ -218,7 +218,6 @@ func TestRun_ApplyModeCountsAppliedOnlyWhenApplierReportsWasNew(t *testing.T) {
 func TestRun_AllAlreadyProcessedIsZeroGapsRegardlessOfMode(t *testing.T) {
 	t.Parallel()
 	for _, applyEnabled := range []bool{false, true} {
-		applyEnabled := applyEnabled
 		t.Run(fmt.Sprintf("applyEnabled=%v", applyEnabled), func(t *testing.T) {
 			t.Parallel()
 			h, d := newTestHandler(applyEnabled)

--- a/api-go/internal/appstoreserverapi/client.go
+++ b/api-go/internal/appstoreserverapi/client.go
@@ -1,0 +1,262 @@
+// Package appstoreserverapi is a small, independently-testable client for
+// Apple's App Store Server API — specifically the Get Notification History
+// endpoint the appstorereconcile worker polls to detect ASSN webhook
+// delivery gaps. It mirrors internal/apns in spirit: .p8-key JWT auth, no
+// domain/Postgres knowledge, a real HTTP client hardened with timeouts and a
+// bounded response body.
+package appstoreserverapi
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
+)
+
+const (
+	// productionBaseURL and sandboxBaseURL are Apple's two well-known App Store
+	// Server API hosts, not configurable infrastructure.
+	productionBaseURL = "https://api.storekit.itunes.apple.com"
+	sandboxBaseURL    = "https://api.storekit-sandbox.itunes.apple.com"
+
+	// historyPath is the Get Notification History endpoint.
+	historyPath = "/inApps/v1/notifications/history"
+
+	// requestTimeout bounds a single HTTP request/attempt.
+	requestTimeout = 30 * time.Second
+	// maxRespBytes bounds a single page's response body. A page of
+	// JWS-signed notification history is a few dozen entries at most;
+	// 10 MiB is a generous ceiling matching the platform's outbound-client
+	// default.
+	maxRespBytes = 10 << 20
+	// maxHistoryPages defensively caps pagination so a malformed or
+	// adversarial hasMore:true response can never loop forever.
+	maxHistoryPages = 1000
+	// maxAttempts bounds the retries a single page fetch makes against
+	// repeated 429 responses before giving up.
+	maxAttempts = 5
+	// defaultRetryAfter is used when a 429 response carries no parseable
+	// Retry-After header.
+	defaultRetryAfter = 5 * time.Second
+)
+
+// Options configures the App Store Server API client.
+type Options struct {
+	// SigningKey is the PEM contents of the .p8 auth key (PKCS8 EC private key).
+	SigningKey string
+	// KeyID is the 10-character key id carried in the JWT header (kid).
+	KeyID string
+	// IssuerID is the UUID issuer id carried in the JWT payload (iss).
+	IssuerID string
+	// BundleID is the App Store bundle id carried in the JWT payload (bid).
+	// Callers reuse the existing AppleBundleID config — there is no separate
+	// bundle-id config for this client.
+	BundleID string
+	// Environment selects the base URL: "Sandbox" or "Production".
+	Environment string
+}
+
+// baseURL resolves the App Store Server API host for the configured
+// environment. Anything other than a case-insensitive "sandbox" resolves to
+// Production, matching the fail-safe default used elsewhere in this repo
+// (an unrecognized/unset environment must never silently target Sandbox).
+func (o Options) baseURL() string {
+	if strings.EqualFold(o.Environment, "Sandbox") {
+		return sandboxBaseURL
+	}
+	return productionBaseURL
+}
+
+func (o Options) validate() error {
+	if o.KeyID == "" {
+		return fmt.Errorf("%w: KeyID is empty", ErrInvalidOptions)
+	}
+	if o.IssuerID == "" {
+		return fmt.Errorf("%w: IssuerID is empty", ErrInvalidOptions)
+	}
+	if o.BundleID == "" {
+		return fmt.Errorf("%w: BundleID is empty", ErrInvalidOptions)
+	}
+	return nil
+}
+
+// NotificationHistoryItem is one entry from the Get Notification History
+// response: the still-signed (not yet verified) outer notification JWS.
+type NotificationHistoryItem struct {
+	SignedPayload string
+}
+
+// Client is a direct App Store Server API client, scoped to Get Notification
+// History. It mints one ES256 JWT per FetchNotificationHistory call and
+// reuses it across every paginated request that call makes.
+type Client struct {
+	http     *http.Client
+	key      *ecdsa.PrivateKey
+	keyID    string
+	issuerID string
+	bundleID string
+	baseURL  string
+	now      func() time.Time
+}
+
+// NewClient builds a client from validated options. now supplies the clock
+// the minted JWT's iat/exp and Retry-After computations use (production
+// passes time.Now; tests pin it).
+func NewClient(opts Options, now func() time.Time) (*Client, error) {
+	return newClientWithBaseURL(opts, opts.baseURL(), &http.Client{Timeout: requestTimeout}, now)
+}
+
+// newClientWithBaseURL is the constructor seam shared by NewClient and tests:
+// an explicit base URL and HTTP client let an httptest server exercise the
+// request/response logic.
+func newClientWithBaseURL(opts Options, baseURL string, httpClient *http.Client, now func() time.Time) (*Client, error) {
+	if err := opts.validate(); err != nil {
+		return nil, err
+	}
+	key, err := parseP8Key([]byte(opts.SigningKey))
+	if err != nil {
+		return nil, err
+	}
+	return &Client{
+		http:     httpClient,
+		key:      key,
+		keyID:    opts.KeyID,
+		issuerID: opts.IssuerID,
+		bundleID: opts.BundleID,
+		baseURL:  baseURL,
+		now:      now,
+	}, nil
+}
+
+// historyRequest is the Get Notification History POST body. Only startDate
+// and endDate are ever set — no optional filter fields (notificationType,
+// notificationSubtype, transactionId, onlyFailures): gap detection is driven
+// by our own idempotency table, not Apple's bookkeeping, so the full
+// unfiltered window is pulled.
+type historyRequest struct {
+	StartDate       int64  `json:"startDate"`
+	EndDate         int64  `json:"endDate"`
+	PaginationToken string `json:"paginationToken,omitempty"`
+}
+
+type historyResponseItem struct {
+	SignedPayload string `json:"signedPayload"`
+}
+
+type historyResponse struct {
+	NotificationHistory []historyResponseItem `json:"notificationHistory"`
+	HasMore             bool                  `json:"hasMore"`
+	PaginationToken     string                `json:"paginationToken"`
+}
+
+// FetchNotificationHistory pages through Get Notification History for
+// [start, end), following paginationToken/hasMore until exhausted (capped at
+// maxHistoryPages), and returns every item across all pages. The JWT is
+// minted once at the start of the call and reused for every page.
+func (c *Client) FetchNotificationHistory(ctx context.Context, start, end time.Time) ([]NotificationHistoryItem, error) {
+	token, err := mintJWT(c.key, c.keyID, c.issuerID, c.bundleID, c.now())
+	if err != nil {
+		return nil, fmt.Errorf("appstoreserverapi: mint jwt: %w", err)
+	}
+
+	var items []NotificationHistoryItem
+	paginationToken := ""
+	for page := 0; ; page++ {
+		if page >= maxHistoryPages {
+			return nil, fmt.Errorf("%w: exceeded %d pages", ErrTooManyPages, maxHistoryPages)
+		}
+
+		resp, err := c.fetchPage(ctx, token, start, end, paginationToken)
+		if err != nil {
+			return nil, err
+		}
+		for _, it := range resp.NotificationHistory {
+			items = append(items, NotificationHistoryItem{SignedPayload: it.SignedPayload})
+		}
+		if !resp.HasMore {
+			return items, nil
+		}
+		paginationToken = resp.PaginationToken
+	}
+}
+
+// fetchPage posts one Get Notification History page, retrying a bounded
+// number of times on 429 (honoring Retry-After in both the seconds and
+// HTTP-date forms). Any other non-2xx status fails immediately with no
+// retry.
+func (c *Client) fetchPage(ctx context.Context, jwtToken string, start, end time.Time, paginationToken string) (historyResponse, error) {
+	body, err := json.Marshal(historyRequest{
+		StartDate:       start.UnixMilli(),
+		EndDate:         end.UnixMilli(),
+		PaginationToken: paginationToken,
+	})
+	if err != nil {
+		return historyResponse{}, fmt.Errorf("appstoreserverapi: marshal request body: %w", err)
+	}
+
+	for attempt := 1; ; attempt++ {
+		status, retryAfter, respBody, err := c.doOnce(ctx, jwtToken, body)
+		if err != nil {
+			return historyResponse{}, err
+		}
+
+		if status == http.StatusTooManyRequests {
+			if attempt >= maxAttempts {
+				return historyResponse{}, fmt.Errorf("%w: gave up after %d attempts", ErrRateLimited, attempt)
+			}
+			wait, ok := parseRetryAfter(retryAfter, c.now())
+			if !ok {
+				wait = defaultRetryAfter
+			}
+			if err := platform.Sleep(ctx, wait); err != nil {
+				return historyResponse{}, err
+			}
+			continue
+		}
+
+		if status < 200 || status >= 300 {
+			return historyResponse{}, fmt.Errorf("%w: %d", ErrUnexpectedStatus, status)
+		}
+
+		var parsed historyResponse
+		if err := json.Unmarshal(respBody, &parsed); err != nil {
+			return historyResponse{}, fmt.Errorf("appstoreserverapi: decode response: %w", err)
+		}
+		return parsed, nil
+	}
+}
+
+// doOnce performs a single HTTP attempt and returns the status code, the raw
+// Retry-After header value (empty when absent), and the response body
+// (bounded by maxRespBytes).
+func (c *Client) doOnce(ctx context.Context, jwtToken string, body []byte) (status int, retryAfter string, respBody []byte, err error) {
+	reqCtx, cancel := context.WithTimeout(ctx, requestTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, c.baseURL+historyPath, bytes.NewReader(body))
+	if err != nil {
+		return 0, "", nil, fmt.Errorf("appstoreserverapi: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+jwtToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return 0, "", nil, fmt.Errorf("appstoreserverapi: request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err = io.ReadAll(io.LimitReader(resp.Body, maxRespBytes))
+	if err != nil {
+		return 0, "", nil, fmt.Errorf("appstoreserverapi: read response: %w", err)
+	}
+
+	return resp.StatusCode, resp.Header.Get("Retry-After"), respBody, nil
+}

--- a/api-go/internal/appstoreserverapi/client.go
+++ b/api-go/internal/appstoreserverapi/client.go
@@ -178,7 +178,7 @@ func (c *Client) FetchNotificationHistory(ctx context.Context, start, end time.T
 			return nil, err
 		}
 		for _, it := range resp.NotificationHistory {
-			items = append(items, NotificationHistoryItem{SignedPayload: it.SignedPayload})
+			items = append(items, NotificationHistoryItem(it))
 		}
 		if !resp.HasMore {
 			return items, nil

--- a/api-go/internal/appstoreserverapi/client_test.go
+++ b/api-go/internal/appstoreserverapi/client_test.go
@@ -1,0 +1,462 @@
+package appstoreserverapi
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newTestKeyPEM generates a P-256 ECDSA key encoded as a PKCS8 PEM block, the
+// same shape Apple ships a .p8 auth key in — mirrors internal/apns/jwt_test.go.
+func newTestKeyPEM(t *testing.T) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal pkcs8: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+}
+
+func decodeSegment(t *testing.T, seg string) []byte {
+	t.Helper()
+	b, err := base64.RawURLEncoding.DecodeString(seg)
+	if err != nil {
+		t.Fatalf("base64url decode %q: %v", seg, err)
+	}
+	return b
+}
+
+const (
+	testKeyID    = "ABCDE12345"
+	testIssuerID = "57246542-96fe-1a63-e053-0824d011072a"
+	testBundleID = "uk.towncrierapp.mobile"
+)
+
+func newTestOptions(pemBytes []byte, environment string) Options {
+	return Options{
+		SigningKey:  string(pemBytes),
+		KeyID:       testKeyID,
+		IssuerID:    testIssuerID,
+		BundleID:    testBundleID,
+		Environment: environment,
+	}
+}
+
+// --- JWT shape ---
+
+// TestClient_FetchNotificationHistory_MintsValidJWT decodes the
+// Authorization: Bearer header server-side and asserts the header/claims
+// shape the spec pins: alg=ES256/kid=<KeyID>, iss=<IssuerID>,
+// exp<=iat+3600, aud=appstoreconnect-v1, bid=<BundleID>.
+func TestClient_FetchNotificationHistory_MintsValidJWT(t *testing.T) {
+	t.Parallel()
+	pemBytes := newTestKeyPEM(t)
+
+	var capturedAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedAuth = r.Header.Get("Authorization")
+		writeHistoryResponse(w, historyResponse{})
+	}))
+	defer srv.Close()
+
+	now := time.Unix(1_800_000_000, 0).UTC()
+	client, err := newClientWithBaseURL(newTestOptions(pemBytes, "Production"), srv.URL, srv.Client(), func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("newClientWithBaseURL: %v", err)
+	}
+
+	if _, err := client.FetchNotificationHistory(context.Background(), now.Add(-time.Hour), now); err != nil {
+		t.Fatalf("FetchNotificationHistory: %v", err)
+	}
+
+	if !strings.HasPrefix(capturedAuth, "Bearer ") {
+		t.Fatalf("Authorization header = %q, want Bearer prefix", capturedAuth)
+	}
+	token := strings.TrimPrefix(capturedAuth, "Bearer ")
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		t.Fatalf("token must have 3 dot-separated parts, got %d", len(parts))
+	}
+
+	var header jwtHeader
+	if err := json.Unmarshal(decodeSegment(t, parts[0]), &header); err != nil {
+		t.Fatalf("decode header: %v", err)
+	}
+	if header.Alg != "ES256" {
+		t.Errorf("header.alg = %q, want ES256", header.Alg)
+	}
+	if header.Kid != testKeyID {
+		t.Errorf("header.kid = %q, want %q", header.Kid, testKeyID)
+	}
+	if header.Typ != "JWT" {
+		t.Errorf("header.typ = %q, want JWT", header.Typ)
+	}
+
+	var claims jwtClaims
+	if err := json.Unmarshal(decodeSegment(t, parts[1]), &claims); err != nil {
+		t.Fatalf("decode claims: %v", err)
+	}
+	if claims.Iss != testIssuerID {
+		t.Errorf("claims.iss = %q, want %q", claims.Iss, testIssuerID)
+	}
+	if claims.Iat != now.Unix() {
+		t.Errorf("claims.iat = %d, want %d", claims.Iat, now.Unix())
+	}
+	if claims.Exp > claims.Iat+3600 {
+		t.Errorf("claims.exp = %d, iat = %d: exp exceeds iat+3600", claims.Exp, claims.Iat)
+	}
+	if claims.Exp <= claims.Iat {
+		t.Errorf("claims.exp = %d, iat = %d: exp must be after iat", claims.Exp, claims.Iat)
+	}
+	if claims.Aud != "appstoreconnect-v1" {
+		t.Errorf("claims.aud = %q, want appstoreconnect-v1", claims.Aud)
+	}
+	if claims.Bid != testBundleID {
+		t.Errorf("claims.bid = %q, want %q", claims.Bid, testBundleID)
+	}
+}
+
+// --- base URL selection ---
+
+func TestClient_BaseURLSelection(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		env  string
+		want string
+	}{
+		{"production", "Production", productionBaseURL},
+		{"sandbox", "Sandbox", sandboxBaseURL},
+		{"sandbox case-insensitive", "sandbox", sandboxBaseURL},
+		{"unset defaults to production", "", productionBaseURL},
+		{"unrecognized defaults to production", "Staging", productionBaseURL},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := newTestOptions(nil, tc.env).baseURL()
+			if got != tc.want {
+				t.Errorf("baseURL() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// --- single-page fetch ---
+
+func writeHistoryResponse(w http.ResponseWriter, resp historyResponse) {
+	w.Header().Set("Content-Type", "application/json")
+	body, _ := json.Marshal(resp)
+	_, _ = w.Write(body)
+}
+
+func TestClient_FetchNotificationHistory_SinglePage(t *testing.T) {
+	t.Parallel()
+	pemBytes := newTestKeyPEM(t)
+
+	var capturedBody historyRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&capturedBody)
+		writeHistoryResponse(w, historyResponse{
+			NotificationHistory: []historyResponseItem{
+				{SignedPayload: "jws-1"},
+				{SignedPayload: "jws-2"},
+			},
+			HasMore: false,
+		})
+	}))
+	defer srv.Close()
+
+	now := time.Unix(1_800_000_000, 0).UTC()
+	client, err := newClientWithBaseURL(newTestOptions(pemBytes, "Production"), srv.URL, srv.Client(), func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("newClientWithBaseURL: %v", err)
+	}
+
+	start := now.Add(-24 * time.Hour)
+	items, err := client.FetchNotificationHistory(context.Background(), start, now)
+	if err != nil {
+		t.Fatalf("FetchNotificationHistory: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("items = %v, want 2 entries", items)
+	}
+	if items[0].SignedPayload != "jws-1" || items[1].SignedPayload != "jws-2" {
+		t.Errorf("items = %+v, want [jws-1 jws-2]", items)
+	}
+	if capturedBody.StartDate != start.UnixMilli() {
+		t.Errorf("startDate = %d, want %d", capturedBody.StartDate, start.UnixMilli())
+	}
+	if capturedBody.EndDate != now.UnixMilli() {
+		t.Errorf("endDate = %d, want %d", capturedBody.EndDate, now.UnixMilli())
+	}
+	if capturedBody.PaginationToken != "" {
+		t.Errorf("paginationToken = %q, want empty on first page", capturedBody.PaginationToken)
+	}
+}
+
+// --- multi-page fetch ---
+
+func TestClient_FetchNotificationHistory_MultiPageThreadsToken(t *testing.T) {
+	t.Parallel()
+	pemBytes := newTestKeyPEM(t)
+
+	var capturedTokens []string
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req historyRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		capturedTokens = append(capturedTokens, req.PaginationToken)
+		callCount++
+		switch callCount {
+		case 1:
+			writeHistoryResponse(w, historyResponse{
+				NotificationHistory: []historyResponseItem{{SignedPayload: "page1-a"}},
+				HasMore:             true,
+				PaginationToken:     "token-2",
+			})
+		case 2:
+			writeHistoryResponse(w, historyResponse{
+				NotificationHistory: []historyResponseItem{{SignedPayload: "page2-a"}},
+				HasMore:             true,
+				PaginationToken:     "token-3",
+			})
+		default:
+			writeHistoryResponse(w, historyResponse{
+				NotificationHistory: []historyResponseItem{{SignedPayload: "page3-a"}},
+				HasMore:             false,
+			})
+		}
+	}))
+	defer srv.Close()
+
+	now := time.Unix(1_800_000_000, 0).UTC()
+	client, err := newClientWithBaseURL(newTestOptions(pemBytes, "Production"), srv.URL, srv.Client(), func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("newClientWithBaseURL: %v", err)
+	}
+
+	items, err := client.FetchNotificationHistory(context.Background(), now.Add(-time.Hour), now)
+	if err != nil {
+		t.Fatalf("FetchNotificationHistory: %v", err)
+	}
+	if len(items) != 3 {
+		t.Fatalf("items = %v, want 3 entries across 3 pages", items)
+	}
+	wantTokens := []string{"", "token-2", "token-3"}
+	if len(capturedTokens) != len(wantTokens) {
+		t.Fatalf("capturedTokens = %v, want %v", capturedTokens, wantTokens)
+	}
+	for i, want := range wantTokens {
+		if capturedTokens[i] != want {
+			t.Errorf("capturedTokens[%d] = %q, want %q", i, capturedTokens[i], want)
+		}
+	}
+}
+
+// --- 429 handling ---
+
+func TestClient_FetchNotificationHistory_RetriesOn429WithSecondsRetryAfter(t *testing.T) {
+	t.Parallel()
+	pemBytes := newTestKeyPEM(t)
+
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount == 1 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		writeHistoryResponse(w, historyResponse{})
+	}))
+	defer srv.Close()
+
+	now := time.Unix(1_800_000_000, 0).UTC()
+	client, err := newClientWithBaseURL(newTestOptions(pemBytes, "Production"), srv.URL, srv.Client(), func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("newClientWithBaseURL: %v", err)
+	}
+
+	if _, err := client.FetchNotificationHistory(context.Background(), now.Add(-time.Hour), now); err != nil {
+		t.Fatalf("FetchNotificationHistory: %v", err)
+	}
+	if callCount != 2 {
+		t.Errorf("callCount = %d, want 2 (one 429 then success)", callCount)
+	}
+}
+
+func TestClient_FetchNotificationHistory_RetriesOn429WithHTTPDateRetryAfter(t *testing.T) {
+	t.Parallel()
+	pemBytes := newTestKeyPEM(t)
+
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount == 1 {
+			// An HTTP-date Retry-After effectively "now" so the test does not
+			// actually sleep.
+			w.Header().Set("Retry-After", time.Now().UTC().Format(http.TimeFormat))
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		writeHistoryResponse(w, historyResponse{})
+	}))
+	defer srv.Close()
+
+	now := time.Unix(1_800_000_000, 0).UTC()
+	client, err := newClientWithBaseURL(newTestOptions(pemBytes, "Production"), srv.URL, srv.Client(), func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("newClientWithBaseURL: %v", err)
+	}
+
+	if _, err := client.FetchNotificationHistory(context.Background(), now.Add(-time.Hour), now); err != nil {
+		t.Fatalf("FetchNotificationHistory: %v", err)
+	}
+	if callCount != 2 {
+		t.Errorf("callCount = %d, want 2 (one 429 then success)", callCount)
+	}
+}
+
+func TestClient_FetchNotificationHistory_RetriesExhaustedReturnsError(t *testing.T) {
+	t.Parallel()
+	pemBytes := newTestKeyPEM(t)
+
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Retry-After", "0")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	now := time.Unix(1_800_000_000, 0).UTC()
+	client, err := newClientWithBaseURL(newTestOptions(pemBytes, "Production"), srv.URL, srv.Client(), func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("newClientWithBaseURL: %v", err)
+	}
+
+	_, err = client.FetchNotificationHistory(context.Background(), now.Add(-time.Hour), now)
+	if err == nil {
+		t.Fatal("FetchNotificationHistory: want error after exhausting retries, got nil")
+	}
+	if callCount < 2 {
+		t.Errorf("callCount = %d, want at least 2 attempts before giving up", callCount)
+	}
+	if callCount > maxAttempts {
+		t.Errorf("callCount = %d, want at most maxAttempts=%d", callCount, maxAttempts)
+	}
+}
+
+// --- non-429 error ---
+
+func TestClient_FetchNotificationHistory_NonRetryableStatusFailsImmediately(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		status int
+	}{
+		{"unauthorized", http.StatusUnauthorized},
+		{"internal server error", http.StatusInternalServerError},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			pemBytes := newTestKeyPEM(t)
+
+			callCount := 0
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				callCount++
+				w.WriteHeader(tc.status)
+			}))
+			defer srv.Close()
+
+			now := time.Unix(1_800_000_000, 0).UTC()
+			client, err := newClientWithBaseURL(newTestOptions(pemBytes, "Production"), srv.URL, srv.Client(), func() time.Time { return now })
+			if err != nil {
+				t.Fatalf("newClientWithBaseURL: %v", err)
+			}
+
+			_, err = client.FetchNotificationHistory(context.Background(), now.Add(-time.Hour), now)
+			if err == nil {
+				t.Fatalf("FetchNotificationHistory: want error for status %d, got nil", tc.status)
+			}
+			if callCount != 1 {
+				t.Errorf("callCount = %d, want 1 (no retry on a non-429 error)", callCount)
+			}
+		})
+	}
+}
+
+// --- max-page cap guard ---
+
+func TestClient_FetchNotificationHistory_MaxPageCapGuardsAgainstInfiniteLoop(t *testing.T) {
+	t.Parallel()
+	pemBytes := newTestKeyPEM(t)
+
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		writeHistoryResponse(w, historyResponse{
+			NotificationHistory: []historyResponseItem{{SignedPayload: fmt.Sprintf("jws-%d", callCount)}},
+			HasMore:             true, // never terminates on its own
+			PaginationToken:     strconv.Itoa(callCount),
+		})
+	}))
+	defer srv.Close()
+
+	now := time.Unix(1_800_000_000, 0).UTC()
+	client, err := newClientWithBaseURL(newTestOptions(pemBytes, "Production"), srv.URL, srv.Client(), func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("newClientWithBaseURL: %v", err)
+	}
+
+	_, err = client.FetchNotificationHistory(context.Background(), now.Add(-time.Hour), now)
+	if err == nil {
+		t.Fatal("FetchNotificationHistory: want error when hasMore never terminates, got nil")
+	}
+	if callCount != maxHistoryPages {
+		t.Errorf("callCount = %d, want exactly maxHistoryPages=%d (defensive cap fired)", callCount, maxHistoryPages)
+	}
+}
+
+// --- options validation ---
+
+func TestNewClient_RejectsIncompleteOptions(t *testing.T) {
+	t.Parallel()
+	pemBytes := newTestKeyPEM(t)
+	tests := []struct {
+		name string
+		opts Options
+	}{
+		{"missing key id", Options{SigningKey: string(pemBytes), IssuerID: testIssuerID, BundleID: testBundleID}},
+		{"missing issuer id", Options{SigningKey: string(pemBytes), KeyID: testKeyID, BundleID: testBundleID}},
+		{"missing bundle id", Options{SigningKey: string(pemBytes), KeyID: testKeyID, IssuerID: testIssuerID}},
+		{"missing signing key", Options{KeyID: testKeyID, IssuerID: testIssuerID, BundleID: testBundleID}},
+		{"garbage signing key", Options{SigningKey: "not a pem", KeyID: testKeyID, IssuerID: testIssuerID, BundleID: testBundleID}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := NewClient(tc.opts, time.Now); err == nil {
+				t.Error("NewClient: want error, got nil")
+			}
+		})
+	}
+}

--- a/api-go/internal/appstoreserverapi/errors.go
+++ b/api-go/internal/appstoreserverapi/errors.go
@@ -1,0 +1,24 @@
+package appstoreserverapi
+
+import "errors"
+
+// ErrInvalidSigningKey reports that the configured .p8 signing key is not a
+// valid PKCS8-encoded ECDSA private key.
+var ErrInvalidSigningKey = errors.New("appstoreserverapi: invalid signing key")
+
+// ErrInvalidOptions reports that Options is missing a required field (KeyID,
+// IssuerID, or BundleID).
+var ErrInvalidOptions = errors.New("appstoreserverapi: invalid options")
+
+// ErrRateLimited reports that FetchNotificationHistory exhausted its bounded
+// retry budget against repeated 429 responses.
+var ErrRateLimited = errors.New("appstoreserverapi: rate limited")
+
+// ErrUnexpectedStatus reports a non-2xx, non-429 response from the App Store
+// Server API.
+var ErrUnexpectedStatus = errors.New("appstoreserverapi: unexpected status")
+
+// ErrTooManyPages reports that pagination exceeded the defensive max-page
+// cap without hasMore ever reporting false — a malformed or adversarial
+// response looping forever.
+var ErrTooManyPages = errors.New("appstoreserverapi: too many pages")

--- a/api-go/internal/appstoreserverapi/jwt.go
+++ b/api-go/internal/appstoreserverapi/jwt.go
@@ -1,0 +1,100 @@
+package appstoreserverapi
+
+import (
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"time"
+)
+
+// jwtValidity is how long a minted JWT is valid for, measured from iat. Apple
+// requires exp <= iat+3600 (60 minutes); this reconciliation job mints exactly
+// one token per short-lived job execution (no caching/refresh, unlike the
+// long-lived APNs client), so a comfortable margin under Apple's ceiling is
+// used rather than the full hour.
+const jwtValidity = 55 * time.Minute
+
+// jwtHeader is the JWS header the App Store Server API expects: ES256 with
+// the 10-character key id and an explicit typ.
+type jwtHeader struct {
+	Alg string `json:"alg"`
+	Kid string `json:"kid"`
+	Typ string `json:"typ"`
+}
+
+// jwtClaims is the JWS payload App Store Connect API auth requires: issuer,
+// issued-at, expiry, audience, and the bundle id.
+type jwtClaims struct {
+	Iss string `json:"iss"`
+	Iat int64  `json:"iat"`
+	Exp int64  `json:"exp"`
+	Aud string `json:"aud"`
+	Bid string `json:"bid"`
+}
+
+// parseP8Key decodes a PEM block and parses the PKCS8-encoded EC private key
+// Apple ships as a .p8 file — the same shape internal/apns/jwt.go parses.
+func parseP8Key(pemBytes []byte) (*ecdsa.PrivateKey, error) {
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil, fmt.Errorf("%w", ErrInvalidSigningKey)
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse pkcs8 signing key: %w", err)
+	}
+	key, ok := parsed.(*ecdsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("%w: signing key is not an ECDSA key", ErrInvalidSigningKey)
+	}
+	return key, nil
+}
+
+// mintJWT signs a fresh ES256 JWT for one App Store Server API call. Minted
+// once per job execution — see jwtValidity — never cached or refreshed.
+func mintJWT(key *ecdsa.PrivateKey, keyID, issuerID, bundleID string, now time.Time) (string, error) {
+	headerJSON, err := json.Marshal(jwtHeader{Alg: "ES256", Kid: keyID, Typ: "JWT"})
+	if err != nil {
+		return "", fmt.Errorf("marshal jwt header: %w", err)
+	}
+
+	iat := now.Unix()
+	claimsJSON, err := json.Marshal(jwtClaims{
+		Iss: issuerID,
+		Iat: iat,
+		Exp: iat + int64(jwtValidity.Seconds()),
+		Aud: "appstoreconnect-v1",
+		Bid: bundleID,
+	})
+	if err != nil {
+		return "", fmt.Errorf("marshal jwt claims: %w", err)
+	}
+
+	signingInput := base64.RawURLEncoding.EncodeToString(headerJSON) + "." +
+		base64.RawURLEncoding.EncodeToString(claimsJSON)
+
+	digest := sha256.Sum256([]byte(signingInput))
+	r, s, err := ecdsa.Sign(rand.Reader, key, digest[:])
+	if err != nil {
+		return "", fmt.Errorf("sign jwt: %w", err)
+	}
+
+	sig := jwsSignature(r, s)
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(sig), nil
+}
+
+// jwsSignature encodes an ECDSA (r, s) pair as the 64-byte r||s form ES256
+// requires, left-padding each integer to 32 bytes.
+func jwsSignature(r, s *big.Int) []byte {
+	const size = 32
+	sig := make([]byte, 2*size)
+	r.FillBytes(sig[:size])
+	s.FillBytes(sig[size:])
+	return sig
+}

--- a/api-go/internal/appstoreserverapi/retryafter.go
+++ b/api-go/internal/appstoreserverapi/retryafter.go
@@ -1,0 +1,38 @@
+package appstoreserverapi
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// parseRetryAfter parses an HTTP Retry-After header value, supporting both the
+// delta-seconds form ("120") and the HTTP-date form
+// ("Wed, 21 Oct 2015 07:28:00 GMT", parsed via the stdlib http.ParseTime).
+// Malformed, negative, or absent values report ok=false so the caller falls
+// back to a default wait; a past HTTP-date clamps to zero. now anchors the
+// HTTP-date delta computation.
+func parseRetryAfter(header string, now time.Time) (time.Duration, bool) {
+	header = strings.TrimSpace(header)
+	if header == "" {
+		return 0, false
+	}
+
+	if seconds, err := strconv.Atoi(header); err == nil {
+		if seconds < 0 {
+			return 0, false
+		}
+		return time.Duration(seconds) * time.Second, true
+	}
+
+	if target, err := http.ParseTime(header); err == nil {
+		delta := target.Sub(now)
+		if delta < 0 {
+			delta = 0
+		}
+		return delta, true
+	}
+
+	return 0, false
+}

--- a/api-go/internal/platform/config.go
+++ b/api-go/internal/platform/config.go
@@ -118,6 +118,34 @@ type Config struct {
 	// testing phase. Matching is case-insensitive at use-time.
 	AppleEnvironments []string
 
+	// AppStoreReconcile* configure the WORKER_MODE=appstore-reconcile job (GH
+	// #1011, tc-97k35.6): a periodic poll of Apple's Get Notification History
+	// API that detects (and, once soaked, recovers) a missed ASSN webhook
+	// delivery. AppStoreReconcileEnabled gates whether the job's App Store
+	// Server API client is constructed at all; when false (or when the key
+	// material is missing/malformed) cmd/worker's builder returns nil and the
+	// mode logs and exits 0 rather than crash-looping an optional,
+	// still-rolling-out feature. AppStoreServerAPIKey is the PEM contents of
+	// the .p8 signing key (the appstore-server-api-key secret);
+	// AppStoreServerAPIKeyID and AppStoreServerAPIIssuerID are the matching
+	// Apple-issued identifiers. AppStoreServerAPIEnvironment selects
+	// "Sandbox" or "Production" — dev talks to Sandbox, prod talks to
+	// Production, driven by config, not hardcoded. There is no separate
+	// bundle-id config: the client reuses AppleBundleID above.
+	// AppStoreReconcileApplyEnabled gates whether a detected gap is actually
+	// replayed through the NotificationProcessor; it defaults to false
+	// (observe-only) and this bead never flips it — a later, separate
+	// decision does. AppStoreReconcileLookbackHours sizes the
+	// [now-lookback, now) scan window each cycle (default 30, a few hours of
+	// slack over a daily cadence).
+	AppStoreReconcileEnabled       bool
+	AppStoreServerAPIKey           SecretString
+	AppStoreServerAPIKeyID         string
+	AppStoreServerAPIIssuerID      string
+	AppStoreServerAPIEnvironment   string
+	AppStoreReconcileApplyEnabled  bool
+	AppStoreReconcileLookbackHours int
+
 	// APNs* configure the direct APNs HTTP/2 push client the digest worker modes
 	// use to deliver instant and digest alerts (epic tc-wad3, enabler tc-qlqn).
 	// APNsEnabled gates whether the real sender is constructed; when false the
@@ -341,6 +369,14 @@ func LoadConfig() (Config, error) {
 
 		AppleBundleID:     getenv("APPLE_BUNDLE_ID", defaultAppleBundleID),
 		AppleEnvironments: parseAppleEnvironments(os.Getenv("APPLE_ENVIRONMENT")),
+
+		AppStoreReconcileEnabled:       getenvBool("APPSTORE_RECONCILE_ENABLED"),
+		AppStoreServerAPIKey:           NewSecret(os.Getenv("APPSTORE_SERVER_API_KEY")),
+		AppStoreServerAPIKeyID:         os.Getenv("APPSTORE_SERVER_API_KEY_ID"),
+		AppStoreServerAPIIssuerID:      os.Getenv("APPSTORE_SERVER_API_ISSUER_ID"),
+		AppStoreServerAPIEnvironment:   getenv("APPSTORE_SERVER_API_ENVIRONMENT", defaultAppleEnvironment),
+		AppStoreReconcileApplyEnabled:  getenvBool("APPSTORE_RECONCILE_APPLY_ENABLED"),
+		AppStoreReconcileLookbackHours: getenvInt("APPSTORE_RECONCILE_LOOKBACK_HOURS", 30),
 
 		APNsEnabled:    getenvBool("APNS_ENABLED"),
 		APNsAuthKey:    NewSecret(os.Getenv("APNS_AUTH_KEY")),

--- a/api-go/internal/platform/config_test.go
+++ b/api-go/internal/platform/config_test.go
@@ -574,6 +574,71 @@ func TestLoadConfig_AppleEnvironments(t *testing.T) {
 	}
 }
 
+func TestLoadConfig_AppStoreReconcile(t *testing.T) {
+	t.Run("set", func(t *testing.T) {
+		t.Setenv("APPSTORE_RECONCILE_ENABLED", "true")
+		t.Setenv("APPSTORE_SERVER_API_KEY", "-----BEGIN PRIVATE KEY-----\nMIG...\n-----END PRIVATE KEY-----")
+		t.Setenv("APPSTORE_SERVER_API_KEY_ID", "ABCDE12345")
+		t.Setenv("APPSTORE_SERVER_API_ISSUER_ID", "57246542-96fe-1a63-e053-0824d011072a")
+		t.Setenv("APPSTORE_SERVER_API_ENVIRONMENT", "Sandbox")
+		t.Setenv("APPSTORE_RECONCILE_APPLY_ENABLED", "true")
+		t.Setenv("APPSTORE_RECONCILE_LOOKBACK_HOURS", "48")
+
+		cfg, err := LoadConfig()
+		if err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+		if !cfg.AppStoreReconcileEnabled {
+			t.Error("AppStoreReconcileEnabled: got false, want true")
+		}
+		if cfg.AppStoreServerAPIKey.Expose() == "" {
+			t.Error("AppStoreServerAPIKey: got empty")
+		}
+		if cfg.AppStoreServerAPIKeyID != "ABCDE12345" {
+			t.Errorf("AppStoreServerAPIKeyID: got %q", cfg.AppStoreServerAPIKeyID)
+		}
+		if cfg.AppStoreServerAPIIssuerID != "57246542-96fe-1a63-e053-0824d011072a" {
+			t.Errorf("AppStoreServerAPIIssuerID: got %q", cfg.AppStoreServerAPIIssuerID)
+		}
+		if cfg.AppStoreServerAPIEnvironment != "Sandbox" {
+			t.Errorf("AppStoreServerAPIEnvironment: got %q", cfg.AppStoreServerAPIEnvironment)
+		}
+		if !cfg.AppStoreReconcileApplyEnabled {
+			t.Error("AppStoreReconcileApplyEnabled: got false, want true")
+		}
+		if cfg.AppStoreReconcileLookbackHours != 48 {
+			t.Errorf("AppStoreReconcileLookbackHours: got %d, want 48", cfg.AppStoreReconcileLookbackHours)
+		}
+	})
+
+	t.Run("absent defaults to observe-only and unconfigured", func(t *testing.T) {
+		t.Setenv("APPSTORE_RECONCILE_ENABLED", "")
+		t.Setenv("APPSTORE_SERVER_API_KEY", "")
+		t.Setenv("APPSTORE_SERVER_API_KEY_ID", "")
+		t.Setenv("APPSTORE_SERVER_API_ISSUER_ID", "")
+		t.Setenv("APPSTORE_SERVER_API_ENVIRONMENT", "")
+		t.Setenv("APPSTORE_RECONCILE_APPLY_ENABLED", "")
+		t.Setenv("APPSTORE_RECONCILE_LOOKBACK_HOURS", "")
+
+		cfg, err := LoadConfig()
+		if err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+		if cfg.AppStoreReconcileEnabled {
+			t.Error("AppStoreReconcileEnabled: got true, want false by default")
+		}
+		if cfg.AppStoreServerAPIEnvironment != "Production" {
+			t.Errorf("AppStoreServerAPIEnvironment default: got %q, want Production", cfg.AppStoreServerAPIEnvironment)
+		}
+		if cfg.AppStoreReconcileApplyEnabled {
+			t.Error("AppStoreReconcileApplyEnabled: got true, want false by default (observe-only)")
+		}
+		if cfg.AppStoreReconcileLookbackHours != 30 {
+			t.Errorf("AppStoreReconcileLookbackHours default: got %d, want 30", cfg.AppStoreReconcileLookbackHours)
+		}
+	})
+}
+
 func TestLoadConfig_DevSeed(t *testing.T) {
 	t.Run("set", func(t *testing.T) {
 		t.Setenv("DEV_SEED_LIMIT", "10")

--- a/api-go/internal/subscriptions/handler.go
+++ b/api-go/internal/subscriptions/handler.go
@@ -10,9 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
-
 	"github.com/AmyDe/town-crier/api-go/internal/auth"
 	"github.com/AmyDe/town-crier/api-go/internal/httputil"
 	"github.com/AmyDe/town-crier/api-go/internal/platform"
@@ -65,15 +62,17 @@ type idempotencyStore interface {
 }
 
 type handler struct {
-	verifier            jwsVerifier
-	profilesByUser      profileByUser
+	verifier       jwsVerifier
+	profilesByUser profileByUser
+	// profilesByTxn is used directly by the verify path's F2 ownership check
+	// (runVerify); the webhook path reaches the same store through processor.
 	profilesByTxn       profileByTxn
 	auth0               tierSync
-	idempotency         idempotencyStore
 	bundleID            string
 	allowedEnvironments []string
 	now                 func() time.Time
 	logger              *slog.Logger
+	processor           *NotificationProcessor
 }
 
 // conflictError signals that the transaction's originalTransactionId is already
@@ -128,11 +127,11 @@ func Routes(mux *http.ServeMux, verifier jwsVerifier, profilesByUser profileByUs
 		profilesByUser:      profilesByUser,
 		profilesByTxn:       profilesByTxn,
 		auth0:               auth0,
-		idempotency:         idempotency,
 		bundleID:            bundleID,
 		allowedEnvironments: allowedEnvironments,
 		now:                 now,
 		logger:              logger,
+		processor:           NewNotificationProcessor(verifier, profilesByTxn, auth0, idempotency, allowedEnvironments, logger),
 	}
 	mux.HandleFunc("POST /v1/subscriptions/verify", h.verify)
 	mux.HandleFunc("POST /v1/webhooks/appstore", h.webhook)
@@ -339,136 +338,11 @@ func (h *handler) webhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.runWebhook(r.Context(), req.SignedPayload); err != nil {
+	if _, err := h.processor.Process(r.Context(), req.SignedPayload); err != nil {
 		h.writeWebhookError(r, w, err)
 		return
 	}
 	w.WriteHeader(http.StatusOK)
-}
-
-// runWebhook verifies the outer notification JWS, dedupes it, verifies the inner
-// transaction JWS, locates the subscriber cross-partition, applies the lifecycle
-// event, and records the notification as processed — the
-// HandleAppStoreNotificationCommandHandler logic.
-func (h *handler) runWebhook(ctx context.Context, signedPayload string) error {
-	outerJSON, err := h.verifier.VerifyAndDecode(signedPayload)
-	if err != nil {
-		return err
-	}
-	notification, err := DecodeNotification(outerJSON)
-	if err != nil {
-		return err
-	}
-
-	// Stamp the notification type on the live request span as soon as it's
-	// decoded, before any idempotency/ignore logic runs — visibility into what
-	// Apple actually sent is the point, including for notifications this
-	// handler goes on to ignore (unknown subscriber, environment mismatch).
-	// These are enum strings, no PII.
-	span := trace.SpanFromContext(ctx)
-	span.SetAttributes(attribute.String("assn.notification_type", notification.NotificationType))
-	if notification.Subtype != "" {
-		span.SetAttributes(attribute.String("assn.subtype", notification.Subtype))
-	}
-
-	processed, err := h.idempotency.IsProcessed(ctx, notification.NotificationUUID)
-	if err != nil {
-		return fmt.Errorf("check notification idempotency: %w", err)
-	}
-	if processed {
-		return nil
-	}
-
-	txnJSON, err := h.verifier.VerifyAndDecode(notification.SignedTransactionInfo)
-	if err != nil {
-		return err
-	}
-	txn, err := DecodeTransaction(txnJSON)
-	if err != nil {
-		return err
-	}
-
-	profile, err := h.profilesByTxn.GetByOriginalTransactionID(ctx, txn.OriginalTransactionID)
-	switch {
-	case errors.Is(err, profiles.ErrNotFound):
-		profile = nil
-	case err != nil:
-		return fmt.Errorf("locate subscriber: %w", err)
-	}
-
-	// F1: on the webhook, an environment mismatch is swallowed — the notification
-	// is still marked processed so Apple does not retry, but the profile is not
-	// mutated. This mirrors the "mark processed, no state change" contract of
-	// unknown-subscriber and no-change events already in this path.
-	if profile != nil && envAllowed(txn.Environment, h.allowedEnvironments) {
-		changed, err := applyNotification(profile, notification, txn)
-		if err != nil {
-			return err
-		}
-		if changed {
-			if err := h.profilesByTxn.Save(ctx, profile); err != nil {
-				return fmt.Errorf("save profile %q: %w", profile.UserID, err)
-			}
-			if err := h.auth0.UpdateSubscriptionTier(ctx, profile.UserID, profile.Tier.String()); err != nil {
-				return fmt.Errorf("sync auth0 tier %q: %w", profile.UserID, err)
-			}
-		}
-	}
-
-	if err := h.idempotency.MarkProcessed(ctx, notification.NotificationUUID); err != nil {
-		return fmt.Errorf("mark notification processed: %w", err)
-	}
-	return nil
-}
-
-// applyNotification mutates the profile per the App Store notification type and
-// reports whether any state changed (a no-change event needs no save/sync).
-func applyNotification(profile *profiles.UserProfile, notification DecodedNotification, txn DecodedTransaction) (bool, error) {
-	switch notification.NotificationType {
-	case "SUBSCRIBED", "OFFER_REDEEMED":
-		tier, err := TierForProduct(txn.ProductID)
-		if err != nil {
-			return false, err
-		}
-		profile.ActivateSubscription(tier, txn.ExpiresDate)
-		return true, nil
-
-	case "DID_RENEW":
-		tier, err := TierForProduct(txn.ProductID)
-		if err != nil {
-			return false, err
-		}
-		profile.ActivateSubscription(tier, txn.ExpiresDate)
-		return true, nil
-
-	case "DID_CHANGE_RENEWAL_PREF":
-		if notification.Subtype == "UPGRADE" {
-			tier, err := TierForProduct(txn.ProductID)
-			if err != nil {
-				return false, err
-			}
-			profile.ActivateSubscription(tier, txn.ExpiresDate)
-			return true, nil
-		}
-		// DOWNGRADE: no state change — it takes effect at the next renewal.
-		return false, nil
-
-	case "DID_FAIL_TO_RENEW":
-		if notification.Subtype == "GRACE_PERIOD" {
-			profile.EnterGracePeriod(txn.ExpiresDate)
-			return true, nil
-		}
-		profile.ExpireSubscription()
-		return true, nil
-
-	case "EXPIRED", "GRACE_PERIOD_EXPIRED", "REFUND", "REVOKE":
-		profile.ExpireSubscription()
-		return true, nil
-
-	default:
-		// TEST, PRICE_INCREASE, REFUND_DECLINED, etc. — ignore.
-		return false, nil
-	}
 }
 
 func (h *handler) writeVerifyError(r *http.Request, w http.ResponseWriter, err error) {

--- a/api-go/internal/subscriptions/processor.go
+++ b/api-go/internal/subscriptions/processor.go
@@ -1,0 +1,172 @@
+package subscriptions
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+)
+
+// NotificationProcessor applies one already-fetched, not-yet-verified App
+// Store Server Notification JWS: verify (outer + inner), dedupe, apply the
+// lifecycle event, save, sync Auth0, and mark processed. Both the live
+// POST /v1/webhooks/appstore handler and the appstorereconcile worker call
+// this — the single choke point where idempotency is enforced, so recovering
+// a missed notification through reconciliation can never double-apply it
+// against a concurrent live delivery.
+type NotificationProcessor struct {
+	verifier            jwsVerifier
+	profilesByTxn       profileByTxn
+	auth0               tierSync
+	idempotency         idempotencyStore
+	allowedEnvironments []string
+	logger              *slog.Logger
+}
+
+// NewNotificationProcessor builds a processor over the given collaborators.
+func NewNotificationProcessor(verifier jwsVerifier, profilesByTxn profileByTxn, auth0 tierSync, idempotency idempotencyStore, allowedEnvironments []string, logger *slog.Logger) *NotificationProcessor {
+	return &NotificationProcessor{
+		verifier:            verifier,
+		profilesByTxn:       profilesByTxn,
+		auth0:               auth0,
+		idempotency:         idempotency,
+		allowedEnvironments: allowedEnvironments,
+		logger:              logger,
+	}
+}
+
+// Process verifies the outer notification JWS, dedupes it, verifies the inner
+// transaction JWS, locates the subscriber cross-partition, applies the
+// lifecycle event, and records the notification as processed — the
+// HandleAppStoreNotificationCommandHandler logic (formerly handler.runWebhook).
+// wasNew reports whether this call actually mutated the profile — false for an
+// already-processed duplicate, an unknown subscriber, an environment mismatch,
+// or a no-change event (e.g. a downgrade DID_CHANGE_RENEWAL_PREF). It is
+// informational only; callers must not use it to decide whether to retry.
+func (p *NotificationProcessor) Process(ctx context.Context, signedPayload string) (bool, error) {
+	outerJSON, err := p.verifier.VerifyAndDecode(signedPayload)
+	if err != nil {
+		return false, err
+	}
+	notification, err := DecodeNotification(outerJSON)
+	if err != nil {
+		return false, err
+	}
+
+	// Stamp the notification type on the live request span as soon as it's
+	// decoded, before any idempotency/ignore logic runs — visibility into what
+	// Apple actually sent is the point, including for notifications this
+	// processor goes on to ignore (unknown subscriber, environment mismatch).
+	// These are enum strings, no PII.
+	span := trace.SpanFromContext(ctx)
+	span.SetAttributes(attribute.String("assn.notification_type", notification.NotificationType))
+	if notification.Subtype != "" {
+		span.SetAttributes(attribute.String("assn.subtype", notification.Subtype))
+	}
+
+	processed, err := p.idempotency.IsProcessed(ctx, notification.NotificationUUID)
+	if err != nil {
+		return false, fmt.Errorf("check notification idempotency: %w", err)
+	}
+	if processed {
+		return false, nil
+	}
+
+	txnJSON, err := p.verifier.VerifyAndDecode(notification.SignedTransactionInfo)
+	if err != nil {
+		return false, err
+	}
+	txn, err := DecodeTransaction(txnJSON)
+	if err != nil {
+		return false, err
+	}
+
+	profile, err := p.profilesByTxn.GetByOriginalTransactionID(ctx, txn.OriginalTransactionID)
+	switch {
+	case errors.Is(err, profiles.ErrNotFound):
+		profile = nil
+	case err != nil:
+		return false, fmt.Errorf("locate subscriber: %w", err)
+	}
+
+	// F1: on the webhook, an environment mismatch is swallowed — the notification
+	// is still marked processed so Apple does not retry, but the profile is not
+	// mutated. This mirrors the "mark processed, no state change" contract of
+	// unknown-subscriber and no-change events already in this path.
+	wasNew := false
+	if profile != nil && envAllowed(txn.Environment, p.allowedEnvironments) {
+		changed, err := applyNotification(profile, notification, txn)
+		if err != nil {
+			return false, err
+		}
+		if changed {
+			if err := p.profilesByTxn.Save(ctx, profile); err != nil {
+				return false, fmt.Errorf("save profile %q: %w", profile.UserID, err)
+			}
+			if err := p.auth0.UpdateSubscriptionTier(ctx, profile.UserID, profile.Tier.String()); err != nil {
+				return false, fmt.Errorf("sync auth0 tier %q: %w", profile.UserID, err)
+			}
+			wasNew = true
+		}
+	}
+
+	if err := p.idempotency.MarkProcessed(ctx, notification.NotificationUUID); err != nil {
+		return false, fmt.Errorf("mark notification processed: %w", err)
+	}
+	return wasNew, nil
+}
+
+// applyNotification mutates the profile per the App Store notification type and
+// reports whether any state changed (a no-change event needs no save/sync).
+func applyNotification(profile *profiles.UserProfile, notification DecodedNotification, txn DecodedTransaction) (bool, error) {
+	switch notification.NotificationType {
+	case "SUBSCRIBED", "OFFER_REDEEMED":
+		tier, err := TierForProduct(txn.ProductID)
+		if err != nil {
+			return false, err
+		}
+		profile.ActivateSubscription(tier, txn.ExpiresDate)
+		return true, nil
+
+	case "DID_RENEW":
+		tier, err := TierForProduct(txn.ProductID)
+		if err != nil {
+			return false, err
+		}
+		profile.ActivateSubscription(tier, txn.ExpiresDate)
+		return true, nil
+
+	case "DID_CHANGE_RENEWAL_PREF":
+		if notification.Subtype == "UPGRADE" {
+			tier, err := TierForProduct(txn.ProductID)
+			if err != nil {
+				return false, err
+			}
+			profile.ActivateSubscription(tier, txn.ExpiresDate)
+			return true, nil
+		}
+		// DOWNGRADE: no state change — it takes effect at the next renewal.
+		return false, nil
+
+	case "DID_FAIL_TO_RENEW":
+		if notification.Subtype == "GRACE_PERIOD" {
+			profile.EnterGracePeriod(txn.ExpiresDate)
+			return true, nil
+		}
+		profile.ExpireSubscription()
+		return true, nil
+
+	case "EXPIRED", "GRACE_PERIOD_EXPIRED", "REFUND", "REVOKE":
+		profile.ExpireSubscription()
+		return true, nil
+
+	default:
+		// TEST, PRICE_INCREASE, REFUND_DECLINED, etc. — ignore.
+		return false, nil
+	}
+}

--- a/api-go/internal/subscriptions/processor_test.go
+++ b/api-go/internal/subscriptions/processor_test.go
@@ -1,0 +1,220 @@
+package subscriptions
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+)
+
+// newTestProcessor builds a NotificationProcessor over freshly minted fakes for
+// direct (non-HTTP) Process calls, mirroring newTestDepsWithEnvsAndLogger's
+// wiring so the two test surfaces (HTTP handler_test.go, direct
+// processor_test.go) exercise identical collaborator behaviour.
+type processorTestDeps struct {
+	verifier    *fakeVerifier
+	byTxn       *fakeProfileByTxn
+	auth0       *fakeAuth0
+	idempotency *fakeIdempotency
+	processor   *NotificationProcessor
+}
+
+func newTestProcessor(allowedEnvs []string) *processorTestDeps {
+	d := &processorTestDeps{
+		verifier:    &fakeVerifier{results: map[string]string{}, errs: map[string]error{}},
+		byTxn:       &fakeProfileByTxn{},
+		auth0:       &fakeAuth0{},
+		idempotency: newFakeIdempotency(),
+	}
+	d.processor = NewNotificationProcessor(d.verifier, d.byTxn, d.auth0, d.idempotency, allowedEnvs, slog.New(slog.DiscardHandler))
+	return d
+}
+
+// TestNotificationProcessor_Process_SubscribedActivatesProfile pins wasNew=true
+// for a SUBSCRIBED notification against a known subscriber — the byte-identical
+// behaviour of the former runWebhook, extended with the new return value.
+func TestNotificationProcessor_Process_SubscribedActivatesProfile(t *testing.T) {
+	t.Parallel()
+	d := newTestProcessor(testAllowedEnvs)
+	d.byTxn.profile = freshProfile(t)
+	d.verifier.results["hdr.OUTER.sig"] = notificationJSON("SUBSCRIBED", "uuid-1", "INNER")
+	d.verifier.results["INNER"] = txnJSON(ProductProMonthly, testBundleID, "orig-1", futureExpiryMs())
+
+	wasNew, err := d.processor.Process(context.Background(), "hdr.OUTER.sig")
+
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	if !wasNew {
+		t.Error("wasNew = false, want true (profile activated)")
+	}
+	if d.byTxn.saved == nil || d.byTxn.saved.Tier != profiles.TierPro {
+		t.Error("profile not activated to Pro")
+	}
+	if len(d.auth0.tiers) != 1 || d.auth0.tiers[0] != "Pro" {
+		t.Errorf("auth0 sync = %v, want [Pro]", d.auth0.tiers)
+	}
+	if len(d.idempotency.marked) != 1 || d.idempotency.marked[0] != "uuid-1" {
+		t.Errorf("marked = %v, want [uuid-1]", d.idempotency.marked)
+	}
+}
+
+// TestNotificationProcessor_Process_DidRenewIsWasNewTrue pins wasNew=true for a
+// DID_RENEW event against a known subscriber.
+func TestNotificationProcessor_Process_DidRenewIsWasNewTrue(t *testing.T) {
+	t.Parallel()
+	d := newTestProcessor(testAllowedEnvs)
+	d.byTxn.profile = freshProfile(t)
+	d.verifier.results["hdr.OUTER.sig"] = notificationJSON("DID_RENEW", "uuid-renew", "INNER")
+	d.verifier.results["INNER"] = txnJSON(ProductProMonthly, testBundleID, "orig-1", futureExpiryMs())
+
+	wasNew, err := d.processor.Process(context.Background(), "hdr.OUTER.sig")
+
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	if !wasNew {
+		t.Error("wasNew = false, want true (renewal applied)")
+	}
+}
+
+// TestNotificationProcessor_Process_UpgradeIsWasNewTrue pins wasNew=true for a
+// DID_CHANGE_RENEWAL_PREF/UPGRADE event.
+func TestNotificationProcessor_Process_UpgradeIsWasNewTrue(t *testing.T) {
+	t.Parallel()
+	d := newTestProcessor(testAllowedEnvs)
+	d.byTxn.profile = freshProfile(t)
+	d.verifier.results["hdr.OUTER.sig"] = notificationJSONWithSubtype("DID_CHANGE_RENEWAL_PREF", "UPGRADE", "uuid-up", "INNER")
+	d.verifier.results["INNER"] = txnJSON(ProductProMonthly, testBundleID, "orig-1", futureExpiryMs())
+
+	wasNew, err := d.processor.Process(context.Background(), "hdr.OUTER.sig")
+
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	if !wasNew {
+		t.Error("wasNew = false, want true (upgrade applied)")
+	}
+}
+
+// TestNotificationProcessor_Process_DowngradeIsWasNewFalse pins wasNew=false for
+// a DID_CHANGE_RENEWAL_PREF/DOWNGRADE event — a no-op that takes effect at the
+// next renewal, so no state actually changed.
+func TestNotificationProcessor_Process_DowngradeIsWasNewFalse(t *testing.T) {
+	t.Parallel()
+	d := newTestProcessor(testAllowedEnvs)
+	d.byTxn.profile = freshProfile(t)
+	d.verifier.results["hdr.OUTER.sig"] = notificationJSONWithSubtype("DID_CHANGE_RENEWAL_PREF", "DOWNGRADE", "uuid-down", "INNER")
+	d.verifier.results["INNER"] = txnJSON(ProductProMonthly, testBundleID, "orig-1", futureExpiryMs())
+
+	wasNew, err := d.processor.Process(context.Background(), "hdr.OUTER.sig")
+
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	if wasNew {
+		t.Error("wasNew = true, want false (downgrade is a no-op until next renewal)")
+	}
+	if d.byTxn.saved != nil {
+		t.Error("downgrade must not save the profile")
+	}
+	// A no-change event is still marked processed so Apple does not retry.
+	if len(d.idempotency.marked) != 1 {
+		t.Errorf("marked = %v, want exactly one entry", d.idempotency.marked)
+	}
+}
+
+// TestNotificationProcessor_Process_DuplicateIsWasNewFalse pins wasNew=false
+// for an already-processed notification (dedup).
+func TestNotificationProcessor_Process_DuplicateIsWasNewFalse(t *testing.T) {
+	t.Parallel()
+	d := newTestProcessor(testAllowedEnvs)
+	d.byTxn.profile = freshProfile(t)
+	d.idempotency.processed["uuid-dup"] = true
+	d.verifier.results["hdr.OUTER.sig"] = notificationJSON("SUBSCRIBED", "uuid-dup", "INNER")
+	d.verifier.results["INNER"] = txnJSON(ProductProMonthly, testBundleID, "orig-1", futureExpiryMs())
+
+	wasNew, err := d.processor.Process(context.Background(), "hdr.OUTER.sig")
+
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	if wasNew {
+		t.Error("wasNew = true, want false (duplicate)")
+	}
+	if d.byTxn.saved != nil {
+		t.Error("duplicate should not save the profile")
+	}
+	if len(d.idempotency.marked) != 0 {
+		t.Errorf("duplicate should not re-mark, got %v", d.idempotency.marked)
+	}
+}
+
+// TestNotificationProcessor_Process_UnknownSubscriberIsWasNewFalse pins
+// wasNew=false when no profile owns the transaction's original transaction id.
+func TestNotificationProcessor_Process_UnknownSubscriberIsWasNewFalse(t *testing.T) {
+	t.Parallel()
+	d := newTestProcessor(testAllowedEnvs)
+	d.byTxn.profile = nil // no matching subscriber
+	d.verifier.results["hdr.OUTER.sig"] = notificationJSON("DID_RENEW", "uuid-unknown", "INNER")
+	d.verifier.results["INNER"] = txnJSON(ProductProMonthly, testBundleID, "orig-x", futureExpiryMs())
+
+	wasNew, err := d.processor.Process(context.Background(), "hdr.OUTER.sig")
+
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	if wasNew {
+		t.Error("wasNew = true, want false (unknown subscriber)")
+	}
+	if len(d.idempotency.marked) != 1 {
+		t.Errorf("should still mark processed, got %v", d.idempotency.marked)
+	}
+}
+
+// TestNotificationProcessor_Process_EnvironmentMismatchIsWasNewFalse pins
+// wasNew=false when the inner transaction's environment is outside the
+// allowlist.
+func TestNotificationProcessor_Process_EnvironmentMismatchIsWasNewFalse(t *testing.T) {
+	t.Parallel()
+	d := newTestProcessor(testAllowedEnvs) // allowedEnvs = ["Production"]
+	d.byTxn.profile = freshProfile(t)
+	d.verifier.results["hdr.OUTER.sig"] = notificationJSON("SUBSCRIBED", "uuid-env", "INNER_SBX")
+	d.verifier.results["INNER_SBX"] = txnJSONEnv(ProductProMonthly, testBundleID, "orig-1", futureExpiryMs(), "Sandbox")
+
+	wasNew, err := d.processor.Process(context.Background(), "hdr.OUTER.sig")
+
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	if wasNew {
+		t.Error("wasNew = true, want false (environment mismatch)")
+	}
+	if d.byTxn.saved != nil {
+		t.Error("profile must not be mutated on environment mismatch")
+	}
+	if len(d.auth0.tiers) != 0 {
+		t.Error("auth0 must not be synced on environment mismatch")
+	}
+	if len(d.idempotency.marked) != 1 || d.idempotency.marked[0] != "uuid-env" {
+		t.Errorf("should still mark processed, got %v", d.idempotency.marked)
+	}
+}
+
+// TestNotificationProcessor_Process_VerifierErrorPropagates asserts a JWS
+// verification failure surfaces as an error with wasNew=false.
+func TestNotificationProcessor_Process_VerifierErrorPropagates(t *testing.T) {
+	t.Parallel()
+	d := newTestProcessor(testAllowedEnvs)
+	d.verifier.errs["hdr.BAD.sig"] = &JWSVerificationError{Message: "bad chain"}
+
+	wasNew, err := d.processor.Process(context.Background(), "hdr.BAD.sig")
+
+	if err == nil {
+		t.Fatal("Process: want error, got nil")
+	}
+	if wasNew {
+		t.Error("wasNew = true, want false on error")
+	}
+}

--- a/api-go/internal/worker/dispatch.go
+++ b/api-go/internal/worker/dispatch.go
@@ -54,6 +54,13 @@ const purgeBudget = 10 * time.Minute
 // process exits cleanly and flushes telemetry.
 const devSeedBudget = 5 * time.Minute
 
+// reconcileBudget is the soft self-cancel for a single appstore-reconcile run.
+// The cycle is one paginated App Store Server API call plus, in apply mode, a
+// handful of NotificationProcessor.Process calls for the (small) gap set; 10
+// minutes is generous while still bounded well under the Container Apps
+// replicaTimeout so the process exits cleanly and flushes telemetry.
+const reconcileBudget = 10 * time.Minute
+
 // DigestRunner is the consumer-side slice of the digest handler the dispatcher
 // invokes. *digest.Handler satisfies it; the worker depends only on these two
 // methods so it need not know the handler's internals. It is exported so main()
@@ -142,24 +149,42 @@ type DevSeedRunner interface {
 	Run(ctx context.Context) (int, error)
 }
 
+// AppStoreReconcileRunner is the consumer-side slice of the appstore-reconcile
+// handler the dispatcher invokes. *appstorereconcile.Handler satisfies it;
+// Run returns the scanned/gap/applied counts so the dispatcher can record
+// them as telemetry tags. It is exported so main() can hold a genuinely nil
+// interface value when the job is missing its App Store Server API key
+// material — passing a typed-nil *appstorereconcile.Handler would defeat the
+// nil guard below. Unlike SweepRunner/DormantRunner (nil = fatal), a nil
+// AppStoreReconcileRunner is a deliberate, non-fatal no-op: this feature is
+// genuinely optional during rollout, and unconfigured key material must not
+// crash-loop the job.
+type AppStoreReconcileRunner interface {
+	Run(ctx context.Context) (scanned, gaps, applied int, err error)
+}
+
 // Run dispatches on WORKER_MODE and returns the process exit code. It is the
 // testable core of cmd/worker/main.go — main() only loads config, wires the
 // Service Bus client + bootstrapper, sets up telemetry, and propagates this
 // code.
 //
 // poll-bootstrap, digest, hourly-digest, dormant-cleanup, subscription-sweep,
-// and pg-purge are implemented; poll-sb remains a loud stub that exits 1 until
-// its own bead (tc-yng2) lands. The Go worker image is not deployed to any job
-// until the final cutover bead, so a stub can never run in production. An unset
-// or unknown mode is a deployment accident and also fails fast.
+// pg-purge, and appstore-reconcile are implemented; poll-sb remains a loud
+// stub that exits 1 until its own bead (tc-yng2) lands. The Go worker image is
+// not deployed to any job until the final cutover bead, so a stub can never
+// run in production. An unset or unknown mode is a deployment accident and
+// also fails fast.
 //
 // bootstrapper may be nil when the job has no Service Bus config; poll-bootstrap
 // then refuses to run rather than nil-panicking. purger may be nil when no purge
 // runner is configured; pg-purge then logs and exits 0, so this is never an
 // error. devSeeder may be nil when the job is missing its dedicated prod-read
 // config; dev-seed then refuses to run rather than nil-panicking (it is a
-// dev-only job — tc-grvu.6 — so this never fires in prod).
-func Run(ctx context.Context, mode string, bootstrapper *Bootstrapper, digester DigestRunner, dormant DormantRunner, poller PollOrchestrator, sweeper SweepRunner, purger PurgeRunner, devSeeder DevSeedRunner, logger *slog.Logger) int {
+// dev-only job — tc-grvu.6 — so this never fires in prod). reconciler may be
+// nil when the job is missing its App Store Server API key material;
+// appstore-reconcile then logs and exits 0 rather than crash-looping — this
+// feature is genuinely optional during rollout.
+func Run(ctx context.Context, mode string, bootstrapper *Bootstrapper, digester DigestRunner, dormant DormantRunner, poller PollOrchestrator, sweeper SweepRunner, purger PurgeRunner, devSeeder DevSeedRunner, reconciler AppStoreReconcileRunner, logger *slog.Logger) int {
 	switch mode {
 	case "":
 		// WORKER_MODE is always set by infra; an unset value is a deployment
@@ -190,6 +215,9 @@ func Run(ctx context.Context, mode string, bootstrapper *Bootstrapper, digester 
 
 	case "dev-seed":
 		return runDevSeed(ctx, devSeeder, logger)
+
+	case "appstore-reconcile":
+		return runAppStoreReconcile(ctx, reconciler, logger)
 
 	default:
 		logger.ErrorContext(ctx, "unknown WORKER_MODE; refusing to run", "mode", mode)
@@ -407,6 +435,45 @@ func runDevSeed(ctx context.Context, runner DevSeedRunner, logger *slog.Logger) 
 		return 1
 	}
 	span.SetAttributes(attribute.Int("dev_seed.ingested_count", ingested))
+	return 0
+}
+
+// runAppStoreReconcile executes one appstore-reconcile cycle under a soft
+// self-cancel budget, inside a telemetry span named "App Store Reconcile
+// Cycle". It tags the span with the scanned/gap/applied counts. Unlike
+// runSweep/runDormant (nil runner = fatal), a nil runner here logs and exits 0
+// — mirroring runPurge's "backend doesn't apply here" pattern — because this
+// is a genuinely optional feature during rollout: unconfigured App Store
+// Server API key material must not crash-loop the job. A non-nil runner error
+// (Apple unreachable, retries exhausted) exits 1 so the job surfaces the
+// failure.
+func runAppStoreReconcile(ctx context.Context, runner AppStoreReconcileRunner, logger *slog.Logger) int {
+	tracer := otel.Tracer(tracerName)
+	ctx, span := tracer.Start(ctx, "App Store Reconcile Cycle")
+	defer span.End()
+
+	if runner == nil {
+		logger.InfoContext(ctx, "appstore-reconcile unconfigured (APPSTORE_RECONCILE_ENABLED / key material unset); skipping")
+		return 0
+	}
+
+	cycleCtx, cancel := context.WithTimeout(ctx, reconcileBudget)
+	defer cancel()
+
+	scanned, gaps, applied, err := runner.Run(cycleCtx)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		logger.ErrorContext(ctx, "appstore-reconcile cycle failed", "error", err)
+		return 1
+	}
+	span.SetAttributes(
+		attribute.Int("appstore_reconcile.scanned_count", scanned),
+		attribute.Int("appstore_reconcile.gaps_count", gaps),
+		attribute.Int("appstore_reconcile.applied_count", applied),
+	)
+	logger.InfoContext(ctx, "appstore-reconcile cycle completed",
+		"scanned", scanned, "gaps", gaps, "applied", applied)
 	return 0
 }
 

--- a/api-go/internal/worker/dispatch_test.go
+++ b/api-go/internal/worker/dispatch_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
@@ -157,12 +158,28 @@ func (f *fakeDevSeed) Run(context.Context) (int, error) {
 	return f.ingested, f.err
 }
 
+// fakeAppStoreReconcile is a hand-written double for the AppStoreReconcileRunner
+// the dispatcher invokes. It records the call and can be primed with
+// scanned/gap/applied counts or an error.
+type fakeAppStoreReconcile struct {
+	calls   int
+	scanned int
+	gaps    int
+	applied int
+	err     error
+}
+
+func (f *fakeAppStoreReconcile) Run(context.Context) (int, int, int, error) {
+	f.calls++
+	return f.scanned, f.gaps, f.applied, f.err
+}
+
 func TestRun_UnsetModeFailsFast(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "", nil, nil, nil, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "", nil, nil, nil, nil, nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 for unset mode", code)
@@ -177,7 +194,7 @@ func TestRun_DigestModeRunsWeeklyAndExitsZero(t *testing.T) {
 	d := &fakeDigester{}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "digest", nil, d, nil, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "digest", nil, d, nil, nil, nil, nil, nil, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0", code)
@@ -192,7 +209,7 @@ func TestRun_HourlyDigestModeRunsHourlyAndExitsZero(t *testing.T) {
 	d := &fakeDigester{}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "hourly-digest", nil, d, nil, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "hourly-digest", nil, d, nil, nil, nil, nil, nil, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0", code)
@@ -209,7 +226,7 @@ func TestRun_DigestModeWithoutHandlerExitsOne(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "digest", nil, nil, nil, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "digest", nil, nil, nil, nil, nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 when digest handler is unconfigured", code)
@@ -221,7 +238,7 @@ func TestRun_DigestCycleErrorExitsOne(t *testing.T) {
 	d := &fakeDigester{weeklyErr: errors.New("cosmos down")}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "digest", nil, d, nil, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "digest", nil, d, nil, nil, nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 on digest cycle error", code)
@@ -252,7 +269,7 @@ func TestRun_PollSBRunsOrchestratorAndExitsZeroOnSuccess(t *testing.T) {
 	}}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "poll-sb", nil, nil, nil, o, nil, nil, nil, logger)
+	code := Run(context.Background(), "poll-sb", nil, nil, nil, o, nil, nil, nil, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0 for a successful poll cycle", code)
@@ -269,7 +286,7 @@ func TestRun_PollSBWithoutOrchestratorExitsOne(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "poll-sb", nil, nil, nil, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "poll-sb", nil, nil, nil, nil, nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 when poll-sb is unconfigured", code)
@@ -309,7 +326,7 @@ func TestRun_PollSBExitsOneOnlyWhenNoAppsAndAuthorityErrors(t *testing.T) {
 			t.Parallel()
 			o := &fakePollOrchestrator{result: tc.result}
 			logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
-			code := Run(context.Background(), "poll-sb", nil, nil, nil, o, nil, nil, nil, logger)
+			code := Run(context.Background(), "poll-sb", nil, nil, nil, o, nil, nil, nil, nil, logger)
 			if code != tc.wantExit {
 				t.Errorf("exit code: got %d, want %d", code, tc.wantExit)
 			}
@@ -331,7 +348,7 @@ func TestRun_PollSBStampsOldestHWMAttributesOnSpan(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
 	span := recordSingleSpan(t, func() {
-		Run(context.Background(), "poll-sb", nil, nil, nil, o, nil, nil, nil, logger)
+		Run(context.Background(), "poll-sb", nil, nil, nil, o, nil, nil, nil, nil, logger)
 	})
 
 	if span.Name() != "Polling Cycle (SB)" {
@@ -361,7 +378,7 @@ func TestRun_PollSBOmitsOldestHWMAttributesWhenAbsent(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
 	span := recordSingleSpan(t, func() {
-		Run(context.Background(), "poll-sb", nil, nil, nil, o, nil, nil, nil, logger)
+		Run(context.Background(), "poll-sb", nil, nil, nil, o, nil, nil, nil, nil, logger)
 	})
 
 	if _, ok := attrFloat64(span, "polling.oldest_hwm_age_seconds"); ok {
@@ -381,7 +398,7 @@ func TestRun_PollSBStampsCycleTypeOnSpan(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
 	span := recordSingleSpan(t, func() {
-		Run(context.Background(), "poll-sb", nil, nil, nil, o, nil, nil, nil, logger)
+		Run(context.Background(), "poll-sb", nil, nil, nil, o, nil, nil, nil, nil, logger)
 	})
 
 	if span.Name() != "Polling Cycle (SB)" {
@@ -403,7 +420,7 @@ func TestRun_PollSBExitsOneOnOrchestratorError(t *testing.T) {
 	o := &fakePollOrchestrator{err: errors.New("orchestrator blew up")}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "poll-sb", nil, nil, nil, o, nil, nil, nil, logger)
+	code := Run(context.Background(), "poll-sb", nil, nil, nil, o, nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 on orchestrator error", code)
@@ -415,7 +432,7 @@ func TestRun_DormantCleanupRunsAndExitsZero(t *testing.T) {
 	d := &fakeDormant{deleted: 3}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "dormant-cleanup", nil, nil, d, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "dormant-cleanup", nil, nil, d, nil, nil, nil, nil, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0 (successful dormant cleanup)", code)
@@ -432,7 +449,7 @@ func TestRun_DormantCleanupWithoutHandlerExitsOne(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "dormant-cleanup", nil, nil, nil, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "dormant-cleanup", nil, nil, nil, nil, nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 when dormant handler is unconfigured", code)
@@ -444,7 +461,7 @@ func TestRun_DormantCleanupCycleErrorExitsOne(t *testing.T) {
 	d := &fakeDormant{err: errors.New("cosmos down")}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "dormant-cleanup", nil, nil, d, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "dormant-cleanup", nil, nil, d, nil, nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 on dormant cleanup error", code)
@@ -456,7 +473,7 @@ func TestRun_SubscriptionSweepRunsAndExitsZero(t *testing.T) {
 	s := &fakeSweep{downgraded: 4}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "subscription-sweep", nil, nil, nil, nil, s, nil, nil, logger)
+	code := Run(context.Background(), "subscription-sweep", nil, nil, nil, nil, s, nil, nil, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0 (successful subscription sweep)", code)
@@ -473,7 +490,7 @@ func TestRun_SubscriptionSweepWithoutHandlerExitsOne(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "subscription-sweep", nil, nil, nil, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "subscription-sweep", nil, nil, nil, nil, nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 when sweep handler is unconfigured", code)
@@ -485,7 +502,7 @@ func TestRun_SubscriptionSweepCycleErrorExitsOne(t *testing.T) {
 	s := &fakeSweep{err: errors.New("cosmos down")}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "subscription-sweep", nil, nil, nil, nil, s, nil, nil, logger)
+	code := Run(context.Background(), "subscription-sweep", nil, nil, nil, nil, s, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 on subscription sweep error", code)
@@ -497,7 +514,7 @@ func TestRun_PgPurgeRunsAndExitsZero(t *testing.T) {
 	p := &fakePurge{notifsPurged: 12, devicesPurged: 3}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "pg-purge", nil, nil, nil, nil, nil, p, nil, logger)
+	code := Run(context.Background(), "pg-purge", nil, nil, nil, nil, nil, p, nil, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0 (successful pg-purge)", code)
@@ -514,7 +531,7 @@ func TestRun_PgPurgeWithNilRunnerExitsZero(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "pg-purge", nil, nil, nil, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "pg-purge", nil, nil, nil, nil, nil, nil, nil, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0 when purger is nil (Cosmos TTL active)", code)
@@ -529,7 +546,7 @@ func TestRun_PgPurgeCycleErrorExitsOne(t *testing.T) {
 	p := &fakePurge{err: errors.New("postgres down")}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "pg-purge", nil, nil, nil, nil, nil, p, nil, logger)
+	code := Run(context.Background(), "pg-purge", nil, nil, nil, nil, nil, p, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 on pg-purge error", code)
@@ -541,7 +558,7 @@ func TestRun_UnknownModeExitsOne(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "banana", nil, nil, nil, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "banana", nil, nil, nil, nil, nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 for unknown mode", code)
@@ -554,7 +571,7 @@ func TestRun_PollBootstrapSeedsAndExitsZero(t *testing.T) {
 	b := newTestBootstrapper(t, q)
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "poll-bootstrap", b, nil, nil, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "poll-bootstrap", b, nil, nil, nil, nil, nil, nil, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0 (successful bootstrap)", code)
@@ -571,7 +588,7 @@ func TestRun_PollBootstrapWithoutQueueExitsOne(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "poll-bootstrap", nil, nil, nil, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "poll-bootstrap", nil, nil, nil, nil, nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 when Service Bus is unconfigured", code)
@@ -586,7 +603,7 @@ func TestRun_PollBootstrapProbeFailureStillExitsZero(t *testing.T) {
 	b := newTestBootstrapper(t, q)
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "poll-bootstrap", b, nil, nil, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "poll-bootstrap", b, nil, nil, nil, nil, nil, nil, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0 (absorbed probe failure is not a job failure)", code)
@@ -615,7 +632,7 @@ func TestRunPollBootstrap_TagsReconciliationAttributes(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
 	span := recordBootstrapSpan(t, func() {
-		code := Run(context.Background(), "poll-bootstrap", b, nil, nil, nil, nil, nil, nil, logger)
+		code := Run(context.Background(), "poll-bootstrap", b, nil, nil, nil, nil, nil, nil, nil, logger)
 		if code != 0 {
 			t.Errorf("exit code: got %d, want 0", code)
 		}
@@ -650,7 +667,7 @@ func TestRunPollBootstrap_TagsLeaseUnavailableAttribute(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
 	span := recordBootstrapSpan(t, func() {
-		code := Run(context.Background(), "poll-bootstrap", b, nil, nil, nil, nil, nil, nil, logger)
+		code := Run(context.Background(), "poll-bootstrap", b, nil, nil, nil, nil, nil, nil, nil, logger)
 		if code != 0 {
 			t.Errorf("exit code: got %d, want 0", code)
 		}
@@ -672,7 +689,7 @@ func TestRun_DevSeedRunsAndExitsZero(t *testing.T) {
 	ds := &fakeDevSeed{ingested: 3}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "dev-seed", nil, nil, nil, nil, nil, nil, ds, logger)
+	code := Run(context.Background(), "dev-seed", nil, nil, nil, nil, nil, nil, ds, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0 (successful dev-seed cycle)", code)
@@ -690,7 +707,7 @@ func TestRun_DevSeedWithoutRunnerExitsOne(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "dev-seed", nil, nil, nil, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "dev-seed", nil, nil, nil, nil, nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 when dev-seed is unconfigured", code)
@@ -702,9 +719,105 @@ func TestRun_DevSeedCycleErrorExitsOne(t *testing.T) {
 	ds := &fakeDevSeed{err: errors.New("postgres down")}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "dev-seed", nil, nil, nil, nil, nil, nil, ds, logger)
+	code := Run(context.Background(), "dev-seed", nil, nil, nil, nil, nil, nil, ds, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 on dev-seed cycle error", code)
+	}
+}
+
+func TestRun_AppStoreReconcileRunsAndExitsZero(t *testing.T) {
+	t.Parallel()
+	r := &fakeAppStoreReconcile{scanned: 10, gaps: 2, applied: 1}
+	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
+
+	code := Run(context.Background(), "appstore-reconcile", nil, nil, nil, nil, nil, nil, nil, r, logger)
+
+	if code != 0 {
+		t.Errorf("exit code: got %d, want 0 (successful appstore-reconcile cycle)", code)
+	}
+	if r.calls != 1 {
+		t.Errorf("appstore-reconcile Run calls: got %d, want 1", r.calls)
+	}
+}
+
+// TestRun_AppStoreReconcileWithNilRunnerExitsZero pins the deliberate
+// deviation from runSweep/runDormant (nil = fatal): appstore-reconcile is a
+// genuinely optional feature during rollout, so unconfigured App Store Server
+// API key material must log and exit 0, not crash-loop the job.
+func TestRun_AppStoreReconcileWithNilRunnerExitsZero(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	code := Run(context.Background(), "appstore-reconcile", nil, nil, nil, nil, nil, nil, nil, nil, logger)
+
+	if code != 0 {
+		t.Errorf("exit code: got %d, want 0 when appstore-reconcile is unconfigured", code)
+	}
+	if !strings.Contains(buf.String(), "appstore-reconcile") {
+		t.Errorf("log should mention appstore-reconcile, got: %s", buf.String())
+	}
+}
+
+func TestRun_AppStoreReconcileCycleErrorExitsOne(t *testing.T) {
+	t.Parallel()
+	r := &fakeAppStoreReconcile{err: errors.New("apple unreachable")}
+	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
+
+	code := Run(context.Background(), "appstore-reconcile", nil, nil, nil, nil, nil, nil, nil, r, logger)
+
+	if code != 1 {
+		t.Errorf("exit code: got %d, want 1 on appstore-reconcile cycle error", code)
+	}
+}
+
+// TestRun_AppStoreReconcileStampsSpanAttributes proves the scanned/gaps/applied
+// counts land on the "App Store Reconcile Cycle" span so they're queryable in
+// App Insights.
+func TestRun_AppStoreReconcileStampsSpanAttributes(t *testing.T) {
+	r := &fakeAppStoreReconcile{scanned: 7, gaps: 3, applied: 2}
+	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
+
+	span := recordSingleSpan(t, func() {
+		code := Run(context.Background(), "appstore-reconcile", nil, nil, nil, nil, nil, nil, nil, r, logger)
+		if code != 0 {
+			t.Errorf("exit code: got %d, want 0", code)
+		}
+	})
+
+	if span.Name() != "App Store Reconcile Cycle" {
+		t.Fatalf("span name: got %q, want %q", span.Name(), "App Store Reconcile Cycle")
+	}
+	if got, ok := attrInt(span, "appstore_reconcile.scanned_count"); !ok || got != 7 {
+		t.Errorf("appstore_reconcile.scanned_count: got %d (ok=%v), want 7", got, ok)
+	}
+	if got, ok := attrInt(span, "appstore_reconcile.gaps_count"); !ok || got != 3 {
+		t.Errorf("appstore_reconcile.gaps_count: got %d (ok=%v), want 3", got, ok)
+	}
+	if got, ok := attrInt(span, "appstore_reconcile.applied_count"); !ok || got != 2 {
+		t.Errorf("appstore_reconcile.applied_count: got %d (ok=%v), want 2", got, ok)
+	}
+}
+
+// TestRun_AppStoreReconcileErrorRecordsSpanError proves a runner error is
+// recorded on the "App Store Reconcile Cycle" span (in addition to the exit
+// code), mirroring every other cycle's error-recording behaviour.
+func TestRun_AppStoreReconcileErrorRecordsSpanError(t *testing.T) {
+	r := &fakeAppStoreReconcile{err: errors.New("apple unreachable")}
+	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
+
+	span := recordSingleSpan(t, func() {
+		code := Run(context.Background(), "appstore-reconcile", nil, nil, nil, nil, nil, nil, nil, r, logger)
+		if code != 1 {
+			t.Errorf("exit code: got %d, want 1", code)
+		}
+	})
+
+	if span.Status().Code != codes.Error {
+		t.Errorf("span status code: got %v, want codes.Error", span.Status().Code)
+	}
+	if span.Status().Description == "" {
+		t.Error("span status description: got empty, want the runner error message")
 	}
 }


### PR DESCRIPTION
## Summary

Implements the Go API portion (items 1-5) of the design in GH #1011: a periodic worker mode that polls Apple's App Store Server API "Get Notification History" endpoint to detect ASSN webhook delivery gaps our push-based webhook may have missed, closing the recovery gap ADR 0010 flagged as future work. `subscription-sweep` only ever downgrades a lapsed entitlement; nothing today can recover a missed renewal/upgrade.

- **`subscriptions.NotificationProcessor`** (new, `processor.go`): the webhook handler's `runWebhook` body extracted verbatim into a reusable, exported type with an additive `wasNew bool` return value. `handler.webhook` now delegates to it — same behaviour, same tests, no HTTP contract change.
- **`appstoreserverapi`** (new package): a small ES256-JWT-authenticated client for Apple's `POST /inApps/v1/notifications/history`, mirroring `internal/apns`'s JWT-signing pattern. Pages via `paginationToken`/`hasMore` (capped at 1000 pages), honors `Retry-After` (both seconds and HTTP-date forms) with bounded retries, mints one token per call (no caching — this is a short-lived job, unlike the long-lived APNs client).
- **`appstorereconcile`** (new package): the worker `Handler` — computes a `[now-lookback, now)` window, treats any notification UUID Apple returned that isn't yet in our idempotency table as a gap, and (only when `applyEnabled`) replays it through `NotificationProcessor.Process` — the same choke point the live webhook uses, so a recovered notification can never double-apply against a concurrent live delivery. Ships **observe-only**: gaps are logged/counted but never auto-applied yet, and a gap is never marked processed in observe mode so it keeps re-alerting until investigated.
- **`worker/dispatch.go` + `cmd/worker/main.go`**: new `WORKER_MODE=appstore-reconcile` case (span `App Store Reconcile Cycle`, `appstore_reconcile.{scanned,gaps,applied}_count` attributes). A nil/unconfigured runner logs and exits 0 rather than crash-looping — this feature is optional during rollout.
- **`platform/config.go`**: new `AppStoreReconcile*`/`AppStoreServerAPI*` config fields, reusing the existing `AppleBundleID`.

### Explicitly out of scope for this PR

- Pulumi/infra wiring for the new Container Apps Job — tracked separately as bead `tc-wcbgt`, since it depends on this landing first and on a manual, non-automatable prerequisite (a new App Store Connect "In-App Purchase" API key — Apple has no key-creation API/CLI).
- Flipping `APPSTORE_RECONCILE_APPLY_ENABLED` to `true` anywhere — a deliberate, separate follow-up PR after an observation soak period.
- Any change to the live `POST /v1/webhooks/appstore` HTTP contract, error codes, or size/shape pre-checks.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] `go test ./...` — all packages pass, including new `appstoreserverapi`/`appstorereconcile`/`processor_test.go` suites (JWT shape, pagination, 429/Retry-After handling in both forms, observe-vs-apply mode, per-item failure isolation, `HistoryFetcher` error propagation)
- [x] All Apple-facing tests use `httptest` — no live network calls anywhere, in tests or otherwise
- [ ] No new migration/SQL — reuses the existing `subscriptions.PostgresNotificationStore`, so no `make test-integration` run needed
- [ ] Not yet deployed/exercised against a live App Store Connect key (that key doesn't exist yet — manual prerequisite, see above)

Refs: bead `tc-97k35.6`, GH #1011.

---

Generated with the Town Crier backlog-runner routine.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NcytYCPutALcD4F6iYuE13)_