### PR TITLE
watchzones: polygon branch in findZonePage/clusters, FindInBoundaryPage (tc-6he3x.5)

### DIFF
--- a/api-go/cmd/api/wiring_test.go
+++ b/api-go/cmd/api/wiring_test.go
@@ -127,6 +127,12 @@ func (fakeAppStore) FindInZonePage(context.Context, applications.InZoneQuery) ([
 func (fakeAppStore) FindClustersInZone(context.Context, applications.ClusterQuery) ([]applications.Cluster, error) {
 	return nil, nil
 }
+func (fakeAppStore) FindInBoundaryPage(context.Context, float64, float64, []applications.Coordinate, int, string) ([]applications.PlanningApplication, string, error) {
+	return nil, "", nil
+}
+func (fakeAppStore) FindClustersInBoundary(context.Context, applications.BoundaryClusterQuery) ([]applications.Cluster, error) {
+	return nil, nil
+}
 func (fakeAppStore) RecentNearestTown(context.Context, string, float64, float64, float64, []applications.TownCentroid, int) ([]applications.PlanningApplication, error) {
 	return nil, nil
 }

--- a/api-go/internal/applications/boundaryclusters.go
+++ b/api-go/internal/applications/boundaryclusters.go
@@ -1,0 +1,145 @@
+package applications
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// BoundaryClusterQuery is FindClustersInBoundary's request descriptor
+// (GH#1031, tc-6he3x.5): the custom-shape zone's polygon (Boundary) replaces
+// ClusterQuery's membership circle (Latitude, Longitude, RadiusMetres); the
+// viewport, grid size, status filter and coalesce threshold carry the same
+// meaning as ClusterQuery's.
+type BoundaryClusterQuery struct {
+	Boundary                 []Coordinate
+	West                     float64
+	South                    float64
+	East                     float64
+	North                    float64
+	GridSizeDegrees          float64
+	Status                   string
+	CoalesceThresholdDegrees float64
+}
+
+// boundaryClusterPolygon is the custom-shape zone's polygon, built from $1 --
+// the GeoJSON-encoded ring. It is the boundary-scoped counterpart to
+// clusterPoint's circle, at a different parameter position (this query has no
+// centre/radius, so the polygon takes the leading placeholder).
+const boundaryClusterPolygon = "ST_GeomFromGeoJSON($1)::geography"
+
+// boundaryClusterQueryHead mirrors clusterQueryHead: identical grid-cell
+// tagging and viewport predicate, with ST_Covers against the polygon replacing
+// ST_DWithin against the circle. $2 is the grid size, $3..$6 the viewport.
+const boundaryClusterQueryHead = `WITH filtered AS (
+	SELECT
+		ST_SnapToGrid(location::geometry, $2) AS cell,
+		COALESCE(app_state, 'Unknown') AS state,
+		authority_code AS authority,
+		planit_name AS name,
+		location::geometry AS geom
+	FROM applications
+	WHERE ST_Covers(` + boundaryClusterPolygon + `, location)
+		AND location::geometry && ST_MakeEnvelope($3, $4, $5, $6, 4326)`
+
+// boundaryClusterQueryTail mirrors clusterQueryTail exactly, renumbered for
+// this query's parameter positions: $7 is the coalesce threshold (clusterTail's
+// $9) and, for boundaryClusterQueryByStatus only, $8 is the status filter
+// (clusterTail's $10). See clusterQueryTail for the full per-cell aggregation
+// rationale, which applies unchanged here.
+const boundaryClusterQueryTail = `
+),
+per_cell_state AS (
+	SELECT
+		cell,
+		state,
+		COUNT(*) AS n,
+		ST_Collect(geom) AS geoms,
+		MIN(authority) AS authority,
+		MIN(name) AS name
+	FROM filtered
+	GROUP BY cell, state
+),
+per_cell AS (
+	SELECT
+		cell,
+		ST_Y(ST_Centroid(ST_Collect(geoms))) AS centroid_lat,
+		ST_X(ST_Centroid(ST_Collect(geoms))) AS centroid_lon,
+		SUM(n)::bigint AS member_count,
+		jsonb_object_agg(state, n) AS status_counts,
+		MIN(authority) AS member_authority,
+		MIN(name) AS member_name
+	FROM per_cell_state
+	GROUP BY cell
+),
+cell_meta AS (
+	SELECT
+		base.cell AS cell,
+		CASE
+			WHEN COUNT(*) > 1
+				AND ST_XMax(ST_Extent(geom)) - ST_XMin(ST_Extent(geom)) < $7
+				AND ST_YMax(ST_Extent(geom)) - ST_YMin(ST_Extent(geom)) < $7
+			THEN (
+				SELECT jsonb_agg(jsonb_build_object('authority', m.authority, 'name', m.name))
+				FROM (
+					SELECT authority, name
+					FROM filtered f
+					WHERE f.cell = base.cell
+					ORDER BY authority, name
+					LIMIT 50
+				) m
+			)
+			ELSE NULL
+		END AS members
+	FROM filtered base
+	GROUP BY base.cell
+)
+SELECT
+	per_cell.centroid_lat,
+	per_cell.centroid_lon,
+	per_cell.member_count,
+	per_cell.status_counts,
+	per_cell.member_authority,
+	per_cell.member_name,
+	cell_meta.members
+FROM per_cell
+JOIN cell_meta ON cell_meta.cell = per_cell.cell
+ORDER BY per_cell.member_count DESC
+LIMIT 1000`
+
+const (
+	boundaryClusterQueryAllStatuses = boundaryClusterQueryHead + boundaryClusterQueryTail
+	boundaryClusterQueryByStatus    = boundaryClusterQueryHead + "\n\t\tAND app_state = $8" + boundaryClusterQueryTail
+)
+
+// FindClustersInBoundary is FindClustersInZone's custom-shape counterpart
+// (GH#1031, tc-6he3x.5): grid-aggregated cluster bubbles for the viewport q,
+// restricted to applications ST_Covers-contained in q.Boundary rather than
+// within a circle. The cell/centroid/status-breakdown/member-list shape is
+// identical to FindClustersInZone's Cluster rows; see FindClustersInZone and
+// clusterQueryHead/clusterQueryTail for the full aggregation rationale, which
+// applies unchanged here -- only the containment predicate differs.
+func (s *PostgresStore) FindClustersInBoundary(ctx context.Context, q BoundaryClusterQuery) ([]Cluster, error) {
+	boundaryJSON, err := encodeBoundaryGeoJSON(q.Boundary)
+	if err != nil {
+		return nil, fmt.Errorf("encode boundary geojson: %w", err)
+	}
+
+	query := boundaryClusterQueryAllStatuses
+	args := []any{boundaryJSON, q.GridSizeDegrees, q.West, q.South, q.East, q.North, q.CoalesceThresholdDegrees}
+	if q.Status != "" {
+		query = boundaryClusterQueryByStatus
+		args = append(args, q.Status)
+	}
+
+	rows, err := s.db.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("find clusters in boundary: %w", err)
+	}
+	clusters, err := pgx.CollectRows(rows, scanClusterRow)
+	if err != nil {
+		return nil, fmt.Errorf("find clusters in boundary: %w", err)
+	}
+	return clusters, nil
+}

--- a/api-go/internal/applications/boundaryclusters_integration_test.go
+++ b/api-go/internal/applications/boundaryclusters_integration_test.go
@@ -1,0 +1,114 @@
+//go:build integration
+
+package applications
+
+import (
+	"context"
+	"testing"
+)
+
+// boundaryClusterQuery is a brief BoundaryClusterQuery builder over the wide
+// viewport shared with the circle cluster tests (zoneclusters_integration_test.go),
+// varying only the boundary, grid size and status.
+func boundaryClusterQuery(boundary []Coordinate, gridSize float64, status string) BoundaryClusterQuery {
+	return BoundaryClusterQuery{
+		Boundary:        boundary,
+		West:            bboxWest,
+		South:           bboxSouth,
+		East:            bboxEast,
+		North:           bboxNorth,
+		GridSizeDegrees: gridSize,
+		Status:          status,
+	}
+}
+
+// TestPostgresStore_FindClustersInBoundary_CoversPolygonNotEnclosingCircle
+// proves the boundary-scoped cluster aggregation is genuinely polygon-shaped,
+// not circle-shaped: a point inside the polygon's enclosing circle but outside
+// the polygon itself is excluded from every cluster -- the exact spatial
+// distinction a fake store cannot honestly model (ADR 0032).
+func TestPostgresStore_FindClustersInBoundary_CoversPolygonNotEnclosingCircle(t *testing.T) {
+	ctx := context.Background()
+	store := newAppPGStore(t)
+
+	boundary := squareBoundary(0.005)
+
+	inside := clusterApp("INSIDE", 100, 0.001, 0.001)
+	outsideSquareInsideCircle := clusterApp("OUTSIDE-SQUARE", 100, 0.02, 0.02)
+
+	for _, a := range []PlanningApplication{inside, outsideSquareInsideCircle} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	clusters, err := store.FindClustersInBoundary(ctx, boundaryClusterQuery(boundary, 1e-6, ""))
+	if err != nil {
+		t.Fatalf("FindClustersInBoundary: %v", err)
+	}
+	if got := sumCounts(clusters); got != 1 {
+		t.Fatalf("summed cluster count: got %d, want 1 (only the in-polygon point)", got)
+	}
+	for _, c := range clusters {
+		if c.Member == nil || c.Member.Name != "INSIDE" {
+			t.Errorf("surviving cluster member: got %+v, want INSIDE", c.Member)
+		}
+	}
+}
+
+// TestPostgresStore_FindClustersInBoundary_CountConservation mirrors
+// TestPostgresStore_FindClustersInZone_CountConservation: the summed cluster
+// Count equals a plain COUNT(*) over the same in-polygon, in-viewport
+// predicate, at several grid sizes -- no double counting and no omission.
+func TestPostgresStore_FindClustersInBoundary_CountConservation(t *testing.T) {
+	ctx := context.Background()
+	store := newAppPGStore(t)
+	seedSpread(t, store)
+
+	// A generous square comfortably containing every seedSpread point.
+	boundary := squareBoundary(0.2)
+
+	for _, grid := range []float64{10.0, 0.01, 1e-6} {
+		q := boundaryClusterQuery(boundary, grid, "")
+		clusters, err := store.FindClustersInBoundary(ctx, q)
+		if err != nil {
+			t.Fatalf("grid %v: FindClustersInBoundary: %v", grid, err)
+		}
+		if got, want := sumCounts(clusters), 8; got != want {
+			t.Errorf("grid %v: summed Count = %d, want %d", grid, got, want)
+		}
+		for _, c := range clusters {
+			if got := sumStatusCounts(c); got != c.Count {
+				t.Errorf("grid %v: cluster statusCounts sum = %d, want Count %d", grid, got, c.Count)
+			}
+		}
+	}
+}
+
+// TestPostgresStore_FindClustersInBoundary_StatusFilter mirrors
+// TestPostgresStore_FindClustersInZone_StatusFilter: ?status= restricts the
+// boundary-scoped aggregation to matching rows.
+func TestPostgresStore_FindClustersInBoundary_StatusFilter(t *testing.T) {
+	ctx := context.Background()
+	store := newAppPGStore(t)
+	permitted, rejected := pgPtr("Permitted"), pgPtr("Rejected")
+	boundary := squareBoundary(0.2)
+
+	for _, a := range []PlanningApplication{
+		withState(clusterApp("P1", 100, 0.0000, 0.0000), permitted),
+		withState(clusterApp("P2", 100, 0.0001, 0.0000), permitted),
+		withState(clusterApp("R1", 100, 0.0003, 0.0000), rejected),
+	} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	permittedOnly, err := store.FindClustersInBoundary(ctx, boundaryClusterQuery(boundary, 10.0, "Permitted"))
+	if err != nil {
+		t.Fatalf("filtered: %v", err)
+	}
+	if got := sumCounts(permittedOnly); got != 2 {
+		t.Fatalf("filtered count: got %d, want 2 (only Permitted)", got)
+	}
+}

--- a/api-go/internal/applications/boundarypage.go
+++ b/api-go/internal/applications/boundarypage.go
@@ -1,0 +1,118 @@
+package applications
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// Coordinate is a single lon/lat vertex of a custom-shape watch-zone boundary
+// polygon, GeoJSON-ordered (longitude first) to match watchzones.Boundary's
+// wire/store encoding (watchzones/store_postgres.go's encodeBoundaryGeoJSON)
+// and what PostGIS's ST_GeomFromGeoJSON expects. It is this package's own
+// type -- applications cannot import watchzones, which already imports
+// applications -- so a caller (watchzones/nearby.go) converts its own
+// Boundary/Coordinate ring into a []Coordinate of this shape before calling
+// FindInBoundaryPage or FindClustersInBoundary.
+type Coordinate struct {
+	Longitude float64
+	Latitude  float64
+}
+
+// boundaryGeoJSON is the GeoJSON Polygon shape ST_GeomFromGeoJSON(...) expects:
+// a single exterior ring, [longitude, latitude] coordinate order -- byte-for-
+// byte the same shape watchzones/store_postgres.go's pgBoundaryGeoJSON
+// produces, so a zone's persisted boundary and the ad hoc boundary query
+// parameter here encode identically.
+type boundaryGeoJSON struct {
+	Type        string         `json:"type"`
+	Coordinates [][][2]float64 `json:"coordinates"`
+}
+
+// errEmptyBoundary signals a caller bug: FindInBoundaryPage and
+// FindClustersInBoundary are reached only for a custom-shape zone, whose
+// Boundary is guaranteed non-empty by watchzones.NewBoundary.
+var errEmptyBoundary = errors.New("boundary must not be empty")
+
+// encodeBoundaryGeoJSON renders ring as GeoJSON Polygon text for
+// ST_GeomFromGeoJSON($n)::geography.
+func encodeBoundaryGeoJSON(ring []Coordinate) (string, error) {
+	if len(ring) == 0 {
+		return "", errEmptyBoundary
+	}
+	coords := make([][2]float64, len(ring))
+	for i, v := range ring {
+		coords[i] = [2]float64{v.Longitude, v.Latitude}
+	}
+	raw, err := json.Marshal(boundaryGeoJSON{Type: "Polygon", Coordinates: [][][2]float64{coords}})
+	if err != nil {
+		return "", fmt.Errorf("encode boundary geojson: %w", err)
+	}
+	return string(raw), nil
+}
+
+// boundaryPolygon is the custom-shape zone's polygon, built from $3 -- the
+// GeoJSON-encoded ring ST_GeomFromGeoJSON parses back into a geography. It
+// pairs with nearbyPoint ($1 longitude, $2 latitude -- the zone's derived
+// centroid, supplied by the caller so distance-ordering and its keyset cursor
+// stay byte-identical in shape to FindNearbyPage's) for the KNN ORDER BY.
+const boundaryPolygon = "ST_GeomFromGeoJSON($3)::geography"
+
+// findBoundaryFirstPageQuery mirrors findNearbyFirstPageQuery: the same
+// nearest-centroid-first KNN ordering and (distance, planit_name) keyset shape,
+// with ST_Covers against the polygon replacing ST_DWithin against the circle.
+const findBoundaryFirstPageQuery = "SELECT " + appColumns + ", location <-> " + nearbyPoint + " AS distance " +
+	"FROM applications WHERE ST_Covers(" + boundaryPolygon + ", location) " +
+	"ORDER BY location <-> " + nearbyPoint + ", planit_name LIMIT $4"
+
+// findBoundaryKeysetQuery mirrors findNearbyKeysetQuery: the identical keyset
+// predicate, with the same polygon containment swap.
+const findBoundaryKeysetQuery = "SELECT " + appColumns + ", location <-> " + nearbyPoint + " AS distance " +
+	"FROM applications WHERE ST_Covers(" + boundaryPolygon + ", location) " +
+	"AND (location <-> " + nearbyPoint + " > $5 " +
+	"OR (location <-> " + nearbyPoint + " = $5 AND planit_name > $6)) " +
+	"ORDER BY location <-> " + nearbyPoint + ", planit_name LIMIT $4"
+
+// FindInBoundaryPage is FindNearbyPage's custom-shape counterpart (GH#1031,
+// tc-6he3x.5): one nearest-first page of up to limit applications ST_Covers-
+// contained in boundary (a closed polygon ring, [longitude, latitude]-ordered),
+// plus an opaque continuation cursor byte-identical in shape to
+// FindNearbyPage's. latitude and longitude are the zone's derived centroid
+// (see watchzones.WatchZone.WithBoundary) and are used ONLY to order the page
+// nearest-centroid-first -- containment is decided entirely by ST_Covers
+// against the polygon, never by the centroid or any implied radius.
+func (s *PostgresStore) FindInBoundaryPage(ctx context.Context, latitude, longitude float64, boundary []Coordinate, limit int, cursor string) ([]PlanningApplication, string, error) {
+	boundaryJSON, err := encodeBoundaryGeoJSON(boundary)
+	if err != nil {
+		return nil, "", fmt.Errorf("encode boundary geojson: %w", err)
+	}
+
+	var rows pgx.Rows
+	if cursor == "" {
+		rows, err = s.db.Query(ctx, findBoundaryFirstPageQuery, longitude, latitude, boundaryJSON, limit)
+	} else {
+		dist, name, decodeErr := decodeNearbyCursor(cursor)
+		if decodeErr != nil {
+			return nil, "", fmt.Errorf("decode boundary cursor: %w", decodeErr)
+		}
+		rows, err = s.db.Query(ctx, findBoundaryKeysetQuery, longitude, latitude, boundaryJSON, limit, dist, name)
+	}
+	wrap := func(err error) error {
+		return fmt.Errorf("find applications in boundary near (%v, %v): %w", latitude, longitude, err)
+	}
+	if err != nil {
+		return nil, "", wrap(err)
+	}
+	return collectPage(rows, scanNearbyRow, nearbyAppOf,
+		func(last nearbyRow) (string, error) {
+			enc, err := encodeNearbyCursor(last.dist, last.app.Name)
+			if err != nil {
+				return "", fmt.Errorf("encode boundary cursor: %w", err)
+			}
+			return enc, nil
+		},
+		limit, wrap)
+}

--- a/api-go/internal/applications/boundarypage_integration_test.go
+++ b/api-go/internal/applications/boundarypage_integration_test.go
@@ -1,0 +1,129 @@
+//go:build integration
+
+package applications
+
+import (
+	"context"
+	"testing"
+)
+
+// squareBoundary is a small closed square ring around the shared London centre
+// fixture (pgCentreLon/pgCentreLat), [longitude, latitude]-ordered like
+// watchzones.Boundary. halfSide is the ring's half-width in degrees, chosen per
+// test so a fixture point can be placed inside the square, inside its
+// enclosing circle but outside the square, or outside both.
+func squareBoundary(halfSide float64) []Coordinate {
+	return []Coordinate{
+		{Longitude: pgCentreLon + halfSide, Latitude: pgCentreLat + halfSide},
+		{Longitude: pgCentreLon - halfSide, Latitude: pgCentreLat + halfSide},
+		{Longitude: pgCentreLon - halfSide, Latitude: pgCentreLat - halfSide},
+		{Longitude: pgCentreLon + halfSide, Latitude: pgCentreLat - halfSide},
+		{Longitude: pgCentreLon + halfSide, Latitude: pgCentreLat + halfSide},
+	}
+}
+
+// TestPostgresStore_FindInBoundaryPage_CoversPolygonNotEnclosingCircle is the
+// honest real-PostGIS proof ADR 0032 requires: a point inside the polygon
+// matches, and a point inside the polygon's enclosing circle but outside the
+// polygon itself does NOT match -- the exact spatial distinction a fake store
+// cannot model.
+func TestPostgresStore_FindInBoundaryPage_CoversPolygonNotEnclosingCircle(t *testing.T) {
+	ctx := context.Background()
+	store := newAppPGStore(t)
+
+	// A ~0.005-degree half-side square (roughly 550m at this latitude). A point
+	// due north-east at ~0.02 degrees sits well inside the square's enclosing
+	// circle but well outside the square itself.
+	boundary := squareBoundary(0.005)
+
+	inside := pgApp("INSIDE", 100)
+	inside.Longitude = pgPtr(pgCentreLon + 0.001)
+	inside.Latitude = pgPtr(pgCentreLat + 0.001)
+
+	outsideSquareInsideCircle := pgApp("OUTSIDE-SQUARE", 100)
+	outsideSquareInsideCircle.Longitude = pgPtr(pgCentreLon + 0.02)
+	outsideSquareInsideCircle.Latitude = pgPtr(pgCentreLat + 0.02)
+
+	farOutside := pgApp("FAR-OUTSIDE", 100)
+	farOutside.Longitude = pgPtr(pgCentreLon + 1.0)
+	farOutside.Latitude = pgPtr(pgCentreLat + 1.0)
+
+	for _, a := range []PlanningApplication{inside, outsideSquareInsideCircle, farOutside} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	page, cursor, err := store.FindInBoundaryPage(ctx, pgCentreLat, pgCentreLon, boundary, 10, "")
+	if err != nil {
+		t.Fatalf("FindInBoundaryPage: %v", err)
+	}
+	assertNames(t, appNames(page), []string{"INSIDE"})
+	if cursor != "" {
+		t.Fatalf("expected empty cursor at exhaustion, got %q", cursor)
+	}
+}
+
+// TestPostgresStore_FindInBoundaryPage_OnEdgeMatches proves ST_Covers, not
+// ST_Contains, is in effect: a point exactly on the boundary edge matches.
+func TestPostgresStore_FindInBoundaryPage_OnEdgeMatches(t *testing.T) {
+	ctx := context.Background()
+	store := newAppPGStore(t)
+
+	boundary := squareBoundary(0.005)
+
+	onEdge := pgApp("ON-EDGE", 100)
+	onEdge.Longitude = pgPtr(pgCentreLon)
+	onEdge.Latitude = pgPtr(pgCentreLat + 0.005) // exactly on the north edge
+
+	if err := store.Upsert(ctx, onEdge); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	page, _, err := store.FindInBoundaryPage(ctx, pgCentreLat, pgCentreLon, boundary, 10, "")
+	if err != nil {
+		t.Fatalf("FindInBoundaryPage: %v", err)
+	}
+	assertNames(t, appNames(page), []string{"ON-EDGE"})
+}
+
+// TestPostgresStore_FindInBoundaryPage_Paginates proves the boundary page keeps
+// FindNearbyPage's nearest-centroid-first ordering and keyset pagination: a
+// full page returns a continuation cursor, and paging with it resumes without
+// overlap or gap.
+func TestPostgresStore_FindInBoundaryPage_Paginates(t *testing.T) {
+	ctx := context.Background()
+	store := newAppPGStore(t)
+
+	// A generous square comfortably containing every fixture point, so ordering
+	// and pagination -- not containment -- is what this test proves.
+	boundary := squareBoundary(0.2)
+
+	for _, a := range []PlanningApplication{
+		at(pgApp("APP-100", 100), 100),
+		at(pgApp("APP-500", 100), 500),
+		at(pgApp("APP-5000", 100), 5000),
+	} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	page1, cursor1, err := store.FindInBoundaryPage(ctx, pgCentreLat, pgCentreLon, boundary, 2, "")
+	if err != nil {
+		t.Fatalf("FindInBoundaryPage page1: %v", err)
+	}
+	assertNames(t, appNames(page1), []string{"APP-100", "APP-500"})
+	if cursor1 == "" {
+		t.Fatal("expected a continuation cursor after a full page")
+	}
+
+	page2, cursor2, err := store.FindInBoundaryPage(ctx, pgCentreLat, pgCentreLon, boundary, 2, cursor1)
+	if err != nil {
+		t.Fatalf("FindInBoundaryPage page2: %v", err)
+	}
+	assertNames(t, appNames(page2), []string{"APP-5000"})
+	if cursor2 != "" {
+		t.Fatalf("expected empty cursor at exhaustion, got %q", cursor2)
+	}
+}

--- a/api-go/internal/applications/store_postgres.go
+++ b/api-go/internal/applications/store_postgres.go
@@ -39,6 +39,8 @@ type Store interface {
 	RecentNearPoint(ctx context.Context, latitude, longitude, radiusMetres float64, limit int) ([]PlanningApplication, error)
 	FindInZonePage(ctx context.Context, q InZoneQuery) ([]PlanningApplication, string, error)
 	FindClustersInZone(ctx context.Context, q ClusterQuery) ([]Cluster, error)
+	FindInBoundaryPage(ctx context.Context, latitude, longitude float64, boundary []Coordinate, limit int, cursor string) ([]PlanningApplication, string, error)
+	FindClustersInBoundary(ctx context.Context, q BoundaryClusterQuery) ([]Cluster, error)
 	RecentNearestTown(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64, siblings []TownCentroid, cap int) ([]PlanningApplication, error)
 	BreakdownNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64) ([]StateCount, error)
 	Search(ctx context.Context, query, authorityCode string, lat, lon float64, limit int) ([]PlanningApplication, bool, error)

--- a/api-go/internal/watchzones/nearby.go
+++ b/api-go/internal/watchzones/nearby.go
@@ -63,10 +63,17 @@ type authorityResolver interface {
 // breakdown) for a viewport, so the map renders a handful of aggregates instead
 // of eager-draining every application. *applications.PostgresStore satisfies all
 // three.
+// FindInBoundaryPage and FindClustersInBoundary (GH#1031, tc-6he3x.5) are the
+// custom-shape counterparts to FindNearbyPage and FindClustersInZone: the
+// containment test is ST_Covers against the zone's polygon rather than
+// ST_DWithin against its circle. See findZonePage and clusters for the
+// zone.IsCustomShape() branch that routes to them.
 type appFinder interface {
 	FindNearbyPage(ctx context.Context, latitude, longitude, radiusMetres float64, limit int, cursor string) ([]applications.PlanningApplication, string, error)
 	FindInZonePage(ctx context.Context, q applications.InZoneQuery) ([]applications.PlanningApplication, string, error)
 	FindClustersInZone(ctx context.Context, q applications.ClusterQuery) ([]applications.Cluster, error)
+	FindInBoundaryPage(ctx context.Context, latitude, longitude float64, boundary []applications.Coordinate, limit int, cursor string) ([]applications.PlanningApplication, string, error)
+	FindClustersInBoundary(ctx context.Context, q applications.BoundaryClusterQuery) ([]applications.Cluster, error)
 }
 
 // unreadReader batches the per-application latest-unread lookup (read_at IS NULL,
@@ -430,6 +437,16 @@ func (h *handler) applications(w http.ResponseWriter, r *http.Request) {
 // restricts on. rawLimit is the unparsed ?limit= value; cursor is the
 // transport-unwrapped continuation token.
 func (h *handler) findZonePage(ctx context.Context, userID string, zone WatchZone, sort applications.Sort, sortPresent bool, status string, unread bool, rawLimit, cursor string) ([]applications.PlanningApplication, string, error) {
+	// Custom-shape zones (GH#1031, tc-6he3x.5) always take the plain boundary-
+	// scoped page, regardless of ?sort=/?status=/?unread=: there is no
+	// boundary-aware counterpart to FindInZonePage yet, so those params are a
+	// silent no-op here (escalated and decided 2026-08-01 — option A). Circle
+	// zones are completely unaffected; a follow-up bead tracks the
+	// boundary-aware sort/filter equivalent.
+	if zone.IsCustomShape() {
+		limit := parseLimit(rawLimit, defaultNearbyLimit)
+		return h.apps.FindInBoundaryPage(ctx, zone.Latitude, zone.Longitude, boundaryCoordinates(zone.Boundary), limit, cursor)
+	}
 	if !sortPresent && status == "" && !unread {
 		limit := parseLimit(rawLimit, defaultNearbyLimit)
 		return h.apps.FindNearbyPage(ctx, zone.Latitude, zone.Longitude, zone.RadiusMetres, limit, cursor)
@@ -489,23 +506,43 @@ func (h *handler) clusters(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	clusters, err := h.apps.FindClustersInZone(r.Context(), applications.ClusterQuery{
-		Latitude:        zone.Latitude,
-		Longitude:       zone.Longitude,
-		RadiusMetres:    zone.RadiusMetres,
-		West:            box.West,
-		South:           box.South,
-		East:            box.East,
-		North:           box.North,
-		GridSizeDegrees: gridSize,
-		Status:          status,
-		// The coalesce threshold is the finest (zoom-20) grid cell size, not the
-		// request's own grid: a multi-member cell whose member points already span
-		// less than this can never be split by zooming, so the store attaches an
-		// applicationIds member list. applications.FinestGridDegrees() keeps it
-		// tracking the shared zoom -> grid policy (GH#924) with no separate constant.
-		CoalesceThresholdDegrees: applications.FinestGridDegrees(),
-	})
+	// Custom-shape zones (GH#1031, tc-6he3x.5) branch to the boundary-scoped
+	// cluster query: ST_Covers against the polygon rather than ST_DWithin
+	// against the circle. Every other param (viewport, status, coalesce
+	// threshold) carries the same meaning as the circle path unchanged.
+	var clusters []applications.Cluster
+	if zone.IsCustomShape() {
+		clusters, err = h.apps.FindClustersInBoundary(r.Context(), applications.BoundaryClusterQuery{
+			Boundary:        boundaryCoordinates(zone.Boundary),
+			West:            box.West,
+			South:           box.South,
+			East:            box.East,
+			North:           box.North,
+			GridSizeDegrees: gridSize,
+			Status:          status,
+			// See the circle path below for the coalesce-threshold rationale --
+			// identical here.
+			CoalesceThresholdDegrees: applications.FinestGridDegrees(),
+		})
+	} else {
+		clusters, err = h.apps.FindClustersInZone(r.Context(), applications.ClusterQuery{
+			Latitude:        zone.Latitude,
+			Longitude:       zone.Longitude,
+			RadiusMetres:    zone.RadiusMetres,
+			West:            box.West,
+			South:           box.South,
+			East:            box.East,
+			North:           box.North,
+			GridSizeDegrees: gridSize,
+			Status:          status,
+			// The coalesce threshold is the finest (zoom-20) grid cell size, not the
+			// request's own grid: a multi-member cell whose member points already span
+			// less than this can never be split by zooming, so the store attaches an
+			// applicationIds member list. applications.FinestGridDegrees() keeps it
+			// tracking the shared zoom -> grid policy (GH#924) with no separate constant.
+			CoalesceThresholdDegrees: applications.FinestGridDegrees(),
+		})
+	}
 	if err != nil {
 		h.serverError(w, r, "find clusters in zone", err)
 		return
@@ -679,6 +716,18 @@ func (h *handler) atomicQuotaIncrement(ctx context.Context, userID string, limit
 	}
 	// Exhausted retries: conservative 403.
 	return false, nil
+}
+
+// boundaryCoordinates converts a watch zone's Boundary ring into the
+// applications package's own Coordinate slice. applications cannot import
+// watchzones (which already imports applications), so each polygon-scoped
+// store call re-encodes the ring into that package's boundary parameter type.
+func boundaryCoordinates(b Boundary) []applications.Coordinate {
+	out := make([]applications.Coordinate, len(b))
+	for i, v := range b {
+		out[i] = applications.Coordinate{Longitude: v.Longitude, Latitude: v.Latitude}
+	}
+	return out
 }
 
 // boolOrTrue resolves an optional bool flag, defaulting an absent value to true.

--- a/api-go/internal/watchzones/nearby_test.go
+++ b/api-go/internal/watchzones/nearby_test.go
@@ -58,6 +58,13 @@ type fakeAppFinder struct {
 	clusterErr       error
 	clustersCalled   bool
 	lastClusterQuery applications.ClusterQuery
+
+	boundaryCalled           bool
+	lastBoundaryLatitude     float64
+	lastBoundaryLongitude    float64
+	lastBoundary             []applications.Coordinate
+	boundaryClustersCalled   bool
+	lastBoundaryClusterQuery applications.BoundaryClusterQuery
 }
 
 func (f *fakeAppFinder) FindNearbyPage(_ context.Context, _, _, _ float64, limit int, cursor string) ([]applications.PlanningApplication, string, error) {
@@ -99,6 +106,32 @@ func (f *fakeAppFinder) FindInZonePage(_ context.Context, q applications.InZoneQ
 func (f *fakeAppFinder) FindClustersInZone(_ context.Context, q applications.ClusterQuery) ([]applications.Cluster, error) {
 	f.clustersCalled = true
 	f.lastClusterQuery = q
+	if f.clusterErr != nil {
+		return nil, f.clusterErr
+	}
+	return f.clusters, nil
+}
+
+func (f *fakeAppFinder) FindInBoundaryPage(_ context.Context, latitude, longitude float64, boundary []applications.Coordinate, limit int, cursor string) ([]applications.PlanningApplication, string, error) {
+	f.boundaryCalled = true
+	f.lastBoundaryLatitude = latitude
+	f.lastBoundaryLongitude = longitude
+	f.lastBoundary = boundary
+	f.lastLimit = limit
+	f.lastCursor = cursor
+	if f.err != nil {
+		return nil, "", f.err
+	}
+	apps := f.apps
+	if limit > 0 && len(apps) > limit {
+		apps = apps[:limit]
+	}
+	return apps, f.next, nil
+}
+
+func (f *fakeAppFinder) FindClustersInBoundary(_ context.Context, q applications.BoundaryClusterQuery) ([]applications.Cluster, error) {
+	f.boundaryClustersCalled = true
+	f.lastBoundaryClusterQuery = q
 	if f.clusterErr != nil {
 		return nil, f.clusterErr
 	}
@@ -842,6 +875,106 @@ func TestApplications_ParamlessUsesLegacyDistancePath(t *testing.T) {
 	if apps.lastLimit != 500 {
 		t.Errorf("legacy default limit: got %d, want 500", apps.lastLimit)
 	}
+	if apps.boundaryCalled {
+		t.Error("a circle zone must never route to the boundary-scoped finder")
+	}
+}
+
+// TestApplications_CircleZoneStillUsesLegacyDistancePath is the explicit
+// regression this bead calls for (tc-6he3x.5): a circle zone's applications
+// list is completely unaffected by the new polygon branch, sort/filter
+// requests included -- it keeps routing to FindNearbyPage/FindInZonePage
+// exactly as before, never FindInBoundaryPage.
+func TestApplications_CircleZoneStillUsesLegacyDistancePath(t *testing.T) {
+	t.Parallel()
+	apps := &fakeAppFinder{}
+	mux := newNearbyMux(t, sortDeps(t, apps))
+
+	rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications?sort=newest", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	if !apps.inZoneCalled {
+		t.Error("a circle zone's ?sort= request must still use FindInZonePage")
+	}
+	if apps.boundaryCalled {
+		t.Error("a circle zone must never route to the boundary-scoped finder")
+	}
+}
+
+// TestApplications_CustomShapeZoneUsesBoundaryPath proves a custom-shape zone's
+// applications list branches to FindInBoundaryPage, threading the zone's
+// derived centroid and its boundary ring -- and never falls through to
+// FindNearbyPage/FindInZonePage.
+func TestApplications_CustomShapeZoneUsesBoundaryPath(t *testing.T) {
+	t.Parallel()
+	zone := mustCustomShapeZone(t, "zone-1", 471)
+	apps := &fakeAppFinder{}
+	d := nearbyDeps{
+		store:    &fakeZoneStore{zones: []WatchZone{zone}},
+		apps:     apps,
+		profiles: &fakeProfileReader{},
+		resolver: &fakeResolver{},
+		unread:   &fakeUnread{},
+	}
+	mux := newNearbyMux(t, d)
+
+	rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if !apps.boundaryCalled {
+		t.Fatal("a custom-shape zone must route to FindInBoundaryPage")
+	}
+	if apps.called || apps.inZoneCalled {
+		t.Error("a custom-shape zone must never route to FindNearbyPage/FindInZonePage")
+	}
+	if apps.lastBoundaryLatitude != zone.Latitude || apps.lastBoundaryLongitude != zone.Longitude {
+		t.Errorf("boundary centre: got (%v, %v), want the zone's derived centroid (%v, %v)",
+			apps.lastBoundaryLatitude, apps.lastBoundaryLongitude, zone.Latitude, zone.Longitude)
+	}
+	if len(apps.lastBoundary) != len(zone.Boundary) {
+		t.Fatalf("boundary ring length: got %d, want %d", len(apps.lastBoundary), len(zone.Boundary))
+	}
+	for i, v := range zone.Boundary {
+		got := apps.lastBoundary[i]
+		if got.Longitude != v.Longitude || got.Latitude != v.Latitude {
+			t.Errorf("boundary[%d]: got %+v, want %+v", i, got, v)
+		}
+	}
+	if apps.lastLimit != defaultNearbyLimit {
+		t.Errorf("boundary path default limit: got %d, want %d", apps.lastLimit, defaultNearbyLimit)
+	}
+}
+
+// TestApplications_CustomShapeZoneIgnoresSortAndFilterParams proves the
+// documented interim gap (tc-6he3x.5; a boundary-aware FindInZonePage
+// equivalent is a follow-up, per the escalated decision): a custom-shape
+// zone's ?sort=/?status=/?unread= are silent no-ops, always serving the plain
+// boundary page rather than erroring or falling through to FindInZonePage.
+func TestApplications_CustomShapeZoneIgnoresSortAndFilterParams(t *testing.T) {
+	t.Parallel()
+	zone := mustCustomShapeZone(t, "zone-1", 471)
+	apps := &fakeAppFinder{}
+	d := nearbyDeps{
+		store:    &fakeZoneStore{zones: []WatchZone{zone}},
+		apps:     apps,
+		profiles: &fakeProfileReader{},
+		resolver: &fakeResolver{},
+		unread:   &fakeUnread{},
+	}
+	mux := newNearbyMux(t, d)
+
+	rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications?sort=newest&status=Permitted", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if !apps.boundaryCalled {
+		t.Fatal("a custom-shape zone must still route to FindInBoundaryPage even with ?sort=/?status=")
+	}
+	if apps.inZoneCalled {
+		t.Error("?sort=/?status= must be a no-op for a custom-shape zone, not route to FindInZonePage")
+	}
 }
 
 // TestApplications_SortRoutesToSortAwarePath proves ?sort= routes to
@@ -1265,6 +1398,19 @@ func mustZone(t *testing.T, id string, authorityID int) WatchZone {
 	return z
 }
 
+// mustCustomShapeZone builds a custom-shape zone (londonSquare, from
+// zone_test.go) over the same base fields as mustZone, for the polygon-branch
+// tests in findZonePage and clusters.
+func mustCustomShapeZone(t *testing.T, id string, authorityID int) WatchZone {
+	t.Helper()
+	z := mustZone(t, id, authorityID)
+	z, err := z.WithBoundary(londonSquare(t))
+	if err != nil {
+		t.Fatalf("WithBoundary: %v", err)
+	}
+	return z
+}
+
 // clusterDeps builds a standard dependency set for the clusters-endpoint tests:
 // one seeded zone (lat 51.5, lng -0.12, radius 1000) and a configurable finder.
 func clusterDeps(t *testing.T, apps *fakeAppFinder) nearbyDeps {
@@ -1333,6 +1479,62 @@ func TestClusters_PassesZoneAndParamsToStore(t *testing.T) {
 	// request's own zoom: it is the "zooming can never separate these" boundary
 	// below which a multi-member cell gets an applicationIds member list.
 	wantThreshold := 45.0 / float64(uint64(1)<<20) // 360/2^(20+3)
+	if q.CoalesceThresholdDegrees != wantThreshold {
+		t.Errorf("coalesce threshold: got %v, want the finest-grid size %v", q.CoalesceThresholdDegrees, wantThreshold)
+	}
+	if apps.boundaryClustersCalled {
+		t.Error("a circle zone must never route to the boundary-scoped cluster query")
+	}
+}
+
+// TestClusters_CustomShapeZoneUsesBoundaryClusterQuery proves a custom-shape
+// zone's clusters endpoint branches to FindClustersInBoundary, threading the
+// zone's boundary ring plus the same viewport/status/coalesce params as the
+// circle path -- and never falls through to FindClustersInZone.
+func TestClusters_CustomShapeZoneUsesBoundaryClusterQuery(t *testing.T) {
+	t.Parallel()
+	zone := mustCustomShapeZone(t, "zone-1", 471)
+	apps := &fakeAppFinder{}
+	d := nearbyDeps{
+		store:    &fakeZoneStore{zones: []WatchZone{zone}},
+		apps:     apps,
+		profiles: &fakeProfileReader{},
+		resolver: &fakeResolver{},
+		unread:   &fakeUnread{},
+	}
+	mux := newNearbyMux(t, d)
+
+	rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications/clusters?bbox=-0.2,51.4,-0.05,51.6&zoom=12&status=Permitted", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if !apps.boundaryClustersCalled {
+		t.Fatal("a custom-shape zone must route to FindClustersInBoundary")
+	}
+	if apps.clustersCalled {
+		t.Error("a custom-shape zone must never route to FindClustersInZone")
+	}
+	q := apps.lastBoundaryClusterQuery
+	if len(q.Boundary) != len(zone.Boundary) {
+		t.Fatalf("boundary ring length: got %d, want %d", len(q.Boundary), len(zone.Boundary))
+	}
+	for i, v := range zone.Boundary {
+		got := q.Boundary[i]
+		if got.Longitude != v.Longitude || got.Latitude != v.Latitude {
+			t.Errorf("boundary[%d]: got %+v, want %+v", i, got, v)
+		}
+	}
+	if q.West != -0.2 || q.South != 51.4 || q.East != -0.05 || q.North != 51.6 {
+		t.Errorf("bbox: got (%v,%v,%v,%v), want (-0.2,51.4,-0.05,51.6)", q.West, q.South, q.East, q.North)
+	}
+	if q.Status != "Permitted" {
+		t.Errorf("status: got %q, want %q", q.Status, "Permitted")
+	}
+	wantGrid := 45.0 / float64(uint64(1)<<12)
+	if q.GridSizeDegrees != wantGrid {
+		t.Errorf("grid size for zoom 12: got %v, want %v", q.GridSizeDegrees, wantGrid)
+	}
+	wantThreshold := 45.0 / float64(uint64(1)<<20)
 	if q.CoalesceThresholdDegrees != wantThreshold {
 		t.Errorf("coalesce threshold: got %v, want the finest-grid size %v", q.CoalesceThresholdDegrees, wantThreshold)
 	}


### PR DESCRIPTION
## Summary

Part of #1031 (custom-shape/polygon watch zones), section 6 (Applications store) plus the read-branching half of section 5 (HTTP). Depends on #1039 (`IsCustomShape`/`Boundary`, merged) and #1044 (migration 0024 + `ST_Covers` matching, merged).

- `applications.FindInBoundaryPage` and `applications.FindClustersInBoundary`: polygon-scoped counterparts to `FindNearbyPage`/`FindClustersInZone`, using `ST_Covers(ST_GeomFromGeoJSON(...)::geography, location)` in place of `ST_DWithin`. Same KNN ordering, keyset cursor shape, and GeoJSON encoding as the existing circle-zone paths (byte-identical to `watchzones/store_postgres.go`'s boundary encoding, no import cycle).
- `watchzones/nearby.go`'s `findZonePage` and `clusters` now branch on `zone.IsCustomShape()`, routing polygon zones to the new methods with the zone's derived centroid + boundary ring. Circle-zone behaviour is unchanged (regression-tested).

## Scope note — sort/filter gap on custom-shape zones (escalated, decided)

GH#1031 section 6 and its acceptance criteria only call for the plain (no sort/filter) applications list and clusters to become polygon-scoped — there's no boundary-aware counterpart to `FindInZonePage` (the `?sort=`/`?status=`/`?unread=` path). I escalated this mid-implementation and decided: a custom-shape zone always serves the plain boundary page, silently ignoring `?sort=`/`?status=`/`?unread=` for now (circle zones are completely unaffected). This is flagged with a code comment at the branch point, and I've filed `tc-acbsh` (`discovered-from tc-6he3x.5`) to build the boundary-aware sort/filter equivalent as a follow-up. No live-customer impact: the HTTP layer that lets a user actually create a polygon zone (tc-6he3x.4) hasn't shipped yet.

## Out of scope (untouched, per the bead)

Tier-gating/403/400 error codes, entitlement checks (`profiles/profile.go`), migrations, HTTP create/patch boundary wiring (`handler.go`), GDPR export, iOS, web, notify/digest fan-out — all separate beads (tc-6he3x.4, tc-6he3x.6, etc.).

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`, `gofmt -l .` — all clean
- [x] `go test -race ./...` — all green
- [x] New unit tests in `nearby_test.go`: circle zone regression (unaffected, including with `?sort=`), custom-shape zone routes to `FindInBoundaryPage`/`FindClustersInBoundary` with correct centroid/boundary threaded through, custom-shape zone's sort/filter params are a documented no-op
- [x] New real-PostGIS integration tests (`boundarypage_integration_test.go`, `boundaryclusters_integration_test.go`, `//go:build integration`): point inside polygon matches, point inside the enclosing circle but outside the polygon does not, on-edge point matches (`ST_Covers`), pagination, count conservation, status filter
- [ ] Could not run the integration suite against a live Postgres in this sandbox (no Docker daemon available) — compiles cleanly under `-tags=integration`; pr-gate's real-Postgres suite will run it in CI

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Kqc9Y7wSeTGtxmeUYNYGu6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for searching applications within custom-shaped watch zones.
  * Added boundary-based pagination with nearest-location ordering and cursor navigation.
  * Added application clustering within custom boundaries, including status-based counts.
  * Circle-based watch zones continue using the existing search behavior.

* **Bug Fixes**
  * Improved boundary accuracy by including polygon edges while excluding points outside the selected shape.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->