### PR TITLE
fix(api): burst-tolerant token bucket for anonymous rate limiter (tc-vwobf)

### DIFF
--- a/api-go/cmd/api/anonratelimit_wiring_test.go
+++ b/api-go/cmd/api/anonratelimit_wiring_test.go
@@ -26,11 +26,12 @@ func anonRateLimitRequest(t *testing.T, h http.Handler, path, remoteAddr string)
 }
 
 // newRouterWithAnonLimit builds a minimal store-less router with a
-// caller-chosen anonymous rate-limit budget, so tests can drive the limiter
-// past its threshold without waiting out the production 60-request default.
-func newRouterWithAnonLimit(t *testing.T, logger *slog.Logger, anonRequests, anonWindowSeconds int) http.Handler {
+// caller-chosen anonymous token-bucket budget (burst capacity + refill rate),
+// so tests can drive the limiter past its threshold without waiting out the
+// production defaults.
+func newRouterWithAnonLimit(t *testing.T, logger *slog.Logger, anonBurst, anonRefillPerMinute int) http.Handler {
 	t.Helper()
-	return newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", "", nil, nil, "", nil, nil, nil, anonRequests, anonWindowSeconds, logger)
+	return newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", "", nil, nil, "", nil, nil, nil, anonBurst, anonRefillPerMinute, logger)
 }
 
 // TestRouter_AnonRateLimitAppliesToAnonymousRoutes proves AnonRateLimit is

--- a/api-go/cmd/api/main.go
+++ b/api-go/cmd/api/main.go
@@ -188,7 +188,7 @@ func main() {
 		log.Fatalf("designations client: %v", err)
 	}
 
-	srv := platform.NewServer(":"+cfg.Port, newRouter(validator, cfg.CorsAllowedOrigins, store, manager, cascade, exportReaders, deviceStore, stateStore, notifStore, watchZoneStore, appStore, savedStore, geocodeClient, designationClient, offerStore, adminStore, cfg.AdminAPIKey, cfg.SiteBuildKey, jwsVerifier, appleNotifStore, cfg.AppleBundleID, cfg.AppleEnvironments, registry, shareCardCache, cfg.AnonRateLimitRequests, cfg.AnonRateLimitWindowSeconds, logger))
+	srv := platform.NewServer(":"+cfg.Port, newRouter(validator, cfg.CorsAllowedOrigins, store, manager, cascade, exportReaders, deviceStore, stateStore, notifStore, watchZoneStore, appStore, savedStore, geocodeClient, designationClient, offerStore, adminStore, cfg.AdminAPIKey, cfg.SiteBuildKey, jwsVerifier, appleNotifStore, cfg.AppleBundleID, cfg.AppleEnvironments, registry, shareCardCache, cfg.AnonRateLimitBurst, cfg.AnonRateLimitRefillPerMinute, logger))
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()

--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -240,8 +240,8 @@ func newRouter(
 	appleEnvironments []string,
 	registry *metrics.Registry,
 	shareCardCache *blobstore.Store,
-	anonRateLimitRequests int,
-	anonRateLimitWindowSeconds int,
+	anonRateLimitBurst int,
+	anonRateLimitRefillPerMinute int,
 	logger *slog.Logger,
 ) http.Handler {
 	mux := http.NewServeMux()
@@ -273,12 +273,13 @@ func newRouter(
 			middleware.RecordActivity(profiles.NewActivityRecorder(store), time.Now, logger)(mux),
 		)
 	}
-	// AnonRateLimit (GH#868 Phase 1) always wraps whatever dispatch chain was
-	// built above — unlike RateLimit/RecordActivity, it needs no profile store,
-	// so it must not be skipped on a store-less boot: that would leave every
-	// anonymous route (a scraping target for a future public geo endpoint, and
-	// load that ultimately lands on PlanIt) completely unmetered. It is a no-op
-	// for authenticated requests, so it never interferes with the per-subject
+	// AnonRateLimit (GH#868 Phase 1, reworked to a token bucket tc-vwobf)
+	// always wraps whatever dispatch chain was built above — unlike
+	// RateLimit/RecordActivity, it needs no profile store, so it must not be
+	// skipped on a store-less boot: that would leave every anonymous route (a
+	// scraping target for a future public geo endpoint, and load that
+	// ultimately lands on PlanIt) completely unmetered. It is a no-op for
+	// authenticated requests, so it never interferes with the per-subject
 	// RateLimit it wraps.
 	//
 	// The exemption predicate recognises a valid X-Build-Key via
@@ -288,9 +289,9 @@ func newRouter(
 	// including the CI seo-refresh job's ~418 sequential requests from one
 	// runner IP — is wrongly metered as anonymous. A missing or wrong key still
 	// exempts nothing, preserving the anti-scraping posture for everyone else.
-	anonWindow := time.Duration(anonRateLimitWindowSeconds) * time.Second
+	anonRefillPerSecond := float64(anonRateLimitRefillPerMinute) / 60
 	buildKeyExempt := func(r *http.Request) bool { return applications.BuildKeyMatches(r, siteBuildKey) }
-	dispatch = middleware.AnonRateLimit(middleware.NewAnonRateLimitStore(anonWindow), anonRateLimitRequests, buildKeyExempt, logger)(dispatch)
+	dispatch = middleware.AnonRateLimit(middleware.NewAnonRateLimitStore(anonRefillPerSecond), anonRateLimitBurst, buildKeyExempt, logger)(dispatch)
 	if deviceStore != nil {
 		devicetokens.Routes(mux, deviceStore, time.Now, logger)
 	}

--- a/api-go/internal/middleware/anonratelimit.go
+++ b/api-go/internal/middleware/anonratelimit.go
@@ -24,14 +24,28 @@ var healthCheckPaths = map[string]struct{}{
 	"/v1/health": {},
 }
 
-// AnonRateLimit returns middleware enforcing a fixed-window rate limit keyed
-// by resolved client IP (internal/clientip), applied ONLY to requests with no
-// authenticated subject (auth.Subject(ctx) == ""). Authenticated traffic
-// passes straight through untouched: it is metered by the sibling per-subject
-// RateLimit instead, and this middleware never inspects or affects it
-// (GH#868 Phase 1). A point+radius public endpoint is a whole-table scraping
-// target and drives unmetered load onto PlanIt (our free, single-operator
-// upstream) if left uncapped, hence this second limiter.
+// AnonRateLimit returns middleware enforcing a per-IP token-bucket rate limit
+// keyed by resolved client IP (internal/clientip), applied ONLY to requests
+// with no authenticated subject (auth.Subject(ctx) == ""). Authenticated
+// traffic passes straight through untouched: it is metered by the sibling
+// per-subject RateLimit instead, and this middleware never inspects or
+// affects it (GH#868 Phase 1). A point+radius public endpoint is a
+// whole-table scraping target and drives unmetered load onto PlanIt (our
+// free, single-operator upstream) if left uncapped, hence this second
+// limiter.
+//
+// burst is the bucket's capacity: the number of requests an IP can make in
+// an instantaneous burst before it starts drawing on the steady refill rate
+// carried by store (see NewAnonRateLimitStore). This replaced a flat
+// fixed-window counter (tc-vwobf): a real anonymous session panning the map
+// fans a single pan/zoom settle event out across several endpoints
+// (GET /v1/applications/clusters, GET /v1/me/watch-zones/{id}/applications/
+// clusters, GET /v1/applications/near-point, ...) even though both clients
+// already debounce pan/zoom client-side at ~250ms — so a flat per-window
+// budget throttled ordinary browsing, not just scraping. A token bucket lets
+// that fan-out through as a burst while the refill rate still caps
+// sustained/scraping-shaped load at roughly the same long-run rate as before
+// (see the config doc comment for the chosen numbers).
 //
 // Requests whose client IP cannot be resolved (clientip.FromRequest returns
 // the invalid zero Addr — which per the clientip package doc happens only
@@ -62,7 +76,7 @@ var healthCheckPaths = map[string]struct{}{
 // this in-memory accounting: only the numeric limit/retry values are recorded
 // on a throttle, honouring the clientip package's "in-memory, non-persisted
 // purpose only" constraint.
-func AnonRateLimit(store *anonRateLimitStore, limit int, exempt func(*http.Request) bool, logger *slog.Logger) func(http.Handler) http.Handler {
+func AnonRateLimit(store *anonRateLimitStore, burst int, exempt func(*http.Request) bool, logger *slog.Logger) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if auth.Subject(r.Context()) != "" {
@@ -79,89 +93,109 @@ func AnonRateLimit(store *anonRateLimitStore, limit int, exempt func(*http.Reque
 			}
 
 			addr := clientip.FromRequest(r)
-			result := store.checkAndIncrement(addr, limit)
+			result := store.checkAndIncrement(addr, burst)
 			if !result.allowed {
-				w.Header().Set("X-RateLimit-Limit", strconv.Itoa(limit))
+				w.Header().Set("X-RateLimit-Limit", strconv.Itoa(burst))
 				w.Header().Set("X-RateLimit-Remaining", "0")
 				w.Header().Set("Retry-After", strconv.Itoa(result.retryAfterSeconds()))
 				logger.WarnContext(r.Context(), "anonymous rate limit exceeded",
-					"limit", limit, "retryAfterSeconds", result.retryAfterSeconds())
+					"limit", burst, "retryAfterSeconds", result.retryAfterSeconds())
 				w.WriteHeader(http.StatusTooManyRequests)
 				return
 			}
 
-			w.Header().Set("X-RateLimit-Limit", strconv.Itoa(limit))
+			w.Header().Set("X-RateLimit-Limit", strconv.Itoa(burst))
 			w.Header().Set("X-RateLimit-Remaining", strconv.Itoa(result.remaining))
 			next.ServeHTTP(w, r)
 		})
 	}
 }
 
-// anonRateLimitStore is an in-memory sliding-window counter keyed by resolved
-// client IP: a per-IP queue of request timestamps, evicting entries older than
-// the window on every check. It mirrors rateLimitStore's mechanism (see
-// ratelimit.go) generalised to a configurable window and a netip.Addr key
-// instead of a user-id string — netip.Addr is a small comparable value, so it
-// works directly as a map key with no string conversion (and therefore no
-// temptation to log it).
+// anonBucket is one IP's token-bucket state as of lastRefill. Tokens are
+// computed lazily on each check — elapsed time since lastRefill multiplied by
+// the store's refill rate — rather than on a background ticker, so an IP that
+// never returns costs nothing beyond the map entry itself, and no goroutine
+// needs a shutdown path.
+type anonBucket struct {
+	tokens     float64
+	lastRefill time.Time
+}
+
+// anonRateLimitStore is an in-memory token bucket keyed by resolved client
+// IP: each IP gets a bucket that starts full (at the per-call burst
+// capacity), drains by one token per allowed request, and refills at a
+// steady rate (refillPerSecond, injected at construction so tests can pin it)
+// independent of any fixed window boundary. netip.Addr is a small comparable
+// value, so it works directly as a map key with no string conversion (and
+// therefore no temptation to log it).
 //
 // Eviction is mandatory from day one (regression guard for GH#518, where a
-// per-subject map once grew unbounded because keys were never reclaimed): once
-// an IP's timestamps have all aged out of the window, the map key is deleted
-// rather than left holding an empty slice. This matters even more here than
-// for the per-subject store: the anonymous caller population is unbounded
-// (any IP on the internet), not the bounded set of registered users.
+// per-subject map once grew unbounded because keys were never reclaimed): the
+// token-bucket analogue of "all timestamps aged out of the window" is "the
+// bucket has refilled all the way back to capacity" — that state carries no
+// information beyond "no entry", so once a check computes a fully-refilled
+// bucket the key is deleted rather than left sitting in memory holding a full
+// bucket forever. This matters even more here than for the per-subject
+// store: the anonymous caller population is unbounded (any IP on the
+// internet), not the bounded set of registered users.
 type anonRateLimitStore struct {
-	now    func() time.Time
-	window time.Duration
+	now             func() time.Time
+	refillPerSecond float64
 
-	mu       sync.Mutex
-	requests map[netip.Addr][]time.Time
+	mu      sync.Mutex
+	buckets map[netip.Addr]anonBucket
 }
 
-// newAnonRateLimitStore builds a store using the given clock and window
-// (injected for tests).
-func newAnonRateLimitStore(now func() time.Time, window time.Duration) *anonRateLimitStore {
-	return &anonRateLimitStore{now: now, window: window, requests: map[netip.Addr][]time.Time{}}
+// newAnonRateLimitStore builds a store using the given clock and refill rate
+// (tokens added per second), injected for tests.
+func newAnonRateLimitStore(now func() time.Time, refillPerSecond float64) *anonRateLimitStore {
+	return &anonRateLimitStore{now: now, refillPerSecond: refillPerSecond, buckets: map[netip.Addr]anonBucket{}}
 }
 
-// NewAnonRateLimitStore builds the production store on the real clock with the
-// given fixed window. It returns the unexported concrete type so callers can
-// only pass it back to AnonRateLimit.
-func NewAnonRateLimitStore(window time.Duration) *anonRateLimitStore {
-	return newAnonRateLimitStore(time.Now, window)
+// NewAnonRateLimitStore builds the production store on the real clock with
+// the given steady refill rate (tokens/second).
+func NewAnonRateLimitStore(refillPerSecond float64) *anonRateLimitStore {
+	return newAnonRateLimitStore(time.Now, refillPerSecond)
 }
 
-// checkAndIncrement evicts expired timestamps for addr, then either records
-// the request (returning the remaining budget) or denies it (returning the
-// retry-after until the oldest in-window timestamp ages out). See
-// rateLimitStore.checkAndIncrement for the identical compaction/eviction
-// reasoning this mirrors.
-func (s *anonRateLimitStore) checkAndIncrement(addr netip.Addr, limit int) rateLimitResult {
+// checkAndIncrement refills addr's bucket for elapsed time since its last
+// touch (capped at burst, the per-call capacity), then either spends one
+// token (returning the remaining balance) or denies the request (returning
+// the retry-after until one token is earned back). See rateLimitStore.
+// checkAndIncrement for the sibling per-subject store this generalises from a
+// fixed window to continuous refill.
+func (s *anonRateLimitStore) checkAndIncrement(addr netip.Addr, burst int) rateLimitResult {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	now := s.now()
-	windowStart := now.Add(-s.window)
+	capacity := float64(burst)
 
-	times := s.requests[addr]
-	kept := times[:0]
-	for _, t := range times {
-		if t.After(windowStart) {
-			kept = append(kept, t)
+	tokens := capacity
+	if b, ok := s.buckets[addr]; ok {
+		tokens = b.tokens
+		if s.refillPerSecond > 0 {
+			if elapsed := now.Sub(b.lastRefill).Seconds(); elapsed > 0 {
+				tokens += elapsed * s.refillPerSecond
+			}
+		}
+		if tokens > capacity {
+			tokens = capacity
 		}
 	}
 
-	if len(kept) == 0 {
-		delete(s.requests, addr)
-	} else {
-		s.requests[addr] = kept
+	// A bucket back at full capacity carries no information beyond "no
+	// entry" — reclaim it now rather than leave a stale full bucket sitting
+	// in the map forever (GH#518 regression guard, token-bucket analogue of
+	// the sliding-window's "all timestamps aged out" eviction).
+	if tokens >= capacity {
+		delete(s.buckets, addr)
 	}
 
-	if len(kept) >= limit {
+	if tokens < 1 {
 		var retryAfter time.Duration
-		if len(kept) > 0 {
-			retryAfter = kept[0].Add(s.window).Sub(now)
+		if s.refillPerSecond > 0 {
+			retryAfter = time.Duration((1 - tokens) / s.refillPerSecond * float64(time.Second))
 		}
 		if retryAfter < time.Millisecond {
 			retryAfter = time.Millisecond
@@ -169,7 +203,7 @@ func (s *anonRateLimitStore) checkAndIncrement(addr netip.Addr, limit int) rateL
 		return rateLimitResult{allowed: false, remaining: 0, retryAfter: retryAfter}
 	}
 
-	kept = append(kept, now)
-	s.requests[addr] = kept
-	return rateLimitResult{allowed: true, remaining: limit - len(kept)}
+	tokens--
+	s.buckets[addr] = anonBucket{tokens: tokens, lastRefill: now}
+	return rateLimitResult{allowed: true, remaining: int(tokens)}
 }

--- a/api-go/internal/middleware/anonratelimit_test.go
+++ b/api-go/internal/middleware/anonratelimit_test.go
@@ -35,7 +35,7 @@ func TestAnonRateLimit_AllowedRequestSetsHeaders(t *testing.T) {
 	t.Parallel()
 
 	clock := &fixedClock{t: time.Unix(2000, 0)}
-	store := newAnonRateLimitStore(clock.now, time.Minute)
+	store := newAnonRateLimitStore(clock.now, 1)
 	mw := AnonRateLimit(store, 60, nil, slogDiscard())
 
 	rec := httptest.NewRecorder()
@@ -52,11 +52,11 @@ func TestAnonRateLimit_AllowedRequestSetsHeaders(t *testing.T) {
 	}
 }
 
-func TestAnonRateLimit_RequestsBelowLimitAreUnaffected(t *testing.T) {
+func TestAnonRateLimit_RequestsUpToBurstCapacitySucceed(t *testing.T) {
 	t.Parallel()
 
 	clock := &fixedClock{t: time.Unix(2000, 0)}
-	store := newAnonRateLimitStore(clock.now, time.Minute)
+	store := newAnonRateLimitStore(clock.now, 1)
 	mw := AnonRateLimit(store, 5, nil, slogDiscard())
 	h := mw(okHandler())
 
@@ -64,16 +64,16 @@ func TestAnonRateLimit_RequestsBelowLimitAreUnaffected(t *testing.T) {
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, anonRequest("203.0.113.12:51000"))
 		if rec.Code != http.StatusOK {
-			t.Fatalf("request %d: got %d, want 200 (below limit)", i, rec.Code)
+			t.Fatalf("request %d: got %d, want 200 (within burst capacity)", i, rec.Code)
 		}
 	}
 }
 
-func TestAnonRateLimit_ExceededReturns429WithHeaders(t *testing.T) {
+func TestAnonRateLimit_ExceedsBurstReturns429WithHeaders(t *testing.T) {
 	t.Parallel()
 
 	clock := &fixedClock{t: time.Unix(2000, 0)}
-	store := newAnonRateLimitStore(clock.now, time.Minute)
+	store := newAnonRateLimitStore(clock.now, 1)
 	mw := AnonRateLimit(store, 60, nil, slogDiscard())
 	h := mw(okHandler())
 
@@ -104,12 +104,12 @@ func TestAnonRateLimit_ExceededReturns429WithHeaders(t *testing.T) {
 // TestAnonRateLimit_AuthenticatedRequestPassesThrough is the acceptance-
 // criterion test: authenticated traffic must never be touched by the
 // anonymous limiter, even when it shares an IP with an anonymous caller who
-// has exhausted the (deliberately tiny, limit=1) anonymous budget.
+// has exhausted the (deliberately tiny, burst=1) anonymous budget.
 func TestAnonRateLimit_AuthenticatedRequestPassesThrough(t *testing.T) {
 	t.Parallel()
 
 	clock := &fixedClock{t: time.Unix(2000, 0)}
-	store := newAnonRateLimitStore(clock.now, time.Minute)
+	store := newAnonRateLimitStore(clock.now, 1)
 	mw := AnonRateLimit(store, 1, nil, slogDiscard())
 	h := mw(okHandler())
 
@@ -128,7 +128,7 @@ func TestAnonRateLimit_AuthenticatedRequestPassesThrough(t *testing.T) {
 
 	// The same IP, now making its first genuinely anonymous request, still has
 	// its full budget — proving the authenticated loop above never touched the
-	// IP's counter.
+	// IP's bucket.
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, anonRequest("203.0.113.13:51000"))
 	if rec.Code != http.StatusOK {
@@ -145,7 +145,7 @@ func TestAnonRateLimit_ExemptPredicatePassesThroughUnmetered(t *testing.T) {
 	t.Parallel()
 
 	clock := &fixedClock{t: time.Unix(2000, 0)}
-	store := newAnonRateLimitStore(clock.now, time.Minute)
+	store := newAnonRateLimitStore(clock.now, 1)
 	exempt := func(r *http.Request) bool { return r.Header.Get("X-Build-Key") == "s3cret" }
 	mw := AnonRateLimit(store, 1, exempt, slogDiscard())
 	h := mw(okHandler())
@@ -169,7 +169,7 @@ func TestAnonRateLimit_ExemptPredicatePassesThroughUnmetered(t *testing.T) {
 
 	// The same IP, now making its first genuinely anonymous (keyless) request,
 	// still has its full budget — proving the exempt loop above never touched
-	// the IP's counter.
+	// the IP's bucket.
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, anonRequest("203.0.113.70:51000"))
 	if rec.Code != http.StatusOK {
@@ -185,7 +185,7 @@ func TestAnonRateLimit_ExemptPredicateFalseIsMeteredNormally(t *testing.T) {
 	t.Parallel()
 
 	clock := &fixedClock{t: time.Unix(2000, 0)}
-	store := newAnonRateLimitStore(clock.now, time.Minute)
+	store := newAnonRateLimitStore(clock.now, 1)
 	exempt := func(r *http.Request) bool { return r.Header.Get("X-Build-Key") == "s3cret" }
 	mw := AnonRateLimit(store, 1, exempt, slogDiscard())
 	h := mw(okHandler())
@@ -216,7 +216,7 @@ func TestAnonRateLimit_DifferentIPsHaveIndependentBudgets(t *testing.T) {
 	t.Parallel()
 
 	clock := &fixedClock{t: time.Unix(2000, 0)}
-	store := newAnonRateLimitStore(clock.now, time.Minute)
+	store := newAnonRateLimitStore(clock.now, 1)
 	mw := AnonRateLimit(store, 1, nil, slogDiscard())
 	h := mw(okHandler())
 
@@ -250,7 +250,7 @@ func TestAnonRateLimit_UnresolvableIPsShareOneConservativeBucket(t *testing.T) {
 	t.Parallel()
 
 	clock := &fixedClock{t: time.Unix(2000, 0)}
-	store := newAnonRateLimitStore(clock.now, time.Minute)
+	store := newAnonRateLimitStore(clock.now, 1)
 	mw := AnonRateLimit(store, 1, nil, slogDiscard())
 	h := mw(okHandler())
 
@@ -281,7 +281,7 @@ func TestAnonRateLimit_HealthCheckPathsExempt(t *testing.T) {
 	t.Parallel()
 
 	clock := &fixedClock{t: time.Unix(2000, 0)}
-	store := newAnonRateLimitStore(clock.now, time.Minute)
+	store := newAnonRateLimitStore(clock.now, 1)
 	mw := AnonRateLimit(store, 1, nil, slogDiscard())
 	h := mw(okHandler())
 
@@ -299,11 +299,15 @@ func TestAnonRateLimit_HealthCheckPathsExempt(t *testing.T) {
 	}
 }
 
-func TestAnonRateLimit_WindowResets(t *testing.T) {
+// TestAnonRateLimit_PartialRefillRestoresPartialCapacity is the token-bucket
+// behaviour that replaces the old fixed-window's all-or-nothing reset: after
+// the burst is exhausted, a partial idle period restores only the tokens the
+// refill rate actually earned, not the full bucket.
+func TestAnonRateLimit_PartialRefillRestoresPartialCapacity(t *testing.T) {
 	t.Parallel()
 
 	clock := &fixedClock{t: time.Unix(2000, 0)}
-	store := newAnonRateLimitStore(clock.now, time.Minute)
+	store := newAnonRateLimitStore(clock.now, 1) // 1 token/second refill
 	mw := AnonRateLimit(store, 2, nil, slogDiscard())
 	h := mw(okHandler())
 
@@ -313,14 +317,54 @@ func TestAnonRateLimit_WindowResets(t *testing.T) {
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, anonRequest("203.0.113.50:1"))
 	if rec.Code != http.StatusTooManyRequests {
-		t.Fatalf("expected throttle before window reset, got %d", rec.Code)
+		t.Fatalf("expected throttle once burst is exhausted, got %d", rec.Code)
+	}
+
+	// Only 1 second passes: exactly 1 of the 2 burst tokens is earned back.
+	clock.t = clock.t.Add(1 * time.Second)
+
+	allowed := httptest.NewRecorder()
+	h.ServeHTTP(allowed, anonRequest("203.0.113.50:1"))
+	if allowed.Code != http.StatusOK {
+		t.Fatalf("after partial refill: got %d, want 200 (1 token earned back)", allowed.Code)
+	}
+
+	// The single earned-back token was just spent; immediately trying again
+	// (no further time elapsed) must throttle again.
+	immediatelyAfter := httptest.NewRecorder()
+	h.ServeHTTP(immediatelyAfter, anonRequest("203.0.113.50:1"))
+	if immediatelyAfter.Code != http.StatusTooManyRequests {
+		t.Fatalf("immediately after spending the earned token: got %d, want 429", immediatelyAfter.Code)
+	}
+}
+
+// TestAnonRateLimit_FullIdleRestoresFullBurstCapacity confirms that idling
+// long enough to earn back the whole burst behaves like a fresh bucket.
+func TestAnonRateLimit_FullIdleRestoresFullBurstCapacity(t *testing.T) {
+	t.Parallel()
+
+	clock := &fixedClock{t: time.Unix(2000, 0)}
+	store := newAnonRateLimitStore(clock.now, 1) // 1 token/second refill
+	mw := AnonRateLimit(store, 2, nil, slogDiscard())
+	h := mw(okHandler())
+
+	for range 2 {
+		h.ServeHTTP(httptest.NewRecorder(), anonRequest("203.0.113.51:1"))
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, anonRequest("203.0.113.51:1"))
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected throttle before idling, got %d", rec.Code)
 	}
 
 	clock.t = clock.t.Add(61 * time.Second)
 	rec2 := httptest.NewRecorder()
-	h.ServeHTTP(rec2, anonRequest("203.0.113.50:1"))
+	h.ServeHTTP(rec2, anonRequest("203.0.113.51:1"))
 	if rec2.Code != http.StatusOK {
-		t.Errorf("after window reset: got %d, want 200", rec2.Code)
+		t.Errorf("after long idle: got %d, want 200", rec2.Code)
+	}
+	if got := rec2.Header().Get("X-RateLimit-Remaining"); got != "1" {
+		t.Errorf("after long idle: X-RateLimit-Remaining got %q, want 1 (fresh bucket minus this request)", got)
 	}
 }
 
@@ -336,7 +380,7 @@ func TestAnonRateLimit_NoClientIPInLogs(t *testing.T) {
 
 	spy := &logSpy{}
 	clock := &fixedClock{t: time.Unix(2000, 0)}
-	store := newAnonRateLimitStore(clock.now, time.Minute)
+	store := newAnonRateLimitStore(clock.now, 1)
 	mw := AnonRateLimit(store, 1, nil, slog.New(spy))
 	h := mw(okHandler())
 
@@ -361,32 +405,35 @@ func TestAnonRateLimit_NoClientIPInLogs(t *testing.T) {
 	}
 }
 
-// hasKey and keyLen are test-only accessors mirroring rateLimitStore's (see
-// ratelimit_test.go), used to assert eviction behaviour without exposing them
-// in production code.
+// hasKey and tokensFor are test-only accessors used to assert eviction and
+// refill behaviour without exposing them in production code.
 func (s *anonRateLimitStore) hasKey(addr netip.Addr) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	_, ok := s.requests[addr]
+	_, ok := s.buckets[addr]
 	return ok
 }
 
-func (s *anonRateLimitStore) keyLen(addr netip.Addr) int {
+func (s *anonRateLimitStore) tokensFor(addr netip.Addr) float64 {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return len(s.requests[addr])
+	return s.buckets[addr].tokens
 }
 
 // TestAnonRateLimitStore_EvictsIdleIPKey is the GH#518 regression guard for the
-// per-IP store: once an IP's in-window timestamps have all aged out, the next
-// checkAndIncrement call for that IP must reclaim the map key (delete) rather
-// than leave a stale entry sitting in memory forever.
+// per-IP store, ported to token-bucket semantics: once an IP's bucket has
+// fully refilled (idle long enough that it holds no information beyond "no
+// entry"), the next checkAndIncrement call for that IP must reclaim the map
+// key (delete) rather than leave a stale full bucket sitting in memory
+// forever. burst=0 on the follow-up call forces the denied path (capacity 0
+// clamps tokens to 0, which is also >= capacity so the delete fires) without
+// re-adding an entry, making the deletion observable immediately.
 func TestAnonRateLimitStore_EvictsIdleIPKey(t *testing.T) {
 	t.Parallel()
 
 	addr := netip.MustParseAddr("203.0.113.60")
 	clock := &fixedClock{t: time.Unix(2000, 0)}
-	store := newAnonRateLimitStore(clock.now, time.Minute)
+	store := newAnonRateLimitStore(clock.now, 1)
 
 	store.checkAndIncrement(addr, 60)
 	if !store.hasKey(addr) {
@@ -395,27 +442,25 @@ func TestAnonRateLimitStore_EvictsIdleIPKey(t *testing.T) {
 
 	clock.t = clock.t.Add(61 * time.Second)
 
-	// limit=0 forces the denied path with kept==0 in a single call, making the
-	// deletion observable immediately (mirrors TestRateLimitStore_EvictsIdleUserKey).
 	store.checkAndIncrement(addr, 0)
 
 	if store.hasKey(addr) {
-		t.Error("expected map key deleted after all timestamps aged out, but key still present")
+		t.Error("expected map key deleted after bucket fully refilled, but key still present")
 	}
 }
 
-// TestAnonRateLimitStore_MapStaysBoundedAcrossWindows is the acceptance-
-// criterion test that the store's size shrinks/stays bounded after window
-// expiry, not merely "doesn't grow in the happy path": it seeds several IPs,
-// lets the window expire, then drives a second wave of one request per IP —
-// exactly what continuing real traffic looks like — and asserts the store
-// neither accumulates a second stale timestamp per IP nor grows beyond the
-// active population.
-func TestAnonRateLimitStore_MapStaysBoundedAcrossWindows(t *testing.T) {
+// TestAnonRateLimitStore_MapStaysBoundedAcrossRefills is the acceptance-
+// criterion test that the store's size shrinks/stays bounded after full
+// refill, not merely "doesn't grow in the happy path": it seeds several IPs,
+// lets each bucket fully refill, then drives a second wave of one request per
+// IP — exactly what continuing real traffic looks like — and asserts the
+// store neither accumulates stale per-IP state nor grows beyond the active
+// population.
+func TestAnonRateLimitStore_MapStaysBoundedAcrossRefills(t *testing.T) {
 	t.Parallel()
 
 	clock := &fixedClock{t: time.Unix(2000, 0)}
-	store := newAnonRateLimitStore(clock.now, time.Minute)
+	store := newAnonRateLimitStore(clock.now, 1)
 
 	addrs := []netip.Addr{
 		netip.MustParseAddr("203.0.113.61"),
@@ -425,23 +470,23 @@ func TestAnonRateLimitStore_MapStaysBoundedAcrossWindows(t *testing.T) {
 	for _, a := range addrs {
 		store.checkAndIncrement(a, 60)
 	}
-	if got := len(store.requests); got != len(addrs) {
+	if got := len(store.buckets); got != len(addrs) {
 		t.Fatalf("setup: store size = %d, want %d", got, len(addrs))
 	}
 
-	// Advance past the window: every seeded timestamp is now stale.
+	// Advance well past full refill for every seeded bucket.
 	clock.t = clock.t.Add(2 * time.Minute)
 
 	for _, a := range addrs {
 		store.checkAndIncrement(a, 60)
 	}
 
-	if got := len(store.requests); got != len(addrs) {
-		t.Errorf("store size after second window = %d, want %d (bounded, not accumulating)", got, len(addrs))
+	if got := len(store.buckets); got != len(addrs) {
+		t.Errorf("store size after refill wave = %d, want %d (bounded, not accumulating)", got, len(addrs))
 	}
 	for _, a := range addrs {
-		if got := store.keyLen(a); got != 1 {
-			t.Errorf("addr %v: stored len = %d, want 1 (stale timestamp evicted before recording the new one)", a, got)
+		if got := store.tokensFor(a); got != 59 {
+			t.Errorf("addr %v: tokens = %v, want 59 (fresh bucket minus the one request just made)", a, got)
 		}
 	}
 }

--- a/api-go/internal/platform/config.go
+++ b/api-go/internal/platform/config.go
@@ -37,16 +37,35 @@ type Config struct {
 	// Defaults to localhost dev origin.
 	CorsAllowedOrigins []string
 
-	// AnonRateLimitRequests and AnonRateLimitWindowSeconds configure the
-	// per-IP anonymous rate limiter (middleware.AnonRateLimit, GH#868 Phase 1):
-	// the request budget and fixed window applied to every unauthenticated
-	// request, keyed on the client IP resolved via internal/clientip. Loaded
-	// from ANON_RATE_LIMIT_REQUESTS / ANON_RATE_LIMIT_WINDOW_SECONDS,
-	// defaulting to 60 requests per 60-second window so an unset env never
-	// leaves anonymous routes (a scraping target for a public geo endpoint,
-	// and load that ultimately lands on PlanIt) unmetered.
-	AnonRateLimitRequests      int
-	AnonRateLimitWindowSeconds int
+	// AnonRateLimitBurst and AnonRateLimitRefillPerMinute configure the per-IP
+	// anonymous token-bucket rate limiter (middleware.AnonRateLimit, GH#868
+	// Phase 1, reworked tc-vwobf), keyed on the client IP resolved via
+	// internal/clientip: AnonRateLimitBurst is the bucket capacity (how many
+	// requests an IP can make back-to-back before it starts drawing on the
+	// steady refill rate), AnonRateLimitRefillPerMinute is that steady rate.
+	// Loaded from ANON_RATE_LIMIT_BURST / ANON_RATE_LIMIT_REFILL_PER_MINUTE.
+	//
+	// tc-vwobf: the previous flat 60-requests-per-60-second sliding window
+	// throttled ordinary anonymous map browsing — panning the map fans a
+	// single pan/zoom settle event out across several endpoints
+	// (GET /v1/applications/clusters, GET /v1/me/watch-zones/{id}/
+	// applications/clusters, GET /v1/applications/near-point, ...) even
+	// though both clients already debounce pan/zoom at ~250ms client-side, so
+	// a real session hit 41+ 429s in 9 minutes with no scraping involved.
+	//
+	// Defaults: burst 120, refill 60/minute (1 token/second).
+	//   - Burst=120 is double the old flat budget: generous enough to absorb
+	//     a single active map session's fan-out — several endpoints firing
+	//     roughly every 250ms while the user is actively panning — as one
+	//     instantaneous burst, without needing to wait on the refill rate at
+	//     all for a normal browsing session.
+	//   - Refill=60/minute exactly matches the old default's long-run rate
+	//     (60 requests / 60 seconds), so sustained/scraping-shaped load past
+	//     the initial burst is capped at the same steady-state rate as
+	//     before; only the front-loaded tolerance changed, not the ceiling on
+	//     continuous abuse.
+	AnonRateLimitBurst           int
+	AnonRateLimitRefillPerMinute int
 
 	// AzureClientID pins the user-assigned managed identity used for AAD auth
 	// (azidentity) by the Postgres pool (passwordless Entra token) and the Service
@@ -348,8 +367,8 @@ func LoadConfig() (Config, error) {
 		Auth0Audience:      os.Getenv("AUTH0_AUDIENCE"),
 		CorsAllowedOrigins: parseOrigins(os.Getenv("CORS_ALLOWED_ORIGINS")),
 
-		AnonRateLimitRequests:      getenvInt("ANON_RATE_LIMIT_REQUESTS", 60),
-		AnonRateLimitWindowSeconds: getenvInt("ANON_RATE_LIMIT_WINDOW_SECONDS", 60),
+		AnonRateLimitBurst:           getenvInt("ANON_RATE_LIMIT_BURST", 120),
+		AnonRateLimitRefillPerMinute: getenvInt("ANON_RATE_LIMIT_REFILL_PER_MINUTE", 60),
 
 		AzureClientID: os.Getenv("AZURE_CLIENT_ID"),
 

--- a/api-go/internal/platform/config_test.go
+++ b/api-go/internal/platform/config_test.go
@@ -373,34 +373,34 @@ func TestLoadConfig_CorsAllowedOrigins(t *testing.T) {
 }
 
 func TestLoadConfig_AnonRateLimitDefaults(t *testing.T) {
-	t.Setenv("ANON_RATE_LIMIT_REQUESTS", "")
-	t.Setenv("ANON_RATE_LIMIT_WINDOW_SECONDS", "")
+	t.Setenv("ANON_RATE_LIMIT_BURST", "")
+	t.Setenv("ANON_RATE_LIMIT_REFILL_PER_MINUTE", "")
 
 	cfg, err := LoadConfig()
 	if err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}
-	if cfg.AnonRateLimitRequests != 60 {
-		t.Errorf("AnonRateLimitRequests default: got %d, want 60", cfg.AnonRateLimitRequests)
+	if cfg.AnonRateLimitBurst != 120 {
+		t.Errorf("AnonRateLimitBurst default: got %d, want 120", cfg.AnonRateLimitBurst)
 	}
-	if cfg.AnonRateLimitWindowSeconds != 60 {
-		t.Errorf("AnonRateLimitWindowSeconds default: got %d, want 60", cfg.AnonRateLimitWindowSeconds)
+	if cfg.AnonRateLimitRefillPerMinute != 60 {
+		t.Errorf("AnonRateLimitRefillPerMinute default: got %d, want 60", cfg.AnonRateLimitRefillPerMinute)
 	}
 }
 
 func TestLoadConfig_AnonRateLimitOverrides(t *testing.T) {
-	t.Setenv("ANON_RATE_LIMIT_REQUESTS", "30")
-	t.Setenv("ANON_RATE_LIMIT_WINDOW_SECONDS", "10")
+	t.Setenv("ANON_RATE_LIMIT_BURST", "30")
+	t.Setenv("ANON_RATE_LIMIT_REFILL_PER_MINUTE", "10")
 
 	cfg, err := LoadConfig()
 	if err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}
-	if cfg.AnonRateLimitRequests != 30 {
-		t.Errorf("AnonRateLimitRequests override: got %d, want 30", cfg.AnonRateLimitRequests)
+	if cfg.AnonRateLimitBurst != 30 {
+		t.Errorf("AnonRateLimitBurst override: got %d, want 30", cfg.AnonRateLimitBurst)
 	}
-	if cfg.AnonRateLimitWindowSeconds != 10 {
-		t.Errorf("AnonRateLimitWindowSeconds override: got %d, want 10", cfg.AnonRateLimitWindowSeconds)
+	if cfg.AnonRateLimitRefillPerMinute != 10 {
+		t.Errorf("AnonRateLimitRefillPerMinute override: got %d, want 10", cfg.AnonRateLimitRefillPerMinute)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replaces the anonymous rate limiter's flat sliding-window counter (`internal/middleware/anonratelimit.go`) with a per-IP token bucket, so a normal map-pan session's multi-endpoint fan-out no longer gets throttled the way a real user's session did (41x 429s in 9 minutes, tc-vwobf).
- Both the web and iOS clients already debounce map pan/zoom at ~250ms client-side, so the throttling wasn't a client bug — the flat per-60s budget was just too tight for one session's legitimate fan-out across `/v1/applications/clusters`, `/v1/me/watch-zones/{id}/applications/clusters`, `/v1/applications/near-point`, etc.
- New config: `ANON_RATE_LIMIT_BURST` (default 120, double the old flat budget) and `ANON_RATE_LIMIT_REFILL_PER_MINUTE` (default 60, matching the old steady-state rate) replace `ANON_RATE_LIMIT_REQUESTS`/`ANON_RATE_LIMIT_WINDOW_SECONDS`. Burst absorbs a session's fan-out instantly; refill keeps the long-run cap on sustained/scraping-shaped load unchanged from before.
- Response contract (429 + `Retry-After` + `X-RateLimit-*` headers), exemptions (authenticated bypass, health checks, `X-Build-Key`), and the GH#518 idle-eviction guarantee are all preserved.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test ./...` (all packages pass)
- [ ] `golangci-lint run ./...` — could not run in this environment: the installed binary is built with go1.25 but `go.mod` targets go1.26 (`can't load config: the Go language version (go1.25) used to build golangci-lint is lower than the targeted Go version (1.26)`). Confirmed this fails identically on `main` with no changes applied, so it's a pre-existing environment/tooling mismatch, not something introduced by this PR. CI's `pr-gate` uses a matched golangci-lint version and should run this cleanly.
- Backend-only change; no UI to verify.

Bead: tc-vwobf

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8X88jUYNoctvY5nmpDe5R)_