### PR TITLE
infra: bot-filtered saved KQL functions for share-page volume by slug (tc-kg77x)

### DIFF
--- a/infra/shared.go
+++ b/infra/shared.go
@@ -1660,14 +1660,24 @@ tolower(ua) matches regex @"(bot|spider|crawl|slurp|facebookexternalhit|whatsapp
 // slug and day.
 //
 // IMPORTANT — burst threshold is an unvalidated starting estimate, not a tuned value: more
-// than 5 requests to the same url.path within a rolling 10-minute window, bucketed by UA+day.
-// Chosen because the GH #1020 sample's confirmed-bot cluster showed dozens of hits within
-// minutes to the same path, while plausible human traffic was single-digit and spread out
-// across a session — but nobody has run this function against live prod data yet (no `az`
+// than 5 requests to the same (Ua, Path) within any genuine rolling 10-minute window, bucketed
+// by UA+day. Chosen because the GH #1020 sample's confirmed-bot cluster showed dozens of hits
+// within minutes to the same path, while plausible human traffic was single-digit and spread
+// out across a session — but nobody has run this function against live prod data yet (no `az`
 // CLI / Log Analytics access from the environment this was authored in). Before relying on the
 // organic-count output: run it against 30+ days of prod data from a local session with `az`
 // access, sanity-check the result against known usage, and adjust burstThreshold/burstWindow
 // below if it's over- or under-flagging.
+//
+// The window is a genuine per-request rolling window (self-join: for each candidate request,
+// count same-Ua+Path requests in [TimeGenerated, TimeGenerated+burstWindow)), not a fixed
+// bin(TimeGenerated, burstWindow) bucket — bin() would let a burst straddling a bucket boundary
+// (e.g. 4 hits just before the boundary, 4 just after) dodge the threshold in both buckets even
+// though all 8 fall inside a real 10-minute span. The self-join is the standard KQL pattern for
+// this (matches the sliding-window intent of api-go/internal/middleware/anonratelimit.go and
+// ratelimit.go, translated to KQL since there's no native rolling-window aggregate); it's O(n^2)
+// over the candidate set, which is fine at share-page traffic volumes but worth knowing if this
+// function is ever pointed at a much larger AppRequests slice.
 //
 // Where this lives: saved function "SharePageHumanTraffic" in the log-town-crier-shared Log
 // Analytics workspace (Azure Portal > Log Analytics workspaces > log-town-crier-shared > Logs >
