### PR TITLE
feat(api): HTTP surface for custom-shape watch zones (tc-6he3x.4)

### DIFF
--- a/api-go/cmd/api/export_adapters.go
+++ b/api-go/cmd/api/export_adapters.go
@@ -59,9 +59,24 @@ func (r watchZoneExportReader) WatchZonesByUser(ctx context.Context, userID stri
 			RadiusMetres: z.RadiusMetres,
 			AuthorityID:  z.AuthorityID,
 			CreatedAt:    platform.DotNetTime(z.CreatedAt),
+			Boundary:     exportedBoundaryOf(z.Boundary),
 		})
 	}
 	return rows, nil
+}
+
+// exportedBoundaryOf converts a watch zone's domain Boundary to its GDPR
+// export wire representation (tc-6he3x.4), or nil for a circle zone (nil or
+// empty Boundary) -- matching a null "boundary" field on the exported row.
+func exportedBoundaryOf(b watchzones.Boundary) *profiles.ExportedBoundary {
+	if len(b) == 0 {
+		return nil
+	}
+	ring := make([][2]float64, len(b))
+	for i, v := range b {
+		ring[i] = [2]float64{v.Longitude, v.Latitude}
+	}
+	return &profiles.ExportedBoundary{Type: "Polygon", Coordinates: [][][2]float64{ring}}
 }
 
 // allByUserReader is the narrowest consumer-side interface

--- a/api-go/cmd/api/export_adapters_test.go
+++ b/api-go/cmd/api/export_adapters_test.go
@@ -68,3 +68,57 @@ func TestWatchZoneExportReader_ReadsThroughStoreInterface(t *testing.T) {
 		t.Errorf("row[0].CreatedAt = %v, want %v", time.Time(rows[0].CreatedAt), created)
 	}
 }
+
+// TestWatchZoneExportReader_IncludesBoundaryForCustomShapeZones proves the
+// GDPR export carries a custom-shape zone's boundary as a GeoJSON Polygon
+// (tc-6he3x.4) and leaves it null for a plain circle zone.
+func TestWatchZoneExportReader_IncludesBoundaryForCustomShapeZones(t *testing.T) {
+	t.Parallel()
+
+	created := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	circle := watchzones.WatchZone{
+		ID: "zone-1", UserID: "u1", Name: "Home",
+		Latitude: 51.5, Longitude: -0.1, RadiusMetres: 500, AuthorityID: 384, CreatedAt: created,
+	}
+
+	base, err := watchzones.NewWatchZone("zone-2", "u1", "Shape", 51.5, -0.1, 500, 384, created, true, true)
+	if err != nil {
+		t.Fatalf("NewWatchZone: %v", err)
+	}
+	shaped, err := base.WithBoundary([]watchzones.Coordinate{
+		{Longitude: -0.13, Latitude: 51.51},
+		{Longitude: -0.11, Latitude: 51.51},
+		{Longitude: -0.11, Latitude: 51.49},
+		{Longitude: -0.13, Latitude: 51.49},
+	})
+	if err != nil {
+		t.Fatalf("WithBoundary: %v", err)
+	}
+
+	store := &fakeWatchZoneStore{zones: []watchzones.WatchZone{circle, shaped}}
+	var reader profiles.WatchZoneReader = watchZoneExportReader{store: store}
+	rows, err := reader.WatchZonesByUser(context.Background(), "u1")
+	if err != nil {
+		t.Fatalf("WatchZonesByUser: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2", len(rows))
+	}
+	if rows[0].Boundary != nil {
+		t.Errorf("circle zone must export a null boundary, got %+v", rows[0].Boundary)
+	}
+	if rows[1].Boundary == nil {
+		t.Fatal("custom-shape zone must export a non-null boundary")
+	}
+	if rows[1].Boundary.Type != "Polygon" {
+		t.Errorf("boundary type: got %q, want Polygon", rows[1].Boundary.Type)
+	}
+	if len(rows[1].Boundary.Coordinates) != 1 || len(rows[1].Boundary.Coordinates[0]) != 5 {
+		// 4 supplied vertices plus NewBoundary's auto-close repeat of the first.
+		t.Fatalf("boundary ring: got %+v", rows[1].Boundary.Coordinates)
+	}
+	ring := rows[1].Boundary.Coordinates[0]
+	if ring[0] != ring[len(ring)-1] {
+		t.Errorf("ring must be closed: first=%v last=%v", ring[0], ring[len(ring)-1])
+	}
+}

