### PR TITLE
web: CustomShapeUpsell inline SVG upsell component (tc-6he3x.13)

### DIFF
--- a/web/src/features/WatchZones/CustomShapeUpsell.module.css
+++ b/web/src/features/WatchZones/CustomShapeUpsell.module.css
@@ -1,0 +1,66 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--tc-space-md);
+  padding: var(--tc-space-lg);
+  background: var(--tc-surface);
+  border: 1px solid var(--tc-border);
+  border-radius: var(--tc-radius-md);
+  text-align: center;
+}
+
+.graphic {
+  width: 100%;
+  max-width: 220px;
+  height: auto;
+}
+
+/* The circle represents the old, fixed-radius zone: a plain, muted outline. */
+.circleOutline {
+  fill: none;
+  stroke: var(--tc-text-tertiary);
+  stroke-width: 2;
+  stroke-dasharray: 6 6;
+}
+
+/* The irregular polygon represents the new custom-shape zone: drawn in the
+   brand accent so it reads as the thing being promoted. */
+.polygonShape {
+  fill: var(--tc-amber-muted);
+  stroke: var(--tc-amber);
+  stroke-width: 3;
+  stroke-linejoin: round;
+  stroke-linecap: round;
+}
+
+.heading {
+  margin: 0;
+  font-size: var(--tc-text-headline);
+  font-weight: var(--tc-weight-semibold);
+  color: var(--tc-text-primary);
+}
+
+.body {
+  margin: 0;
+  max-width: 40ch;
+  font-size: var(--tc-text-body);
+  color: var(--tc-text-secondary);
+  line-height: var(--tc-leading-relaxed);
+}
+
+.cta {
+  padding: var(--tc-space-sm) var(--tc-space-lg);
+  background: var(--tc-amber);
+  color: var(--tc-text-on-accent);
+  border: none;
+  border-radius: var(--tc-radius-md);
+  font-weight: var(--tc-weight-semibold);
+  font-size: var(--tc-text-body);
+  cursor: pointer;
+  transition: background var(--tc-duration-fast);
+}
+
+.cta:hover {
+  background: var(--tc-amber-hover);
+}

--- a/web/src/features/WatchZones/CustomShapeUpsell.tsx
+++ b/web/src/features/WatchZones/CustomShapeUpsell.tsx
@@ -1,0 +1,41 @@
+import styles from './CustomShapeUpsell.module.css';
+
+interface Props {
+  onUpgradeClick?: () => void;
+}
+
+export function CustomShapeUpsell({ onUpgradeClick }: Props) {
+  return (
+    <div className={styles.container}>
+      <svg
+        className={styles.graphic}
+        viewBox="0 0 200 140"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <circle
+          className={styles.circleOutline}
+          cx="55"
+          cy="70"
+          r="48"
+        />
+        <path
+          className={styles.polygonShape}
+          d="M118 30 L162 42 L178 78 L156 112 L108 118 L96 82 L112 58 Z"
+        />
+      </svg>
+
+      <h2 className={styles.heading}>Draw any shape, not just a circle</h2>
+      <p className={styles.body}>
+        Trace the exact area you care about, a street, an estate, an odd-shaped site.
+        We&apos;ll watch it and notify you the moment something changes.
+      </p>
+
+      {onUpgradeClick && (
+        <button type="button" className={styles.cta} onClick={onUpgradeClick}>
+          Upgrade to draw custom shapes
+        </button>
+      )}
+    </div>
+  );
+}

--- a/web/src/features/WatchZones/__tests__/CustomShapeUpsell.test.tsx
+++ b/web/src/features/WatchZones/__tests__/CustomShapeUpsell.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect } from 'vitest';
+import { CustomShapeUpsell } from '../CustomShapeUpsell';
+
+describe('CustomShapeUpsell', () => {
+  it('renders the heading and value-prop copy', () => {
+    render(<CustomShapeUpsell />);
+
+    expect(
+      screen.getByRole('heading', { name: /draw any shape/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/exact area you care about/i)).toBeInTheDocument();
+  });
+
+  it('renders an inline SVG graphic', () => {
+    const { container } = render(<CustomShapeUpsell />);
+
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('does not render a call-to-action button when no handler is given', () => {
+    render(<CustomShapeUpsell />);
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('renders a call-to-action button that invokes onUpgradeClick when clicked', async () => {
+    const user = userEvent.setup();
+    let clicked = 0;
+
+    render(<CustomShapeUpsell onUpgradeClick={() => (clicked += 1)} />);
+
+    const button = screen.getByRole('button', { name: /upgrade/i });
+    await user.click(button);
+
+    expect(clicked).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `CustomShapeUpsell`, a presentational web component that explains and promotes the upcoming custom-shape (polygon) watch zone entitlement, per item 8 of [GH #1031](https://github.com/AmyDe/town-crier/issues/1031#8-web).
- Renders an inline SVG graphic (a muted dashed circle contrasted with a solid amber irregular polygon) plus a heading, value-prop copy, and an optional CTA button (`onUpgradeClick`) that only appears when a handler is supplied.
- Fully theme-aware: all styling in `CustomShapeUpsell.module.css` uses existing `--tc-*` design tokens (no hardcoded colors), so it renders correctly in light, dark, and OLED dark per ADR 0040.
- No new runtime dependency; graphic is inline SVG, not a raster asset.

## Scope

This bead covers **only** the standalone upsell component itself. It is intentionally **not** wired into any page yet — `WatchZoneCreatePage`/`WatchZoneEditPage`/`OnboardingPage` wiring, the `useBoundaryDrawing` hook, `BoundaryMap`, and `ShapeModeToggle` are separate beads in the epic (tc-6he3x.12, tc-6he3x.14). No backend/API/domain changes.

## Files changed

- `web/src/features/WatchZones/CustomShapeUpsell.tsx` (new)
- `web/src/features/WatchZones/CustomShapeUpsell.module.css` (new)
- `web/src/features/WatchZones/__tests__/CustomShapeUpsell.test.tsx` (new)

## Test plan

- [x] `npx vitest run CustomShapeUpsell` — 4/4 tests pass
- [x] `npx tsc --noEmit` — clean
- [x] Full `npx vitest run` (1325 tests) and `npm run build` — pass (per worker report)
- [x] All CSS custom properties used are defined in `web/src/styles/tokens.css` (verified)
- [ ] Visual verification in light/dark/OLED dark — outstanding; no page wires this component in yet to view it live, so there's nothing to screenshot until tc-6he3x.14 lands. Will need agent-driven browser verification once wired.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MV9rp7hLBf5CxCTxfPcxrq)_