### PR TITLE
test(notifydispatch): polygon watch zones fan out and pause like circles (tc-6he3x.6)

### DIFF
--- a/api-go/internal/notifydispatch/decision_test.go
+++ b/api-go/internal/notifydispatch/decision_test.go
@@ -146,6 +146,40 @@ func TestDecisionDispatcher_ZoneMatch_CreatesDecisionRecordAndQueuesPush(t *test
 	}
 }
 
+func TestDecisionDispatcher_ZoneMatch_PolygonZone_CreatesDecisionRecord(t *testing.T) {
+	t.Parallel()
+	// A custom-shape (polygon) zone that FindZonesContaining returns must fan
+	// out through the decision path exactly like a circle zone (tc-6he3x.6):
+	// Dispatch never branches on shape.
+	// proWithZonePrefs hardcodes its opt-in against zone id "zone-1" (matching
+	// every other test in this file), so the polygon fixture reuses that id.
+	zone := testPolygonZoneAt(t, "zone-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	zones := &fakeZones{zones: []watchzones.WatchZone{zone}}
+	saved := &fakeSaved{}
+	profs := &fakeProfiles{byID: map[string]*profiles.UserProfile{
+		"auth0|alice": proWithZonePrefs(t, true),
+	}}
+	d, notifs, queue := newDecisionHarness(t, zones, saved, profs)
+	app := decisionApp(t, "Permitted", coord(51.5), coord(-0.1))
+
+	if err := d.Dispatch(context.Background(), app); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if len(notifs.created) != 1 {
+		t.Fatalf("expected 1 decision record for the matching polygon zone, got %d", len(notifs.created))
+	}
+	rec := notifs.created[0]
+	if rec.WatchZoneID == nil || *rec.WatchZoneID != "zone-1" {
+		t.Errorf("zone id: got %v, want zone-1", rec.WatchZoneID)
+	}
+	if !zone.IsCustomShape() {
+		t.Fatal("fixture must be a custom shape")
+	}
+	if len(queue.queued) != 1 {
+		t.Errorf("paid tier with decision push opted in should queue exactly one push, got %d", len(queue.queued))
+	}
+}
+
 func TestDecisionDispatcher_Dispatch_MatchesZoneRegardlessOfAuthority(t *testing.T) {
 	t.Parallel()
 	// Decision fan-out is now boundary-agnostic (tc-b179): the zone lookup is purely

--- a/api-go/internal/notifydispatch/decision_test.go
+++ b/api-go/internal/notifydispatch/decision_test.go
@@ -153,7 +153,7 @@ func TestDecisionDispatcher_ZoneMatch_PolygonZone_CreatesDecisionRecord(t *testi
 	// Dispatch never branches on shape.
 	// proWithZonePrefs hardcodes its opt-in against zone id "zone-1" (matching
 	// every other test in this file), so the polygon fixture reuses that id.
-	zone := testPolygonZoneAt(t, "zone-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	zone := testPolygonZoneAt(t, "zone-1", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
 	zones := &fakeZones{zones: []watchzones.WatchZone{zone}}
 	saved := &fakeSaved{}
 	profs := &fakeProfiles{byID: map[string]*profiles.UserProfile{

--- a/api-go/internal/notifydispatch/enqueuer_test.go
+++ b/api-go/internal/notifydispatch/enqueuer_test.go
@@ -117,6 +117,30 @@ func testZoneAt(t *testing.T, id, userID string, createdAt time.Time) watchzones
 	return z
 }
 
+// testPolygonZoneAt builds a custom-shape (polygon) watch zone: a small square
+// ring around the same point testZoneAt uses, so the two fixtures are
+// interchangeable in the fan-out tests apart from shape. The dispatchers under
+// test never inspect Boundary directly, so the fake stores are free to return
+// this without any real geometric containment check.
+func testPolygonZoneAt(t *testing.T, id, userID string, createdAt time.Time) watchzones.WatchZone {
+	t.Helper()
+	z := testZoneAt(t, id, userID, createdAt)
+	vertices := []watchzones.Coordinate{
+		{Longitude: -0.11, Latitude: 51.49},
+		{Longitude: -0.09, Latitude: 51.49},
+		{Longitude: -0.09, Latitude: 51.51},
+		{Longitude: -0.11, Latitude: 51.51},
+	}
+	polygon, err := z.WithBoundary(vertices)
+	if err != nil {
+		t.Fatalf("WithBoundary: %v", err)
+	}
+	if !polygon.IsCustomShape() {
+		t.Fatalf("testPolygonZoneAt: fixture must be a custom shape")
+	}
+	return polygon
+}
+
 func newEnqueuerHarness(t *testing.T, tier profiles.SubscriptionTier) (*Enqueuer, *fakeNotifications, *fakePushQueue) {
 	t.Helper()
 	enq, notifs, queue, _ := newEnqueuerHarnessWithZones(t, tier, nil)
@@ -518,6 +542,72 @@ func TestEnqueuer_LapsedPaidTier_RankedAgainstFreeLimit(t *testing.T) {
 	}
 	if len(notifs.created) != 0 {
 		t.Errorf("a lapsed paid tier must be ranked against the Free limit, got %d records for rank-2 zone", len(notifs.created))
+	}
+}
+
+func TestEnqueuer_EnqueueForApplication_FansOutToContainingPolygonZone(t *testing.T) {
+	t.Parallel()
+	// A custom-shape (polygon) zone that FindZonesContaining returns must fan
+	// out exactly like a circle zone (tc-6he3x.6): the fan-out loop is
+	// shape-agnostic, so it must not require a circle's radius/lat/lng.
+	zone := testPolygonZoneAt(t, "zone-polygon-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	zones := &fakeZones{zones: []watchzones.WatchZone{zone}}
+	enq, notifs, _, _ := newEnqueuerHarnessWithZones(t, profiles.TierPro, zones)
+	app := testApplication(t, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
+
+	if err := enq.EnqueueForApplication(context.Background(), app); err != nil {
+		t.Fatalf("EnqueueForApplication: %v", err)
+	}
+	if len(notifs.created) != 1 {
+		t.Fatalf("a within-quota polygon zone must fan out exactly once, got %d", len(notifs.created))
+	}
+	if notifs.created[0].WatchZoneID == nil || *notifs.created[0].WatchZoneID != "zone-polygon-1" {
+		t.Errorf("record should carry the matching polygon zone id: %+v", notifs.created[0].WatchZoneID)
+	}
+}
+
+func TestEnqueuer_PausedPolygonZone_NoFanOutAndZoneUnchanged(t *testing.T) {
+	t.Parallel()
+	// Free tier (limit 1) with 3 polygon zones ranked oldest-first: rank 2
+	// (zone-polygon-2) is paused per the existing GH#889 ranking, exactly as a
+	// circle zone would be. Per the epic's "Quota / downgrade" section, a
+	// downgraded polygon zone must pause, never convert to a circle or get
+	// deleted — assert the fake store's copy is untouched afterward.
+	z1 := testPolygonZoneAt(t, "zone-polygon-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	z2 := testPolygonZoneAt(t, "zone-polygon-2", "auth0|alice", time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC))
+	z3 := testPolygonZoneAt(t, "zone-polygon-3", "auth0|alice", time.Date(2026, 6, 3, 0, 0, 0, 0, time.UTC))
+	allZones := []watchzones.WatchZone{z1, z2, z3}
+	zones := &fakeZones{zones: allZones}
+	enq, notifs, queue, _ := newEnqueuerHarnessWithZones(t, profiles.TierFree, zones)
+	app := testApplication(t, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
+
+	if err := enq.Enqueue(context.Background(), app, z2); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if len(notifs.created) != 0 {
+		t.Errorf("paused (over-quota) polygon zone must create NO record, got %d", len(notifs.created))
+	}
+	if len(queue.queued) != 0 {
+		t.Errorf("paused polygon zone must not queue a push, got %d", len(queue.queued))
+	}
+
+	// The paused zone must still exist in the store, unmodified: still a
+	// custom shape, with its boundary intact — never deleted, never silently
+	// downgraded to a circle.
+	var found *watchzones.WatchZone
+	for i, z := range zones.zones {
+		if z.ID == "zone-polygon-2" {
+			found = &zones.zones[i]
+		}
+	}
+	if found == nil {
+		t.Fatal("paused polygon zone must still exist in the store")
+	}
+	if !found.IsCustomShape() {
+		t.Error("paused polygon zone must still report IsCustomShape() == true, not have been converted to a circle")
+	}
+	if len(found.Boundary) != len(z2.Boundary) {
+		t.Errorf("paused polygon zone's boundary must be untouched: got %d vertices, want %d", len(found.Boundary), len(z2.Boundary))
 	}
 }
 

--- a/api-go/internal/notifydispatch/enqueuer_test.go
+++ b/api-go/internal/notifydispatch/enqueuer_test.go
@@ -122,9 +122,9 @@ func testZoneAt(t *testing.T, id, userID string, createdAt time.Time) watchzones
 // interchangeable in the fan-out tests apart from shape. The dispatchers under
 // test never inspect Boundary directly, so the fake stores are free to return
 // this without any real geometric containment check.
-func testPolygonZoneAt(t *testing.T, id, userID string, createdAt time.Time) watchzones.WatchZone {
+func testPolygonZoneAt(t *testing.T, id string, createdAt time.Time) watchzones.WatchZone {
 	t.Helper()
-	z := testZoneAt(t, id, userID, createdAt)
+	z := testZoneAt(t, id, "auth0|alice", createdAt)
 	vertices := []watchzones.Coordinate{
 		{Longitude: -0.11, Latitude: 51.49},
 		{Longitude: -0.09, Latitude: 51.49},
@@ -550,7 +550,7 @@ func TestEnqueuer_EnqueueForApplication_FansOutToContainingPolygonZone(t *testin
 	// A custom-shape (polygon) zone that FindZonesContaining returns must fan
 	// out exactly like a circle zone (tc-6he3x.6): the fan-out loop is
 	// shape-agnostic, so it must not require a circle's radius/lat/lng.
-	zone := testPolygonZoneAt(t, "zone-polygon-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	zone := testPolygonZoneAt(t, "zone-polygon-1", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
 	zones := &fakeZones{zones: []watchzones.WatchZone{zone}}
 	enq, notifs, _, _ := newEnqueuerHarnessWithZones(t, profiles.TierPro, zones)
 	app := testApplication(t, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
@@ -573,9 +573,9 @@ func TestEnqueuer_PausedPolygonZone_NoFanOutAndZoneUnchanged(t *testing.T) {
 	// circle zone would be. Per the epic's "Quota / downgrade" section, a
 	// downgraded polygon zone must pause, never convert to a circle or get
 	// deleted — assert the fake store's copy is untouched afterward.
-	z1 := testPolygonZoneAt(t, "zone-polygon-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
-	z2 := testPolygonZoneAt(t, "zone-polygon-2", "auth0|alice", time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC))
-	z3 := testPolygonZoneAt(t, "zone-polygon-3", "auth0|alice", time.Date(2026, 6, 3, 0, 0, 0, 0, time.UTC))
+	z1 := testPolygonZoneAt(t, "zone-polygon-1", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	z2 := testPolygonZoneAt(t, "zone-polygon-2", time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC))
+	z3 := testPolygonZoneAt(t, "zone-polygon-3", time.Date(2026, 6, 3, 0, 0, 0, 0, time.UTC))
 	allZones := []watchzones.WatchZone{z1, z2, z3}
 	zones := &fakeZones{zones: allZones}
 	enq, notifs, queue, _ := newEnqueuerHarnessWithZones(t, profiles.TierFree, zones)


### PR DESCRIPTION
## Summary

Bead `tc-6he3x.6` (child of epic `tc-6he3x`, GH#1031 — custom-shape/polygon watch zones as a paid entitlement). Locks in the notify fan-out and pause/downgrade behaviour for polygon zones with explicit test coverage, per the epic's Test Strategy section ("`notifydispatch` tests: a polygon zone fans out; a paused polygon zone does not").

**Finding: no production bug, just missing coverage.** Traced every touchpoint in the fan-out path (`Enqueuer.EnqueueForApplication`/`Enqueue` in `enqueuer.go`, `DecisionDispatcher.Dispatch` in `decision.go`) and the pause/quota logic (`isPaused`, ranks purely by `CreatedAt`/`ID`) — none of it references `Boundary` or any circle-only field. This was already shape-agnostic, built on top of the already-merged `FindZonesContaining` ST_Covers branch (tc-6he3x.2) and `WatchZone.IsCustomShape()`/`Boundary` (tc-6he3x.1). Verified by exercising real polygon fixtures rather than assuming.

- `enqueuer_test.go`: new `testPolygonZoneAt` fixture helper (circle fixture + `WithBoundary`); a within-quota polygon zone fans out exactly like a circle; a paused (over-quota) polygon zone creates no record and no push, and — critically — the zone is confirmed to still exist in the store afterward, still `IsCustomShape() == true`, with its `Boundary` intact (never deleted or silently converted to a circle, per GH#1031's "Quota / downgrade" section).
- `decision_test.go`: a matched polygon zone fans out through `Dispatch` and queues a push exactly like a circle zone.

**Note for visibility (not fixed here, out of scope):** `DecisionDispatcher.Dispatch` has no pause/quota check at all — this is pre-existing behaviour unrelated to polygons (only `Enqueuer.Enqueue` implements `isPaused`), so the "paused zone doesn't fan out" coverage only targets the `Enqueuer` path, matching how the bead scoped that requirement.

No production code changed — test-only, scoped entirely to `api-go/internal/notifydispatch/`. Does not touch `handler.go` or `nearby.go`'s `findZonePage`/`clusters`, which belong to the separate in-flight PR #1045 (tc-6he3x.4).

## Test plan

- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test -race ./internal/notifydispatch/...` — 56/56 subtests pass
- [x] `go test ./...` (full suite) — all packages green
- [ ] `make test-integration` — not run; this PR is test-only and adds no new SQL/store behaviour, so the real-Postgres suite isn't expected to add signal here (CI's PR gate runs it regardless)
- [ ] `golangci-lint` did not run locally (sandbox's binary is built with go1.25, below this module's `go 1.26` — pre-existing environment gap unrelated to this change); CI's linter should run cleanly

Refs: GH#1031 (epic), tc-6he3x.6 (bead)


---
_Generated by [Claude Code](https://claude.ai/code/session_0151y2D3wPPq3rpVJyDbaeV7)_