### PR TITLE
web: ApiWatchZoneRepository boundary field and domain types (tc-6he3x.11)

### DIFF
--- a/web/src/api/__tests__/watchZones.test.ts
+++ b/web/src/api/__tests__/watchZones.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { createApiClient } from '../client';
+import { watchZonesApi } from '../watchZones';
+import type { WatchZoneBoundary, WatchZoneSummary } from '../../domain/types';
+import { asAuthorityId, asWatchZoneId } from '../../domain/types';
+
+interface RecordedRequest {
+  readonly url: string;
+  readonly init: RequestInit | undefined;
+}
+
+/**
+ * Hand-written fetch spy — records the request and returns a caller-supplied
+ * Response. No `vi.fn()`, in keeping with the no-mocking-frameworks policy.
+ */
+class SpyFetch {
+  calls: RecordedRequest[] = [];
+  response: Response = new Response('null', { status: 200 });
+
+  readonly fn = (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    this.calls.push({ url: String(input), init });
+    return Promise.resolve(this.response);
+  };
+}
+
+function clientWith(spy: SpyFetch) {
+  return createApiClient('https://api.test', () => Promise.resolve('tok-123'), spy.fn);
+}
+
+/** Parses the JSON body of a recorded request; asserts one was made. */
+function sentBody(spy: SpyFetch): unknown {
+  const call = spy.calls[0];
+  if (!call) {
+    throw new Error('expected a request to have been made');
+  }
+  return JSON.parse(call.init?.body as string);
+}
+
+const aBoundary: WatchZoneBoundary = {
+  type: 'Polygon',
+  coordinates: [
+    [
+      [0.1, 52.2],
+      [0.12, 52.2],
+      [0.12, 52.21],
+      [0.1, 52.2],
+    ],
+  ],
+};
+
+function aZoneSummary(overrides?: Partial<WatchZoneSummary>): WatchZoneSummary {
+  return {
+    id: asWatchZoneId('zone-1'),
+    name: 'Home',
+    latitude: 52.2053,
+    longitude: 0.1218,
+    radiusMetres: 2000,
+    authorityId: asAuthorityId(1),
+    pushEnabled: true,
+    emailInstantEnabled: true,
+    paused: false,
+    boundary: null,
+    ...overrides,
+  };
+}
+
+describe('watchZonesApi — boundary wire behaviour', () => {
+  it('list() returns each zone boundary field unchanged, including null and a Polygon', async () => {
+    const spy = new SpyFetch();
+    const zones = [aZoneSummary({ boundary: null }), aZoneSummary({ id: asWatchZoneId('zone-2'), boundary: aBoundary })];
+    spy.response = new Response(JSON.stringify({ zones }), { status: 200 });
+    const api = watchZonesApi(clientWith(spy));
+
+    const result = await api.list();
+
+    expect(result).toEqual(zones);
+  });
+
+  it('create() sends a boundary in the POST body, preserving [lon, lat] tuple order', async () => {
+    const spy = new SpyFetch();
+    spy.response = new Response(JSON.stringify(aZoneSummary({ boundary: aBoundary })), { status: 201 });
+    const api = watchZonesApi(clientWith(spy));
+
+    await api.create({
+      name: 'Home',
+      latitude: 52.2053,
+      longitude: 0.1218,
+      radiusMetres: 2000,
+      boundary: aBoundary,
+    });
+
+    expect(sentBody(spy)).toMatchObject({ boundary: aBoundary });
+  });
+
+  it('updateZone() omits the boundary key entirely when the caller does not set it (tri-state: leave untouched)', async () => {
+    const spy = new SpyFetch();
+    spy.response = new Response(JSON.stringify(aZoneSummary()), { status: 200 });
+    const api = watchZonesApi(clientWith(spy));
+
+    await api.updateZone('zone-1', { name: 'Office' });
+
+    const body = sentBody(spy) as Record<string, unknown>;
+    expect('boundary' in body).toBe(false);
+  });
+
+  it('updateZone() sends an explicit null boundary to revert a zone to a circle', async () => {
+    const spy = new SpyFetch();
+    spy.response = new Response(JSON.stringify(aZoneSummary()), { status: 200 });
+    const api = watchZonesApi(clientWith(spy));
+
+    await api.updateZone('zone-1', { boundary: null });
+
+    const body = sentBody(spy) as Record<string, unknown>;
+    expect('boundary' in body).toBe(true);
+    expect(body['boundary']).toBeNull();
+  });
+
+  it('updateZone() sends the new boundary value when setting a shape', async () => {
+    const spy = new SpyFetch();
+    spy.response = new Response(JSON.stringify(aZoneSummary({ boundary: aBoundary })), { status: 200 });
+    const api = watchZonesApi(clientWith(spy));
+
+    await api.updateZone('zone-1', { boundary: aBoundary });
+
+    expect(sentBody(spy)).toEqual({ boundary: aBoundary });
+  });
+});