--- a/api-go/internal/profiles/export.go
+++ b/api-go/internal/profiles/export.go
@@ -66,6 +66,23 @@ type ExportedWatchZone struct {
 	RadiusMetres float64             `json:"radiusMetres"`
 	AuthorityID  int                 `json:"authorityId"`
 	CreatedAt    platform.DotNetTime `json:"createdAt"`
+	// Boundary is null for a circle zone and a GeoJSON Polygon for a
+	// custom-shape one (tc-6he3x.4), mirroring the HTTP watch-zone handlers'
+	// "boundary" field.
+	Boundary *ExportedBoundary `json:"boundary"`
+}
+
+// ExportedBoundary is the GeoJSON Polygon wire representation of a
+// custom-shape watch zone's boundary (tc-6he3x.4), matching the shape the
+// HTTP watch-zone handlers already emit (watchzones' unexported
+// boundaryGeoJSON type). It is declared here, not reused from watchzones,
+// because profiles must not import watchzones -- watchzones already imports
+// profiles (for SubscriptionTier), so a back-import would close a cycle (see
+// the import-cycle note in export_readers.go); cmd/api/export_adapters.go,
+// which imports both, does the domain -> wire conversion.
+type ExportedBoundary struct {
+	Type        string         `json:"type"`
+	Coordinates [][][2]float64 `json:"coordinates"`
 }
 
 type ExportedNotification struct {

--- a/api-go/internal/watchzones/handler.go
+++ b/api-go/internal/watchzones/handler.go
@@ -1,6 +1,7 @@
 package watchzones
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -24,6 +25,52 @@ const maxBodyBytes = 1 << 20
 // invalidPayloadMessage is the error text for a watch-zone validation failure
 // (Create/Update endpoints).
 const invalidPayloadMessage = "Invalid watch zone payload."
+
+// Custom-shape boundary error codes and messages (tc-6he3x.4). Unlike
+// invalidPayloadMessage above (whose text IS the apiErrorResponse "error"
+// field, an established watchzones convention this bead does not touch),
+// these carry a stable machine-readable code separately from the human
+// message -- the same (code, message) shape internal/offercodes and
+// internal/subscriptions already use -- because a client (iOS/web) needs to
+// tell "wrong tier" apart from "bad shape" apart from "too big" to route to
+// the right UX (paywall vs. a validation error vs. a resize prompt).
+const (
+	// boundaryRequiresPaidTierCode/-Message: 403, a Free-tier caller supplied a
+	// non-null boundary on create, or on a PATCH that sets one.
+	boundaryRequiresPaidTierCode    = "boundary_requires_paid_tier"
+	boundaryRequiresPaidTierMessage = "Custom-shape watch zones require a paid subscription."
+	// boundaryInvalidCode/-Message: 400, the supplied boundary failed the
+	// domain's own shape validation (NewBoundary's sentinel errors in zone.go
+	// -- vertex count, duplicate vertex, self-intersection, out of UK bounds)
+	// or was not well-formed GeoJSON.
+	boundaryInvalidCode    = "boundary_invalid"
+	boundaryInvalidMessage = "The supplied boundary is not a valid shape."
+	// boundaryTooLargeCode/-Message: 400, the boundary's enclosing radius
+	// exceeds either the hard server ceiling (maxRadiusMetres, nearby.go) or
+	// the caller's tier cap (profiles.SubscriptionTier.MaxZoneRadiusMetres).
+	boundaryTooLargeCode    = "boundary_too_large"
+	boundaryTooLargeMessage = "The boundary is too large for your subscription tier."
+)
+
+// errProfileReaderNotWired signals a wiring bug: setting a watch-zone boundary
+// requires the profile reader to check the caller's tier entitlement, and the
+// handler refuses to run an unverified tier check without it. Unreachable in
+// production, where Routes/NearbyRoutes are always wired WithProfileReader
+// whenever a profile store is configured (cmd/api/wiring.go).
+var errProfileReaderNotWired = errors.New("profile reader not wired for boundary tier gate")
+
+// isBoundaryValidationError reports whether err is one of the shape-validation
+// sentinels NewBoundary returns (see zone.go), which WithUpdates propagates
+// unwrapped from a PATCH that sets an invalid boundary. The handler maps these
+// to a 400 boundary_invalid rather than the generic 500 a merge failure (e.g.
+// a blank name) gets -- reusing the domain's own validation rather than
+// re-implementing geometry checks at the HTTP layer.
+func isBoundaryValidationError(err error) bool {
+	return errors.Is(err, ErrBoundaryVertexCount) ||
+		errors.Is(err, ErrBoundaryDuplicateVertex) ||
+		errors.Is(err, ErrBoundarySelfIntersecting) ||
+		errors.Is(err, ErrBoundaryOutOfBounds)
+}
 
 // zoneStore is the consumer-side store the handlers use. *CosmosStore satisfies
 // it; tests substitute a hand-written fake.
@@ -131,6 +178,11 @@ type watchZoneSummary struct {
 	PushEnabled         bool    `json:"pushEnabled"`
 	EmailInstantEnabled bool    `json:"emailInstantEnabled"`
 	Paused              bool    `json:"paused"`
+	// Boundary is null for a circle zone and a GeoJSON Polygon for a
+	// custom-shape one (tc-6he3x.4); Latitude/Longitude/RadiusMetres remain
+	// the polygon's derived centroid/enclosing radius either way, so every
+	// pre-existing circle-shaped consumer keeps working unchanged.
+	Boundary *boundaryGeoJSON `json:"boundary"`
 }
 
 func summaryOf(z WatchZone, paused bool) watchZoneSummary {
@@ -144,6 +196,7 @@ func summaryOf(z WatchZone, paused bool) watchZoneSummary {
 		PushEnabled:         z.PushEnabled,
 		EmailInstantEnabled: z.EmailInstantEnabled,
 		Paused:              paused,
+		Boundary:            boundaryToGeoJSON(z.Boundary),
 	}
 }
 
@@ -229,14 +282,20 @@ func pausedIDs(zones []WatchZone, limit int) map[string]bool {
 }
 
 // patchRequest is the PATCH body: every field optional (nil = unchanged).
+// Boundary is tri-state (absent/null/value, see decodeBoundaryUpdate and
+// ZoneUpdate.Boundary) so it cannot be a plain pointer-to-value like the rest
+// of the fields; json.RawMessage captures the field's exact presence and raw
+// bytes, which a *boundaryGeoJSON cannot: that would collapse absent and
+// explicit null to the same nil value.
 type patchRequest struct {
-	Name                *string  `json:"name"`
-	Latitude            *float64 `json:"latitude"`
-	Longitude           *float64 `json:"longitude"`
-	RadiusMetres        *float64 `json:"radiusMetres"`
-	AuthorityID         *int     `json:"authorityId"`
-	PushEnabled         *bool    `json:"pushEnabled"`
-	EmailInstantEnabled *bool    `json:"emailInstantEnabled"`
+	Name                *string         `json:"name"`
+	Latitude            *float64        `json:"latitude"`
+	Longitude           *float64        `json:"longitude"`
+	RadiusMetres        *float64        `json:"radiusMetres"`
+	AuthorityID         *int            `json:"authorityId"`
+	PushEnabled         *bool           `json:"pushEnabled"`
+	EmailInstantEnabled *bool           `json:"emailInstantEnabled"`
+	Boundary            json.RawMessage `json:"boundary"`
 }
 
 // rangeValid reports whether the present coordinate/radius/authority fields are
@@ -261,12 +320,9 @@ func (req patchRequest) rangeValid() bool {
 	return true
 }
 
-func (req patchRequest) toUpdate() ZoneUpdate {
-	// ZoneUpdate.Boundary is domain-only for now (tc-6he3x.1): patchRequest
-	// does not yet expose a boundary field, so a field-by-field copy is
-	// required instead of the old field-identical type conversion. Wiring
-	// json.RawMessage tri-state boundary decoding into patchRequest is
-	// tc-6he3x.4.
+// toUpdate builds the domain ZoneUpdate, threading the already-decoded
+// tri-state boundary (see decodeBoundaryUpdate) into ZoneUpdate.Boundary.
+func (req patchRequest) toUpdate(boundary *Boundary) ZoneUpdate {
 	return ZoneUpdate{
 		Name:                req.Name,
 		Latitude:            req.Latitude,
@@ -275,13 +331,49 @@ func (req patchRequest) toUpdate() ZoneUpdate {
 		AuthorityID:         req.AuthorityID,
 		PushEnabled:         req.PushEnabled,
 		EmailInstantEnabled: req.EmailInstantEnabled,
+		Boundary:            boundary,
 	}
 }
 
+// decodeBoundaryUpdate resolves the PATCH body's tri-state "boundary" field
+// (raw, exactly as captured by patchRequest.Boundary's json.RawMessage) into
+// ZoneUpdate.Boundary's pointer-to-slice shape (see that field's doc comment):
+//
+//   - raw is nil (the JSON key was absent): (nil, nil) -- leave the zone's
+//     shape alone.
+//   - raw is the 4-byte JSON literal null (the key was present, explicitly
+//     null): a pointer to an empty Boundary -- revert to a circle.
+//   - raw is a GeoJSON Polygon value: a pointer to its raw, UNVALIDATED
+//     vertices. WithUpdates validates them (via NewBoundary) when it applies
+//     the merge; this function does not re-implement that check.
+//
+// A value that is valid JSON but not a GeoJSON-shaped object (e.g. a bare
+// string or number) returns an error; the caller maps it to the
+// boundary_invalid response, matching the malformed-shape case WithUpdates
+// itself would otherwise report.
+func decodeBoundaryUpdate(raw json.RawMessage) (*Boundary, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	if bytes.Equal(raw, []byte("null")) {
+		empty := Boundary{}
+		return &empty, nil
+	}
+	var g boundaryGeoJSON
+	if err := json.Unmarshal(raw, &g); err != nil {
+		return nil, fmt.Errorf("decode boundary update: %w", err)
+	}
+	b := Boundary(g.vertices())
+	return &b, nil
+}
+
 // patch implements PATCH /v1/me/watch-zones/{zoneId}: range-validate the body
-// (400), load the zone (404 if absent), apply the merge, persist, and return the
-// updated summary. A merge that violates a domain invariant (e.g. a blank name)
-// is a 500.
+// (400), decode the tri-state boundary field (400 boundary_invalid on
+// malformed GeoJSON), gate a boundary-setting update on the caller's tier
+// (403 boundary_requires_paid_tier), load the zone (404 if absent), apply the
+// merge (400 boundary_invalid on an invalid shape, 500 on any other domain
+// invariant violation e.g. a blank name), gate the resulting radius (400
+// boundary_too_large), persist, and return the updated summary.
 func (h *handler) patch(w http.ResponseWriter, r *http.Request) {
 	userID := auth.Subject(r.Context())
 	zoneID := r.PathValue("zoneId")
@@ -297,6 +389,37 @@ func (h *handler) patch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	boundaryUpdate, err := decodeBoundaryUpdate(req.Boundary)
+	if err != nil {
+		h.writeErrorCode(w, r, http.StatusBadRequest, boundaryInvalidCode, boundaryInvalidMessage)
+		return
+	}
+	// "Setting" a boundary (as opposed to leaving it alone, or explicitly
+	// nulling it back to a circle) is the only case the paid-tier gate and the
+	// radius ceiling apply to (tc-6he3x.4 acceptance criteria 4 and 6).
+	settingBoundary := boundaryUpdate != nil && len(*boundaryUpdate) > 0
+
+	var tier profiles.SubscriptionTier
+	if settingBoundary {
+		if h.profiles == nil {
+			h.serverError(w, r, "boundary tier gate", errProfileReaderNotWired)
+			return
+		}
+		profile, perr := h.profiles.Get(r.Context(), userID)
+		if perr != nil || profile == nil {
+			// A missing profile for an authenticated caller is a server-side
+			// inconsistency (the iOS app always registers on first launch) --
+			// mirroring nearby.go's create-path quota check.
+			h.serverError(w, r, "load profile for boundary tier gate", perr)
+			return
+		}
+		tier = profile.EffectiveTier(h.now())
+		if !tier.AllowsCustomBoundary() {
+			h.writeErrorCode(w, r, http.StatusForbidden, boundaryRequiresPaidTierCode, boundaryRequiresPaidTierMessage)
+			return
+		}
+	}
+
 	zone, err := h.store.Get(r.Context(), userID, zoneID)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
@@ -307,11 +430,25 @@ func (h *handler) patch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	updated, err := zone.WithUpdates(req.toUpdate())
+	updated, err := zone.WithUpdates(req.toUpdate(boundaryUpdate))
 	if err != nil {
+		if isBoundaryValidationError(err) {
+			h.writeErrorCode(w, r, http.StatusBadRequest, boundaryInvalidCode, boundaryInvalidMessage)
+			return
+		}
 		h.serverError(w, r, "apply watch-zone update", err)
 		return
 	}
+
+	// Gate A (hard server ceiling) and Gate B (per-tier cap) both apply only
+	// when this update actually set a new shape -- reverting to a circle or
+	// leaving the shape alone never re-checks a radius that was already
+	// accepted (or is unrelated to a boundary) on a prior write.
+	if settingBoundary && (updated.RadiusMetres > maxRadiusMetres || updated.RadiusMetres > tier.MaxZoneRadiusMetres()) {
+		h.writeErrorCode(w, r, http.StatusBadRequest, boundaryTooLargeCode, boundaryTooLargeMessage)
+		return
+	}
+
 	if err := h.store.Save(r.Context(), updated); err != nil {
 		h.serverError(w, r, "save watch zone", err)
 		return
@@ -440,6 +577,27 @@ func (h *handler) writeJSON(w http.ResponseWriter, r *http.Request, status int, 
 // application/json; charset=utf-8 content type.
 func (h *handler) writeError(w http.ResponseWriter, r *http.Request, status int, message string) {
 	body, err := httputil.EncodeJSON(apiErrorResponse{Error: message})
+	if err != nil {
+		h.serverError(w, r, "encode error", err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	if _, err := w.Write(body); err != nil {
+		h.logger.ErrorContext(r.Context(), "write error body", "error", err)
+	}
+}
+
+// writeErrorCode emits the error envelope with a stable, machine-readable code
+// in the "error" field and a human message in "message" -- the same shape
+// internal/offercodes and internal/subscriptions use. writeError (above) stays
+// exactly as-is for its pre-existing call sites, whose "error" field carries
+// prose text with "message" always null; this is for new call sites (the
+// boundary_* errors, tc-6he3x.4) that need a stable discriminator a client can
+// branch on.
+func (h *handler) writeErrorCode(w http.ResponseWriter, r *http.Request, status int, code, message string) {
+	msg := message
+	body, err := httputil.EncodeJSON(apiErrorResponse{Error: code, Message: &msg})
 	if err != nil {
 		h.serverError(w, r, "encode error", err)
 		return

--- a/api-go/internal/watchzones/handler_test.go
+++ b/api-go/internal/watchzones/handler_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -297,6 +298,226 @@ func TestHandler_Patch_BlankNameIsServerError(t *testing.T) {
 	}
 }
 
+// --- PATCH boundary tri-state tests (tc-6he3x.4) ----------------------------
+
+// TestHandler_Patch_Boundary_AbsentLeavesShapeUnchanged proves an absent
+// "boundary" key leaves an existing custom shape untouched (acceptance
+// criteria 3, the "absent" tri-state branch), and does not require a profile
+// reader to be wired.
+func TestHandler_Patch_Boundary_AbsentLeavesShapeUnchanged(t *testing.T) {
+	t.Parallel()
+	base := testZone(t)
+	z, err := base.WithBoundary(squareVertices(base.Latitude, base.Longitude, 500))
+	if err != nil {
+		t.Fatalf("WithBoundary: %v", err)
+	}
+	store := &fakeZoneStore{zones: []WatchZone{z}}
+	rec := doReq(t, testMux(t, store), http.MethodPatch, "/v1/me/watch-zones/"+z.ID, `{"name":"Renamed"}`)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (body %s)", rec.Code, rec.Body)
+	}
+	if store.saved == nil || !store.saved.IsCustomShape() {
+		t.Fatalf("boundary must be untouched by an absent field: %+v", store.saved)
+	}
+	if !reflect.DeepEqual(store.saved.Boundary, z.Boundary) {
+		t.Errorf("boundary changed: got %+v, want %+v", store.saved.Boundary, z.Boundary)
+	}
+	var got struct {
+		Zone watchZoneSummary `json:"zone"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Zone.Boundary == nil {
+		t.Error("response boundary must remain non-null")
+	}
+}
+
+// TestHandler_Patch_Boundary_ExplicitNullConvertsToCircle proves a literal
+// `"boundary":null` reverts a custom-shape zone to a circle while preserving
+// its existing centre and radius (acceptance criteria 3), and that this
+// revert path needs no tier check at all -- testMux wires no profile reader,
+// and the request still succeeds, because the tier gate only applies to
+// setting a non-null boundary (acceptance criteria 4).
+func TestHandler_Patch_Boundary_ExplicitNullConvertsToCircle(t *testing.T) {
+	t.Parallel()
+	base := testZone(t)
+	z, err := base.WithBoundary(squareVertices(base.Latitude, base.Longitude, 500))
+	if err != nil {
+		t.Fatalf("WithBoundary: %v", err)
+	}
+	wantLat, wantLon, wantRadius := z.Latitude, z.Longitude, z.RadiusMetres
+	store := &fakeZoneStore{zones: []WatchZone{z}}
+	rec := doReq(t, testMux(t, store), http.MethodPatch, "/v1/me/watch-zones/"+z.ID, `{"boundary":null}`)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (body %s)", rec.Code, rec.Body)
+	}
+	if store.saved == nil || store.saved.IsCustomShape() {
+		t.Fatalf("zone must revert to a circle: %+v", store.saved)
+	}
+	if store.saved.Latitude != wantLat || store.saved.Longitude != wantLon || store.saved.RadiusMetres != wantRadius {
+		t.Errorf("centre/radius must be preserved on revert: got (%v,%v,%v), want (%v,%v,%v)",
+			store.saved.Latitude, store.saved.Longitude, store.saved.RadiusMetres, wantLat, wantLon, wantRadius)
+	}
+	var got struct {
+		Zone watchZoneSummary `json:"zone"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Zone.Boundary != nil {
+		t.Error("response boundary must be null after reverting to a circle")
+	}
+}
+
+// TestHandler_Patch_Boundary_ValueRequiresPaidTier403 proves a Free-tier
+// caller's PATCH that sets a non-null boundary is rejected with 403
+// boundary_requires_paid_tier (acceptance criteria 4) and never persisted.
+func TestHandler_Patch_Boundary_ValueRequiresPaidTier403(t *testing.T) {
+	t.Parallel()
+	z := testZone(t)
+	store := &fakeZoneStore{zones: []WatchZone{z}}
+	mux := http.NewServeMux()
+	Routes(mux, store, slog.New(slog.DiscardHandler), WithProfileReader(&fakeProfileReader{profile: freeProfile(t)}))
+
+	body := mustJSON(t, struct {
+		Boundary *boundaryGeoJSON `json:"boundary"`
+	}{Boundary: boundaryToGeoJSON(mustBoundary(t, squareVertices(z.Latitude, z.Longitude, 500)))})
+	rec := doReq(t, mux, http.MethodPatch, "/v1/me/watch-zones/"+z.ID, body)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status: got %d, want 403 (body %s)", rec.Code, rec.Body)
+	}
+	var env apiErrorResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode error envelope: %v", err)
+	}
+	if env.Error != boundaryRequiresPaidTierCode {
+		t.Errorf("error code: got %q, want %q", env.Error, boundaryRequiresPaidTierCode)
+	}
+	if store.saved != nil {
+		t.Error("must not save a zone when the boundary tier gate rejects the request")
+	}
+}
+
+// TestHandler_Patch_Boundary_ValueSetsShape proves a paid-tier caller's PATCH
+// that sets a valid boundary derives and persists the new centroid/enclosing
+// radius (acceptance criteria 3's "value" branch).
+func TestHandler_Patch_Boundary_ValueSetsShape(t *testing.T) {
+	t.Parallel()
+	z := testZone(t)
+	b := mustBoundary(t, squareVertices(z.Latitude, z.Longitude, 500))
+	wantLat, wantLon := b.Centroid()
+	wantRadius := b.EnclosingRadiusMetres()
+
+	store := &fakeZoneStore{zones: []WatchZone{z}}
+	mux := http.NewServeMux()
+	Routes(mux, store, slog.New(slog.DiscardHandler), WithProfileReader(&fakeProfileReader{profile: personalProfile(t)}))
+
+	body := mustJSON(t, struct {
+		Boundary *boundaryGeoJSON `json:"boundary"`
+	}{Boundary: boundaryToGeoJSON(b)})
+	rec := doReq(t, mux, http.MethodPatch, "/v1/me/watch-zones/"+z.ID, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (body %s)", rec.Code, rec.Body)
+	}
+	if store.saved == nil || !store.saved.IsCustomShape() {
+		t.Fatalf("zone must become a custom shape: %+v", store.saved)
+	}
+	if store.saved.Latitude != wantLat || store.saved.Longitude != wantLon || store.saved.RadiusMetres != wantRadius {
+		t.Errorf("derived fields: got (%v,%v,%v), want (%v,%v,%v)",
+			store.saved.Latitude, store.saved.Longitude, store.saved.RadiusMetres, wantLat, wantLon, wantRadius)
+	}
+}
+
+// TestHandler_Patch_Boundary_TooLargeIs400 proves a paid-tier caller's PATCH
+// that sets a boundary exceeding their own tier's radius cap (but under the
+// hard server ceiling) is rejected with 400 boundary_too_large and never
+// persisted (acceptance criteria 6, Gate B).
+func TestHandler_Patch_Boundary_TooLargeIs400(t *testing.T) {
+	t.Parallel()
+	z := testZone(t)
+	// Personal tier caps at 5000m; a 4000m half-extent square's corner-derived
+	// enclosing radius (~5657m) exceeds it while staying under the hard 10000m
+	// ceiling, isolating Gate B (the tier cap) from Gate A (the hard ceiling).
+	b := mustBoundary(t, squareVertices(z.Latitude, z.Longitude, 4000))
+	store := &fakeZoneStore{zones: []WatchZone{z}}
+	mux := http.NewServeMux()
+	Routes(mux, store, slog.New(slog.DiscardHandler), WithProfileReader(&fakeProfileReader{profile: personalProfile(t)}))
+
+	body := mustJSON(t, struct {
+		Boundary *boundaryGeoJSON `json:"boundary"`
+	}{Boundary: boundaryToGeoJSON(b)})
+	rec := doReq(t, mux, http.MethodPatch, "/v1/me/watch-zones/"+z.ID, body)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400 (body %s)", rec.Code, rec.Body)
+	}
+	var env apiErrorResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode error envelope: %v", err)
+	}
+	if env.Error != boundaryTooLargeCode {
+		t.Errorf("error code: got %q, want %q", env.Error, boundaryTooLargeCode)
+	}
+	if store.saved != nil {
+		t.Error("must not save a zone whose boundary is too large")
+	}
+}
+
+// TestHandler_Patch_Boundary_InvalidShapeIs400 proves a paid-tier caller's
+// PATCH that sets a malformed shape (here, fewer than the domain's minimum 3
+// vertices) surfaces as 400 boundary_invalid via WithUpdates' own NewBoundary
+// validation, not a re-implemented HTTP-layer check (acceptance criteria 5).
+func TestHandler_Patch_Boundary_InvalidShapeIs400(t *testing.T) {
+	t.Parallel()
+	z := testZone(t)
+	store := &fakeZoneStore{zones: []WatchZone{z}}
+	mux := http.NewServeMux()
+	Routes(mux, store, slog.New(slog.DiscardHandler), WithProfileReader(&fakeProfileReader{profile: proProfile(t)}))
+
+	body := `{"boundary":{"type":"Polygon","coordinates":[[[-0.12,51.5],[-0.11,51.51]]]}}`
+	rec := doReq(t, mux, http.MethodPatch, "/v1/me/watch-zones/"+z.ID, body)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400 (body %s)", rec.Code, rec.Body)
+	}
+	var env apiErrorResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode error envelope: %v", err)
+	}
+	if env.Error != boundaryInvalidCode {
+		t.Errorf("error code: got %q, want %q", env.Error, boundaryInvalidCode)
+	}
+	if store.saved != nil {
+		t.Error("must not save a zone with an invalid boundary")
+	}
+}
+
+// TestHandler_Patch_Boundary_NoProfileReaderWiredIs500 proves that attempting
+// to SET a boundary without a profile reader wired is a 500 (a wiring bug,
+// never reachable in production), not a silent allow or a false 403 -- the
+// tier entitlement genuinely cannot be checked.
+func TestHandler_Patch_Boundary_NoProfileReaderWiredIs500(t *testing.T) {
+	t.Parallel()
+	z := testZone(t)
+	store := &fakeZoneStore{zones: []WatchZone{z}}
+	body := mustJSON(t, struct {
+		Boundary *boundaryGeoJSON `json:"boundary"`
+	}{Boundary: boundaryToGeoJSON(mustBoundary(t, squareVertices(z.Latitude, z.Longitude, 500)))})
+	rec := doReq(t, testMux(t, store), http.MethodPatch, "/v1/me/watch-zones/"+z.ID, body)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status: got %d, want 500", rec.Code)
+	}
+	if store.saved != nil {
+		t.Error("must not save when the tier gate cannot be verified")
+	}
+}
+
 func TestHandler_Delete(t *testing.T) {
 	t.Parallel()
 	z := testZone(t)
@@ -365,7 +586,8 @@ func TestHandler_List_MarksPausedZonesOverEffectiveTierLimit(t *testing.T) {
 	}
 
 	// Golden-check first: every pre-existing field must round-trip unchanged,
-	// and "paused" must be the only addition (9 keys total per zone).
+	// and "paused" plus "boundary" (tc-6he3x.4) are the only additions (10
+	// keys total per zone).
 	var raw struct {
 		Zones []map[string]any `json:"zones"`
 	}
@@ -375,7 +597,7 @@ func TestHandler_List_MarksPausedZonesOverEffectiveTierLimit(t *testing.T) {
 	if len(raw.Zones) != 3 {
 		t.Fatalf("zones: got %d, want 3", len(raw.Zones))
 	}
-	wantKeys := []string{"id", "name", "latitude", "longitude", "radiusMetres", "authorityId", "pushEnabled", "emailInstantEnabled", "paused"}
+	wantKeys := []string{"id", "name", "latitude", "longitude", "radiusMetres", "authorityId", "pushEnabled", "emailInstantEnabled", "paused", "boundary"}
 	for i, obj := range raw.Zones {
 		if len(obj) != len(wantKeys) {
 			t.Errorf("zone %d: got %d keys %v, want %d keys %v", i, len(obj), keysOf(obj), len(wantKeys), wantKeys)

--- a/api-go/internal/watchzones/nearby.go
+++ b/api-go/internal/watchzones/nearby.go
@@ -109,15 +109,19 @@ func NearbyRoutes(
 }
 
 // createRequest is the POST body. The optional flags default to true
-// and authorityId defaults to nil (resolve from coordinates).
+// and authorityId defaults to nil (resolve from coordinates). Boundary is an
+// optional GeoJSON polygon (tc-6he3x.4): when present, Latitude/Longitude/
+// RadiusMetres are ignored and derived server-side from the boundary's
+// centroid and enclosing radius instead (see create and (createRequest).valid).
 type createRequest struct {
-	Name                string  `json:"name"`
-	Latitude            float64 `json:"latitude"`
-	Longitude           float64 `json:"longitude"`
-	RadiusMetres        float64 `json:"radiusMetres"`
-	AuthorityID         *int    `json:"authorityId"`
-	PushEnabled         *bool   `json:"pushEnabled"`
-	EmailInstantEnabled *bool   `json:"emailInstantEnabled"`
+	Name                string           `json:"name"`
+	Latitude            float64          `json:"latitude"`
+	Longitude           float64          `json:"longitude"`
+	RadiusMetres        float64          `json:"radiusMetres"`
+	AuthorityID         *int             `json:"authorityId"`
+	PushEnabled         *bool            `json:"pushEnabled"`
+	EmailInstantEnabled *bool            `json:"emailInstantEnabled"`
+	Boundary            *boundaryGeoJSON `json:"boundary"`
 }
 
 // maxRadiusMetres is the server-side ceiling for a watch-zone radius. It matches
@@ -171,11 +175,23 @@ const invalidUnreadMessage = "Invalid unread filter."
 const filterConflictMessage = "status and unread filters are mutually exclusive."
 
 // valid reports whether the create request passes the pre-handler guard:
-// non-blank name, positive radius within the server ceiling, in-range
-// coordinates, and a positive authority id when one is supplied.
+// non-blank name and a positive authority id when one is supplied, always;
+// PLUS, for a plain circle request (Boundary absent), positive radius within
+// the server ceiling and in-range coordinates. A boundary-carrying request
+// skips those circle-shaped checks entirely -- Latitude/Longitude/RadiusMetres
+// are ignored and overwritten from the boundary in create, so whatever (or
+// nothing) the caller sent for them is irrelevant; the boundary's own shape
+// and radius are validated separately in create (NewBoundary, then the
+// maxRadiusMetres/tier ceiling gates).
 func (req createRequest) valid() bool {
 	if strings.TrimSpace(req.Name) == "" {
 		return false
+	}
+	if req.AuthorityID != nil && *req.AuthorityID <= 0 {
+		return false
+	}
+	if req.Boundary != nil {
+		return true
 	}
 	if math.IsNaN(req.Latitude) || math.IsInf(req.Latitude, 0) {
 		return false
@@ -195,21 +211,31 @@ func (req createRequest) valid() bool {
 	if req.Longitude < -180 || req.Longitude > 180 {
 		return false
 	}
-	if req.AuthorityID != nil && *req.AuthorityID <= 0 {
-		return false
-	}
 	return true
 }
 
-// createResult is the POST /v1/me/watch-zones response: { nearbyApplications: [...] }.
-// The applications are the raw-domain wire shape (no latestUnreadEvent).
+// createResult is the POST /v1/me/watch-zones response. Latitude, Longitude,
+// RadiusMetres and Boundary always reflect the persisted zone regardless of
+// which create path was used (tc-6he3x.4): for a plain circle request they
+// echo back exactly what the caller sent, and for a boundary-carrying request
+// they carry the server-derived centroid/enclosing-radius/shape -- so an
+// existing client that only reads lat/lon/radius keeps working unchanged, and
+// a boundary-aware client can read the derived circle fields off the same
+// response without a follow-up GET.
 type createResult struct {
+	Latitude           float64                     `json:"latitude"`
+	Longitude          float64                     `json:"longitude"`
+	RadiusMetres       float64                     `json:"radiusMetres"`
+	Boundary           *boundaryGeoJSON            `json:"boundary"`
 	NearbyApplications []applications.NearbyResult `json:"nearbyApplications"`
 }
 
-// create implements POST /v1/me/watch-zones: validate (400), enforce the tier's
-// watch-zone quota (403), resolve the authority from coordinates when absent,
-// persist the zone, and return 201 Created with the applications already nearby.
+// create implements POST /v1/me/watch-zones: validate (400), gate a
+// boundary-carrying request on the caller's tier (403
+// boundary_requires_paid_tier) and shape/radius (400 boundary_invalid /
+// boundary_too_large), enforce the tier's watch-zone quota (403), resolve the
+// authority from coordinates when absent, persist the zone, and return 201
+// Created with the applications already nearby.
 func (h *handler) create(w http.ResponseWriter, r *http.Request) {
 	userID := auth.Subject(r.Context())
 
@@ -230,6 +256,35 @@ func (h *handler) create(w http.ResponseWriter, r *http.Request) {
 		h.serverError(w, r, "load profile for quota check", err)
 		return
 	}
+	tier := profile.EffectiveTier(h.now())
+
+	// A boundary-carrying request is gated on the caller's tier before its
+	// shape is even parsed (cheapest check first), then on shape validity,
+	// then on the enclosing radius against both the hard server ceiling and
+	// the tier's own cap. On success Latitude/Longitude/RadiusMetres are
+	// overwritten with the boundary's derived values, so every existing
+	// circle-shaped step below (authority resolution, NewWatchZone, the
+	// nearby-applications fetch) runs unchanged against them.
+	var boundary Boundary
+	if req.Boundary != nil {
+		if !tier.AllowsCustomBoundary() {
+			h.writeErrorCode(w, r, http.StatusForbidden, boundaryRequiresPaidTierCode, boundaryRequiresPaidTierMessage)
+			return
+		}
+		b, berr := NewBoundary(req.Boundary.vertices())
+		if berr != nil {
+			h.writeErrorCode(w, r, http.StatusBadRequest, boundaryInvalidCode, boundaryInvalidMessage)
+			return
+		}
+		radius := b.EnclosingRadiusMetres()
+		if radius > maxRadiusMetres || radius > tier.MaxZoneRadiusMetres() {
+			h.writeErrorCode(w, r, http.StatusBadRequest, boundaryTooLargeCode, boundaryTooLargeMessage)
+			return
+		}
+		boundary = b
+		req.Latitude, req.Longitude = b.Centroid()
+		req.RadiusMetres = radius
+	}
 
 	// Atomic quota gate: the CAS-backed profile counter is the ONLY create path,
 	// so there is no non-atomic footgun. A nil profileCAS at request time is a
@@ -242,7 +297,7 @@ func (h *handler) create(w http.ResponseWriter, r *http.Request) {
 	}
 	// Quota is keyed on the effective tier: a lapsed paid subscription
 	// (EffectiveTier) falls back to the Free limit.
-	ok, casErr := h.atomicQuotaIncrement(r.Context(), userID, profile.EffectiveTier(h.now()).WatchZoneLimit())
+	ok, casErr := h.atomicQuotaIncrement(r.Context(), userID, tier.WatchZoneLimit())
 	if casErr != nil {
 		h.serverError(w, r, "atomic quota check", casErr)
 		return
@@ -272,6 +327,10 @@ func (h *handler) create(w http.ResponseWriter, r *http.Request) {
 		h.serverError(w, r, "build watch zone", err)
 		return
 	}
+	// Attach the already-validated boundary directly (mirroring scanZone's
+	// read-path pattern) rather than re-deriving it through WithBoundary: the
+	// centroid/radius above were already computed from the same b.
+	zone.Boundary = boundary
 	if err := h.store.Save(r.Context(), zone); err != nil {
 		h.serverError(w, r, "save watch zone", err)
 		return
@@ -293,7 +352,13 @@ func (h *handler) create(w http.ResponseWriter, r *http.Request) {
 	for _, a := range nearby {
 		results = append(results, applications.NearbyResultOf(a))
 	}
-	h.writeCreated(w, r, "/v1/me/watch-zones/"+zone.ID, createResult{NearbyApplications: results})
+	h.writeCreated(w, r, "/v1/me/watch-zones/"+zone.ID, createResult{
+		Latitude:           zone.Latitude,
+		Longitude:          zone.Longitude,
+		RadiusMetres:       zone.RadiusMetres,
+		Boundary:           boundaryToGeoJSON(zone.Boundary),
+		NearbyApplications: results,
+	})
 }
 
 // latestUnreadEventWire is the per-row unread descriptor on the applications
@@ -429,6 +494,14 @@ func (h *handler) applications(w http.ResponseWriter, r *http.Request) {
 // per-user notification data the recent-activity sort joins and the unread filter
 // restricts on. rawLimit is the unparsed ?limit= value; cursor is the
 // transport-unwrapped continuation token.
+//
+// INTERIM (tc-6he3x.4): neither finder is boundary-aware yet. For a
+// custom-shape zone (zone.IsCustomShape()) both branches below run against
+// zone.Latitude/Longitude/RadiusMetres -- the polygon's derived centroid and
+// ENCLOSING radius (see WithBoundary), i.e. a circle no smaller than the true
+// shape, so results are a safe over-fetch, never an under-fetch. A
+// polygon-scoped finder (FindInBoundaryPage) replaces this fallback in
+// tc-6he3x.5.
 func (h *handler) findZonePage(ctx context.Context, userID string, zone WatchZone, sort applications.Sort, sortPresent bool, status string, unread bool, rawLimit, cursor string) ([]applications.PlanningApplication, string, error) {
 	if !sortPresent && status == "" && !unread {
 		limit := parseLimit(rawLimit, defaultNearbyLimit)
@@ -455,6 +528,12 @@ func (h *handler) findZonePage(ctx context.Context, userID string, zone WatchZon
 // zoom into a PostGIS grid cell size, and return the grid-aggregated clusters for
 // the visible rect as a JSON array. The store stays a pure spatial primitive: the
 // zoom -> grid-size policy lives here so density can be tuned without a store change.
+//
+// INTERIM (tc-6he3x.4): like findZonePage, the cluster query below is not
+// boundary-aware yet -- it threads zone.Latitude/Longitude/RadiusMetres (the
+// polygon's derived centroid/ENCLOSING radius for a custom-shape zone), a
+// superset of the true shape. tc-6he3x.5 replaces this with a
+// boundary-scoped store method.
 func (h *handler) clusters(w http.ResponseWriter, r *http.Request) {
 	userID := auth.Subject(r.Context())
 	zoneID := r.PathValue("zoneId")

--- a/api-go/internal/watchzones/nearby_test.go
+++ b/api-go/internal/watchzones/nearby_test.go
@@ -54,14 +54,23 @@ type fakeAppFinder struct {
 	lastStatus   string
 	lastUnread   bool
 
+	// lastLatitude/lastLongitude/lastRadiusMetres capture the circle FindNearbyPage
+	// was called with -- for a custom-shape zone these are the polygon's derived
+	// centroid/enclosing radius (tc-6he3x.4's documented interim fallback in
+	// findZonePage/clusters, ahead of tc-6he3x.5's boundary-scoped finder).
+	lastLatitude, lastLongitude, lastRadiusMetres float64
+
 	clusters         []applications.Cluster
 	clusterErr       error
 	clustersCalled   bool
 	lastClusterQuery applications.ClusterQuery
 }
 
-func (f *fakeAppFinder) FindNearbyPage(_ context.Context, _, _, _ float64, limit int, cursor string) ([]applications.PlanningApplication, string, error) {
+func (f *fakeAppFinder) FindNearbyPage(_ context.Context, latitude, longitude, radiusMetres float64, limit int, cursor string) ([]applications.PlanningApplication, string, error) {
 	f.called = true
+	f.lastLatitude = latitude
+	f.lastLongitude = longitude
+	f.lastRadiusMetres = radiusMetres
 	f.lastLimit = limit
 	f.lastCursor = cursor
 	if f.err != nil {
@@ -166,6 +175,59 @@ func freeProfile(t *testing.T) *profiles.UserProfile {
 		t.Fatalf("NewProfile: %v", err)
 	}
 	return p
+}
+
+func personalProfile(t *testing.T) *profiles.UserProfile {
+	t.Helper()
+	p, err := profiles.NewProfile(testUser, "", nearbyNow)
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	p.Tier = profiles.TierPersonal
+	return p
+}
+
+// mustJSON marshals v (typically a createRequest/patchRequest literal) to a
+// JSON string for a request body, failing the test on a marshal error.
+func mustJSON(t *testing.T, v any) string {
+	t.Helper()
+	raw, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal %T: %v", v, err)
+	}
+	return string(raw)
+}
+
+// mustBoundary validates vertices through NewBoundary, failing the test on any
+// validation error -- a test-only convenience for building a known-good
+// Boundary fixture.
+func mustBoundary(t *testing.T, vertices []Coordinate) Boundary {
+	t.Helper()
+	b, err := NewBoundary(vertices)
+	if err != nil {
+		t.Fatalf("NewBoundary: %v", err)
+	}
+	return b
+}
+
+// squareVertices returns a closed square ring centred at (centreLat,
+// centreLon) whose half-extent along each axis is approximately
+// halfExtentMetres, using the same lat/lon-degree scaling as zone.go's
+// boundingBox. It is a test-only shape generator for building a boundary with
+// a roughly-known EnclosingRadiusMetres (the corner-to-centre distance, a
+// factor of sqrt(2) above halfExtentMetres for a square) -- callers needing an
+// exact figure should read it back off the constructed Boundary rather than
+// assume the multiplier.
+func squareVertices(centreLat, centreLon, halfExtentMetres float64) []Coordinate {
+	const metresPerDegreeLat = 111320
+	dLat := halfExtentMetres / metresPerDegreeLat
+	dLon := halfExtentMetres / (metresPerDegreeLat * math.Cos(centreLat*math.Pi/180))
+	return []Coordinate{
+		{Longitude: centreLon + dLon, Latitude: centreLat + dLat},
+		{Longitude: centreLon - dLon, Latitude: centreLat + dLat},
+		{Longitude: centreLon - dLon, Latitude: centreLat - dLat},
+		{Longitude: centreLon + dLon, Latitude: centreLat - dLat},
+	}
 }
 
 func testApp(uid, name string) applications.PlanningApplication {
@@ -805,6 +867,267 @@ func TestValid_RejectsNonFiniteCoordinates(t *testing.T) {
 				t.Errorf("%s: valid() returned true, want false", tc.name)
 			}
 		})
+	}
+}
+
+// --- Boundary (custom-shape) create tests (tc-6he3x.4) ---------------------
+
+// TestCreate_Boundary_FreeTierIs403 proves a Free-tier caller supplying a
+// non-null boundary on create is rejected with 403 boundary_requires_paid_tier
+// before any shape validation or persistence -- the entitlement gate runs
+// first (acceptance criteria 4).
+func TestCreate_Boundary_FreeTierIs403(t *testing.T) {
+	t.Parallel()
+	authorityID := 471
+	d := nearbyDeps{
+		store:    &fakeZoneStore{},
+		profiles: &fakeProfileReader{profile: freeProfile(t)},
+		resolver: &fakeResolver{},
+		apps:     &fakeAppFinder{},
+		unread:   &fakeUnread{},
+	}
+	mux := newNearbyMux(t, d)
+
+	body := mustJSON(t, createRequest{
+		Name:        "My Shape",
+		AuthorityID: &authorityID,
+		Boundary:    boundaryToGeoJSON(mustBoundary(t, squareVertices(51.5, -0.12, 500))),
+	})
+	rec := doReq(t, mux, http.MethodPost, "/v1/me/watch-zones", body)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status: got %d, want 403 (body %s)", rec.Code, rec.Body)
+	}
+	var env apiErrorResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode error envelope: %v", err)
+	}
+	if env.Error != boundaryRequiresPaidTierCode {
+		t.Errorf("error code: got %q, want %q", env.Error, boundaryRequiresPaidTierCode)
+	}
+	if d.store.saved != nil {
+		t.Error("must not save a zone when the boundary tier gate rejects the request")
+	}
+}
+
+// TestCreate_Boundary_DerivesLatLonRadiusAndPersistsShape proves a paid-tier
+// caller's boundary-carrying create derives latitude/longitude/radiusMetres
+// server-side from the shape, returns all of them plus the boundary in the
+// response (acceptance criteria 2), and persists a custom-shape zone.
+func TestCreate_Boundary_DerivesLatLonRadiusAndPersistsShape(t *testing.T) {
+	t.Parallel()
+	authorityID := 471
+	vertices := squareVertices(51.5, -0.12, 500)
+	b := mustBoundary(t, vertices)
+	wantLat, wantLon := b.Centroid()
+	wantRadius := b.EnclosingRadiusMetres()
+
+	d := nearbyDeps{
+		store:    &fakeZoneStore{},
+		profiles: &fakeProfileReader{profile: personalProfile(t)},
+		resolver: &fakeResolver{},
+		apps:     &fakeAppFinder{},
+		unread:   &fakeUnread{},
+	}
+	mux := newNearbyMux(t, d)
+
+	body := mustJSON(t, createRequest{
+		Name:        "My Shape",
+		AuthorityID: &authorityID,
+		Boundary:    boundaryToGeoJSON(b),
+	})
+	rec := doReq(t, mux, http.MethodPost, "/v1/me/watch-zones", body)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status: got %d, want 201 (body %s)", rec.Code, rec.Body)
+	}
+	if d.store.saved == nil {
+		t.Fatal("zone not persisted")
+	}
+	if !d.store.saved.IsCustomShape() {
+		t.Errorf("saved zone must be a custom shape: %+v", d.store.saved)
+	}
+	if d.store.saved.Latitude != wantLat || d.store.saved.Longitude != wantLon || d.store.saved.RadiusMetres != wantRadius {
+		t.Errorf("saved derived fields: got (%v,%v,%v), want (%v,%v,%v)",
+			d.store.saved.Latitude, d.store.saved.Longitude, d.store.saved.RadiusMetres, wantLat, wantLon, wantRadius)
+	}
+
+	var got struct {
+		Latitude     float64          `json:"latitude"`
+		Longitude    float64          `json:"longitude"`
+		RadiusMetres float64          `json:"radiusMetres"`
+		Boundary     *boundaryGeoJSON `json:"boundary"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v; raw=%s", err, rec.Body.String())
+	}
+	if got.Latitude != wantLat || got.Longitude != wantLon || got.RadiusMetres != wantRadius {
+		t.Errorf("response derived fields: got (%v,%v,%v), want (%v,%v,%v)",
+			got.Latitude, got.Longitude, got.RadiusMetres, wantLat, wantLon, wantRadius)
+	}
+	if got.Boundary == nil {
+		t.Fatal("response boundary must be non-null for a custom-shape create")
+	}
+}
+
+// TestCreate_Boundary_TooLarge proves the two radius-ceiling gates (acceptance
+// criteria 6): a Pro-tier caller whose boundary exceeds the hard server
+// ceiling (maxRadiusMetres) is rejected, and a Personal-tier caller whose
+// boundary is under that hard ceiling but over their own tier's cap
+// (MaxZoneRadiusMetres) is also rejected -- both as 400 boundary_too_large.
+func TestCreate_Boundary_TooLarge(t *testing.T) {
+	t.Parallel()
+	authorityID := 471
+	tests := []struct {
+		name             string
+		profile          *profiles.UserProfile
+		halfExtentMetres float64
+	}{
+		{"Pro tier over the hard server ceiling", proProfile(t), 8000},
+		{"Personal tier over its own tier cap but under the hard ceiling", personalProfile(t), 4000},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			b := mustBoundary(t, squareVertices(51.5, -0.12, tc.halfExtentMetres))
+			d := nearbyDeps{
+				store:    &fakeZoneStore{},
+				profiles: &fakeProfileReader{profile: tc.profile},
+				resolver: &fakeResolver{},
+				apps:     &fakeAppFinder{},
+				unread:   &fakeUnread{},
+			}
+			mux := newNearbyMux(t, d)
+			body := mustJSON(t, createRequest{Name: "Big Shape", AuthorityID: &authorityID, Boundary: boundaryToGeoJSON(b)})
+			rec := doReq(t, mux, http.MethodPost, "/v1/me/watch-zones", body)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status: got %d, want 400 (body %s)", rec.Code, rec.Body)
+			}
+			var env apiErrorResponse
+			if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+				t.Fatalf("decode error envelope: %v", err)
+			}
+			if env.Error != boundaryTooLargeCode {
+				t.Errorf("error code: got %q, want %q", env.Error, boundaryTooLargeCode)
+			}
+			if d.store.saved != nil {
+				t.Error("must not save a zone whose boundary is too large")
+			}
+		})
+	}
+}
+
+// TestCreate_Boundary_InvalidShapeIs400 proves a paid-tier caller's malformed
+// shape (here, fewer than the domain's minimum 3 vertices) surfaces as 400
+// boundary_invalid, reusing zone.go's own NewBoundary validation rather than
+// re-implementing a geometry check at the HTTP layer (acceptance criteria 5).
+func TestCreate_Boundary_InvalidShapeIs400(t *testing.T) {
+	t.Parallel()
+	authorityID := 471
+	d := nearbyDeps{
+		store:    &fakeZoneStore{},
+		profiles: &fakeProfileReader{profile: proProfile(t)},
+		resolver: &fakeResolver{},
+		apps:     &fakeAppFinder{},
+		unread:   &fakeUnread{},
+	}
+	mux := newNearbyMux(t, d)
+
+	body := mustJSON(t, createRequest{
+		Name:        "Too Few Vertices",
+		AuthorityID: &authorityID,
+		Boundary: &boundaryGeoJSON{
+			Type: "Polygon",
+			Coordinates: [][][2]float64{{
+				{-0.12, 51.5}, {-0.11, 51.51},
+			}},
+		},
+	})
+	rec := doReq(t, mux, http.MethodPost, "/v1/me/watch-zones", body)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400 (body %s)", rec.Code, rec.Body)
+	}
+	var env apiErrorResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode error envelope: %v", err)
+	}
+	if env.Error != boundaryInvalidCode {
+		t.Errorf("error code: got %q, want %q", env.Error, boundaryInvalidCode)
+	}
+	if d.store.saved != nil {
+		t.Error("must not save a zone with an invalid boundary")
+	}
+}
+
+// TestApplications_CustomShapeZone_UsesEnclosingRadiusInterimFallback pins the
+// documented interim behaviour (tc-6he3x.4, replaced by tc-6he3x.5): a
+// custom-shape zone's applications page still runs through the legacy circle
+// finder (FindNearbyPage) using the polygon's derived centroid and ENCLOSING
+// radius, never a boundary-scoped query.
+func TestApplications_CustomShapeZone_UsesEnclosingRadiusInterimFallback(t *testing.T) {
+	t.Parallel()
+	base := mustZone(t, "zone-1", 471)
+	zone, err := base.WithBoundary(squareVertices(51.5, -0.12, 500))
+	if err != nil {
+		t.Fatalf("WithBoundary: %v", err)
+	}
+	if !zone.IsCustomShape() {
+		t.Fatal("fixture zone must be a custom shape")
+	}
+	apps := &fakeAppFinder{}
+	d := nearbyDeps{
+		store:    &fakeZoneStore{zones: []WatchZone{zone}},
+		apps:     apps,
+		profiles: &fakeProfileReader{},
+		resolver: &fakeResolver{},
+		unread:   &fakeUnread{},
+	}
+	mux := newNearbyMux(t, d)
+
+	rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (body %s)", rec.Code, rec.Body)
+	}
+	if !apps.called || apps.inZoneCalled {
+		t.Fatalf("a param-less request for a custom-shape zone must still use the legacy FindNearbyPage path: called=%v inZone=%v", apps.called, apps.inZoneCalled)
+	}
+	if apps.lastLatitude != zone.Latitude || apps.lastLongitude != zone.Longitude || apps.lastRadiusMetres != zone.RadiusMetres {
+		t.Errorf("interim fallback must query the polygon's derived centroid/enclosing radius: got (%v,%v,%v), want (%v,%v,%v)",
+			apps.lastLatitude, apps.lastLongitude, apps.lastRadiusMetres, zone.Latitude, zone.Longitude, zone.RadiusMetres)
+	}
+}
+
+// TestClusters_CustomShapeZone_UsesEnclosingRadiusInterimFallback is the
+// clusters-endpoint sibling of the applications test above: the cluster query
+// threads the same polygon-derived centroid/enclosing radius, never a
+// boundary-scoped query (tc-6he3x.5 replaces this).
+func TestClusters_CustomShapeZone_UsesEnclosingRadiusInterimFallback(t *testing.T) {
+	t.Parallel()
+	base := mustZone(t, "zone-1", 471)
+	zone, err := base.WithBoundary(squareVertices(51.5, -0.12, 500))
+	if err != nil {
+		t.Fatalf("WithBoundary: %v", err)
+	}
+	apps := &fakeAppFinder{}
+	d := nearbyDeps{
+		store:    &fakeZoneStore{zones: []WatchZone{zone}},
+		apps:     apps,
+		profiles: &fakeProfileReader{},
+		resolver: &fakeResolver{},
+		unread:   &fakeUnread{},
+	}
+	mux := newNearbyMux(t, d)
+
+	rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications/clusters"+validClusterQuery, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (body %s)", rec.Code, rec.Body)
+	}
+	q := apps.lastClusterQuery
+	if q.Latitude != zone.Latitude || q.Longitude != zone.Longitude || q.RadiusMetres != zone.RadiusMetres {
+		t.Errorf("interim fallback must query the polygon's derived centroid/enclosing radius: got (%v,%v,%v), want (%v,%v,%v)",
+			q.Latitude, q.Longitude, q.RadiusMetres, zone.Latitude, zone.Longitude, zone.RadiusMetres)
 	}
 }
 

--- a/api-go/internal/watchzones/store_postgres.go
+++ b/api-go/internal/watchzones/store_postgres.go
@@ -96,15 +96,47 @@ func scanZone(row pgx.Row) (WatchZone, error) {
 	return zone, nil
 }
 
-// pgBoundaryGeoJSON is the GeoJSON Polygon encoding of a Boundary ring
-// exchanged with Postgres: a single exterior ring, [longitude, latitude]
-// coordinate order (GeoJSON/RFC 7946 convention), matching what
-// ST_GeomFromGeoJSON expects on write and what ST_AsGeoJSON produces on read.
-// Single outer ring only -- no holes, no multi-polygon, mirroring the
-// domain's Boundary type.
-type pgBoundaryGeoJSON struct {
+// boundaryGeoJSON is the GeoJSON Polygon wire representation of a Boundary
+// ring: a single exterior ring, [longitude, latitude] coordinate order
+// (GeoJSON/RFC 7946 convention). It is shared by two layers: this store, which
+// round-trips it as a JSON string for ST_GeomFromGeoJSON (write) and
+// ST_AsGeoJSON (read), and the HTTP handlers (handler.go, nearby.go) plus the
+// GDPR export adapter (cmd/api/export_adapters.go), which round-trip it
+// directly as a JSON value in request/response bodies. Single outer ring only
+// -- no holes, no multi-polygon, mirroring the domain's Boundary type.
+type boundaryGeoJSON struct {
 	Type        string         `json:"type"`
 	Coordinates [][][2]float64 `json:"coordinates"`
+}
+
+// boundaryToGeoJSON renders b as its GeoJSON Polygon wire representation, or
+// nil for a circle zone (nil/empty Boundary) -- the "no shape" value at every
+// layer that uses this type, matching a NULL boundary column here and a null
+// "boundary" JSON field at the HTTP layer.
+func boundaryToGeoJSON(b Boundary) *boundaryGeoJSON {
+	if len(b) == 0 {
+		return nil
+	}
+	ring := make([][2]float64, len(b))
+	for i, v := range b {
+		ring[i] = [2]float64{v.Longitude, v.Latitude}
+	}
+	return &boundaryGeoJSON{Type: "Polygon", Coordinates: [][][2]float64{ring}}
+}
+
+// vertices extracts the outer ring as raw, UNVALIDATED Coordinates -- callers
+// must pass them through NewBoundary (directly, or via WithBoundary /
+// WithUpdates) before trusting them as a valid shape.
+func (g boundaryGeoJSON) vertices() []Coordinate {
+	if len(g.Coordinates) == 0 {
+		return nil
+	}
+	ring := g.Coordinates[0]
+	out := make([]Coordinate, len(ring))
+	for i, pt := range ring {
+		out[i] = Coordinate{Longitude: pt[0], Latitude: pt[1]}
+	}
+	return out
 }
 
 // encodeBoundaryGeoJSON renders b as the GeoJSON text ST_GeomFromGeoJSON(...)
@@ -112,14 +144,11 @@ type pgBoundaryGeoJSON struct {
 // which the caller binds as SQL NULL so ST_GeomFromGeoJSON(NULL)::geography
 // also yields NULL -- clearing any previously-persisted boundary on update.
 func encodeBoundaryGeoJSON(b Boundary) (*string, error) {
-	if len(b) == 0 {
+	g := boundaryToGeoJSON(b)
+	if g == nil {
 		return nil, nil
 	}
-	ring := make([][2]float64, len(b))
-	for i, v := range b {
-		ring[i] = [2]float64{v.Longitude, v.Latitude}
-	}
-	raw, err := json.Marshal(pgBoundaryGeoJSON{Type: "Polygon", Coordinates: [][][2]float64{ring}})
+	raw, err := json.Marshal(g)
 	if err != nil {
 		return nil, fmt.Errorf("encode boundary geojson: %w", err)
 	}
@@ -132,17 +161,13 @@ func encodeBoundaryGeoJSON(b Boundary) (*string, error) {
 // string in practice -- scanZone only calls this when the boundary column
 // scanned non-NULL.
 func decodeBoundaryGeoJSON(raw string) (Boundary, error) {
-	var g pgBoundaryGeoJSON
+	var g boundaryGeoJSON
 	if err := json.Unmarshal([]byte(raw), &g); err != nil {
 		return nil, fmt.Errorf("decode boundary geojson: %w", err)
 	}
-	if len(g.Coordinates) == 0 || len(g.Coordinates[0]) == 0 {
+	vertices := g.vertices()
+	if len(vertices) == 0 {
 		return nil, nil
-	}
-	ring := g.Coordinates[0]
-	vertices := make([]Coordinate, len(ring))
-	for i, pt := range ring {
-		vertices[i] = Coordinate{Longitude: pt[0], Latitude: pt[1]}
 	}
 	return NewBoundary(vertices)
 }


### PR DESCRIPTION
## Summary

Implements section 5 of GH#1031 (HTTP surface for custom-shape watch zones), the fourth child bead of epic tc-6he3x. Builds on the already-merged domain (`tc-6he3x.1`, #1039), storage (`tc-6he3x.2`, #1044), and entitlement (`tc-6he3x.3`, #1040) layers.

- `POST /v1/me/watch-zones` accepts an optional `boundary` (GeoJSON Polygon). When present, `latitude`/`longitude`/`radiusMetres` are derived server-side from the boundary's centroid/enclosing radius; the response always carries all four fields so existing clients are unaffected.
- `PATCH /v1/me/watch-zones/{id}` gains a tri-state `boundary` field (absent = untouched, `null` = revert to circle, value = set/replace shape), decoded via `json.RawMessage` since a plain pointer can't distinguish "absent" from "explicit null".
- Tier gate: a boundary-setting request from a Free-tier caller returns `403 boundary_requires_paid_tier`.
- Shape validation reuses the domain's own `NewBoundary` sentinel errors rather than re-implementing geometry checks; a rejected shape returns `400 boundary_invalid`.
- **Radius ceiling gap closed** (flagged during review of tc-6he3x.1): a polygon's enclosing radius is now checked against both the existing hard server ceiling (`maxRadiusMetres = 10000`, previously circle-only) and the new per-tier `profiles.SubscriptionTier.MaxZoneRadiusMetres()` (previously zero call sites) — `400 boundary_too_large` on either. Per the parent issue's explicit carve-out, this never applies retroactively to existing circle zones or the circle create path (tracked separately as `tc-ohbaz`).
- `GET /v1/me/data` (GDPR export) now includes the boundary for custom-shape zones.
- `findZonePage`/`clusters` in `nearby.go` are left querying the polygon's derived enclosing-radius circle for a custom-shape zone (a documented, safe over-fetch) — a real boundary-scoped store method is `tc-6he3x.5`'s job per the issue's own section split; the interim state is called out with `INTERIM (tc-6he3x.4)` comments and locked in by tests.

## Test plan

- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./...` — all packages green
- [x] New handler/nearby/export tests cover: Free-tier 403, derived lat/lon/radius on create, PATCH tri-state (absent/null/value), `boundary_too_large` via both gates, `boundary_invalid` for a rejected shape, GDPR export boundary presence/absence
- [ ] `make test-integration` (real Postgres/PostGIS) — not run locally, Docker unavailable in this sandbox; this change doesn't add new SQL (store refactor only shares an existing GeoJSON wire type), but the PR gate runs the real-Postgres suite regardless
- [ ] `golangci-lint` did not run locally (sandbox's golangci-lint binary is built with go1.25, below this module's `go 1.26` — a pre-existing environment gap unrelated to this change); CI's linter should run cleanly

Refs: GH#1031 (epic), tc-6he3x.4 (bead)


---
_Generated by [Claude Code](https://claude.ai/code/session_01JTKiEUQCmS5TaDwL5pVQv8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating and updating watch zones with custom GeoJSON polygon boundaries.
  * Added boundary data to watch-zone list, update, and GDPR export responses.
  * Automatically derives the zone’s center and radius from custom boundaries.

* **Bug Fixes**
  * Added validation for malformed, oversized, unauthorized, and invalid boundary shapes.
  * Preserved clear distinctions between omitted, null, and populated boundary values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->