### PR TITLE
watchzones: migration 0024 boundary column + polygon persistence and ST_Covers matching (tc-6he3x.2)

### DIFF
--- a/api-go/internal/platform/postgres/migrations/0024_watch_zone_boundary.sql
+++ b/api-go/internal/platform/postgres/migrations/0024_watch_zone_boundary.sql
@@ -1,0 +1,28 @@
+-- +goose Up
+
+-- Custom-shape (polygon) watch zones (epic #1031, tc-6he3x). A watch zone is
+-- either a circle (the existing location + radius_metres, unchanged) or, when
+-- boundary is non-NULL, a hand-drawn polygon; boundary IS NOT NULL is the
+-- sole discriminator the store and matching queries key on -- no separate
+-- zone-type column. location/radius_metres stay NOT NULL: for a polygon zone
+-- the server also writes the polygon's centroid into location and its
+-- enclosing radius into radius_metres, so every existing circle-shaped read
+-- path (map centring, list rows, boundingBox, GDPR export) keeps working
+-- unchanged against a custom-shape zone underneath (watchzones/zone.go,
+-- WithBoundary).
+--
+-- Additive and nullable: no backfill, and no existing row is touched.
+ALTER TABLE watch_zones
+    ADD COLUMN boundary geography(Polygon, 4326);
+
+-- GiST index serving the ST_Covers polygon-containment branch of the notify
+-- hot path (FindZonesContaining, store_postgres.go) -- the polygon
+-- counterpart to watch_zones_location_gist's ST_DWithin circle branch.
+CREATE INDEX watch_zones_boundary_gist ON watch_zones USING gist (boundary);
+
+-- +goose Down
+
+DROP INDEX IF EXISTS watch_zones_boundary_gist;
+
+ALTER TABLE watch_zones
+    DROP COLUMN IF EXISTS boundary;

--- a/api-go/internal/platform/postgres/migrations/0024_watch_zone_boundary.sql
+++ b/api-go/internal/platform/postgres/migrations/0024_watch_zone_boundary.sql
@@ -1,3 +1,4 @@
+-- +goose NO TRANSACTION
 -- +goose Up
 
 -- Custom-shape (polygon) watch zones (epic #1031, tc-6he3x). A watch zone is
@@ -18,11 +19,21 @@ ALTER TABLE watch_zones
 -- GiST index serving the ST_Covers polygon-containment branch of the notify
 -- hot path (FindZonesContaining, store_postgres.go) -- the polygon
 -- counterpart to watch_zones_location_gist's ST_DWithin circle branch.
-CREATE INDEX watch_zones_boundary_gist ON watch_zones USING gist (boundary);
+--
+-- CONCURRENTLY (tc-5i07d precedent, migration 0018): plain CREATE INDEX
+-- takes a lock that blocks writes to watch_zones for the whole build, and
+-- this table is on a live write path (zone create/update/delete) for a
+-- product with paying customers. CONCURRENTLY avoids that lock at the cost
+-- of a longer build (two table scans) and requires running outside a
+-- transaction -- see the NO TRANSACTION directive above, which also means
+-- this file's statements are NOT atomic as a group: a failed CONCURRENTLY
+-- build can leave behind an INVALID index that IF NOT EXISTS will not
+-- replace (see incident notes on tc-5i07d).
+CREATE INDEX CONCURRENTLY IF NOT EXISTS watch_zones_boundary_gist ON watch_zones USING gist (boundary);
 
 -- +goose Down
 
-DROP INDEX IF EXISTS watch_zones_boundary_gist;
+DROP INDEX CONCURRENTLY IF EXISTS watch_zones_boundary_gist;
 
 ALTER TABLE watch_zones
     DROP COLUMN IF EXISTS boundary;

--- a/api-go/internal/watchzones/store_postgres.go
+++ b/api-go/internal/watchzones/store_postgres.go
@@ -2,6 +2,7 @@ package watchzones
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -53,15 +54,19 @@ func NewPostgresStore(db querier) *PostgresStore {
 }
 
 // pgZoneColumns is the read projection. id is rendered as text; ST_Y is the
-// latitude and ST_X the longitude of the (NOT NULL) geography point. The order
-// MUST match scanZone.
+// latitude and ST_X the longitude of the (NOT NULL) geography point;
+// ST_AsGeoJSON(boundary) is NULL for a circle zone and a GeoJSON Polygon for a
+// custom-shape one. The order MUST match scanZone.
 const pgZoneColumns = "id::text, user_id, name, ST_Y(location::geometry), " +
 	"ST_X(location::geometry), radius_metres, authority_id, created_at, " +
-	"push_enabled, email_instant_enabled"
+	"push_enabled, email_instant_enabled, ST_AsGeoJSON(boundary)"
 
 // scanZone hydrates one zone through NewWatchZone, so the same invariants the
 // domain enforces (positive radius and authority id, non-blank id/user/name) gate
-// a row read from the database.
+// a row read from the database. A non-NULL boundary column is decoded from
+// GeoJSON and re-validated through NewBoundary (via decodeBoundaryGeoJSON),
+// applying the same domain invariants to a boundary read back from the
+// database as to one supplied by a client.
 func scanZone(row pgx.Row) (WatchZone, error) {
 	var (
 		id, userID, name       string
@@ -70,13 +75,76 @@ func scanZone(row pgx.Row) (WatchZone, error) {
 		authorityID            int
 		createdAt              time.Time
 		pushEnabled, emailFlag bool
+		boundaryGeoJSON        *string
 	)
 	if err := row.Scan(&id, &userID, &name, &latitude, &longitude, &radiusMetres,
-		&authorityID, &createdAt, &pushEnabled, &emailFlag); err != nil {
+		&authorityID, &createdAt, &pushEnabled, &emailFlag, &boundaryGeoJSON); err != nil {
 		return WatchZone{}, err
 	}
-	return NewWatchZone(id, userID, name, latitude, longitude, radiusMetres,
+	zone, err := NewWatchZone(id, userID, name, latitude, longitude, radiusMetres,
 		authorityID, createdAt, pushEnabled, emailFlag)
+	if err != nil {
+		return WatchZone{}, err
+	}
+	if boundaryGeoJSON != nil {
+		boundary, err := decodeBoundaryGeoJSON(*boundaryGeoJSON)
+		if err != nil {
+			return WatchZone{}, fmt.Errorf("hydrate watch zone %q boundary: %w", id, err)
+		}
+		zone.Boundary = boundary
+	}
+	return zone, nil
+}
+
+// pgBoundaryGeoJSON is the GeoJSON Polygon encoding of a Boundary ring
+// exchanged with Postgres: a single exterior ring, [longitude, latitude]
+// coordinate order (GeoJSON/RFC 7946 convention), matching what
+// ST_GeomFromGeoJSON expects on write and what ST_AsGeoJSON produces on read.
+// Single outer ring only -- no holes, no multi-polygon, mirroring the
+// domain's Boundary type.
+type pgBoundaryGeoJSON struct {
+	Type        string         `json:"type"`
+	Coordinates [][][2]float64 `json:"coordinates"`
+}
+
+// encodeBoundaryGeoJSON renders b as the GeoJSON text ST_GeomFromGeoJSON(...)
+// expects. A nil or empty Boundary (a circle zone) encodes to a nil *string,
+// which the caller binds as SQL NULL so ST_GeomFromGeoJSON(NULL)::geography
+// also yields NULL -- clearing any previously-persisted boundary on update.
+func encodeBoundaryGeoJSON(b Boundary) (*string, error) {
+	if len(b) == 0 {
+		return nil, nil
+	}
+	ring := make([][2]float64, len(b))
+	for i, v := range b {
+		ring[i] = [2]float64{v.Longitude, v.Latitude}
+	}
+	raw, err := json.Marshal(pgBoundaryGeoJSON{Type: "Polygon", Coordinates: [][][2]float64{ring}})
+	if err != nil {
+		return nil, fmt.Errorf("encode boundary geojson: %w", err)
+	}
+	s := string(raw)
+	return &s, nil
+}
+
+// decodeBoundaryGeoJSON parses ST_AsGeoJSON(boundary)'s text back into a
+// Boundary, re-validating it through NewBoundary. raw is never the empty
+// string in practice -- scanZone only calls this when the boundary column
+// scanned non-NULL.
+func decodeBoundaryGeoJSON(raw string) (Boundary, error) {
+	var g pgBoundaryGeoJSON
+	if err := json.Unmarshal([]byte(raw), &g); err != nil {
+		return nil, fmt.Errorf("decode boundary geojson: %w", err)
+	}
+	if len(g.Coordinates) == 0 || len(g.Coordinates[0]) == 0 {
+		return nil, nil
+	}
+	ring := g.Coordinates[0]
+	vertices := make([]Coordinate, len(ring))
+	for i, pt := range ring {
+		vertices[i] = Coordinate{Longitude: pt[0], Latitude: pt[1]}
+	}
+	return NewBoundary(vertices)
 }
 
 // scanZoneRow adapts scanZone to pgx.CollectRows over a multi-row result.
@@ -118,10 +186,10 @@ func (s *PostgresStore) Get(ctx context.Context, userID, zoneID string) (WatchZo
 const pgSaveZoneQuery = `
 INSERT INTO watch_zones (
 	id, user_id, name, location, radius_metres, authority_id,
-	push_enabled, email_instant_enabled, created_at
+	push_enabled, email_instant_enabled, created_at, boundary
 ) VALUES (
 	$1::uuid, $2, $3, ST_SetSRID(ST_MakePoint($4, $5), 4326)::geography,
-	$6, $7, $8, $9, $10
+	$6, $7, $8, $9, $10, ST_GeomFromGeoJSON($11)::geography
 )
 ON CONFLICT (id) DO UPDATE SET
 	user_id = EXCLUDED.user_id,
@@ -131,13 +199,22 @@ ON CONFLICT (id) DO UPDATE SET
 	authority_id = EXCLUDED.authority_id,
 	push_enabled = EXCLUDED.push_enabled,
 	email_instant_enabled = EXCLUDED.email_instant_enabled,
-	created_at = EXCLUDED.created_at`
+	created_at = EXCLUDED.created_at,
+	boundary = EXCLUDED.boundary`
 
-// Save upserts the zone keyed on its uuid id.
+// Save upserts the zone keyed on its uuid id, creating it or overwriting every
+// column -- including boundary -- on an existing row. A nil/empty z.Boundary
+// (a circle zone) writes SQL NULL, so saving a zone that previously had a
+// custom shape with Boundary cleared correctly reverts the persisted row to a
+// circle rather than leaving a stale polygon behind.
 func (s *PostgresStore) Save(ctx context.Context, z WatchZone) error {
-	_, err := s.db.Exec(ctx, pgSaveZoneQuery,
+	boundaryGeoJSON, err := encodeBoundaryGeoJSON(z.Boundary)
+	if err != nil {
+		return fmt.Errorf("encode watch zone %q boundary: %w", z.ID, err)
+	}
+	_, err = s.db.Exec(ctx, pgSaveZoneQuery,
 		z.ID, z.UserID, z.Name, z.Longitude, z.Latitude, z.RadiusMetres,
-		z.AuthorityID, z.PushEnabled, z.EmailInstantEnabled, z.CreatedAt,
+		z.AuthorityID, z.PushEnabled, z.EmailInstantEnabled, z.CreatedAt, boundaryGeoJSON,
 	)
 	if err != nil {
 		return fmt.Errorf("upsert watch zone %q: %w", z.ID, err)
@@ -190,13 +267,20 @@ func (s *PostgresStore) DistinctAuthorityIDs(ctx context.Context) ([]int, error)
 }
 
 const pgFindZonesContainingQuery = "SELECT " + pgZoneColumns +
-	" FROM watch_zones WHERE ST_DWithin(location, " +
-	"ST_SetSRID(ST_MakePoint($1, $2), 4326)::geography, radius_metres) ORDER BY id"
+	" FROM watch_zones WHERE " +
+	"(boundary IS NULL AND ST_DWithin(location, ST_SetSRID(ST_MakePoint($1, $2), 4326)::geography, radius_metres)) " +
+	"OR (boundary IS NOT NULL AND ST_Covers(boundary, ST_SetSRID(ST_MakePoint($1, $2), 4326)::geography)) " +
+	"ORDER BY id"
 
 // FindZonesContaining returns every watch zone (across all users, all authorities)
-// whose circle contains the point (latitude, longitude). Matching is purely
-// geographic via one GiST-served ST_DWithin against each zone's centre and radius —
-// the notify hot path. Zones are hydrated through NewWatchZone.
+// that contains the point (latitude, longitude): a circle zone (boundary IS NULL)
+// via ST_DWithin against its centre and radius, a custom-shape zone (boundary IS
+// NOT NULL) via ST_Covers against its polygon. ST_Covers, not ST_Intersects or
+// ST_Contains, is deliberate: the application is a point, and ST_Covers includes a
+// point exactly on the boundary edge while being well-defined for geography. Each
+// branch is served by its own GiST index (watch_zones_location_gist,
+// watch_zones_boundary_gist) — the notify hot path. Zones are hydrated through
+// NewWatchZone.
 func (s *PostgresStore) FindZonesContaining(ctx context.Context, latitude, longitude float64) ([]WatchZone, error) {
 	rows, err := s.db.Query(ctx, pgFindZonesContainingQuery, longitude, latitude)
 	if err != nil {

--- a/api-go/internal/watchzones/store_postgres_test.go
+++ b/api-go/internal/watchzones/store_postgres_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -73,6 +74,42 @@ func assertStrings(t *testing.T, got, want []string) {
 	t.Helper()
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+// assertZoneEqualExceptBoundary is assertZoneEqual minus the Boundary field:
+// Latitude/Longitude/RadiusMetres round-trip through the geography point
+// column bit-for-bit (as assertZoneEqual already proves for circle zones),
+// but Boundary round-trips through GeoJSON text (ST_AsGeoJSON's default
+// 9-decimal-degree precision), so it needs the tolerance-based
+// assertBoundaryNear instead of reflect.DeepEqual.
+func assertZoneEqualExceptBoundary(t *testing.T, got, want WatchZone) {
+	t.Helper()
+	if !got.CreatedAt.Equal(want.CreatedAt) {
+		t.Errorf("CreatedAt: got %v, want %v", got.CreatedAt, want.CreatedAt)
+	}
+	g, w := got, want
+	g.CreatedAt, w.CreatedAt = time.Time{}, time.Time{}
+	g.Boundary, w.Boundary = nil, nil
+	if !reflect.DeepEqual(g, w) {
+		t.Errorf("watch zone mismatch (excluding boundary):\n got = %+v\nwant = %+v", g, w)
+	}
+}
+
+// assertBoundaryNear compares two (already-closed) boundary rings
+// vertex-by-vertex within tolMetres, absorbing the precision a GeoJSON text
+// round trip through ST_AsGeoJSON's default 9-decimal-degree truncation loses
+// relative to the full-precision float64 the domain computed.
+func assertBoundaryNear(t *testing.T, got, want Boundary, tolMetres float64) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("boundary vertex count = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		d := haversineMetres(got[i].Latitude, got[i].Longitude, want[i].Latitude, want[i].Longitude)
+		if d > tolMetres {
+			t.Errorf("vertex %d: got %+v, want %+v (%.6fm apart, tol %.6fm)", i, got[i], want[i], d, tolMetres)
+		}
 	}
 }
 
@@ -283,5 +320,258 @@ func TestWatchZonePostgresStore_FindZonesContaining(t *testing.T) {
 		if z.AuthorityID <= 0 || z.UserID == "" {
 			t.Errorf("hydrated zone invalid: %+v", z)
 		}
+	}
+}
+
+// TestWatchZonePostgresStore_Boundary_SaveGetRoundTrip persists a custom-shape
+// zone and reads it back via both Get and GetByUserID, proving the boundary
+// column round-trips through ST_GeomFromGeoJSON on write and ST_AsGeoJSON on
+// read: the ring's vertices, and the derived centroid/enclosing-radius circle
+// fields WithBoundary computed before Save, all come back unchanged.
+func TestWatchZonePostgresStore_Boundary_SaveGetRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	store := newZonePGStore(t)
+
+	base := pgZone(t, uuidN(1), "user-1", "Custom shape", wzCentreLat, wzCentreLon, 1, 10)
+	want, err := base.WithBoundary(londonSquare(t))
+	if err != nil {
+		t.Fatalf("WithBoundary: %v", err)
+	}
+	if err := store.Save(ctx, want); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := store.Get(ctx, "user-1", uuidN(1))
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !got.IsCustomShape() {
+		t.Fatal("Get: expected a custom-shape zone")
+	}
+	assertZoneEqualExceptBoundary(t, got, want)
+	assertBoundaryNear(t, got.Boundary, want.Boundary, 0.01)
+
+	list, err := store.GetByUserID(ctx, "user-1")
+	if err != nil {
+		t.Fatalf("GetByUserID: %v", err)
+	}
+	if len(list) != 1 || !list[0].IsCustomShape() {
+		t.Fatalf("GetByUserID: want exactly 1 custom-shape zone, got %+v", list)
+	}
+	assertZoneEqualExceptBoundary(t, list[0], want)
+	assertBoundaryNear(t, list[0].Boundary, want.Boundary, 0.01)
+}
+
+// TestWatchZonePostgresStore_Save_BoundaryUpsertTransitions proves Save (the
+// store's single upsert path, used for both create and update/patch) persists
+// a boundary change on an existing row in both directions: a circle gaining a
+// custom shape, and a custom shape reverting to a circle. The revert case is
+// the one a naive "only write boundary when non-nil" implementation would get
+// wrong -- ON CONFLICT must overwrite the column with SQL NULL, not leave the
+// previous polygon stale.
+func TestWatchZonePostgresStore_Save_BoundaryUpsertTransitions(t *testing.T) {
+	ctx := context.Background()
+	store := newZonePGStore(t)
+
+	circle := pgZone(t, uuidN(1), "user-1", "zone", wzCentreLat, wzCentreLon, 2000, 10)
+	if err := store.Save(ctx, circle); err != nil {
+		t.Fatalf("Save circle: %v", err)
+	}
+	got, err := store.Get(ctx, "user-1", uuidN(1))
+	if err != nil {
+		t.Fatalf("Get after circle save: %v", err)
+	}
+	if got.IsCustomShape() {
+		t.Fatal("freshly-saved circle zone must not report IsCustomShape")
+	}
+
+	polygon, err := circle.WithBoundary(londonSquare(t))
+	if err != nil {
+		t.Fatalf("WithBoundary: %v", err)
+	}
+	if err := store.Save(ctx, polygon); err != nil {
+		t.Fatalf("Save polygon (update): %v", err)
+	}
+	got, err = store.Get(ctx, "user-1", uuidN(1))
+	if err != nil {
+		t.Fatalf("Get after polygon save: %v", err)
+	}
+	if !got.IsCustomShape() {
+		t.Fatal("zone updated with a boundary must report IsCustomShape")
+	}
+	assertBoundaryNear(t, got.Boundary, polygon.Boundary, 0.01)
+
+	// Revert to a circle: same row (same id), Boundary cleared.
+	reverted := got
+	reverted.Boundary = nil
+	if err := store.Save(ctx, reverted); err != nil {
+		t.Fatalf("Save reverted circle: %v", err)
+	}
+	got, err = store.Get(ctx, "user-1", uuidN(1))
+	if err != nil {
+		t.Fatalf("Get after revert: %v", err)
+	}
+	if got.IsCustomShape() {
+		t.Fatal("reverted zone must not report IsCustomShape; boundary column should be NULL")
+	}
+	if len(got.Boundary) != 0 {
+		t.Errorf("reverted zone Boundary = %+v, want empty", got.Boundary)
+	}
+}
+
+// TestWatchZonePostgresStore_FindZonesContaining_Boundary_PointInsidePolygonMatches
+// proves the ST_Covers branch: a point inside a custom-shape zone's polygon
+// matches.
+func TestWatchZonePostgresStore_FindZonesContaining_Boundary_PointInsidePolygonMatches(t *testing.T) {
+	ctx := context.Background()
+	store := newZonePGStore(t)
+
+	base := pgZone(t, uuidN(1), "user-1", "polygon", wzCentreLat, wzCentreLon, 1, 10)
+	polygon, err := base.WithBoundary(londonSquare(t))
+	if err != nil {
+		t.Fatalf("WithBoundary: %v", err)
+	}
+	if err := store.Save(ctx, polygon); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// londonSquare's half-side is ~1000m, so 500m north of centre sits well
+	// inside it.
+	matched, err := store.FindZonesContaining(ctx, wzLatNorth(500), wzCentreLon)
+	if err != nil {
+		t.Fatalf("FindZonesContaining: %v", err)
+	}
+	assertStrings(t, zoneNames(matched), []string{"polygon"})
+}
+
+// TestWatchZonePostgresStore_FindZonesContaining_Boundary_PointInEnclosingCircleButOutsidePolygon_NoMatch
+// proves ST_Covers rejects a point that a circle-shaped zone with the same
+// derived (centroid, enclosing radius) would have matched: the case
+// ST_DWithin cannot distinguish, and the whole reason FindZonesContaining
+// branches on boundary rather than always matching by circle.
+func TestWatchZonePostgresStore_FindZonesContaining_Boundary_PointInEnclosingCircleButOutsidePolygon_NoMatch(t *testing.T) {
+	ctx := context.Background()
+	store := newZonePGStore(t)
+
+	base := pgZone(t, uuidN(1), "user-1", "polygon", wzCentreLat, wzCentreLon, 1, 10)
+	polygon, err := base.WithBoundary(londonSquare(t))
+	if err != nil {
+		t.Fatalf("WithBoundary: %v", err)
+	}
+	const testPointMetresNorth = 1200
+	if polygon.RadiusMetres <= testPointMetresNorth {
+		t.Fatalf("fixture assumption broken: enclosing radius %.2fm must exceed %vm",
+			polygon.RadiusMetres, testPointMetresNorth)
+	}
+	if err := store.Save(ctx, polygon); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// 1200m north of centre is inside londonSquare's ~1412.7m enclosing circle
+	// (so it WOULD match a circle-shaped zone with the same derived centre and
+	// radius) but outside the square itself, whose north edge sits at the
+	// square's half-side, ~1000m.
+	matched, err := store.FindZonesContaining(ctx, wzLatNorth(testPointMetresNorth), wzCentreLon)
+	if err != nil {
+		t.Fatalf("FindZonesContaining: %v", err)
+	}
+	if len(matched) != 0 {
+		t.Fatalf("matched = %v, want none (point outside the polygon)", zoneNames(matched))
+	}
+}
+
+// TestWatchZonePostgresStore_FindZonesContaining_Boundary_AndCircle_BothMatchInOneCall
+// proves a single FindZonesContaining call serves both zone shapes together:
+// the ST_DWithin and ST_Covers branches of the WHERE clause both contribute
+// rows to the same result set.
+func TestWatchZonePostgresStore_FindZonesContaining_Boundary_AndCircle_BothMatchInOneCall(t *testing.T) {
+	ctx := context.Background()
+	store := newZonePGStore(t)
+
+	circle := pgZone(t, uuidN(1), "user-1", "circle", wzCentreLat, wzCentreLon, 2000, 10)
+	polygonBase := pgZone(t, uuidN(2), "user-2", "polygon", wzCentreLat, wzCentreLon, 1, 20)
+	polygon, err := polygonBase.WithBoundary(londonSquare(t))
+	if err != nil {
+		t.Fatalf("WithBoundary: %v", err)
+	}
+	for _, z := range []WatchZone{circle, polygon} {
+		if err := store.Save(ctx, z); err != nil {
+			t.Fatalf("Save %s: %v", z.Name, err)
+		}
+	}
+
+	// 500m north of centre matches the polygon (inside londonSquare) and the
+	// circle (well within its 2km radius).
+	matched, err := store.FindZonesContaining(ctx, wzLatNorth(500), wzCentreLon)
+	if err != nil {
+		t.Fatalf("FindZonesContaining: %v", err)
+	}
+	assertStrings(t, zoneNames(matched), []string{"circle", "polygon"})
+}
+
+// TestWatchZonePostgresStore_FindZonesContaining_Boundary_ExplainUsesGiSTIndex
+// proves the boundary/ST_Covers branch stays index-served rather than
+// degrading FindZonesContaining (the notify hot path) to a sequential scan.
+// enable_seqscan is disabled for the EXPLAIN so the planner is forced to
+// reveal whether an index plan is even possible, rather than preferring a
+// sequential scan over the small fixture table (mirrors
+// TestPostgresStore_FindClustersInZone_ExplainUsesGiSTIndex in the
+// applications package).
+func TestWatchZonePostgresStore_FindZonesContaining_Boundary_ExplainUsesGiSTIndex(t *testing.T) {
+	ctx := context.Background()
+	// Acquire the pool directly (rather than via newZonePGStore) so the same
+	// connection can both seed fixtures and run the EXPLAIN below.
+	pool := pgtest.New(t)
+	pgtest.Truncate(t, pool, "applications", "watch_zones")
+	store := NewPostgresStore(pool)
+
+	circle := pgZone(t, uuidN(1), "user-1", "circle", wzCentreLat, wzCentreLon, 2000, 10)
+	polygonBase := pgZone(t, uuidN(2), "user-2", "polygon", wzCentreLat, wzCentreLon, 1, 20)
+	polygon, err := polygonBase.WithBoundary(londonSquare(t))
+	if err != nil {
+		t.Fatalf("WithBoundary: %v", err)
+	}
+	for _, z := range []WatchZone{circle, polygon} {
+		if err := store.Save(ctx, z); err != nil {
+			t.Fatalf("Save %s: %v", z.Name, err)
+		}
+	}
+
+	// SET enable_seqscan = off and the EXPLAIN must run on the SAME connection
+	// (the setting is session state), so acquire one pooled connection for both.
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("acquire connection: %v", err)
+	}
+	defer conn.Release()
+	if _, err := conn.Exec(ctx, "SET enable_seqscan = off"); err != nil {
+		t.Fatalf("disable seqscan: %v", err)
+	}
+
+	rows, err := conn.Query(ctx, "EXPLAIN (ANALYZE, FORMAT TEXT) "+pgFindZonesContainingQuery,
+		wzCentreLon, wzLatNorth(500))
+	if err != nil {
+		t.Fatalf("EXPLAIN: %v", err)
+	}
+	var plan strings.Builder
+	for rows.Next() {
+		var line string
+		if err := rows.Scan(&line); err != nil {
+			rows.Close()
+			t.Fatalf("scan plan line: %v", err)
+		}
+		plan.WriteString(line)
+		plan.WriteByte('\n')
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("read plan: %v", err)
+	}
+
+	lower := strings.ToLower(plan.String())
+	if strings.Contains(lower, "seq scan") {
+		t.Errorf("EXPLAIN plan uses a sequential scan with enable_seqscan=off:\n%s", plan.String())
+	}
+	if !strings.Contains(lower, "watch_zones_boundary_gist") && !strings.Contains(lower, "watch_zones_location_gist") {
+		t.Errorf("EXPLAIN plan does not reference either GiST index:\n%s", plan.String())
 	}
 }


### PR DESCRIPTION
## Summary

- Adds migration `0024_watch_zone_boundary.sql`: a nullable `boundary geography(Polygon, 4326)` column on `watch_zones` plus a `watch_zones_boundary_gist` GiST index. Additive only — `location`/`radius_metres` stay `NOT NULL` and untouched for existing rows.
- Wires boundary persistence into `PostgresStore`: `Save` writes the boundary via `ST_GeomFromGeoJSON(...)::geography` (SQL `NULL` for a circle zone, correctly clearing a previously-persisted polygon on revert), the select projection gains `ST_AsGeoJSON(boundary)`, and `scanZone` decodes and re-validates a non-NULL boundary through `NewBoundary`.
- `FindZonesContaining` (the notify hot path) now branches per zone: circle zones match via the existing `ST_DWithin`, custom-shape zones via `ST_Covers` against the polygon — each served by its own GiST index.

This is bead `tc-6he3x.2`, part of the custom-shape watch zones epic (#1031), sections "1. Database" and "3. Store". Domain support for `Boundary` (validation, centroid, enclosing radius) landed separately in #1039; tier entitlements landed in #1040. This PR is deliberately scoped to migration + store only — HTTP surface (tier gating, request/response fields) is a separate bead (tc-6he3x.4) that depends on this one, and `findZonePage`/`clusters` polygon-aware reads are tracked separately (tc-6he3x.5).

## Test plan

- [x] `gofmt -l .` clean
- [x] `go vet ./...` and `go vet -tags=integration ./...` clean
- [x] `go build ./...` clean
- [x] `go test -race ./internal/watchzones/...` green
- [ ] `go test -tags=integration ./...` (real PostGIS) — new tests added (boundary save/get round trip, circle↔polygon upsert transitions including clearing to NULL, point-inside-polygon match, point-inside-enclosing-circle-but-outside-polygon no-match, circle+polygon both matching in one `FindZonesContaining` call, and an `EXPLAIN`/`enable_seqscan=off` proof the plan stays index-served) but **not verified locally** — Docker wasn't available in this sandbox (image pull blocked by proxy egress policy). The PR gate runs the real-Postgres integration suite; please confirm it's green before merging.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012Rj7CwXXzFUmrmNdRDgEx6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom polygon-shaped watch zones.
  * Watch zones can now be saved, updated, and retrieved with polygon boundaries.
  * Location searches accurately match points inside polygon zones alongside existing circular zones.

* **Bug Fixes**
  * Improved handling when switching zones between circular and polygon shapes.

* **Tests**
  * Added coverage for polygon persistence, matching behavior, transitions, and spatial query performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->