### PR TITLE
watchzones: Boundary value type, validation, centroid, enclosing radius, tri-state ZoneUpdate (tc-6he3x.1)

### DIFF
--- a/api-go/internal/watchzones/handler.go
+++ b/api-go/internal/watchzones/handler.go
@@ -262,9 +262,20 @@ func (req patchRequest) rangeValid() bool {
 }
 
 func (req patchRequest) toUpdate() ZoneUpdate {
-	// patchRequest and ZoneUpdate are field-identical; the request type exists
-	// only to carry the JSON tags, so a direct conversion is exact.
-	return ZoneUpdate(req)
+	// ZoneUpdate.Boundary is domain-only for now (tc-6he3x.1): patchRequest
+	// does not yet expose a boundary field, so a field-by-field copy is
+	// required instead of the old field-identical type conversion. Wiring
+	// json.RawMessage tri-state boundary decoding into patchRequest is
+	// tc-6he3x.4.
+	return ZoneUpdate{
+		Name:                req.Name,
+		Latitude:            req.Latitude,
+		Longitude:           req.Longitude,
+		RadiusMetres:        req.RadiusMetres,
+		AuthorityID:         req.AuthorityID,
+		PushEnabled:         req.PushEnabled,
+		EmailInstantEnabled: req.EmailInstantEnabled,
+	}
 }
 
 // patch implements PATCH /v1/me/watch-zones/{zoneId}: range-validate the body

--- a/api-go/internal/watchzones/handler_test.go
+++ b/api-go/internal/watchzones/handler_test.go
@@ -186,6 +186,54 @@ func TestHandler_Patch_UpdatesAndReturnsZone(t *testing.T) {
 	}
 }
 
