### PR TITLE
feat(ios): CustomShapeUpsellGraphic onboarding component (tc-6he3x.9)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/CustomShapeUpsellGraphic.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/CustomShapeUpsellGraphic.swift
@@ -1,0 +1,92 @@
+import Foundation
+import SwiftUI
+
+/// Decorative onboarding graphic contrasting the default **circle** watch
+/// zone with a **custom shape** (polygon) watch zone, to visually explain the
+/// paid "draw a custom shape instead of a circle" entitlement (GH#1031).
+///
+/// Drawn entirely in code with SwiftUI `Path`, never a raster asset — ADR
+/// 0040 single-sources design tokens, and a bitmap can't follow the
+/// light/dark/OLED theme. The muted, dashed circle reads as the existing,
+/// unremarkable default; the solid `tcAmber` polygon reads as the premium
+/// capability, matching the app's convention that `tcAmber` marks brand and
+/// interactive emphasis. Purely presentational: no ViewModel, no external
+/// state — every color and spacing value comes from a design token, so the
+/// graphic needs no wiring to render correctly in any theme.
+///
+/// Not yet wired into any screen — that's a separate bead (onboarding step
+/// placement).
+public struct CustomShapeUpsellGraphic: View {
+  private static let tileSize: CGFloat = 96
+
+  public init() {}
+
+  public var body: some View {
+    HStack(spacing: TCSpacing.large) {
+      Circle()
+        .stroke(Color.tcTextTertiary, style: StrokeStyle(lineWidth: 2, dash: [6, 4]))
+        .frame(width: Self.tileSize, height: Self.tileSize)
+
+      Image(systemName: "arrow.right")
+        .font(TCTypography.body)
+        .foregroundStyle(Color.tcTextSecondary)
+
+      CustomShapePolygon()
+        .stroke(Color.tcAmber, style: StrokeStyle(lineWidth: 2, lineJoin: .round))
+        .frame(width: Self.tileSize, height: Self.tileSize)
+    }
+    .padding(TCSpacing.large)
+    .accessibilityElement(children: .ignore)
+    .accessibilityLabel(
+      "Illustration: a plain circle watch zone next to a custom, hand-drawn shape watch zone"
+    )
+  }
+}
+
+/// The irregular polygon ("blob") half of ``CustomShapeUpsellGraphic`` — a
+/// closed shape that reads as hand-drawn rather than a regular polygon, to
+/// contrast visually with the perfectly round circle beside it.
+struct CustomShapePolygon: Shape {
+  func path(in rect: CGRect) -> Path {
+    let vertices = CustomShapePolygonGeometry.vertices(in: rect)
+    var path = Path()
+    guard let first = vertices.first else { return path }
+
+    path.move(to: first)
+    for vertex in vertices.dropFirst() {
+      path.addLine(to: vertex)
+    }
+    path.closeSubpath()
+    return path
+  }
+}
+
+/// Pure geometry for ``CustomShapePolygon``, factored out of the view so the
+/// point generation is unit-testable without instantiating SwiftUI.
+///
+/// Vertices are placed at evenly-spaced angles around the centre of the
+/// given rect, each pulled in from a shared base radius by a fixed,
+/// hand-picked multiplier no greater than `1.0` (so every vertex stays
+/// inscribed within the rect passed to it — no overflow into a neighbouring
+/// element). The multipliers are deliberately irregular (not a smooth curve
+/// or true randomness) so the outline reads as a hand-drawn boundary rather
+/// than a regular polygon — deterministic and simple, since this is a
+/// decorative graphic rather than data-driven geometry.
+enum CustomShapePolygonGeometry {
+  static let radiusMultipliers: [CGFloat] = [0.9, 0.6, 1.0, 0.55, 0.85, 0.5, 0.95, 0.65]
+
+  static func vertices(in rect: CGRect) -> [CGPoint] {
+    let center = CGPoint(x: rect.midX, y: rect.midY)
+    let baseRadius = min(rect.width, rect.height) / 2
+    let count = radiusMultipliers.count
+
+    return radiusMultipliers.enumerated().map { index, multiplier in
+      let angle = (CGFloat(index) / CGFloat(count)) * 2 * .pi
+      let radius = baseRadius * multiplier
+      return CGPoint(
+        x: center.x + radius * cos(angle),
+        y: center.y + radius * sin(angle)
+      )
+    }
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/CustomShapeUpsellGraphicTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/CustomShapeUpsellGraphicTests.swift
@@ -41,8 +41,7 @@ struct CustomShapePolygonGeometryTests {
     let vertices = CustomShapePolygonGeometry.vertices(in: rect)
 
     for vertex in vertices {
-      let distance = (vertex - center).magnitude
-      #expect(distance <= maxRadius + 0.001)
+      #expect(distanceBetween(vertex, center) <= maxRadius + 0.001)
     }
   }
 
@@ -63,20 +62,13 @@ struct CustomShapePolygonGeometryTests {
     let vertices = CustomShapePolygonGeometry.vertices(in: smallRect)
 
     for vertex in vertices {
-      let distance = (vertex - center).magnitude
-      #expect(distance <= maxRadius + 0.001)
+      #expect(distanceBetween(vertex, center) <= maxRadius + 0.001)
     }
   }
 }
 
-extension CGPoint {
-  private static func - (lhs: CGPoint, rhs: CGPoint) -> CGVector {
-    CGVector(dx: lhs.x - rhs.x, dy: lhs.y - rhs.y)
-  }
-}
-
-extension CGVector {
-  private var magnitude: CGFloat {
-    (dx * dx + dy * dy).squareRoot()
-  }
+private func distanceBetween(_ a: CGPoint, _ b: CGPoint) -> CGFloat {
+  let dx = a.x - b.x
+  let dy = a.y - b.y
+  return (dx * dx + dy * dy).squareRoot()
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/CustomShapeUpsellGraphicTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/CustomShapeUpsellGraphicTests.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+import Testing
+
+@testable import TownCrierPresentation
+
+@Suite("CustomShapeUpsellGraphic")
+@MainActor
+struct CustomShapeUpsellGraphicTests {
+
+  @Test func init_rendersWithoutCrashing() {
+    let sut = CustomShapeUpsellGraphic()
+    _ = sut.body
+  }
+}
+
+@Suite("CustomShapePolygonGeometry")
+struct CustomShapePolygonGeometryTests {
+
+  @Test func vertices_returnsOnePointPerRadiusMultiplier() {
+    let rect = CGRect(x: 0, y: 0, width: 100, height: 100)
+
+    let vertices = CustomShapePolygonGeometry.vertices(in: rect)
+
+    #expect(vertices.count == CustomShapePolygonGeometry.radiusMultipliers.count)
+  }
+
+  @Test func vertices_isDeterministicForTheSameRect() {
+    let rect = CGRect(x: 0, y: 0, width: 100, height: 100)
+
+    let first = CustomShapePolygonGeometry.vertices(in: rect)
+    let second = CustomShapePolygonGeometry.vertices(in: rect)
+
+    #expect(first == second)
+  }
+
+  @Test func vertices_areContainedWithinTheRectsBoundingRadius() {
+    let rect = CGRect(x: 0, y: 0, width: 100, height: 100)
+    let center = CGPoint(x: rect.midX, y: rect.midY)
+    let maxRadius = min(rect.width, rect.height) / 2
+
+    let vertices = CustomShapePolygonGeometry.vertices(in: rect)
+
+    for vertex in vertices {
+      let distance = (vertex - center).magnitude
+      #expect(distance <= maxRadius + 0.001)
+    }
+  }
+
+  @Test func vertices_areNotAllIdentical() {
+    let rect = CGRect(x: 0, y: 0, width: 100, height: 100)
+
+    let vertices = CustomShapePolygonGeometry.vertices(in: rect)
+    let distinctVertices = Set(vertices.map { "\($0.x),\($0.y)" })
+
+    #expect(distinctVertices.count == vertices.count)
+  }
+
+  @Test func vertices_scalesWithASmallerRect() {
+    let smallRect = CGRect(x: 0, y: 0, width: 10, height: 10)
+    let center = CGPoint(x: smallRect.midX, y: smallRect.midY)
+    let maxRadius = min(smallRect.width, smallRect.height) / 2
+
+    let vertices = CustomShapePolygonGeometry.vertices(in: smallRect)
+
+    for vertex in vertices {
+      let distance = (vertex - center).magnitude
+      #expect(distance <= maxRadius + 0.001)
+    }
+  }
+}
+
+extension CGPoint {
+  fileprivate static func - (lhs: CGPoint, rhs: CGPoint) -> CGVector {
+    CGVector(dx: lhs.x - rhs.x, dy: lhs.y - rhs.y)
+  }
+}
+
+extension CGVector {
+  fileprivate var magnitude: CGFloat {
+    (dx * dx + dy * dy).squareRoot()
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/CustomShapeUpsellGraphicTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/CustomShapeUpsellGraphicTests.swift
@@ -67,8 +67,8 @@ struct CustomShapePolygonGeometryTests {
   }
 }
 
-private func distanceBetween(_ a: CGPoint, _ b: CGPoint) -> CGFloat {
-  let dx = a.x - b.x
-  let dy = a.y - b.y
-  return (dx * dx + dy * dy).squareRoot()
+private func distanceBetween(_ lhs: CGPoint, _ rhs: CGPoint) -> CGFloat {
+  let deltaX = lhs.x - rhs.x
+  let deltaY = lhs.y - rhs.y
+  return (deltaX * deltaX + deltaY * deltaY).squareRoot()
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/CustomShapeUpsellGraphicTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/CustomShapeUpsellGraphicTests.swift
@@ -70,13 +70,13 @@ struct CustomShapePolygonGeometryTests {
 }
 
 extension CGPoint {
-  fileprivate static func - (lhs: CGPoint, rhs: CGPoint) -> CGVector {
+  private static func - (lhs: CGPoint, rhs: CGPoint) -> CGVector {
     CGVector(dx: lhs.x - rhs.x, dy: lhs.y - rhs.y)
   }
 }
 
 extension CGVector {
-  fileprivate var magnitude: CGFloat {
+  private var magnitude: CGFloat {
     (dx * dx + dy * dy).squareRoot()
   }
 }


### PR DESCRIPTION
## Summary
- Adds a new, standalone SwiftUI `DesignSystem` component, `CustomShapeUpsellGraphic`, that visually contrasts a plain circle watch zone with a custom-shape (polygon) watch zone, for the onboarding upsell described in [#1031](https://github.com/AmyDe/town-crier/issues/1031) (section "7. iOS").
- Drawn entirely in code with SwiftUI `Path`/`Shape` against design tokens (`tcTextTertiary`, `tcAmber`, `TCSpacing`, `TCTypography`) — no raster asset — so it follows light/dark/OLED-dark theming per ADR 0040.
- Polygon point generation is factored into a pure, testable helper (`CustomShapePolygonGeometry`), separate from the `Shape` conformance.

## Scope
This is bead `tc-6he3x.9`, one task under the `tc-6he3x` epic. Deliberately limited to the standalone graphic only:
- **Not included** (separate beads): wiring into onboarding (`tc-6he3x.10`), the domain `WatchZoneBoundary` type, the editor/drawing UI, or any server-side work.
- **Not included**: simulator/visual verification — that's bead `tc-6he3x.15`. This PR is code + unit tests only.

## Test plan
- [x] Swift Testing suite added: `CustomShapeUpsellGraphicTests.swift` — a view-construction smoke test (matching the convention used by `StatusBadgeView`/`UpgradeBadgeView`/`ZoneMapPreview`), plus focused tests on `CustomShapePolygonGeometry` (vertex count, determinism, containment within the tile's bounding radius, distinctness, scaling).
- [ ] This cloud session has no Swift/Xcode toolchain available (SwiftUI has no Linux implementation), so `swift build` / `swift test` / `swiftlint lint --strict` could not be run locally. Manually reviewed the diff against existing compiling patterns in the repo (token names, `Shape`/`Path`/`StrokeStyle` API usage, `Package.swift` path-based target wiring) and found no issues. The `ios-lint` / `ios-build-test` PR Gate jobs (`macos-15` runners) are the first real compile/lint/test signal for this change.
- [ ] Visual verification (light/dark/OLED, actual rendering) is out of scope for this PR — deferred to `tc-6he3x.15`.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MtuhCyxTAHZ45Vz8angVDD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a decorative upsell graphic featuring a dashed circle, directional arrow, and amber irregular shape.
  * Includes accessibility labeling for improved support with assistive technologies.

* **Tests**
  * Added coverage validating the graphic’s rendering and consistent geometric behavior across sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->