@@ -1678,12 +1688,17 @@ const sharePageHumanTrafficQuery = `// SharePageHumanTraffic(): likely-organic A
 // maintained and how the burst threshold was chosen (tc-kg77x / GH #1020).
 let burstThreshold = 5;
 let burstWindow = 10m;
-let burstFlaggedUaDays =
+let candidateRequests =
     AppRequests
     | extend Ua = tostring(Properties["user_agent.original"])
     | extend Path = tostring(Properties["url.path"])
     | where Path startswith "/a/" or Path startswith "/og/"
-    | summarize RequestsInWindow = count() by Ua, Path, Day = bin(TimeGenerated, 1d), Window = bin(TimeGenerated, burstWindow)
+    | project Ua, Path, TimeGenerated, Day = bin(TimeGenerated, 1d);
+let burstFlaggedUaDays =
+    candidateRequests
+    | join kind=inner (candidateRequests | project Ua2 = Ua, Path2 = Path, TimeGenerated2 = TimeGenerated) on $left.Ua == $right.Ua2, $left.Path == $right.Path2
+    | where TimeGenerated2 between (TimeGenerated .. TimeGenerated + burstWindow)
+    | summarize RequestsInWindow = count() by Ua, Path, TimeGenerated, Day
     | where RequestsInWindow > burstThreshold
     | summarize by Ua, Day;
 AppRequests

--- a/infra/shared.go
+++ b/infra/shared.go
@@ -1021,6 +1021,12 @@ expected
 		return err
 	}
 
+	// Share-page bot-filtered volume by slug (tc-kg77x / GH #1020). Analytics-layer only: two
+	// saved KQL functions over existing AppRequests telemetry, no new logging or stored data.
+	if err = createSharePageAnalytics(ctx, resourceGroup, logAnalytics); err != nil {
+		return err
+	}
+
 	// Phase 5: subscription-level hygiene.
 
 	// Service Health — replaces reliance on the auto-created azureapp-auto action group, which
@@ -1622,5 +1628,113 @@ func createLogAlert(ctx *pulumi.Context, resourceGroup *resources.ResourceGroup,
 		},
 		Tags: tags,
 	})
+	return err
+}
+
+// isLikelyBotQuery is the body of the IsLikelyBot(ua: string): bool saved KQL function
+// (tc-kg77x / GH #1020). Case-insensitive substring/token match against a maintained
+// bot/crawler UA list. To extend: add a new "|token" alternative to the regex below and
+// re-run `pulumi up` for the shared stack — no other file needs to change. Regex-escape any
+// character that is special in RE2 (e.g. the literal "+" in "\\+http").
+//
+// The list starts from the ad hoc regex used in the GH #1020 investigation
+// (bot|spider|crawl|slurp|facebookexternalhit|whatsapp|telegrambot|slackbot|discordbot|
+// preview|headless|curl|python-requests|go-http-client — 91% of /a/ traffic over a 27-day
+// sample), plus two confirmed misses from that same investigation (Google's screen-reader
+// crawler, which carries no "bot" substring, and Facebook's own crawler, which
+// self-identifies via an embedded "+http" URL rather than a "bot" token), plus common SEO/
+// security scanners, plus the AI-crawler allowlist from web/public/robots.txt (deliberately
+// welcomed there for SEO/AI-discoverability — welcomed still means bot traffic for the
+// purposes of this volume count, not organic).
+const isLikelyBotQuery = `// IsLikelyBot(ua: string): bool — see infra/shared.go createSharePageAnalytics for how
+// this function is maintained (tc-kg77x / GH #1020).
+tolower(ua) matches regex @"(bot|spider|crawl|slurp|facebookexternalhit|whatsapp|telegrambot|slackbot|discordbot|preview|headless|curl|python-requests|go-http-client|read-aloud|webindexer|\+http|ahrefsbot|semrushbot|mj12bot|dotbot|censys|zgrab|masscan|gptbot|oai-searchbot|chatgpt-user|google-extended|claudebot|claude-user|anthropic-ai|perplexitybot|perplexity-user|ccbot|applebot-extended)"`
+
+// sharePageHumanTrafficQuery is the body of the SharePageHumanTraffic() saved KQL function
+// (tc-kg77x / GH #1020). Combines IsLikelyBot(ua) with a burst/behavioral heuristic to catch
+// browser-spoofed crawlers presenting a generic desktop UA (the GH #1020 investigation found a
+// 2,243-hit cluster on an all-zero-build Chrome UA — real browsers never report an all-zero
+// patch/build number — hitting the same path dozens of times within minutes), then reports the
+// residual likely-organic AppRequests volume to the share-page routes
+// (`/a/{authoritySlug}/{ref...}` and `/og/{authoritySlug}/{ref...}`, ADR 0037), bucketed by
+// slug and day.
+//
+// IMPORTANT — burst threshold is an unvalidated starting estimate, not a tuned value: more
+// than 5 requests to the same url.path within a rolling 10-minute window, bucketed by UA+day.
+// Chosen because the GH #1020 sample's confirmed-bot cluster showed dozens of hits within
+// minutes to the same path, while plausible human traffic was single-digit and spread out
+// across a session — but nobody has run this function against live prod data yet (no `az`
+// CLI / Log Analytics access from the environment this was authored in). Before relying on the
+// organic-count output: run it against 30+ days of prod data from a local session with `az`
+// access, sanity-check the result against known usage, and adjust burstThreshold/burstWindow
+// below if it's over- or under-flagging.
+//
+// Where this lives: saved function "SharePageHumanTraffic" in the log-town-crier-shared Log
+// Analytics workspace (Azure Portal > Log Analytics workspaces > log-town-crier-shared > Logs >
+// Functions, or query it directly as `SharePageHumanTraffic()`). Depends on the IsLikelyBot
+// saved function existing in the same workspace (see createSharePageAnalytics below).
+const sharePageHumanTrafficQuery = `// SharePageHumanTraffic(): likely-organic AppRequests volume to the share-page routes,
+// by slug and day. See infra/shared.go createSharePageAnalytics for how this function is
+// maintained and how the burst threshold was chosen (tc-kg77x / GH #1020).
+let burstThreshold = 5;
+let burstWindow = 10m;
+let burstFlaggedUaDays =
+    AppRequests
+    | extend Ua = tostring(Properties["user_agent.original"])
+    | extend Path = tostring(Properties["url.path"])
+    | where Path startswith "/a/" or Path startswith "/og/"
+    | summarize RequestsInWindow = count() by Ua, Path, Day = bin(TimeGenerated, 1d), Window = bin(TimeGenerated, burstWindow)
+    | where RequestsInWindow > burstThreshold
+    | summarize by Ua, Day;
+AppRequests
+| extend Ua = tostring(Properties["user_agent.original"])
+| extend Path = tostring(Properties["url.path"])
+| where Path startswith "/a/" or Path startswith "/og/"
+| extend Day = bin(TimeGenerated, 1d)
+| extend Slug = extract(@"^/(?:a|og)/([^/]+)/", 1, Path)
+| where not(IsLikelyBot(Ua))
+| join kind=leftanti burstFlaggedUaDays on Ua, Day
+| summarize OrganicHits = count() by Slug, Day
+| order by Day desc, OrganicHits desc`
+
+// createSharePageAnalytics provisions the two saved KQL functions backing "genuine share-page
+// volume by slug" (tc-kg77x / GH #1020): IsLikelyBot(ua) and SharePageHumanTraffic(), which
+// calls IsLikelyBot — hence the explicit DependsOn below, so a fresh shared-stack apply creates
+// IsLikelyBot first. Analytics-layer only: both read existing AppRequests telemetry
+// (user_agent.original, url.path, TimeGenerated), which is already privacy-clean (client IPs
+// are already collapsed to the shared ingress IP, PR #998/tc-ig52w) — this adds no new logging,
+// no new stored data, nothing new tracked.
+//
+// SavedSearch's Tags field is Azure's per-search portal categorization (Name/Value pairs used
+// to help a human find a saved search), not the ARM resource-tag convention (project/managedBy)
+// used by every other resource in this file — SavedSearch has no top-level ARM tags, so there is
+// no tags parameter here. Category and the function/query names carry that identification
+// instead.
+func createSharePageAnalytics(ctx *pulumi.Context, resourceGroup *resources.ResourceGroup, logAnalytics *operationalinsights.Workspace) error {
+	isLikelyBot, err := operationalinsights.NewSavedSearch(ctx, "saved-search-is-likely-bot", &operationalinsights.SavedSearchArgs{
+		SavedSearchId:      pulumi.String("share-page-is-likely-bot"),
+		ResourceGroupName:  resourceGroup.Name,
+		WorkspaceName:      logAnalytics.Name,
+		Category:           pulumi.String("Town Crier/Share Page Analytics"),
+		DisplayName:        pulumi.String("IsLikelyBot"),
+		FunctionAlias:      pulumi.String("IsLikelyBot"),
+		FunctionParameters: pulumi.String("ua:string"),
+		Query:              pulumi.String(isLikelyBotQuery),
+		Version:            pulumi.Float64(2),
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = operationalinsights.NewSavedSearch(ctx, "saved-search-share-page-human-traffic", &operationalinsights.SavedSearchArgs{
+		SavedSearchId:     pulumi.String("share-page-human-traffic"),
+		ResourceGroupName: resourceGroup.Name,
+		WorkspaceName:     logAnalytics.Name,
+		Category:          pulumi.String("Town Crier/Share Page Analytics"),
+		DisplayName:       pulumi.String("SharePageHumanTraffic"),
+		FunctionAlias:     pulumi.String("SharePageHumanTraffic"),
+		Query:             pulumi.String(sharePageHumanTrafficQuery),
+		Version:           pulumi.Float64(2),
+	}, pulumi.DependsOn([]pulumi.Resource{isLikelyBot}))
 	return err
 }

--- a/infra/shared.go
+++ b/infra/shared.go
@@ -1635,7 +1635,8 @@ func createLogAlert(ctx *pulumi.Context, resourceGroup *resources.ResourceGroup,
 // (tc-kg77x / GH #1020). Case-insensitive substring/token match against a maintained
 // bot/crawler UA list. To extend: add a new "|token" alternative to the regex below and
 // re-run `pulumi up` for the shared stack — no other file needs to change. Regex-escape any
-// character that is special in RE2 (e.g. the literal "+" in "\\+http").
+// character that is special in RE2 (e.g. the literal "+" in "\+http"). The regex sits inside a
+// KQL verbatim string (@"..."), so write a single backslash, not a doubled one.
 //
 // The list starts from the ad hoc regex used in the GH #1020 investigation
 // (bot|spider|crawl|slurp|facebookexternalhit|whatsapp|telegrambot|slackbot|discordbot|
@@ -1690,6 +1691,7 @@ let burstThreshold = 5;
 let burstWindow = 10m;
 let candidateRequests =
     AppRequests
+    | where tostring(Properties["deployment.environment"]) == "prod"
     | extend Ua = tostring(Properties["user_agent.original"])
     | extend Path = tostring(Properties["url.path"])
     | where Path startswith "/a/" or Path startswith "/og/"
@@ -1702,11 +1704,13 @@ let burstFlaggedUaDays =
     | where RequestsInWindow > burstThreshold
     | summarize by Ua, Day;
 AppRequests
+| where tostring(Properties["deployment.environment"]) == "prod"
 | extend Ua = tostring(Properties["user_agent.original"])
 | extend Path = tostring(Properties["url.path"])
 | where Path startswith "/a/" or Path startswith "/og/"
 | extend Day = bin(TimeGenerated, 1d)
-| extend Slug = extract(@"^/(?:a|og)/([^/]+)/", 1, Path)
+| extend Slug = extract(@"^/(?:a|og)/([^/]+)", 1, Path)
+| where isnotempty(Slug)
 | where not(IsLikelyBot(Ua))
 | join kind=leftanti burstFlaggedUaDays on Ua, Day
 | summarize OrganicHits = count() by Slug, Day

--- a/infra/shared_test.go
+++ b/infra/shared_test.go
@@ -73,3 +73,43 @@ func TestBuildAuthorityNamesDatatable_MissingFileErrors(t *testing.T) {
 		t.Fatal("expected an error for a missing file, got nil")
 	}
 }
+
+// TestSharePageAnalyticsQueries_RetainInvariants pins the substrings in isLikelyBotQuery and
+// sharePageHumanTrafficQuery (tc-kg77x / GH #1020) that the compiler cannot check but a future
+// edit could easily break silently: the prod-only filter (dev and prod share one App Insights
+// component), both share-page route prefixes, and the robots.txt AI-crawler allowlist tokens
+// that IsLikelyBot must still treat as bots for volume-counting purposes.
+func TestSharePageAnalyticsQueries_RetainInvariants(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sharePageHumanTrafficQuery", func(t *testing.T) {
+		t.Parallel()
+
+		wantSubstrings := []string{
+			`tostring(Properties["deployment.environment"]) == "prod"`,
+			`Path startswith "/a/" or Path startswith "/og/"`,
+		}
+		for _, want := range wantSubstrings {
+			if !strings.Contains(sharePageHumanTrafficQuery, want) {
+				t.Errorf("sharePageHumanTrafficQuery missing invariant substring %q", want)
+			}
+		}
+	})
+
+	t.Run("isLikelyBotQuery AI-crawler tokens", func(t *testing.T) {
+		t.Parallel()
+
+		// robots.txt (web/public/robots.txt) explicitly welcomes these AI crawlers for
+		// SEO/discoverability, but welcomed still means bot traffic for this volume count.
+		wantTokens := []string{
+			"gptbot", "oai-searchbot", "chatgpt-user", "google-extended",
+			"claudebot", "claude-user", "anthropic-ai",
+			"perplexitybot", "perplexity-user", "ccbot", "applebot-extended",
+		}
+		for _, token := range wantTokens {
+			if !strings.Contains(isLikelyBotQuery, token) {
+				t.Errorf("isLikelyBotQuery missing AI-crawler token %q", token)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Adds two saved KQL functions to the shared Log Analytics workspace (`log-town-crier-shared`), provisioned via Pulumi: `IsLikelyBot(ua: string)` and `SharePageHumanTraffic()`.
- Analytics-layer only — reads existing `AppRequests` telemetry (`user_agent.original`, `url.path`, `TimeGenerated`), already privacy-clean (client IPs already collapsed to the shared ingress IP, PR #998/tc-ig52w). No new logging, no new stored data, no `api-go`/`web`/`mobile` changes.
- `IsLikelyBot` combines the ad hoc UA regex from the investigation with confirmed misses (Google-Read-Aloud, Facebook's `+http`-identifying crawler) plus common SEO/security scanners and the AI-crawler allowlist from `web/public/robots.txt` (deliberately welcomed there for SEO, but still bot traffic for this volume count).
- `SharePageHumanTraffic()` filters `/a/{authoritySlug}/{ref...}` and `/og/{authoritySlug}/{ref...}` `AppRequests`, excludes `IsLikelyBot` matches, adds a burst heuristic (>5 requests to the same `url.path` within a rolling 10-minute window, bucketed by UA+day) to catch browser-spoofed crawlers, and reports likely-organic hits by slug/day.

Closes #1020 (tc-kg77x).

## Validation outstanding
This session has no `az` CLI / Azure credentials, so:
- No `pulumi preview`/`up` was run.
- The burst threshold (`>5 requests / 10min`) is a starting estimate from the issue's own evidence, **not tuned against live data**.
- GH #1020's acceptance criterion of running `SharePageHumanTraffic()` against 30+ days of prod data and sanity-checking the organic count is **not done** — needs a local session with `az`/Log Analytics access, per this project's CLAUDE.md guidance on cloud-session credential limits.

Both points are documented inline in `infra/shared.go` next to the KQL consts, along with where the functions live and how to extend the UA list.

## Test plan
- [x] `cd infra && go build ./...` — passes
- [x] `go vet ./...` — passes
- [x] `gofmt -l .` — clean
- [ ] Run `SharePageHumanTraffic()` against 30+ days of prod data from a local session (`az` access required) and sanity-check the organic count — outstanding, see above
- [ ] Tune `burstThreshold`/`burstWindow` in `sharePageHumanTrafficQuery` if the live-data check shows over/under-flagging

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HseDMU6emn6HfWwEJ1rJSy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added analytics for share-page visits, including daily traffic aggregation by page.
  * Added detection and filtering for bot traffic and browser-spoofed crawlers.
  * Analytics queries are versioned and provisioned with their dependencies in the correct order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->