+func TestHandler_Patch_UpdatesEveryMappedField(t *testing.T) {
+	t.Parallel()
+	z := testZone(t)
+	store := &fakeZoneStore{zones: []WatchZone{z}}
+	body := `{
+		"name":"Renamed Office",
+		"latitude":52.4862,
+		"longitude":-1.8904,
+		"radiusMetres":3000,
+		"authorityId":999,
+		"pushEnabled":false,
+		"emailInstantEnabled":false
+	}`
+	rec := doReq(t, testMux(t, store), http.MethodPatch, "/v1/me/watch-zones/"+z.ID, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (body %s)", rec.Code, rec.Body)
+	}
+	var got struct {
+		Zone watchZoneSummary `json:"zone"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	want := watchZoneSummary{
+		ID:                  z.ID,
+		Name:                "Renamed Office",
+		Latitude:            52.4862,
+		Longitude:           -1.8904,
+		RadiusMetres:        3000,
+		AuthorityID:         999,
+		PushEnabled:         false,
+		EmailInstantEnabled: false,
+		Paused:              got.Zone.Paused,
+	}
+	if got.Zone != want {
+		t.Errorf("response zone: got %+v, want %+v", got.Zone, want)
+	}
+	if store.saved == nil {
+		t.Fatal("zone not persisted")
+	}
+	if store.saved.Name != "Renamed Office" || store.saved.Latitude != 52.4862 ||
+		store.saved.Longitude != -1.8904 || store.saved.RadiusMetres != 3000 ||
+		store.saved.AuthorityID != 999 || store.saved.PushEnabled || store.saved.EmailInstantEnabled {
+		t.Errorf("persisted zone: got %+v", store.saved)
+	}
+}
+
 func TestHandler_Patch_RangeInvalid(t *testing.T) {
 	t.Parallel()
 	z := testZone(t)

--- a/api-go/internal/watchzones/zone.go
+++ b/api-go/internal/watchzones/zone.go
@@ -43,9 +43,9 @@ var (
 // Longitude and RadiusMetres — they hold the polygon's derived centroid and
 // enclosing radius (see WithBoundary) so every existing circle-shaped read
 // path (map centring, list rows, boundingBox, GDPR export) keeps working
-// unchanged; Boundary == nil is the sole "this is a circle" discriminator.
-// Exported fields keep it a plain Go value; the constructor enforces all
-// invariants.
+// unchanged; a zero-length Boundary (nil or empty) is the sole "this is a
+// circle" discriminator — see IsCustomShape. Exported fields keep it a plain
+// Go value; the constructor enforces all invariants.
 type WatchZone struct {
 	ID                  string
 	UserID              string
@@ -120,7 +120,8 @@ func (z WatchZone) boundingBox() (minLat, maxLat, minLon, maxLon float64) {
 }
 
 // IsCustomShape reports whether z is a custom-shape (polygon) zone rather
-// than a circle. Boundary == nil (the zero value) is the sole discriminator.
+// than a circle. A zero-length Boundary — nil or an empty non-nil slice — is
+// the sole discriminator, since the check is on length, not nilness.
 func (z WatchZone) IsCustomShape() bool {
 	return len(z.Boundary) > 0
 }
@@ -206,15 +207,38 @@ func NewBoundary(vertices []Coordinate) (Boundary, error) {
 		seen[v] = struct{}{}
 	}
 	for _, v := range distinct {
+		if math.IsNaN(v.Latitude) || math.IsNaN(v.Longitude) ||
+			math.IsInf(v.Latitude, 0) || math.IsInf(v.Longitude, 0) {
+			return nil, ErrBoundaryOutOfBounds
+		}
 		if v.Latitude < ukMinLatitude || v.Latitude > ukMaxLatitude ||
 			v.Longitude < ukMinLongitude || v.Longitude > ukMaxLongitude {
 			return nil, ErrBoundaryOutOfBounds
 		}
 	}
+	if ring.signedArea() == 0 {
+		// A collinear ring has no interior, so no point can ever be covered
+		// by it; treat it as a degenerate (self-touching) shape.
+		return nil, ErrBoundarySelfIntersecting
+	}
 	if ring.selfIntersects() {
 		return nil, ErrBoundarySelfIntersecting
 	}
 	return ring, nil
+}
+
+// signedArea returns twice the signed shoelace area of the closed ring. It
+// is zero only for a degenerate (zero-area, e.g. collinear) ring.
+func (b Boundary) signedArea() float64 {
+	n := len(b) - 1
+	if n < 1 {
+		return 0
+	}
+	var sum float64
+	for i := range n {
+		sum += b[i].Longitude*b[i+1].Latitude - b[i+1].Longitude*b[i].Latitude
+	}
+	return sum
 }
 
 // selfIntersects reports whether any two non-adjacent edges of the closed
@@ -344,8 +368,11 @@ func (b Boundary) Centroid() (latitude, longitude float64) {
 // columns (see WithBoundary) so every read path built for circles keeps
 // working unchanged.
 func (b Boundary) EnclosingRadiusMetres() float64 {
-	lat, lon := b.Centroid()
 	n := len(b) - 1
+	if n < 1 {
+		return 0
+	}
+	lat, lon := b.Centroid()
 	var maxDistance float64
 	for _, v := range b[:n] {
 		if d := haversineMetres(lat, lon, v.Latitude, v.Longitude); d > maxDistance {
@@ -364,7 +391,10 @@ func (b Boundary) EnclosingRadiusMetres() float64 {
 //   - non-nil, pointing to len-0   — explicit null: convert back to a circle,
 //     keeping the zone's existing centre and radius.
 //   - non-nil, pointing to len>0  — set this custom shape: the centre and
-//     radius are recomputed from it via NewBoundary.
+//     radius are recomputed from it via NewBoundary, overriding any
+//     Latitude/Longitude/RadiusMetres also present on the same update — the
+//     derived geometry always wins so the circle fields stay consistent with
+//     the polygon.
 //
 // This is the domain-level representation of the tri-state; decoding the
 // HTTP PATCH body's `"boundary": null` vs absent vs a value into this shape

--- a/api-go/internal/watchzones/zone.go
+++ b/api-go/internal/watchzones/zone.go
@@ -20,9 +20,32 @@ import (
 // ErrNotFound signals that no watch zone exists for the given (user, zone) pair.
 var ErrNotFound = errors.New("watch zone not found")
 
-// WatchZone is a user's geofenced monitoring area: a circle (centre + radius)
-// scoped to one planning authority. Exported fields keep it a plain Go value;
-// the constructor enforces all invariants.
+// Boundary validation errors. All are returned by NewBoundary (and therefore
+// by WatchZone.WithBoundary and WithUpdates when a new boundary value is
+// supplied); consumers should use errors.Is rather than string matching.
+var (
+	// ErrBoundaryVertexCount signals a ring with fewer than 3 or more than 50
+	// distinct vertices (the closing repeat is not counted).
+	ErrBoundaryVertexCount = errors.New("boundary must have between 3 and 50 distinct vertices")
+	// ErrBoundaryDuplicateVertex signals two non-adjacent-by-closure vertices
+	// with identical coordinates.
+	ErrBoundaryDuplicateVertex = errors.New("boundary vertices must be distinct")
+	// ErrBoundarySelfIntersecting signals two non-adjacent edges of the ring
+	// crossing (the ring is not a simple polygon).
+	ErrBoundarySelfIntersecting = errors.New("boundary must not self-intersect")
+	// ErrBoundaryOutOfBounds signals a vertex outside the UK bounding box.
+	ErrBoundaryOutOfBounds = errors.New("boundary vertices must be within the UK")
+)
+
+// WatchZone is a user's geofenced monitoring area scoped to one planning
+// authority: either a circle (centre + radius) or, when Boundary is non-nil,
+// a custom-shape polygon. A custom-shape zone still carries Latitude,
+// Longitude and RadiusMetres — they hold the polygon's derived centroid and
+// enclosing radius (see WithBoundary) so every existing circle-shaped read
+// path (map centring, list rows, boundingBox, GDPR export) keeps working
+// unchanged; Boundary == nil is the sole "this is a circle" discriminator.
+// Exported fields keep it a plain Go value; the constructor enforces all
+// invariants.
 type WatchZone struct {
 	ID                  string
 	UserID              string
@@ -34,12 +57,19 @@ type WatchZone struct {
 	CreatedAt           time.Time
 	PushEnabled         bool
 	EmailInstantEnabled bool
+	Boundary            Boundary
 }
 
-// NewWatchZone validates and constructs a watch zone. id, user id and name must
-// be non-blank and radius and authority id must be positive. Coordinate range is
-// deliberately NOT checked here — that is an HTTP-layer validation, so the
-// domain accepts any latitude/longitude.
+// NewWatchZone validates and constructs a circle watch zone (Boundary nil).
+// id, user id and name must be non-blank and radius and authority id must be
+// positive. Coordinate range is deliberately NOT checked here — that is an
+// HTTP-layer validation, so the domain accepts any latitude/longitude. This
+// is an intentional asymmetry with custom-shape zones: NewBoundary DOES
+// range-check its vertices against UK bounds, because a hand-drawn polygon
+// with an out-of-range vertex is a client bug worth rejecting at construction
+// (the shape is meaningless outside the UK), whereas a circle's centre is a
+// single point whose plausibility is better judged with request context
+// (e.g. postcode lookup) at the HTTP layer.
 func NewWatchZone(id, userID, name string, latitude, longitude, radiusMetres float64, authorityID int, createdAt time.Time, pushEnabled, emailInstantEnabled bool) (WatchZone, error) {
 	if strings.TrimSpace(id) == "" {
 		return WatchZone{}, errors.New("id is required")
@@ -89,7 +119,256 @@ func (z WatchZone) boundingBox() (minLat, maxLat, minLon, maxLon float64) {
 	return z.Latitude - dLat, z.Latitude + dLat, z.Longitude - dLon, z.Longitude + dLon
 }
 
-// ZoneUpdate is a partial PATCH: a nil field leaves the existing value untouched.
+// IsCustomShape reports whether z is a custom-shape (polygon) zone rather
+// than a circle. Boundary == nil (the zero value) is the sole discriminator.
+func (z WatchZone) IsCustomShape() bool {
+	return len(z.Boundary) > 0
+}
+
+// WithBoundary returns a copy of z converted to a custom-shape zone: vertices
+// is validated and normalised via NewBoundary, and Latitude, Longitude and
+// RadiusMetres are recomputed as the polygon's centroid and enclosing radius.
+// Deriving those three fields keeps every existing circle-shaped read path
+// working unchanged against a custom-shape zone underneath.
+func (z WatchZone) WithBoundary(vertices []Coordinate) (WatchZone, error) {
+	b, err := NewBoundary(vertices)
+	if err != nil {
+		return WatchZone{}, err
+	}
+	lat, lon := b.Centroid()
+	updated, err := NewWatchZone(
+		z.ID, z.UserID, z.Name,
+		lat, lon, b.EnclosingRadiusMetres(),
+		z.AuthorityID, z.CreatedAt,
+		z.PushEnabled, z.EmailInstantEnabled,
+	)
+	if err != nil {
+		return WatchZone{}, err
+	}
+	updated.Boundary = b
+	return updated, nil
+}
+
+// Coordinate is a single lon/lat point, GeoJSON-ordered (longitude first) to
+// match the coordinate order the store and HTTP layers exchange with clients.
+type Coordinate struct {
+	Longitude float64
+	Latitude  float64
+}
+
+// Boundary is a closed polygon ring for a custom-shape watch zone. A nil
+// Boundary means the zone is a circle. Once constructed via NewBoundary, the
+// last vertex always equals the first (a closed ring); NewBoundary is the
+// only supported way to obtain a valid, validated Boundary.
+type Boundary []Coordinate
+
+const (
+	// minBoundaryVertices and maxBoundaryVertices bound the ring size,
+	// excluding the closing repeat: 3 is the geometric minimum for a
+	// polygon, 50 is generous for a hand-drawn shape while bounding payload
+	// size and the cost of the ST_Covers matching query.
+	minBoundaryVertices = 3
+	maxBoundaryVertices = 50
+
+	// ukMinLatitude, ukMaxLatitude, ukMinLongitude and ukMaxLongitude are a
+	// generous bounding box around Great Britain and Northern Ireland, used
+	// only to reject boundary vertices that are obviously not the UK — not a
+	// precise coastline check.
+	ukMinLatitude  = 49.5
+	ukMaxLatitude  = 61.0
+	ukMinLongitude = -8.5
+	ukMaxLongitude = 2.0
+)
+
+// NewBoundary validates and normalises raw vertices into a closed polygon
+// ring: 3-50 distinct vertices (after auto-closing, not counting the closing
+// repeat), an open ring is auto-closed by appending a copy of the first
+// vertex (a ring that already closes is left as-is), all vertices within UK
+// bounds, and the ring must be simple (no two non-adjacent edges cross).
+func NewBoundary(vertices []Coordinate) (Boundary, error) {
+	if len(vertices) == 0 {
+		return nil, ErrBoundaryVertexCount
+	}
+	ring := make(Boundary, len(vertices))
+	copy(ring, vertices)
+	if ring[0] != ring[len(ring)-1] {
+		ring = append(ring, ring[0])
+	}
+	distinct := ring[:len(ring)-1]
+	if len(distinct) < minBoundaryVertices || len(distinct) > maxBoundaryVertices {
+		return nil, ErrBoundaryVertexCount
+	}
+	seen := make(map[Coordinate]struct{}, len(distinct))
+	for _, v := range distinct {
+		if _, ok := seen[v]; ok {
+			return nil, ErrBoundaryDuplicateVertex
+		}
+		seen[v] = struct{}{}
+	}
+	for _, v := range distinct {
+		if v.Latitude < ukMinLatitude || v.Latitude > ukMaxLatitude ||
+			v.Longitude < ukMinLongitude || v.Longitude > ukMaxLongitude {
+			return nil, ErrBoundaryOutOfBounds
+		}
+	}
+	if ring.selfIntersects() {
+		return nil, ErrBoundarySelfIntersecting
+	}
+	return ring, nil
+}
+
+// selfIntersects reports whether any two non-adjacent edges of the closed
+// ring cross. O(n²) over the edges; n is capped at 50 vertices by NewBoundary
+// so this is cheap and a sweep-line algorithm is not warranted.
+func (b Boundary) selfIntersects() bool {
+	n := len(b) - 1 // number of edges (== number of distinct vertices) in the closed ring
+	if n < 3 {
+		return false
+	}
+	for i := 0; i < n; i++ {
+		a1, a2 := b[i], b[i+1]
+		for j := i + 2; j < n; j++ {
+			if i == 0 && j == n-1 {
+				// Edge n-1 (b[n-1]-b[n]) and edge 0 (b[0]-b[1]) share vertex
+				// b[0]==b[n]: adjacent via the ring's wraparound, not a crossing.
+				continue
+			}
+			b1, b2 := b[j], b[j+1]
+			if segmentsIntersect(a1, a2, b1, b2) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// segmentsIntersect reports whether segments p1-p2 and p3-p4 intersect,
+// including one touching the other at an endpoint or lying collinearly on
+// it. Standard orientation-based test (see e.g. CLRS §33.1).
+func segmentsIntersect(p1, p2, p3, p4 Coordinate) bool {
+	d1 := orientation(p3, p4, p1)
+	d2 := orientation(p3, p4, p2)
+	d3 := orientation(p1, p2, p3)
+	d4 := orientation(p1, p2, p4)
+
+	if ((d1 > 0 && d2 < 0) || (d1 < 0 && d2 > 0)) &&
+		((d3 > 0 && d4 < 0) || (d3 < 0 && d4 > 0)) {
+		return true
+	}
+	if d1 == 0 && onSegment(p3, p4, p1) {
+		return true
+	}
+	if d2 == 0 && onSegment(p3, p4, p2) {
+		return true
+	}
+	if d3 == 0 && onSegment(p1, p2, p3) {
+		return true
+	}
+	if d4 == 0 && onSegment(p1, p2, p4) {
+		return true
+	}
+	return false
+}
+
+// orientation returns (twice) the signed area of triangle a,b,c: positive for
+// counter-clockwise, negative for clockwise, zero when the three points are
+// collinear.
+func orientation(a, b, c Coordinate) float64 {
+	return (b.Longitude-a.Longitude)*(c.Latitude-a.Latitude) -
+		(b.Latitude-a.Latitude)*(c.Longitude-a.Longitude)
+}
+
+// onSegment reports whether point p, already known to be collinear with
+// segment a-b, lies within its bounding box — i.e. actually on the segment
+// rather than on the line through it extended beyond either endpoint.
+func onSegment(a, b, p Coordinate) bool {
+	return p.Longitude >= math.Min(a.Longitude, b.Longitude) && p.Longitude <= math.Max(a.Longitude, b.Longitude) &&
+		p.Latitude >= math.Min(a.Latitude, b.Latitude) && p.Latitude <= math.Max(a.Latitude, b.Latitude)
+}
+
+// earthRadiusMetres is the mean Earth radius used by haversineMetres.
+const earthRadiusMetres = 6371000.0
+
+// haversineMetres returns the great-circle distance between two lat/lon
+// points, in metres.
+func haversineMetres(lat1, lon1, lat2, lon2 float64) float64 {
+	const degToRad = math.Pi / 180
+	phi1, phi2 := lat1*degToRad, lat2*degToRad
+	dPhi := (lat2 - lat1) * degToRad
+	dLambda := (lon2 - lon1) * degToRad
+	a := math.Sin(dPhi/2)*math.Sin(dPhi/2) +
+		math.Cos(phi1)*math.Cos(phi2)*math.Sin(dLambda/2)*math.Sin(dLambda/2)
+	c := 2 * math.Atan2(math.Sqrt(a), math.Sqrt(1-a))
+	return earthRadiusMetres * c
+}
+
+// Centroid returns the polygon centroid of the boundary ring: the
+// area-weighted (shoelace-formula) centroid, not the arithmetic mean of the
+// vertices — the two differ for any non-uniform shape (e.g. an L-shape).
+// Longitude and latitude are treated as planar x/y, an acceptable
+// approximation at the sub-tens-of-km scale a hand-drawn watch zone can
+// reach.
+func (b Boundary) Centroid() (latitude, longitude float64) {
+	n := len(b) - 1 // closed ring: last vertex duplicates the first
+	if n < 1 {
+		return 0, 0
+	}
+	var area, cx, cy float64
+	for i := 0; i < n; i++ {
+		p0, p1 := b[i], b[i+1]
+		cross := p0.Longitude*p1.Latitude - p1.Longitude*p0.Latitude
+		area += cross
+		cx += (p0.Longitude + p1.Longitude) * cross
+		cy += (p0.Latitude + p1.Latitude) * cross
+	}
+	area /= 2
+	if area == 0 {
+		// Degenerate (zero-area, e.g. collinear) ring: fall back to the
+		// vertex average rather than dividing by zero.
+		var sumLat, sumLon float64
+		for _, v := range b[:n] {
+			sumLat += v.Latitude
+			sumLon += v.Longitude
+		}
+		return sumLat / float64(n), sumLon / float64(n)
+	}
+	cx /= 6 * area
+	cy /= 6 * area
+	return cy, cx
+}
+
+// EnclosingRadiusMetres returns the greatest great-circle distance from the
+// boundary's centroid to any vertex, in metres: the radius of the smallest
+// centroid-centred circle that fully encloses the shape. This, together with
+// the centroid, is what a polygon zone derives into the existing circle
+// columns (see WithBoundary) so every read path built for circles keeps
+// working unchanged.
+func (b Boundary) EnclosingRadiusMetres() float64 {
+	lat, lon := b.Centroid()
+	n := len(b) - 1
+	var maxDistance float64
+	for _, v := range b[:n] {
+		if d := haversineMetres(lat, lon, v.Latitude, v.Longitude); d > maxDistance {
+			maxDistance = d
+		}
+	}
+	return maxDistance
+}
+
+// ZoneUpdate is a partial PATCH: a nil field leaves the existing value
+// untouched.
+//
+// Boundary is tri-state, which a plain pointer-to-value cannot express, so it
+// is a pointer to the slice type instead:
+//   - nil                          — absent: leave the zone's shape alone.
+//   - non-nil, pointing to len-0   — explicit null: convert back to a circle,
+//     keeping the zone's existing centre and radius.
+//   - non-nil, pointing to len>0  — set this custom shape: the centre and
+//     radius are recomputed from it via NewBoundary.
+//
+// This is the domain-level representation of the tri-state; decoding the
+// HTTP PATCH body's `"boundary": null` vs absent vs a value into this shape
+// is a separate, JSON-layer concern (json.RawMessage) handled by the handler.
 type ZoneUpdate struct {
 	Name                *string
 	Latitude            *float64
@@ -98,12 +377,14 @@ type ZoneUpdate struct {
 	AuthorityID         *int
 	PushEnabled         *bool
 	EmailInstantEnabled *bool
+	Boundary            *Boundary
 }
 
 // WithUpdates returns a copy of the zone with the non-nil fields of u applied,
 // re-validated through the constructor — so a merge that would violate an
 // invariant (e.g. a blank name) returns an error rather than a corrupt zone.
-// Identity (id, user id) and the creation timestamp are immutable across an update.
+// Identity (id, user id) and the creation timestamp are immutable across an
+// update. See ZoneUpdate.Boundary for the tri-state shape semantics.
 func (z WatchZone) WithUpdates(u ZoneUpdate) (WatchZone, error) {
 	updated := z
 	if u.Name != nil {
@@ -127,7 +408,27 @@ func (z WatchZone) WithUpdates(u ZoneUpdate) (WatchZone, error) {
 	if u.EmailInstantEnabled != nil {
 		updated.EmailInstantEnabled = *u.EmailInstantEnabled
 	}
-	return NewWatchZone(
+
+	if u.Boundary != nil {
+		if len(*u.Boundary) == 0 {
+			// Explicit null: revert to a circle, keeping whatever centre and
+			// radius the merge above has settled on (the zone's existing
+			// derived values, unless this same update also set them).
+			updated.Boundary = nil
+		} else {
+			b, err := NewBoundary(*u.Boundary)
+			if err != nil {
+				return WatchZone{}, err
+			}
+			lat, lon := b.Centroid()
+			updated.Boundary = b
+			updated.Latitude = lat
+			updated.Longitude = lon
+			updated.RadiusMetres = b.EnclosingRadiusMetres()
+		}
+	}
+
+	result, err := NewWatchZone(
 		updated.ID,
 		updated.UserID,
 		updated.Name,
@@ -139,4 +440,9 @@ func (z WatchZone) WithUpdates(u ZoneUpdate) (WatchZone, error) {
 		updated.PushEnabled,
 		updated.EmailInstantEnabled,
 	)
+	if err != nil {
+		return WatchZone{}, err
+	}
+	result.Boundary = updated.Boundary
+	return result, nil
 }

--- a/api-go/internal/watchzones/zone.go
+++ b/api-go/internal/watchzones/zone.go
@@ -225,7 +225,7 @@ func (b Boundary) selfIntersects() bool {
 	if n < 3 {
 		return false
 	}
-	for i := 0; i < n; i++ {
+	for i := range n {
 		a1, a2 := b[i], b[i+1]
 		for j := i + 2; j < n; j++ {
 			if i == 0 && j == n-1 {
@@ -314,7 +314,7 @@ func (b Boundary) Centroid() (latitude, longitude float64) {
 		return 0, 0
 	}
 	var area, cx, cy float64
-	for i := 0; i < n; i++ {
+	for i := range n {
 		p0, p1 := b[i], b[i+1]
 		cross := p0.Longitude*p1.Latitude - p1.Longitude*p0.Latitude
 		area += cross

--- a/api-go/internal/watchzones/zone_test.go
+++ b/api-go/internal/watchzones/zone_test.go
@@ -2,6 +2,7 @@ package watchzones
 
 import (
 	"errors"
+	"math"
 	"reflect"
 	"testing"
 	"time"
@@ -222,6 +223,29 @@ func TestNewBoundary_RejectsMoreThanFiftyVertices(t *testing.T) {
 	}
 }
 
+func TestNewBoundary_AcceptsExactlyFiftyVertices(t *testing.T) {
+	t.Parallel()
+	const (
+		centreLat = 51.5074
+		centreLon = -0.1278
+		radiusDeg = 0.05
+		n         = 50
+	)
+	// Points on a small circle, not a collinear run, so this exercises the
+	// vertex-count boundary independently of the self-intersection/area checks.
+	vertices := make([]Coordinate, n)
+	for i := range n {
+		angle := 2 * math.Pi * float64(i) / float64(n)
+		vertices[i] = Coordinate{
+			Longitude: centreLon + radiusDeg*math.Cos(angle),
+			Latitude:  centreLat + radiusDeg*math.Sin(angle),
+		}
+	}
+	if _, err := NewBoundary(vertices); err != nil {
+		t.Fatalf("NewBoundary must accept a 50-vertex ring: %v", err)
+	}
+}
+
 func TestNewBoundary_RejectsSelfIntersectingRing(t *testing.T) {
 	t.Parallel()
 	// A bowtie: the two diagonals of this quadrilateral cross in the middle.
@@ -251,6 +275,52 @@ func TestNewBoundary_RejectsOutOfUKBoundsVertex(t *testing.T) {
 	}
 	if !errors.Is(err, ErrBoundaryOutOfBounds) {
 		t.Errorf("got err=%v, want ErrBoundaryOutOfBounds", err)
+	}
+}
+
+func TestNewBoundary_RejectsNonFiniteVertex(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		vertex Coordinate
+	}{
+		{"NaN latitude", Coordinate{Longitude: -0.1, Latitude: math.NaN()}},
+		{"NaN longitude", Coordinate{Longitude: math.NaN(), Latitude: 51.5}},
+		{"+Inf latitude", Coordinate{Longitude: -0.1, Latitude: math.Inf(1)}},
+		{"-Inf longitude", Coordinate{Longitude: math.Inf(-1), Latitude: 51.5}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := NewBoundary([]Coordinate{
+				{Longitude: -0.10, Latitude: 51.50},
+				{Longitude: -0.09, Latitude: 51.51},
+				tc.vertex,
+			})
+			if err == nil {
+				t.Fatal("NewBoundary must reject a non-finite vertex")
+			}
+			if !errors.Is(err, ErrBoundaryOutOfBounds) {
+				t.Errorf("got err=%v, want ErrBoundaryOutOfBounds", err)
+			}
+		})
+	}
+}
+
+func TestNewBoundary_RejectsZeroAreaRing(t *testing.T) {
+	t.Parallel()
+	// Three distinct but collinear points: no two non-adjacent edges to
+	// cross-check, so selfIntersects alone would accept this degenerate ring.
+	_, err := NewBoundary([]Coordinate{
+		{Longitude: -0.10, Latitude: 51.50},
+		{Longitude: -0.09, Latitude: 51.50},
+		{Longitude: -0.08, Latitude: 51.50},
+	})
+	if err == nil {
+		t.Fatal("NewBoundary must reject a zero-area (collinear) ring")
+	}
+	if !errors.Is(err, ErrBoundarySelfIntersecting) {
+		t.Errorf("got err=%v, want ErrBoundarySelfIntersecting", err)
 	}
 }
 
@@ -370,6 +440,17 @@ func TestBoundary_EnclosingRadiusMetres_KnownSquare(t *testing.T) {
 	}
 }
 
+func TestBoundary_EnclosingRadiusMetres_EmptyBoundaryDoesNotPanic(t *testing.T) {
+	t.Parallel()
+	var nilBoundary Boundary
+	if got := nilBoundary.EnclosingRadiusMetres(); got != 0 {
+		t.Errorf("nil boundary: got %v, want 0", got)
+	}
+	if got := (Boundary{}).EnclosingRadiusMetres(); got != 0 {
+		t.Errorf("empty boundary: got %v, want 0", got)
+	}
+}
+
 func TestWatchZone_IsCustomShape(t *testing.T) {
 	t.Parallel()
 	circle := testZone(t)
@@ -408,9 +489,11 @@ func TestWatchZone_WithBoundary_DerivesCentroidAndRadius(t *testing.T) {
 	if diff := shape.RadiusMetres - wantRadius; diff > tol || diff < -tol {
 		t.Errorf("radiusMetres: got %v, want %v", shape.RadiusMetres, wantRadius)
 	}
-	// Identity and other fields carry over unchanged.
-	if shape.ID != z.ID || shape.UserID != z.UserID || shape.Name != z.Name {
-		t.Errorf("identity fields changed: got %+v", shape)
+	// Identity and every non-derived field carry over unchanged.
+	if shape.ID != z.ID || shape.UserID != z.UserID || shape.Name != z.Name ||
+		shape.AuthorityID != z.AuthorityID || !shape.CreatedAt.Equal(z.CreatedAt) ||
+		shape.PushEnabled != z.PushEnabled || shape.EmailInstantEnabled != z.EmailInstantEnabled {
+		t.Errorf("non-derived fields changed: got %+v, want %+v", shape, z)
 	}
 }
 
@@ -470,8 +553,20 @@ func TestWatchZone_WithUpdates_BoundaryTriState(t *testing.T) {
 		if !updated.IsCustomShape() {
 			t.Fatal("boundary not set")
 		}
-		if updated.Latitude == circleZone.Latitude && updated.Longitude == circleZone.Longitude {
-			t.Error("centre was not recomputed from the new boundary")
+		want, err := NewBoundary(londonSquare(t))
+		if err != nil {
+			t.Fatalf("NewBoundary: %v", err)
+		}
+		wantLat, wantLon := want.Centroid()
+		if updated.Latitude != wantLat || updated.Longitude != wantLon {
+			t.Errorf("centre: got (%v,%v), want (%v,%v)",
+				updated.Latitude, updated.Longitude, wantLat, wantLon)
+		}
+		if wantRadius := want.EnclosingRadiusMetres(); updated.RadiusMetres != wantRadius {
+			t.Errorf("radius: got %v, want %v", updated.RadiusMetres, wantRadius)
+		}
+		if updated.RadiusMetres == circleZone.RadiusMetres {
+			t.Error("radius was not recomputed from the new boundary")
 		}
 	})
 

--- a/api-go/internal/watchzones/zone_test.go
+++ b/api-go/internal/watchzones/zone_test.go
@@ -1,6 +1,8 @@
 package watchzones
 
 import (
+	"errors"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -159,7 +161,325 @@ func TestWatchZone_WithUpdates_EmptyUpdateIsIdentity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("WithUpdates: %v", err)
 	}
-	if updated != z {
+	// WatchZone now carries a slice field (Boundary), so it is no longer
+	// comparable with == / !=; reflect.DeepEqual is the structural equivalent.
+	if !reflect.DeepEqual(updated, z) {
 		t.Errorf("empty update changed zone: got %+v, want %+v", updated, z)
 	}
+}
+
+// --- Boundary (custom-shape) tests ---------------------------------------
+
+// londonSquare is a small closed square near central London, well within UK
+// bounds, symmetric about (51.5074, -0.1278) with an offset chosen so it is
+// roughly a 1km-radius shape (matching the boundingBox test's precomputed
+// formula: dLat = r/111320, dLon = r/(111320*cos(lat))).
+func londonSquare(t *testing.T) []Coordinate {
+	t.Helper()
+	const (
+		centreLat = 51.5074
+		centreLon = -0.1278
+		dLat      = 0.0089831
+		dLon      = 0.0144328
+	)
+	return []Coordinate{
+		{Longitude: centreLon + dLon, Latitude: centreLat + dLat},
+		{Longitude: centreLon - dLon, Latitude: centreLat + dLat},
+		{Longitude: centreLon - dLon, Latitude: centreLat - dLat},
+		{Longitude: centreLon + dLon, Latitude: centreLat - dLat},
+	}
+}
+
+func TestNewBoundary_RejectsFewerThanThreeVertices(t *testing.T) {
+	t.Parallel()
+	_, err := NewBoundary([]Coordinate{
+		{Longitude: -0.1, Latitude: 51.5},
+		{Longitude: -0.11, Latitude: 51.51},
+	})
+	if err == nil {
+		t.Fatal("NewBoundary must reject a 2-vertex ring")
+	}
+	if !errors.Is(err, ErrBoundaryVertexCount) {
+		t.Errorf("got err=%v, want ErrBoundaryVertexCount", err)
+	}
+}
+
+func TestNewBoundary_RejectsMoreThanFiftyVertices(t *testing.T) {
+	t.Parallel()
+	vertices := make([]Coordinate, 0, 51)
+	for i := 0; i < 51; i++ {
+		vertices = append(vertices, Coordinate{
+			Longitude: -0.5 + float64(i)*0.001,
+			Latitude:  51.5,
+		})
+	}
+	_, err := NewBoundary(vertices)
+	if err == nil {
+		t.Fatal("NewBoundary must reject a 51-vertex ring")
+	}
+	if !errors.Is(err, ErrBoundaryVertexCount) {
+		t.Errorf("got err=%v, want ErrBoundaryVertexCount", err)
+	}
+}
+
+func TestNewBoundary_RejectsSelfIntersectingRing(t *testing.T) {
+	t.Parallel()
+	// A bowtie: the two diagonals of this quadrilateral cross in the middle.
+	_, err := NewBoundary([]Coordinate{
+		{Longitude: -0.10, Latitude: 51.50},
+		{Longitude: -0.09, Latitude: 51.51},
+		{Longitude: -0.09, Latitude: 51.50},
+		{Longitude: -0.10, Latitude: 51.51},
+	})
+	if err == nil {
+		t.Fatal("NewBoundary must reject a self-intersecting ring")
+	}
+	if !errors.Is(err, ErrBoundarySelfIntersecting) {
+		t.Errorf("got err=%v, want ErrBoundarySelfIntersecting", err)
+	}
+}
+
+func TestNewBoundary_RejectsOutOfUKBoundsVertex(t *testing.T) {
+	t.Parallel()
+	_, err := NewBoundary([]Coordinate{
+		{Longitude: -0.1, Latitude: 51.5},
+		{Longitude: -0.11, Latitude: 51.51},
+		{Longitude: 40.0, Latitude: 51.5}, // well east of the UK
+	})
+	if err == nil {
+		t.Fatal("NewBoundary must reject a vertex outside UK bounds")
+	}
+	if !errors.Is(err, ErrBoundaryOutOfBounds) {
+		t.Errorf("got err=%v, want ErrBoundaryOutOfBounds", err)
+	}
+}
+
+func TestNewBoundary_RejectsDuplicateVertex(t *testing.T) {
+	t.Parallel()
+	_, err := NewBoundary([]Coordinate{
+		{Longitude: -0.10, Latitude: 51.50},
+		{Longitude: -0.09, Latitude: 51.51},
+		{Longitude: -0.09, Latitude: 51.51}, // duplicate of the previous vertex
+		{Longitude: -0.08, Latitude: 51.50},
+	})
+	if err == nil {
+		t.Fatal("NewBoundary must reject a duplicate interior vertex")
+	}
+	if !errors.Is(err, ErrBoundaryDuplicateVertex) {
+		t.Errorf("got err=%v, want ErrBoundaryDuplicateVertex", err)
+	}
+}
+
+func TestNewBoundary_AutoClosesUnclosedRing(t *testing.T) {
+	t.Parallel()
+	triangle := []Coordinate{
+		{Longitude: -0.10, Latitude: 51.50},
+		{Longitude: -0.09, Latitude: 51.51},
+		{Longitude: -0.09, Latitude: 51.50},
+	}
+	b, err := NewBoundary(triangle)
+	if err != nil {
+		t.Fatalf("NewBoundary: %v", err)
+	}
+	if len(b) != len(triangle)+1 {
+		t.Fatalf("got %d vertices, want %d (auto-closed)", len(b), len(triangle)+1)
+	}
+	if b[0] != b[len(b)-1] {
+		t.Errorf("ring not closed: first=%v last=%v", b[0], b[len(b)-1])
+	}
+}
+
+func TestNewBoundary_AlreadyClosedRingIsNotDoubled(t *testing.T) {
+	t.Parallel()
+	closed := []Coordinate{
+		{Longitude: -0.10, Latitude: 51.50},
+		{Longitude: -0.09, Latitude: 51.51},
+		{Longitude: -0.09, Latitude: 51.50},
+		{Longitude: -0.10, Latitude: 51.50}, // already closes the ring
+	}
+	b, err := NewBoundary(closed)
+	if err != nil {
+		t.Fatalf("NewBoundary: %v", err)
+	}
+	if len(b) != len(closed) {
+		t.Fatalf("got %d vertices, want %d (should not double the closing vertex)", len(b), len(closed))
+	}
+}
+
+func TestBoundary_Centroid_KnownSquare(t *testing.T) {
+	t.Parallel()
+	square := Boundary{
+		{Longitude: 0, Latitude: 0},
+		{Longitude: 0, Latitude: 10},
+		{Longitude: 10, Latitude: 10},
+		{Longitude: 10, Latitude: 0},
+		{Longitude: 0, Latitude: 0},
+	}
+	lat, lon := square.Centroid()
+	const want = 5.0
+	if diff := lat - want; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("lat: got %v, want %v", lat, want)
+	}
+	if diff := lon - want; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("lon: got %v, want %v", lon, want)
+	}
+}
+
+func TestBoundary_Centroid_AsymmetricPolygonNotVertexAverage(t *testing.T) {
+	t.Parallel()
+	// A staircase/L-shape: (0,0),(6,0),(6,2),(2,2),(2,4),(0,4) in (lon,lat).
+	// The true polygon centroid is (2.5, 1.5); the naive vertex average is
+	// (2.667, 2.0) — different enough that a naive-average implementation
+	// fails this test.
+	shape := Boundary{
+		{Longitude: 0, Latitude: 0},
+		{Longitude: 6, Latitude: 0},
+		{Longitude: 6, Latitude: 2},
+		{Longitude: 2, Latitude: 2},
+		{Longitude: 2, Latitude: 4},
+		{Longitude: 0, Latitude: 4},
+		{Longitude: 0, Latitude: 0},
+	}
+	lat, lon := shape.Centroid()
+	const (
+		wantLat = 1.5
+		wantLon = 2.5
+		tol     = 1e-9
+	)
+	if diff := lat - wantLat; diff > tol || diff < -tol {
+		t.Errorf("lat: got %v, want %v", lat, wantLat)
+	}
+	if diff := lon - wantLon; diff > tol || diff < -tol {
+		t.Errorf("lon: got %v, want %v", lon, wantLon)
+	}
+}
+
+func TestBoundary_EnclosingRadiusMetres_KnownSquare(t *testing.T) {
+	t.Parallel()
+	square, err := NewBoundary(londonSquare(t))
+	if err != nil {
+		t.Fatalf("NewBoundary: %v", err)
+	}
+	got := square.EnclosingRadiusMetres()
+	const (
+		want = 1412.694247415168
+		tol  = 0.5
+	)
+	if diff := got - want; diff > tol || diff < -tol {
+		t.Errorf("got %v, want %v (±%v)", got, want, tol)
+	}
+}
+
+func TestWatchZone_IsCustomShape(t *testing.T) {
+	t.Parallel()
+	circle := testZone(t)
+	if circle.IsCustomShape() {
+		t.Error("a circle zone (nil Boundary) must not report IsCustomShape")
+	}
+
+	shape, err := circle.WithBoundary(londonSquare(t))
+	if err != nil {
+		t.Fatalf("WithBoundary: %v", err)
+	}
+	if !shape.IsCustomShape() {
+		t.Error("a zone with a non-nil Boundary must report IsCustomShape")
+	}
+}
+
+func TestWatchZone_WithBoundary_DerivesCentroidAndRadius(t *testing.T) {
+	t.Parallel()
+	z := testZone(t)
+	shape, err := z.WithBoundary(londonSquare(t))
+	if err != nil {
+		t.Fatalf("WithBoundary: %v", err)
+	}
+	const (
+		wantLat    = 51.5074
+		wantLon    = -0.1278
+		wantRadius = 1412.694247415168
+		tol        = 0.5
+	)
+	if diff := shape.Latitude - wantLat; diff > 1e-4 || diff < -1e-4 {
+		t.Errorf("latitude: got %v, want %v", shape.Latitude, wantLat)
+	}
+	if diff := shape.Longitude - wantLon; diff > 1e-4 || diff < -1e-4 {
+		t.Errorf("longitude: got %v, want %v", shape.Longitude, wantLon)
+	}
+	if diff := shape.RadiusMetres - wantRadius; diff > tol || diff < -tol {
+		t.Errorf("radiusMetres: got %v, want %v", shape.RadiusMetres, wantRadius)
+	}
+	// Identity and other fields carry over unchanged.
+	if shape.ID != z.ID || shape.UserID != z.UserID || shape.Name != z.Name {
+		t.Errorf("identity fields changed: got %+v", shape)
+	}
+}
+
+func TestWatchZone_WithBoundary_InvalidVerticesReturnsError(t *testing.T) {
+	t.Parallel()
+	z := testZone(t)
+	if _, err := z.WithBoundary([]Coordinate{{Longitude: -0.1, Latitude: 51.5}}); err == nil {
+		t.Fatal("WithBoundary must reject an invalid ring")
+	}
+}
+
+func TestWatchZone_WithUpdates_BoundaryTriState(t *testing.T) {
+	t.Parallel()
+	circleZone := testZone(t)
+	shapeZone, err := circleZone.WithBoundary(londonSquare(t))
+	if err != nil {
+		t.Fatalf("WithBoundary: %v", err)
+	}
+
+	t.Run("absent leaves shape untouched", func(t *testing.T) {
+		t.Parallel()
+		updated, err := shapeZone.WithUpdates(ZoneUpdate{})
+		if err != nil {
+			t.Fatalf("WithUpdates: %v", err)
+		}
+		if !reflect.DeepEqual(updated.Boundary, shapeZone.Boundary) {
+			t.Errorf("boundary changed by an absent update: got %v, want %v", updated.Boundary, shapeZone.Boundary)
+		}
+	})
+
+	t.Run("explicit null clears the boundary and keeps the derived centroid/radius", func(t *testing.T) {
+		t.Parallel()
+		cleared := Boundary{}
+		updated, err := shapeZone.WithUpdates(ZoneUpdate{Boundary: &cleared})
+		if err != nil {
+			t.Fatalf("WithUpdates: %v", err)
+		}
+		if updated.IsCustomShape() {
+			t.Errorf("boundary not cleared: %v", updated.Boundary)
+		}
+		if updated.Latitude != shapeZone.Latitude || updated.Longitude != shapeZone.Longitude {
+			t.Errorf("centre changed on clear: got (%v,%v), want (%v,%v)",
+				updated.Latitude, updated.Longitude, shapeZone.Latitude, shapeZone.Longitude)
+		}
+		if updated.RadiusMetres != shapeZone.RadiusMetres {
+			t.Errorf("radius changed on clear: got %v, want %v", updated.RadiusMetres, shapeZone.RadiusMetres)
+		}
+	})
+
+	t.Run("a value sets a new boundary and recomputes centroid/radius", func(t *testing.T) {
+		t.Parallel()
+		newShape := Boundary(londonSquare(t))
+		updated, err := circleZone.WithUpdates(ZoneUpdate{Boundary: &newShape})
+		if err != nil {
+			t.Fatalf("WithUpdates: %v", err)
+		}
+		if !updated.IsCustomShape() {
+			t.Fatal("boundary not set")
+		}
+		if updated.Latitude == circleZone.Latitude && updated.Longitude == circleZone.Longitude {
+			t.Error("centre was not recomputed from the new boundary")
+		}
+	})
+
+	t.Run("an invalid value is rejected", func(t *testing.T) {
+		t.Parallel()
+		tooFew := Boundary{{Longitude: -0.1, Latitude: 51.5}}
+		if _, err := circleZone.WithUpdates(ZoneUpdate{Boundary: &tooFew}); err == nil {
+			t.Fatal("WithUpdates must reject an invalid boundary value")
+		}
+	})
 }

--- a/api-go/internal/watchzones/zone_test.go
+++ b/api-go/internal/watchzones/zone_test.go
@@ -207,7 +207,7 @@ func TestNewBoundary_RejectsFewerThanThreeVertices(t *testing.T) {
 func TestNewBoundary_RejectsMoreThanFiftyVertices(t *testing.T) {
 	t.Parallel()
 	vertices := make([]Coordinate, 0, 51)
-	for i := 0; i < 51; i++ {
+	for i := range 51 {
 		vertices = append(vertices, Coordinate{
 			Longitude: -0.5 + float64(i)*0.001,
 			Latitude:  51.5,


### PR DESCRIPTION
## Summary

Domain-layer piece of custom-shape (polygon) watch zones (GH#1031), scoped to `api-go/internal/watchzones/` only. This is child task #2 of epic tc-6he3x — bead [tc-6he3x.1](https://github.com/AmyDe/town-crier/issues/1031#2-domain-watchzoneszonego).

- New `Coordinate` and `Boundary` (`[]Coordinate`) types; `nil` boundary means "circle".
- `NewBoundary` validates: 3–50 distinct vertices, auto-closes an open ring, rejects self-intersecting rings (O(n²) segment test), rejects vertices outside a UK bounding box.
- `WatchZone.IsCustomShape()` and `WatchZone.WithBoundary(vertices)` — the latter derives and stores the polygon's centroid/enclosing radius into the existing `Latitude`/`Longitude`/`RadiusMetres` fields so every circle-shaped read path keeps working unchanged.
- `Boundary.Centroid()` — proper area-weighted (shoelace) polygon centroid, not a naive vertex average.
- `Boundary.EnclosingRadiusMetres()` — max haversine distance from centroid to any vertex.
- `ZoneUpdate.Boundary *Boundary` — tri-state PATCH semantics (absent / explicit empty = revert to circle / populated = set new shape), wired through `WithUpdates`.
- Mechanical fix in `handler.go`: `patchRequest.toUpdate()` used a direct `ZoneUpdate(req)` type conversion that relied on field-identical structs; adding `Boundary` to `ZoneUpdate` broke that, so it's now an explicit field-by-field copy. No behavior change — `patchRequest` does not yet expose a boundary field (that's tc-6he3x.4).

Out of scope for this PR (separate beads in the epic): store/SQL, HTTP boundary wiring, entitlements, iOS, web.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test ./...` (full module, all packages pass)
- [x] TDD: red commit (failing tests) then green commit (implementation)
- New tests in `zone_test.go`: vertex-count rejection (<3, >50), self-intersection, auto-close of an open ring, duplicate-vertex rejection, out-of-UK-bounds rejection, centroid correctness (square + asymmetric polygon), enclosing radius correctness, `IsCustomShape()`, tri-state `ZoneUpdate` behaviour.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01TtrSabH8bN8uaY8mUzayKQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom polygon-shaped watch zones alongside circular zones.
  * Polygon boundaries are validated for vertex count, duplicates, self-intersections, closure, and geographic bounds.
  * Polygon centres and enclosing radii are calculated automatically.
  * Watch zone updates can now add, replace, or remove custom boundaries.

* **Bug Fixes**
  * Improved handling of partial watch zone updates to preserve existing values correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->