--- a/web/src/domain/types.ts
+++ b/web/src/domain/types.ts
@@ -128,6 +128,23 @@ export interface ZoneNotificationPreferences {
 // Watch zones
 // ---------------------------------------------------------------------------
 
+/**
+ * GeoJSON `Polygon` wire shape for a custom-shape watch zone's boundary
+ * (tc-6he3x, paid-tier entitlement). Mirrors the API's `boundaryGeoJSON`
+ * (`api-go/internal/watchzones/store_postgres.go`) byte-for-byte — this
+ * layer does no client-side transformation, matching how every other domain
+ * type in this file passes the wire shape straight through.
+ *
+ * `coordinates` holds exactly one ring (the outer boundary; no holes, no
+ * multi-polygon — see GH#1031 "Out of Scope"), and each vertex tuple is
+ * `[longitude, latitude]` — GeoJSON/RFC 7946 order, the reverse of this
+ * file's `Coordinates` type. Easy to get backwards; do not flip it.
+ */
+export interface WatchZoneBoundary {
+  readonly type: 'Polygon';
+  readonly coordinates: readonly (readonly (readonly [number, number])[])[];
+}
+
 export interface WatchZoneSummary {
   readonly id: WatchZoneId;
   readonly name: string;
@@ -144,6 +161,13 @@ export interface WatchZoneSummary {
    * never computed client-side. Additive, always present on the wire.
    */
   readonly paused: boolean;
+  /**
+   * `null` for a plain circle zone, a GeoJSON `Polygon` for a custom-shape
+   * one (tc-6he3x). Always present on the wire — `latitude`/`longitude`/
+   * `radiusMetres` remain the shape's derived centroid/enclosing radius
+   * either way, so every circle-only consumer keeps working unchanged.
+   */
+  readonly boundary: WatchZoneBoundary | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -373,6 +397,13 @@ export interface CreateWatchZoneRequest {
   readonly authorityId?: number;
   readonly pushEnabled?: boolean;
   readonly emailInstantEnabled?: boolean;
+  /**
+   * Optional GeoJSON `Polygon`. When present, `latitude`/`longitude`/
+   * `radiusMetres` above are ignored — the server derives them from the
+   * boundary's centroid/enclosing radius. Omitted entirely for a plain
+   * circle create (unchanged existing behaviour).
+   */
+  readonly boundary?: WatchZoneBoundary;
 }
 
 export interface UpdateProfileRequest {
@@ -388,6 +419,16 @@ export interface UpdateWatchZoneRequest {
   readonly radiusMetres?: number;
   readonly pushEnabled?: boolean;
   readonly emailInstantEnabled?: boolean;
+  /**
+   * Tri-state, matching the API's `json.RawMessage` PATCH field: the key
+   * being absent from the serialised body means "leave the shape untouched"
+   * (do not set this to `undefined` explicitly — `JSON.stringify` must see
+   * the key genuinely missing, not present with an `undefined` value); an
+   * explicit `null` means "convert this zone back to a circle, preserving
+   * its current centre/radius"; a `WatchZoneBoundary` value means "set/
+   * replace the shape".
+   */
+  readonly boundary?: WatchZoneBoundary | null;
 }
 
 export interface UpdateZonePreferencesRequest {

--- a/web/src/features/WatchZones/__tests__/ApiWatchZoneRepository.test.ts
+++ b/web/src/features/WatchZones/__tests__/ApiWatchZoneRepository.test.ts
@@ -1,19 +1,33 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import type { ApiClient } from '../../../api/client';
 import { ApiWatchZoneRepository } from '../ApiWatchZoneRepository';
-import { aWatchZone } from './fixtures/watch-zone.fixtures';
+import { aWatchZone, aWatchZoneBoundary } from './fixtures/watch-zone.fixtures';
 
 class StubApiClient implements ApiClient {
+  lastGetPath: string | null = null;
+  getResult: unknown = null;
+
+  lastPostPath: string | null = null;
+  lastPostBody: unknown = null;
+  postResult: unknown = null;
+
   lastPatchPath: string | null = null;
   lastPatchBody: unknown = null;
   patchResult: unknown = null;
 
-  async get<T>(): Promise<T> {
-    return {} as T;
+  async get<T>(path: string): Promise<T> {
+    this.lastGetPath = path;
+    return this.getResult as T;
   }
 
-  async post<T>(): Promise<T> {
-    return {} as T;
+  async getWithHeaders<T>(): Promise<{ body: T; headers: Headers }> {
+    return { body: {} as T, headers: new Headers() };
+  }
+
+  async post<T>(path: string, body?: unknown): Promise<T> {
+    this.lastPostPath = path;
+    this.lastPostBody = body;
+    return this.postResult as T;
   }
 
   async put(): Promise<void> {
@@ -49,5 +63,79 @@ describe('ApiWatchZoneRepository', () => {
     expect(stub.lastPatchPath).toBe('/v1/me/watch-zones/zone-1');
     expect(stub.lastPatchBody).toEqual({ name: 'Office' });
     expect(result).toEqual(updated);
+  });
+
+  describe('boundary field', () => {
+    it('list() returns each zone with its boundary field, null and Polygon alike', async () => {
+      const circleZone = aWatchZone({ boundary: null });
+      const customShapeZone = aWatchZone({
+        id: circleZone.id,
+        name: 'Office',
+        boundary: aWatchZoneBoundary(),
+      });
+      stub.getResult = { zones: [circleZone, customShapeZone] };
+
+      const result = await repository.list();
+
+      expect(result).toEqual([circleZone, customShapeZone]);
+    });
+
+    it('create() forwards a boundary in the request and returns the created zone unchanged', async () => {
+      const boundary = aWatchZoneBoundary();
+      const created = aWatchZone({ boundary });
+      stub.postResult = created;
+
+      const result = await repository.create({
+        name: 'Home',
+        latitude: 52.2053,
+        longitude: 0.1218,
+        radiusMetres: 2000,
+        boundary,
+      });
+
+      expect(stub.lastPostPath).toBe('/v1/me/watch-zones');
+      expect(stub.lastPostBody).toMatchObject({ boundary });
+      expect(result).toEqual(created);
+    });
+
+    it('create() omits boundary from the request for a plain circle create', async () => {
+      stub.postResult = aWatchZone();
+
+      await repository.create({
+        name: 'Home',
+        latitude: 52.2053,
+        longitude: 0.1218,
+        radiusMetres: 2000,
+      });
+
+      const body = stub.lastPostBody as Record<string, unknown>;
+      expect('boundary' in body).toBe(false);
+    });
+
+    it('updateZone() forwards the update data without adding a boundary key when the caller omits it', async () => {
+      stub.patchResult = aWatchZone({ name: 'Office' });
+
+      await repository.updateZone('zone-1', { name: 'Office' });
+
+      const body = stub.lastPatchBody as Record<string, unknown>;
+      expect('boundary' in body).toBe(false);
+    });
+
+    it('updateZone() passes an explicit null boundary through unchanged (revert to circle)', async () => {
+      stub.patchResult = aWatchZone({ boundary: null });
+
+      await repository.updateZone('zone-1', { boundary: null });
+
+      expect(stub.lastPatchBody).toEqual({ boundary: null });
+    });
+
+    it('updateZone() passes a new boundary value through unchanged (set/replace shape)', async () => {
+      const boundary = aWatchZoneBoundary();
+      stub.patchResult = aWatchZone({ boundary });
+
+      await repository.updateZone('zone-1', { boundary });
+
+      expect(stub.lastPatchBody).toEqual({ boundary });
+    });
   });
 });

--- a/web/src/features/WatchZones/__tests__/fixtures/watch-zone.fixtures.ts
+++ b/web/src/features/WatchZones/__tests__/fixtures/watch-zone.fixtures.ts
@@ -1,4 +1,5 @@
 import type {
+  WatchZoneBoundary,
   WatchZoneSummary,
   ZoneNotificationPreferences,
 } from '../../../../domain/types';
@@ -15,6 +16,7 @@ export function aWatchZone(overrides?: Partial<WatchZoneSummary>): WatchZoneSumm
     pushEnabled: true,
     emailInstantEnabled: true,
     paused: false,
+    boundary: null,
     ...overrides,
   };
 }
@@ -30,6 +32,28 @@ export function aSecondWatchZone(overrides?: Partial<WatchZoneSummary>): WatchZo
     pushEnabled: true,
     emailInstantEnabled: true,
     paused: false,
+    boundary: null,
+    ...overrides,
+  };
+}
+
+/**
+ * A small closed square ring, [longitude, latitude] tuple order — matches
+ * the wire shape `WatchZoneBoundary` mirrors. First and last vertex are
+ * identical, per the GeoJSON closed-ring convention.
+ */
+export function aWatchZoneBoundary(overrides?: Partial<WatchZoneBoundary>): WatchZoneBoundary {
+  return {
+    type: 'Polygon',
+    coordinates: [
+      [
+        [0.1, 52.2],
+        [0.12, 52.2],
+        [0.12, 52.21],
+        [0.1, 52.21],
+        [0.1, 52.2],
+      ],
+    ],
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

- Adds a `WatchZoneBoundary` domain type to `web/src/domain/types.ts` mirroring the Go API's GeoJSON `Polygon` wire shape (`api-go/internal/watchzones/store_postgres.go`'s `boundaryGeoJSON`) byte-for-byte, with a JSDoc note flagging the `[lon, lat]` tuple order (RFC 7946, the reverse of this file's existing `Coordinates` type) and the single-outer-ring-only constraint.
- Wires `boundary` onto `WatchZoneSummary` (always-present `WatchZoneBoundary | null`), `CreateWatchZoneRequest` (optional), and `UpdateWatchZoneRequest` (optional + nullable — tri-state, matching the API's `json.RawMessage` PATCH semantics: key absent → leave shape untouched, explicit `null` → revert to circle, a value → set/replace).
- Updates `aWatchZone`/`aSecondWatchZone` test fixtures to default `boundary: null`, and adds an `aWatchZoneBoundary()` fixture factory.
- Adds `web/src/api/__tests__/watchZones.test.ts`, driving `watchZonesApi` through the real `createApiClient` and a fetch spy to prove the actual serialized wire body honours the PATCH tri-state contract (omitted key stays omitted, explicit `null` serializes as literal `null`, a `Polygon` value round-trips with `[lon, lat]` order intact).
- Extends `ApiWatchZoneRepository.test.ts` with matching repository-layer coverage.
- No production changes were needed in `api/watchZones.ts` or `ApiWatchZoneRepository.ts` — both already pass typed data straight through generically.

This is bead `tc-6he3x.11` under epic `tc-6he3x` (custom-shape/polygon watch zones as a paid entitlement, [GH#1031](https://github.com/AmyDe/town-crier/issues/1031)#8-web). It depends on `tc-6he3x.4` (the Go HTTP surface), already merged to main. It unblocks `tc-6he3x.12` (the actual drawing UI — hook, map, shape toggle — deliberately out of scope here; this PR adds no UI).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 140 files / 1337 tests passed
- [x] `npx eslint src --max-warnings=0` — clean
- [x] `npm run build` — succeeds
- [ ] pr-gate CI

## Notes

While reading the merged Go source to confirm the wire contract, found a pre-existing, unrelated mismatch between the web `watchZonesApi`'s response typing and the actual Go PATCH/POST response shapes. Filed as [tc-0qipt] (discovered-from this bead) rather than fixed here, since it's out of scope for this purely-additive typing change.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018eT82wfifnTHD8bjdAENXU)_