### PR TITLE
feat(api): tier entitlements for custom-shape watch zones (tc-6he3x.3)

### DIFF
--- a/api-go/internal/profiles/profile.go
+++ b/api-go/internal/profiles/profile.go
@@ -91,6 +91,28 @@ func (t SubscriptionTier) WatchZoneLimit() int {
 	}
 }
 
+// AllowsCustomBoundary reports whether the tier may draw a custom-shape
+// (polygon) watch zone boundary rather than a plain circle: Personal and Pro,
+// never Free. Part of the custom-shape watch zones entitlement (epic GH#1031).
+func (t SubscriptionTier) AllowsCustomBoundary() bool { return t.IsPaid() }
+
+// MaxZoneRadiusMetres returns the maximum enclosing-circle radius, in metres,
+// permitted for a custom-shape polygon boundary: Free=2000, Personal=5000,
+// Pro=10000, mirroring mobile/ios/packages/town-crier-domain/Sources/
+// ValueObjects/WatchZoneLimits.swift. This bounds only the polygon's
+// enclosing radius — it is unrelated to the existing flat circle-zone radius
+// ceiling in internal/watchzones/nearby.go, which this method does not touch.
+func (t SubscriptionTier) MaxZoneRadiusMetres() float64 {
+	switch t {
+	case TierPersonal:
+		return 5000
+	case TierPro:
+		return 10000
+	default:
+		return 2000
+	}
+}
+
 // ErrUnknownTier is returned by ParseSubscriptionTier for an unrecognised value.
 var ErrUnknownTier = errors.New("unknown subscription tier")
 

--- a/api-go/internal/profiles/profile_test.go
+++ b/api-go/internal/profiles/profile_test.go
@@ -173,6 +173,35 @@ func TestSubscriptionTier_IsPaid(t *testing.T) {
 	}
 }
 
+func TestSubscriptionTier_AllowsCustomBoundary(t *testing.T) {
+	t.Parallel()
+
+	if TierFree.AllowsCustomBoundary() {
+		t.Error("Free should not allow a custom boundary")
+	}
+	if !TierPersonal.AllowsCustomBoundary() || !TierPro.AllowsCustomBoundary() {
+		t.Error("Personal and Pro should allow a custom boundary")
+	}
+}
+
+func TestSubscriptionTier_MaxZoneRadiusMetres(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		tier SubscriptionTier
+		want float64
+	}{
+		{TierFree, 2000},
+		{TierPersonal, 5000},
+		{TierPro, 10000},
+	}
+	for _, tc := range tests {
+		if got := tc.tier.MaxZoneRadiusMetres(); got != tc.want {
+			t.Errorf("%v.MaxZoneRadiusMetres(): got %v, want %v", tc.tier, got, tc.want)
+		}
+	}
+}
+
 func TestUserProfile_EffectiveTier(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Add `SubscriptionTier.AllowsCustomBoundary() bool` — Personal and Pro only, gated on the existing `IsPaid()`.
- Add `SubscriptionTier.MaxZoneRadiusMetres() float64` — Free=2000, Personal=5000, Pro=10000, mirroring `WatchZoneLimits.swift`.
- Pure entitlement-profile plumbing in `api-go/internal/profiles/profile.go`, sitting alongside `WatchZoneLimit()`/`HasHourlyDigestEntitlement()`. No HTTP wiring, no `watchzones` package changes — those belong to the downstream bead `tc-6he3x.4`.

Part of epic [GH#1031](https://github.com/AmyDe/town-crier/issues/1031) (custom-shape/polygon watch zones as a paid entitlement), section 4 ("Entitlement (`profiles/profile.go`)"). `MaxZoneRadiusMetres()` is intended to apply only to a polygon's enclosing radius, never to the existing flat 10km circle-zone ceiling in `internal/watchzones/nearby.go` (deliberately untouched per the issue's Out of Scope note — that's tracked separately as `tc-ohbaz`).

## Test plan
- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./...` — all packages pass
- [x] `go test -race ./...` — all packages pass
- [x] New table-driven tests `TestSubscriptionTier_AllowsCustomBoundary` / `TestSubscriptionTier_MaxZoneRadiusMetres` cover all three tiers
- [ ] `golangci-lint` — could not run locally (sandbox binary built with go1.25, `go.mod` targets go1.26); pre-existing environment issue unrelated to this change, will be covered by CI

Bead: tc-6he3x.3

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHQRU731KpevJxrAcRM7TS)_