### PR TITLE
watchzones: boundary-aware sort/filter parity for custom-shape zones (tc-acbsh)

### DIFF
--- a/api-go/cmd/api/wiring_test.go
+++ b/api-go/cmd/api/wiring_test.go
@@ -133,6 +133,9 @@ func (fakeAppStore) FindInBoundaryPage(context.Context, float64, float64, []appl
 func (fakeAppStore) FindClustersInBoundary(context.Context, applications.BoundaryClusterQuery) ([]applications.Cluster, error) {
 	return nil, nil
 }
+func (fakeAppStore) FindInBoundaryZonePage(context.Context, applications.InBoundaryQuery) ([]applications.PlanningApplication, string, error) {
+	return nil, "", nil
+}
 func (fakeAppStore) RecentNearestTown(context.Context, string, float64, float64, float64, []applications.TownCentroid, int) ([]applications.PlanningApplication, error) {
 	return nil, nil
 }

--- a/api-go/internal/applications/boundaryzonepage.go
+++ b/api-go/internal/applications/boundaryzonepage.go
@@ -1,0 +1,483 @@
+package applications
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// InBoundaryQuery is FindInBoundaryZonePage's request descriptor (GH#1031,
+// tc-acbsh): the custom-shape zone's polygon (Boundary, a closed ring,
+// [longitude, latitude]-ordered) replaces InZoneQuery's membership circle
+// (RadiusMetres) as the containment test; Latitude/Longitude are the polygon's
+// derived centroid, used ONLY to order SortDistance nearest-centroid-first
+// (exactly as FindInBoundaryPage's do) -- containment is decided entirely by
+// ST_Covers against Boundary. Sort/Status/Unread/Limit/Cursor carry the exact
+// same meaning as InZoneQuery's, giving a custom-shape zone full sort/filter
+// parity with a circle zone.
+type InBoundaryQuery struct {
+	UserID    string
+	Latitude  float64
+	Longitude float64
+	Boundary  []Coordinate
+	Sort      Sort
+	Status    string
+	Unread    bool
+	Limit     int
+	Cursor    string
+}
+
+// boundaryZonePolygon mirrors boundaryPolygon (boundarypage.go) at the exact
+// parameter position zonepage.go's radius occupies ($3): every fast-path
+// query below keeps the identical shape (and parameter count) of its circle
+// counterpart in zonepage.go, with ST_Covers against the polygon replacing
+// ST_DWithin against the circle.
+const boundaryZonePolygon = "ST_GeomFromGeoJSON($3)::geography"
+
+// boundaryDateFromWhere mirrors dateFromWhere: same projection (dateColumns),
+// same $1/$2 centroid (via nearbyPoint), same $4 limit slot -- ST_Covers
+// against the polygon ($3) replacing ST_DWithin against the circle ($3
+// radius).
+const boundaryDateFromWhere = "SELECT " + dateColumns +
+	" FROM applications WHERE ST_Covers(" + boundaryZonePolygon + ", location)"
+
+// First-page date-sort queries: polygon predicate only, ordered, limited.
+const (
+	boundaryNewestFirstQuery = boundaryDateFromWhere + newestOrderBy
+	boundaryOldestFirstQuery = boundaryDateFromWhere + oldestOrderBy
+)
+
+// Keyset date-sort queries resuming after a cursor on a NON-NULL start_date
+// row. Mirrors newestKeysetQuery/oldestKeysetQuery exactly. $5 the cursor's
+// start_date (::date), $6 authority_code, $7 planit_name.
+const (
+	boundaryNewestKeysetQuery = boundaryDateFromWhere +
+		" AND (start_date < $5::date OR start_date IS NULL" +
+		" OR (start_date = $5::date AND (authority_code, planit_name) > ($6, $7)))" +
+		newestOrderBy
+	boundaryOldestKeysetQuery = boundaryDateFromWhere +
+		" AND (start_date > $5::date OR start_date IS NULL" +
+		" OR (start_date = $5::date AND (authority_code, planit_name) > ($6, $7)))" +
+		oldestOrderBy
+)
+
+// Keyset date-sort queries resuming after a cursor in the NULL-start_date
+// tail. Mirrors newestKeysetNullQuery/oldestKeysetNullQuery. $5 authority_code,
+// $6 planit_name.
+const (
+	boundaryNewestKeysetNullQuery = boundaryDateFromWhere +
+		" AND start_date IS NULL AND (authority_code, planit_name) > ($5, $6)" +
+		newestOrderBy
+	boundaryOldestKeysetNullQuery = boundaryDateFromWhere +
+		" AND start_date IS NULL AND (authority_code, planit_name) > ($5, $6)" +
+		oldestOrderBy
+)
+
+// boundaryStatusFirstQuery is the status first page: polygon predicate only,
+// ordered, limited. It reuses boundaryDateFromWhere (same projection:
+// appColumns + authority_code), mirroring statusFirstQuery.
+const boundaryStatusFirstQuery = boundaryDateFromWhere + statusOrderBy
+
+// Status keyset queries. Mirror the four statusKeyset* constants exactly
+// (see their doc comments for the mixed-direction rationale), with the
+// polygon predicate replacing the radius.
+const (
+	// $5 app_state, $6 start_date(::date), $7 authority_code, $8 planit_name.
+	boundaryStatusKeysetQuery = boundaryDateFromWhere +
+		" AND (app_state > $5 OR app_state IS NULL" +
+		" OR (app_state = $5 AND (start_date < $6::date OR start_date IS NULL))" +
+		" OR (app_state = $5 AND start_date = $6::date AND (authority_code, planit_name) > ($7, $8)))" +
+		statusOrderBy
+	// $5 app_state, $6 authority_code, $7 planit_name.
+	boundaryStatusKeysetDateNullQuery = boundaryDateFromWhere +
+		" AND (app_state > $5 OR app_state IS NULL" +
+		" OR (app_state = $5 AND start_date IS NULL AND (authority_code, planit_name) > ($6, $7)))" +
+		statusOrderBy
+	// $5 start_date(::date), $6 authority_code, $7 planit_name.
+	boundaryStatusKeysetStateNullQuery = boundaryDateFromWhere +
+		" AND app_state IS NULL AND ((start_date < $5::date OR start_date IS NULL)" +
+		" OR (start_date = $5::date AND (authority_code, planit_name) > ($6, $7)))" +
+		statusOrderBy
+	// $5 authority_code, $6 planit_name.
+	boundaryStatusKeysetBothNullQuery = boundaryDateFromWhere +
+		" AND app_state IS NULL AND start_date IS NULL AND (authority_code, planit_name) > ($5, $6)" +
+		statusOrderBy
+)
+
+// boundaryActivityFromWhere mirrors activityFromWhere: same projection
+// (dateColumns + activity_ts), same LEFT JOIN to the caller's unread
+// notifications ($5 userID), same $1/$2 centroid and $4 limit slot --
+// ST_Covers against the polygon ($3) replacing ST_DWithin against the circle.
+const boundaryActivityFromWhere = "SELECT " + dateColumns + ", " + activityExpr + " AS activity_ts" +
+	" FROM applications" +
+	" LEFT JOIN (" + activityUnreadSubquery + ") u" +
+	" ON applications.uid = u.application_uid AND applications.area_id = u.authority_id" +
+	" WHERE ST_Covers(" + boundaryZonePolygon + ", location)"
+
+// boundaryRecentActivityFirstQuery is the recent-activity first page: join +
+// polygon predicate, ordered, limited.
+const boundaryRecentActivityFirstQuery = boundaryActivityFromWhere + activityOrderBy
+
+// Keyset recent-activity queries. Mirror recentActivityKeysetQuery /
+// recentActivityKeysetNullQuery exactly.
+const (
+	// $6 the cursor's activity_ts (::timestamptz), $7 authority_code, $8 planit_name.
+	boundaryRecentActivityKeysetQuery = boundaryActivityFromWhere +
+		" AND (" + activityExpr + " < $6::timestamptz OR " + activityExpr + " IS NULL" +
+		" OR (" + activityExpr + " = $6::timestamptz AND (authority_code, planit_name) > ($7, $8)))" +
+		activityOrderBy
+	// $6 authority_code, $7 planit_name.
+	boundaryRecentActivityKeysetNullQuery = boundaryActivityFromWhere +
+		" AND " + activityExpr + " IS NULL AND (authority_code, planit_name) > ($6, $7)" +
+		activityOrderBy
+)
+
+// FindInBoundaryZonePage is FindInZonePage's custom-shape counterpart
+// (GH#1031, tc-acbsh): one page of up to q.Limit applications ST_Covers-
+// contained in q.Boundary, ordered by q.Sort and filtered by q.Status/
+// q.Unread, plus an opaque sort-and-filter-aware cursor for the next page
+// (empty when exhausted). It supports the same {distance, newest, oldest,
+// status, recent-activity} sorts and status/unread filters as FindInZonePage,
+// with ST_Covers against the polygon replacing ST_DWithin against the circle
+// -- the boundary-aware equivalent findZonePage routes to as soon as a sort
+// or filter is requested for a custom-shape zone (see
+// watchzones/nearby.go's findZonePage). The cursor semantics are identical to
+// FindInZonePage's: a sort mismatch returns ErrCursorSortMismatch, a filter
+// mismatch ErrCursorFilterMismatch, a malformed token ErrCursorInvalid.
+//
+// q.UserID scopes the per-user notification data the recent-activity sort
+// joins and the unread filter restricts on, exactly as InZoneQuery.UserID
+// does.
+func (s *PostgresStore) FindInBoundaryZonePage(ctx context.Context, q InBoundaryQuery) ([]PlanningApplication, string, error) {
+	if !q.Sort.Supported() {
+		return nil, "", fmt.Errorf("sort %q: %w", q.Sort, ErrUnsupportedSort)
+	}
+	var c *pageCursor
+	if q.Cursor != "" {
+		decoded, err := decodePageCursor(q.Cursor)
+		if err != nil {
+			return nil, "", err
+		}
+		if decoded.M != q.Sort {
+			return nil, "", fmt.Errorf("cursor sort %q, request sort %q: %w", decoded.M, q.Sort, ErrCursorSortMismatch)
+		}
+		if decoded.F != q.Status || decoded.U != q.Unread {
+			return nil, "", fmt.Errorf("cursor filter {status:%q unread:%t}, request filter {status:%q unread:%t}: %w",
+				decoded.F, decoded.U, q.Status, q.Unread, ErrCursorFilterMismatch)
+		}
+		c = &decoded
+	}
+
+	boundaryJSON, err := encodeBoundaryGeoJSON(q.Boundary)
+	if err != nil {
+		return nil, "", fmt.Errorf("encode boundary geojson: %w", err)
+	}
+
+	// Filtered requests (a status value and/or the unread flag) take the
+	// dynamic builder, composing the status predicate and/or the unread INNER
+	// JOIN into the sort's query -- exactly as findFilteredZonePage does.
+	// Unfiltered requests stay on the proven per-sort constant queries above.
+	if q.Status != "" || q.Unread {
+		return s.findFilteredBoundaryZonePage(ctx, q, boundaryJSON, c)
+	}
+	if q.Sort == SortDistance {
+		return s.findDistanceBoundaryZonePage(ctx, q.Latitude, q.Longitude, boundaryJSON, q.Limit, c)
+	}
+	if q.Sort == SortStatus {
+		return s.findStatusBoundaryZonePage(ctx, q.Latitude, q.Longitude, boundaryJSON, q.Limit, c)
+	}
+	if q.Sort == SortRecentActivity {
+		return s.findRecentActivityBoundaryZonePage(ctx, q.UserID, q.Latitude, q.Longitude, boundaryJSON, q.Limit, c)
+	}
+	return s.findDateBoundaryZonePage(ctx, q.Latitude, q.Longitude, boundaryJSON, q.Sort, q.Limit, c)
+}
+
+// findDistanceBoundaryZonePage serves SortDistance: the same nearest-centroid
+// KNN query FindInBoundaryPage uses (findBoundaryFirstPageQuery /
+// findBoundaryKeysetQuery, boundarypage.go), but with a sort-aware
+// (mode="distance") cursor so it composes with FindInBoundaryZonePage's
+// shared sort/filter cursor contract -- mirroring zonepage.go's
+// findDistanceZonePage.
+func (s *PostgresStore) findDistanceBoundaryZonePage(ctx context.Context, latitude, longitude float64, boundaryJSON string, limit int, c *pageCursor) ([]PlanningApplication, string, error) {
+	var (
+		rows pgx.Rows
+		err  error
+	)
+	if c == nil {
+		rows, err = s.db.Query(ctx, findBoundaryFirstPageQuery, longitude, latitude, boundaryJSON, limit)
+	} else {
+		dist, perr := strconv.ParseFloat(c.D, 64)
+		if perr != nil {
+			return nil, "", fmt.Errorf("parse distance cursor: %w: %w", ErrCursorInvalid, perr)
+		}
+		rows, err = s.db.Query(ctx, findBoundaryKeysetQuery, longitude, latitude, boundaryJSON, limit, dist, c.N)
+	}
+	wrap := func(err error) error {
+		return fmt.Errorf("find applications by %s near (%v, %v): %w", SortDistance, latitude, longitude, err)
+	}
+	if err != nil {
+		return nil, "", wrap(err)
+	}
+	return collectPage(rows, scanNearbyRow, nearbyAppOf,
+		func(last nearbyRow) (string, error) {
+			enc, err := encodePageCursor(pageCursor{
+				M: SortDistance,
+				D: strconv.FormatFloat(last.dist, 'g', -1, 64),
+				N: last.app.Name,
+			})
+			if err != nil {
+				return "", fmt.Errorf("encode distance cursor: %w", err)
+			}
+			return enc, nil
+		},
+		limit, wrap)
+}
+
+// findDateBoundaryZonePage serves SortNewest/SortOldest, mirroring
+// zonepage.go's findDateZonePage: it reuses collectKeysetPage and
+// dateCursorOf unchanged, only the query selection (boundaryDateZoneQuery)
+// differs.
+func (s *PostgresStore) findDateBoundaryZonePage(ctx context.Context, latitude, longitude float64, boundaryJSON string, sort Sort, limit int, c *pageCursor) ([]PlanningApplication, string, error) {
+	query, args := boundaryDateZoneQuery(sort, latitude, longitude, boundaryJSON, limit, c)
+	return s.collectKeysetPage(ctx, sort, latitude, longitude, query, args, limit, func(last datePageRow) pageCursor {
+		return dateCursorOf(sort, last)
+	})
+}
+
+// boundaryDateZoneQuery mirrors dateZoneQuery: the base args ($1..$4) are
+// longitude, latitude, the boundary GeoJSON, limit; the keyset args extend
+// them exactly as dateZoneQuery's do.
+func boundaryDateZoneQuery(sort Sort, latitude, longitude float64, boundaryJSON string, limit int, c *pageCursor) (string, []any) {
+	base := []any{longitude, latitude, boundaryJSON, limit}
+	switch {
+	case c == nil:
+		if sort == SortNewest {
+			return boundaryNewestFirstQuery, base
+		}
+		return boundaryOldestFirstQuery, base
+	case c.SD == nil:
+		args := append(base, c.AC, c.N)
+		if sort == SortNewest {
+			return boundaryNewestKeysetNullQuery, args
+		}
+		return boundaryOldestKeysetNullQuery, args
+	default:
+		args := append(base, *c.SD, c.AC, c.N)
+		if sort == SortNewest {
+			return boundaryNewestKeysetQuery, args
+		}
+		return boundaryOldestKeysetQuery, args
+	}
+}
+
+// findStatusBoundaryZonePage serves SortStatus, mirroring zonepage.go's
+// findStatusZonePage: it reuses collectKeysetPage and statusCursorOf
+// unchanged, only the query selection (boundaryStatusZoneQuery) differs.
+func (s *PostgresStore) findStatusBoundaryZonePage(ctx context.Context, latitude, longitude float64, boundaryJSON string, limit int, c *pageCursor) ([]PlanningApplication, string, error) {
+	query, args := boundaryStatusZoneQuery(latitude, longitude, boundaryJSON, limit, c)
+	return s.collectKeysetPage(ctx, SortStatus, latitude, longitude, query, args, limit, statusCursorOf)
+}
+
+// boundaryStatusZoneQuery mirrors statusZoneQuery: the base args ($1..$4) are
+// longitude, latitude, the boundary GeoJSON, limit; the keyset args extend
+// them exactly as statusZoneQuery's do.
+func boundaryStatusZoneQuery(latitude, longitude float64, boundaryJSON string, limit int, c *pageCursor) (string, []any) {
+	base := []any{longitude, latitude, boundaryJSON, limit}
+	switch {
+	case c == nil:
+		return boundaryStatusFirstQuery, base
+	case c.AS != nil && c.SD != nil:
+		return boundaryStatusKeysetQuery, append(base, *c.AS, *c.SD, c.AC, c.N)
+	case c.AS != nil: // start_date NULL: cursor in its group's NULL-start_date tail.
+		return boundaryStatusKeysetDateNullQuery, append(base, *c.AS, c.AC, c.N)
+	case c.SD != nil: // app_state NULL: cursor in the NULL-app_state tail.
+		return boundaryStatusKeysetStateNullQuery, append(base, *c.SD, c.AC, c.N)
+	default: // both NULL: the deepest tail.
+		return boundaryStatusKeysetBothNullQuery, append(base, c.AC, c.N)
+	}
+}
+
+// findRecentActivityBoundaryZonePage serves SortRecentActivity, mirroring
+// zonepage.go's findRecentActivityZonePage: it reuses scanActivityPageRow /
+// activityAppOf / activityCursorOf unchanged, only the query selection
+// (boundaryRecentActivityZoneQuery) differs. userID scopes the joined unread
+// notifications.
+func (s *PostgresStore) findRecentActivityBoundaryZonePage(ctx context.Context, userID string, latitude, longitude float64, boundaryJSON string, limit int, c *pageCursor) ([]PlanningApplication, string, error) {
+	query, args := boundaryRecentActivityZoneQuery(userID, latitude, longitude, boundaryJSON, limit, c)
+	wrap := func(err error) error {
+		return fmt.Errorf("find applications by %s near (%v, %v): %w", SortRecentActivity, latitude, longitude, err)
+	}
+	rows, err := s.db.Query(ctx, query, args...)
+	if err != nil {
+		return nil, "", wrap(err)
+	}
+	return collectPage(rows, scanActivityPageRow, activityAppOf,
+		func(last activityPageRow) (string, error) {
+			enc, err := encodePageCursor(activityCursorOf(last))
+			if err != nil {
+				return "", fmt.Errorf("encode %s cursor: %w", SortRecentActivity, err)
+			}
+			return enc, nil
+		},
+		limit, wrap)
+}
+
+// boundaryRecentActivityZoneQuery mirrors recentActivityZoneQuery: the base
+// args ($1..$5) are longitude, latitude, the boundary GeoJSON, limit, userID;
+// the keyset args extend them exactly as recentActivityZoneQuery's do.
+func boundaryRecentActivityZoneQuery(userID string, latitude, longitude float64, boundaryJSON string, limit int, c *pageCursor) (string, []any) {
+	base := []any{longitude, latitude, boundaryJSON, limit, userID}
+	switch {
+	case c == nil:
+		return boundaryRecentActivityFirstQuery, base
+	case c.TS == nil:
+		return boundaryRecentActivityKeysetNullQuery, append(base, c.AC, c.N)
+	default:
+		return boundaryRecentActivityKeysetQuery, append(base, *c.TS, c.AC, c.N)
+	}
+}
+
+// findFilteredBoundaryZonePage serves the status/unread filtered requests,
+// mirroring zonepage.go's findFilteredZonePage: it composes the same per-sort
+// ORDER BY + keyset predicates (via the shared orderByExpr/keysetPredicate)
+// with a status predicate and/or an unread join, then collects with the
+// sort's projection scanner and mints a filter-stamped next cursor. c is the
+// validated (sort- and filter-matched) cursor, nil on the first page.
+func (s *PostgresStore) findFilteredBoundaryZonePage(ctx context.Context, q InBoundaryQuery, boundaryJSON string, c *pageCursor) ([]PlanningApplication, string, error) {
+	query, args, err := buildFilteredBoundaryZoneQuery(q, boundaryJSON, c)
+	if err != nil {
+		return nil, "", err
+	}
+	switch q.Sort {
+	case SortDistance:
+		return s.collectFilteredBoundaryDistancePage(ctx, q, query, args)
+	case SortRecentActivity:
+		return s.collectFilteredBoundaryActivityPage(ctx, q, query, args)
+	default: // newest, oldest, status — the date-projection sorts
+		cursorOf := func(last datePageRow) pageCursor {
+			var cur pageCursor
+			if q.Sort == SortStatus {
+				cur = statusCursorOf(last)
+			} else {
+				cur = dateCursorOf(q.Sort, last)
+			}
+			cur.F, cur.U = q.Status, q.Unread
+			return cur
+		}
+		return s.collectKeysetPage(ctx, q.Sort, q.Latitude, q.Longitude, query, args, q.Limit, cursorOf)
+	}
+}
+
+// buildFilteredBoundaryZoneQuery mirrors buildFilteredZoneQuery: the shape --
+// projection, optional unread join, optional status predicate, keyset
+// predicate, ORDER BY, LIMIT -- is byte-identical, built via the exact same
+// shared orderByExpr/keysetPredicate helpers. Only the spatial predicate
+// differs: ST_Covers against the polygon (boundaryJSON) replacing ST_DWithin
+// against the circle (q.RadiusMetres).
+func buildFilteredBoundaryZoneQuery(q InBoundaryQuery, boundaryJSON string, c *pageCursor) (string, []any, error) {
+	b := &argBuilder{}
+	lonP := b.add(q.Longitude)
+	latP := b.add(q.Latitude)
+	point := "ST_SetSRID(ST_MakePoint(" + lonP + ", " + latP + "), 4326)::geography"
+
+	var projection string
+	switch q.Sort {
+	case SortDistance:
+		projection = appColumns + ", location <-> " + point + " AS distance"
+	case SortRecentActivity:
+		projection = dateColumns + ", " + activityExpr + " AS activity_ts"
+	default:
+		projection = dateColumns
+	}
+
+	var sb strings.Builder
+	sb.WriteString("SELECT ")
+	sb.WriteString(projection)
+	sb.WriteString(" FROM applications")
+
+	if q.Unread || q.Sort == SortRecentActivity {
+		joinType := "LEFT JOIN"
+		if q.Unread {
+			joinType = "JOIN" // INNER: drop applications with no unread for the caller.
+		}
+		userP := b.add(q.UserID)
+		subquery := "SELECT n.application_uid, n.authority_id, MAX(n.created_at) AS created_at" +
+			" FROM notifications n" +
+			" WHERE n.user_id = " + userP + " AND n.read_at IS NULL" +
+			" GROUP BY n.application_uid, n.authority_id"
+		sb.WriteString(" " + joinType + " (" + subquery + ") u" +
+			" ON applications.uid = u.application_uid AND applications.area_id = u.authority_id")
+	}
+
+	polygonP := b.add(boundaryJSON)
+	sb.WriteString(" WHERE ST_Covers(ST_GeomFromGeoJSON(" + polygonP + ")::geography, location)")
+
+	if q.Status != "" {
+		sb.WriteString(" AND app_state = " + b.add(q.Status))
+	}
+
+	if c != nil {
+		predicate, err := keysetPredicate(q.Sort, point, c, b)
+		if err != nil {
+			return "", nil, err
+		}
+		sb.WriteString(" AND " + predicate)
+	}
+
+	sb.WriteString(" ORDER BY " + orderByExpr(q.Sort, point))
+	sb.WriteString(" LIMIT " + b.add(q.Limit))
+
+	return sb.String(), b.args, nil
+}
+
+// collectFilteredBoundaryDistancePage mirrors collectFilteredDistancePage: a
+// filtered distance query (nearbyRow projection) minting a filter-stamped
+// (distance, planit_name) next cursor.
+func (s *PostgresStore) collectFilteredBoundaryDistancePage(ctx context.Context, q InBoundaryQuery, query string, args []any) ([]PlanningApplication, string, error) {
+	wrap := func(err error) error {
+		return fmt.Errorf("find filtered applications by distance near (%v, %v): %w", q.Latitude, q.Longitude, err)
+	}
+	rows, err := s.db.Query(ctx, query, args...)
+	if err != nil {
+		return nil, "", wrap(err)
+	}
+	return collectPage(rows, scanNearbyRow, nearbyAppOf,
+		func(last nearbyRow) (string, error) {
+			enc, err := encodePageCursor(pageCursor{
+				M: SortDistance, F: q.Status, U: q.Unread,
+				D: strconv.FormatFloat(last.dist, 'g', -1, 64), N: last.app.Name,
+			})
+			if err != nil {
+				return "", fmt.Errorf("encode distance cursor: %w", err)
+			}
+			return enc, nil
+		},
+		q.Limit, wrap)
+}
+
+// collectFilteredBoundaryActivityPage mirrors collectFilteredActivityPage: a
+// filtered recent-activity query (activity projection) minting a
+// filter-stamped (activity_ts, authority_code, planit_name) next cursor.
+func (s *PostgresStore) collectFilteredBoundaryActivityPage(ctx context.Context, q InBoundaryQuery, query string, args []any) ([]PlanningApplication, string, error) {
+	wrap := func(err error) error {
+		return fmt.Errorf("find filtered applications by %s near (%v, %v): %w", SortRecentActivity, q.Latitude, q.Longitude, err)
+	}
+	rows, err := s.db.Query(ctx, query, args...)
+	if err != nil {
+		return nil, "", wrap(err)
+	}
+	return collectPage(rows, scanActivityPageRow, activityAppOf,
+		func(last activityPageRow) (string, error) {
+			cur := activityCursorOf(last)
+			cur.F, cur.U = q.Status, q.Unread
+			enc, err := encodePageCursor(cur)
+			if err != nil {
+				return "", fmt.Errorf("encode %s cursor: %w", SortRecentActivity, err)
+			}
+			return enc, nil
+		},
+		q.Limit, wrap)
+}

--- a/api-go/internal/applications/boundaryzonepage.go
+++ b/api-go/internal/applications/boundaryzonepage.go
@@ -30,109 +30,136 @@ type InBoundaryQuery struct {
 	Cursor    string
 }
 
-// boundaryZonePolygon mirrors boundaryPolygon (boundarypage.go) at the exact
-// parameter position zonepage.go's radius occupies ($3): every fast-path
-// query below keeps the identical shape (and parameter count) of its circle
-// counterpart in zonepage.go, with ST_Covers against the polygon replacing
-// ST_DWithin against the circle.
-const boundaryZonePolygon = "ST_GeomFromGeoJSON($3)::geography"
+// boundaryZonePolygonNoPoint is boundaryZonePolygon's (boundarypage.go)
+// counterpart for the non-distance sorts below: ST_Covers containment against
+// the polygon needs no centroid, so -- unlike the KNN/distance queries in
+// boundarypage.go, which keep the circle-mirroring $1/$2 (longitude,
+// latitude) positions because they order by distance from that point -- these
+// queries have no use for a centroid at all. Consequently they do NOT reuse
+// zonepage.go's shared dateFromWhere/statusFirstQuery/activityFromWhere/
+// activityUnreadSubquery/*OrderBy constants: those hardcode $1/$2 as the
+// circle's centroid (referenced inside their ST_DWithin predicate) and $4/$5
+// as the following slots. Reusing them here would carry $1/$2 positions that
+// nothing in an ST_Covers predicate ever references -- Postgres cannot infer
+// an unreferenced placeholder's type ("could not determine data type of
+// parameter $1"), a real prepare-time failure, not a style choice. So this
+// file defines its own ORDER BY/LIMIT and join-subquery constants with
+// positions that start at $1 for what these queries actually use: the
+// boundary GeoJSON, then the limit, then (for recent-activity) the userID.
+const boundaryZonePolygonNoPoint = "ST_GeomFromGeoJSON($1)::geography"
 
-// boundaryDateFromWhere mirrors dateFromWhere: same projection (dateColumns),
-// same $1/$2 centroid (via nearbyPoint), same $4 limit slot -- ST_Covers
-// against the polygon ($3) replacing ST_DWithin against the circle ($3
-// radius).
+// boundaryDateFromWhere mirrors dateFromWhere's shape (projection, ST_Covers
+// replacing ST_DWithin) but not its parameter numbering: $1 the boundary
+// GeoJSON, $2 the limit (via boundaryNewestOrderBy/boundaryOldestOrderBy).
 const boundaryDateFromWhere = "SELECT " + dateColumns +
-	" FROM applications WHERE ST_Covers(" + boundaryZonePolygon + ", location)"
+	" FROM applications WHERE ST_Covers(" + boundaryZonePolygonNoPoint + ", location)"
+
+// boundaryNewestOrderBy/boundaryOldestOrderBy mirror newestOrderBy/
+// oldestOrderBy with LIMIT at $2, not $4 (no centroid/radius slots to skip).
+const (
+	boundaryNewestOrderBy = " ORDER BY start_date DESC NULLS LAST, authority_code, planit_name LIMIT $2"
+	boundaryOldestOrderBy = " ORDER BY start_date ASC NULLS LAST, authority_code, planit_name LIMIT $2"
+)
 
 // First-page date-sort queries: polygon predicate only, ordered, limited.
 const (
-	boundaryNewestFirstQuery = boundaryDateFromWhere + newestOrderBy
-	boundaryOldestFirstQuery = boundaryDateFromWhere + oldestOrderBy
+	boundaryNewestFirstQuery = boundaryDateFromWhere + boundaryNewestOrderBy
+	boundaryOldestFirstQuery = boundaryDateFromWhere + boundaryOldestOrderBy
 )
 
 // Keyset date-sort queries resuming after a cursor on a NON-NULL start_date
-// row. Mirrors newestKeysetQuery/oldestKeysetQuery exactly. $5 the cursor's
-// start_date (::date), $6 authority_code, $7 planit_name.
+// row. Mirrors newestKeysetQuery/oldestKeysetQuery's predicate shape. $3 the
+// cursor's start_date (::date), $4 authority_code, $5 planit_name.
 const (
 	boundaryNewestKeysetQuery = boundaryDateFromWhere +
-		" AND (start_date < $5::date OR start_date IS NULL" +
-		" OR (start_date = $5::date AND (authority_code, planit_name) > ($6, $7)))" +
-		newestOrderBy
+		" AND (start_date < $3::date OR start_date IS NULL" +
+		" OR (start_date = $3::date AND (authority_code, planit_name) > ($4, $5)))" +
+		boundaryNewestOrderBy
 	boundaryOldestKeysetQuery = boundaryDateFromWhere +
-		" AND (start_date > $5::date OR start_date IS NULL" +
-		" OR (start_date = $5::date AND (authority_code, planit_name) > ($6, $7)))" +
-		oldestOrderBy
+		" AND (start_date > $3::date OR start_date IS NULL" +
+		" OR (start_date = $3::date AND (authority_code, planit_name) > ($4, $5)))" +
+		boundaryOldestOrderBy
 )
 
 // Keyset date-sort queries resuming after a cursor in the NULL-start_date
-// tail. Mirrors newestKeysetNullQuery/oldestKeysetNullQuery. $5 authority_code,
-// $6 planit_name.
+// tail. Mirrors newestKeysetNullQuery/oldestKeysetNullQuery. $3 authority_code,
+// $4 planit_name.
 const (
 	boundaryNewestKeysetNullQuery = boundaryDateFromWhere +
-		" AND start_date IS NULL AND (authority_code, planit_name) > ($5, $6)" +
-		newestOrderBy
+		" AND start_date IS NULL AND (authority_code, planit_name) > ($3, $4)" +
+		boundaryNewestOrderBy
 	boundaryOldestKeysetNullQuery = boundaryDateFromWhere +
-		" AND start_date IS NULL AND (authority_code, planit_name) > ($5, $6)" +
-		oldestOrderBy
+		" AND start_date IS NULL AND (authority_code, planit_name) > ($3, $4)" +
+		boundaryOldestOrderBy
 )
+
+// boundaryStatusOrderBy mirrors statusOrderBy with LIMIT at $2.
+const boundaryStatusOrderBy = " ORDER BY app_state ASC NULLS LAST, start_date DESC NULLS LAST, authority_code, planit_name LIMIT $2"
 
 // boundaryStatusFirstQuery is the status first page: polygon predicate only,
 // ordered, limited. It reuses boundaryDateFromWhere (same projection:
-// appColumns + authority_code), mirroring statusFirstQuery.
-const boundaryStatusFirstQuery = boundaryDateFromWhere + statusOrderBy
+// appColumns + authority_code), mirroring statusFirstQuery's shape.
+const boundaryStatusFirstQuery = boundaryDateFromWhere + boundaryStatusOrderBy
 
-// Status keyset queries. Mirror the four statusKeyset* constants exactly
-// (see their doc comments for the mixed-direction rationale), with the
-// polygon predicate replacing the radius.
+// Status keyset queries. Mirror the four statusKeyset* constants' predicate
+// shape exactly (see their doc comments in zonepage.go for the
+// mixed-direction rationale), with the polygon predicate replacing the
+// radius and parameters starting at $3 (no centroid slots to skip).
 const (
-	// $5 app_state, $6 start_date(::date), $7 authority_code, $8 planit_name.
+	// $3 app_state, $4 start_date(::date), $5 authority_code, $6 planit_name.
 	boundaryStatusKeysetQuery = boundaryDateFromWhere +
-		" AND (app_state > $5 OR app_state IS NULL" +
-		" OR (app_state = $5 AND (start_date < $6::date OR start_date IS NULL))" +
-		" OR (app_state = $5 AND start_date = $6::date AND (authority_code, planit_name) > ($7, $8)))" +
-		statusOrderBy
-	// $5 app_state, $6 authority_code, $7 planit_name.
+		" AND (app_state > $3 OR app_state IS NULL" +
+		" OR (app_state = $3 AND (start_date < $4::date OR start_date IS NULL))" +
+		" OR (app_state = $3 AND start_date = $4::date AND (authority_code, planit_name) > ($5, $6)))" +
+		boundaryStatusOrderBy
+	// $3 app_state, $4 authority_code, $5 planit_name.
 	boundaryStatusKeysetDateNullQuery = boundaryDateFromWhere +
-		" AND (app_state > $5 OR app_state IS NULL" +
-		" OR (app_state = $5 AND start_date IS NULL AND (authority_code, planit_name) > ($6, $7)))" +
-		statusOrderBy
-	// $5 start_date(::date), $6 authority_code, $7 planit_name.
+		" AND (app_state > $3 OR app_state IS NULL" +
+		" OR (app_state = $3 AND start_date IS NULL AND (authority_code, planit_name) > ($4, $5)))" +
+		boundaryStatusOrderBy
+	// $3 start_date(::date), $4 authority_code, $5 planit_name.
 	boundaryStatusKeysetStateNullQuery = boundaryDateFromWhere +
-		" AND app_state IS NULL AND ((start_date < $5::date OR start_date IS NULL)" +
-		" OR (start_date = $5::date AND (authority_code, planit_name) > ($6, $7)))" +
-		statusOrderBy
-	// $5 authority_code, $6 planit_name.
+		" AND app_state IS NULL AND ((start_date < $3::date OR start_date IS NULL)" +
+		" OR (start_date = $3::date AND (authority_code, planit_name) > ($4, $5)))" +
+		boundaryStatusOrderBy
+	// $3 authority_code, $4 planit_name.
 	boundaryStatusKeysetBothNullQuery = boundaryDateFromWhere +
-		" AND app_state IS NULL AND start_date IS NULL AND (authority_code, planit_name) > ($5, $6)" +
-		statusOrderBy
+		" AND app_state IS NULL AND start_date IS NULL AND (authority_code, planit_name) > ($3, $4)" +
+		boundaryStatusOrderBy
 )
 
-// boundaryActivityFromWhere mirrors activityFromWhere: same projection
-// (dateColumns + activity_ts), same LEFT JOIN to the caller's unread
-// notifications ($5 userID), same $1/$2 centroid and $4 limit slot --
-// ST_Covers against the polygon ($3) replacing ST_DWithin against the circle.
+// boundaryActivityFromWhere mirrors activityFromWhere's shape (projection,
+// LEFT JOIN to the caller's unread notifications, ST_Covers replacing
+// ST_DWithin) but not its parameter numbering: $1 the boundary GeoJSON, $2
+// the limit, $3 the userID (in the join subquery) -- no centroid slots.
 const boundaryActivityFromWhere = "SELECT " + dateColumns + ", " + activityExpr + " AS activity_ts" +
 	" FROM applications" +
-	" LEFT JOIN (" + activityUnreadSubquery + ") u" +
+	" LEFT JOIN (SELECT n.application_uid, n.authority_id, MAX(n.created_at) AS created_at" +
+	" FROM notifications n WHERE n.user_id = $3 AND n.read_at IS NULL" +
+	" GROUP BY n.application_uid, n.authority_id) u" +
 	" ON applications.uid = u.application_uid AND applications.area_id = u.authority_id" +
-	" WHERE ST_Covers(" + boundaryZonePolygon + ", location)"
+	" WHERE ST_Covers(" + boundaryZonePolygonNoPoint + ", location)"
+
+// boundaryActivityOrderBy mirrors activityOrderBy with LIMIT at $2.
+const boundaryActivityOrderBy = " ORDER BY " + activityExpr + " DESC NULLS LAST, authority_code, planit_name LIMIT $2"
 
 // boundaryRecentActivityFirstQuery is the recent-activity first page: join +
 // polygon predicate, ordered, limited.
-const boundaryRecentActivityFirstQuery = boundaryActivityFromWhere + activityOrderBy
+const boundaryRecentActivityFirstQuery = boundaryActivityFromWhere + boundaryActivityOrderBy
 
 // Keyset recent-activity queries. Mirror recentActivityKeysetQuery /
-// recentActivityKeysetNullQuery exactly.
+// recentActivityKeysetNullQuery's predicate shape, with parameters starting
+// at $4 (after boundary GeoJSON $1, limit $2, userID $3).
 const (
-	// $6 the cursor's activity_ts (::timestamptz), $7 authority_code, $8 planit_name.
+	// $4 the cursor's activity_ts (::timestamptz), $5 authority_code, $6 planit_name.
 	boundaryRecentActivityKeysetQuery = boundaryActivityFromWhere +
-		" AND (" + activityExpr + " < $6::timestamptz OR " + activityExpr + " IS NULL" +
-		" OR (" + activityExpr + " = $6::timestamptz AND (authority_code, planit_name) > ($7, $8)))" +
-		activityOrderBy
-	// $6 authority_code, $7 planit_name.
+		" AND (" + activityExpr + " < $4::timestamptz OR " + activityExpr + " IS NULL" +
+		" OR (" + activityExpr + " = $4::timestamptz AND (authority_code, planit_name) > ($5, $6)))" +
+		boundaryActivityOrderBy
+	// $4 authority_code, $5 planit_name.
 	boundaryRecentActivityKeysetNullQuery = boundaryActivityFromWhere +
-		" AND " + activityExpr + " IS NULL AND (authority_code, planit_name) > ($6, $7)" +
-		activityOrderBy
+		" AND " + activityExpr + " IS NULL AND (authority_code, planit_name) > ($4, $5)" +
+		boundaryActivityOrderBy
 )
 
 // FindInBoundaryZonePage is FindInZonePage's custom-shape counterpart
@@ -241,17 +268,19 @@ func (s *PostgresStore) findDistanceBoundaryZonePage(ctx context.Context, latitu
 // dateCursorOf unchanged, only the query selection (boundaryDateZoneQuery)
 // differs.
 func (s *PostgresStore) findDateBoundaryZonePage(ctx context.Context, latitude, longitude float64, boundaryJSON string, sort Sort, limit int, c *pageCursor) ([]PlanningApplication, string, error) {
-	query, args := boundaryDateZoneQuery(sort, latitude, longitude, boundaryJSON, limit, c)
+	query, args := boundaryDateZoneQuery(sort, boundaryJSON, limit, c)
 	return s.collectKeysetPage(ctx, sort, latitude, longitude, query, args, limit, func(last datePageRow) pageCursor {
 		return dateCursorOf(sort, last)
 	})
 }
 
-// boundaryDateZoneQuery mirrors dateZoneQuery: the base args ($1..$4) are
-// longitude, latitude, the boundary GeoJSON, limit; the keyset args extend
-// them exactly as dateZoneQuery's do.
-func boundaryDateZoneQuery(sort Sort, latitude, longitude float64, boundaryJSON string, limit int, c *pageCursor) (string, []any) {
-	base := []any{longitude, latitude, boundaryJSON, limit}
+// boundaryDateZoneQuery mirrors dateZoneQuery's predicate/keyset shape, not
+// its parameter numbering: the base args ($1, $2) are the boundary GeoJSON
+// and limit -- no centroid, since ST_Covers containment doesn't need one; the
+// keyset args extend them exactly as dateZoneQuery's do, just starting two
+// slots earlier.
+func boundaryDateZoneQuery(sort Sort, boundaryJSON string, limit int, c *pageCursor) (string, []any) {
+	base := []any{boundaryJSON, limit}
 	switch {
 	case c == nil:
 		if sort == SortNewest {
@@ -277,15 +306,16 @@ func boundaryDateZoneQuery(sort Sort, latitude, longitude float64, boundaryJSON 
 // findStatusZonePage: it reuses collectKeysetPage and statusCursorOf
 // unchanged, only the query selection (boundaryStatusZoneQuery) differs.
 func (s *PostgresStore) findStatusBoundaryZonePage(ctx context.Context, latitude, longitude float64, boundaryJSON string, limit int, c *pageCursor) ([]PlanningApplication, string, error) {
-	query, args := boundaryStatusZoneQuery(latitude, longitude, boundaryJSON, limit, c)
+	query, args := boundaryStatusZoneQuery(boundaryJSON, limit, c)
 	return s.collectKeysetPage(ctx, SortStatus, latitude, longitude, query, args, limit, statusCursorOf)
 }
 
-// boundaryStatusZoneQuery mirrors statusZoneQuery: the base args ($1..$4) are
-// longitude, latitude, the boundary GeoJSON, limit; the keyset args extend
-// them exactly as statusZoneQuery's do.
-func boundaryStatusZoneQuery(latitude, longitude float64, boundaryJSON string, limit int, c *pageCursor) (string, []any) {
-	base := []any{longitude, latitude, boundaryJSON, limit}
+// boundaryStatusZoneQuery mirrors statusZoneQuery's predicate/keyset shape,
+// not its parameter numbering: the base args ($1, $2) are the boundary
+// GeoJSON and limit -- no centroid; the keyset args extend them exactly as
+// statusZoneQuery's do, just starting two slots earlier.
+func boundaryStatusZoneQuery(boundaryJSON string, limit int, c *pageCursor) (string, []any) {
+	base := []any{boundaryJSON, limit}
 	switch {
 	case c == nil:
 		return boundaryStatusFirstQuery, base
@@ -306,7 +336,7 @@ func boundaryStatusZoneQuery(latitude, longitude float64, boundaryJSON string, l
 // (boundaryRecentActivityZoneQuery) differs. userID scopes the joined unread
 // notifications.
 func (s *PostgresStore) findRecentActivityBoundaryZonePage(ctx context.Context, userID string, latitude, longitude float64, boundaryJSON string, limit int, c *pageCursor) ([]PlanningApplication, string, error) {
-	query, args := boundaryRecentActivityZoneQuery(userID, latitude, longitude, boundaryJSON, limit, c)
+	query, args := boundaryRecentActivityZoneQuery(userID, boundaryJSON, limit, c)
 	wrap := func(err error) error {
 		return fmt.Errorf("find applications by %s near (%v, %v): %w", SortRecentActivity, latitude, longitude, err)
 	}
@@ -325,11 +355,13 @@ func (s *PostgresStore) findRecentActivityBoundaryZonePage(ctx context.Context, 
 		limit, wrap)
 }
 
-// boundaryRecentActivityZoneQuery mirrors recentActivityZoneQuery: the base
-// args ($1..$5) are longitude, latitude, the boundary GeoJSON, limit, userID;
-// the keyset args extend them exactly as recentActivityZoneQuery's do.
-func boundaryRecentActivityZoneQuery(userID string, latitude, longitude float64, boundaryJSON string, limit int, c *pageCursor) (string, []any) {
-	base := []any{longitude, latitude, boundaryJSON, limit, userID}
+// boundaryRecentActivityZoneQuery mirrors recentActivityZoneQuery's
+// predicate/keyset shape, not its parameter numbering: the base args ($1,
+// $2, $3) are the boundary GeoJSON, limit, userID -- no centroid; the keyset
+// args extend them exactly as recentActivityZoneQuery's do, just starting two
+// slots earlier.
+func boundaryRecentActivityZoneQuery(userID, boundaryJSON string, limit int, c *pageCursor) (string, []any) {
+	base := []any{boundaryJSON, limit, userID}
 	switch {
 	case c == nil:
 		return boundaryRecentActivityFirstQuery, base
@@ -373,15 +405,25 @@ func (s *PostgresStore) findFilteredBoundaryZonePage(ctx context.Context, q InBo
 
 // buildFilteredBoundaryZoneQuery mirrors buildFilteredZoneQuery: the shape --
 // projection, optional unread join, optional status predicate, keyset
-// predicate, ORDER BY, LIMIT -- is byte-identical, built via the exact same
-// shared orderByExpr/keysetPredicate helpers. Only the spatial predicate
-// differs: ST_Covers against the polygon (boundaryJSON) replacing ST_DWithin
-// against the circle (q.RadiusMetres).
+// predicate, ORDER BY, LIMIT -- is otherwise identical, built via the exact
+// same shared orderByExpr/keysetPredicate helpers. Two things differ: the
+// spatial predicate (ST_Covers against the polygon replacing ST_DWithin
+// against the circle), and, following from that, the centroid point is only
+// added as a query argument for SortDistance -- the one sort that still
+// orders by it. orderByExpr/keysetPredicate never reference point for any
+// other sort, so adding it unconditionally (as the circle version does, where
+// the centroid is also the ST_DWithin containment test and so is always
+// used) would leave it an unreferenced placeholder; Postgres cannot infer an
+// unreferenced parameter's type ("could not determine data type of parameter
+// $1").
 func buildFilteredBoundaryZoneQuery(q InBoundaryQuery, boundaryJSON string, c *pageCursor) (string, []any, error) {
 	b := &argBuilder{}
-	lonP := b.add(q.Longitude)
-	latP := b.add(q.Latitude)
-	point := "ST_SetSRID(ST_MakePoint(" + lonP + ", " + latP + "), 4326)::geography"
+	var point string
+	if q.Sort == SortDistance {
+		lonP := b.add(q.Longitude)
+		latP := b.add(q.Latitude)
+		point = "ST_SetSRID(ST_MakePoint(" + lonP + ", " + latP + "), 4326)::geography"
+	}
 
 	var projection string
 	switch q.Sort {

--- a/api-go/internal/applications/boundaryzonepage_integration_test.go
+++ b/api-go/internal/applications/boundaryzonepage_integration_test.go
@@ -1,0 +1,386 @@
+//go:build integration
+
+package applications
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+)
+
+// generousZoneBoundary is a square ring around the shared London centre
+// fixture, large enough (a ~0.02-degree half-side, ~2.2 km) to comfortably
+// contain every sortFixture/statusFixture/activityFixture/unreadFixture point
+// (all offset due north of the centre by at most 800 m), so these tests prove
+// ordering, filtering, pagination and cursor semantics -- not containment.
+// TestPostgresStore_FindInBoundaryZonePage_CoversPolygonNotEnclosingCircle and
+// TestPostgresStore_FindInBoundaryZonePage_RespectsBoundary cover containment
+// itself, mirroring boundarypage_integration_test.go's squareBoundary proof.
+func generousZoneBoundary() []Coordinate {
+	return squareBoundary(0.02)
+}
+
+// boundaryZoneQuery is a brief InBoundaryQuery builder fixed to the standard
+// generous London fixture boundary, for the cursor/sort-error tests -- the
+// boundary-scoped sibling of zoneQuery.
+func boundaryZoneQuery(sort Sort, limit int, cursor string) InBoundaryQuery {
+	return InBoundaryQuery{
+		Latitude: pgCentreLat, Longitude: pgCentreLon, Boundary: generousZoneBoundary(),
+		Sort: sort, Limit: limit, Cursor: cursor,
+	}
+}
+
+// pageAllInBoundaryZone pages FindInBoundaryZonePage to exhaustion as an
+// anonymous caller (no userID), for the sorts that ignore per-user data --
+// the boundary-scoped sibling of pageAllInZone.
+func pageAllInBoundaryZone(t *testing.T, store *PostgresStore, sort Sort, limit int) []string {
+	t.Helper()
+	return pageAllInBoundaryZoneAs(t, store, "", sort, limit)
+}
+
+// pageAllInBoundaryZoneAs pages FindInBoundaryZonePage to exhaustion for the
+// given caller and page size, returning the names in the order seen across
+// pages -- the boundary-scoped sibling of pageAllInZoneAs.
+func pageAllInBoundaryZoneAs(t *testing.T, store *PostgresStore, userID string, sort Sort, limit int) []string {
+	t.Helper()
+	ctx := context.Background()
+	var names []string
+	cursor := ""
+	for range 1000 {
+		page, next, err := store.FindInBoundaryZonePage(ctx, InBoundaryQuery{
+			UserID: userID, Latitude: pgCentreLat, Longitude: pgCentreLon,
+			Boundary: generousZoneBoundary(), Sort: sort, Limit: limit, Cursor: cursor,
+		})
+		if err != nil {
+			t.Fatalf("FindInBoundaryZonePage(%s, cursor=%q): %v", sort, cursor, err)
+		}
+		names = append(names, appNames(page)...)
+		if next == "" {
+			return names
+		}
+		cursor = next
+	}
+	t.Fatalf("FindInBoundaryZonePage(%s) did not exhaust within the safety bound", sort)
+	return nil
+}
+
+// pageAllBoundaryZoneFiltered pages FindInBoundaryZonePage to exhaustion for
+// an arbitrary query (sort + status/unread filter + page size) -- the
+// boundary-scoped sibling of pageAllFiltered.
+func pageAllBoundaryZoneFiltered(t *testing.T, store *PostgresStore, base InBoundaryQuery) []string {
+	t.Helper()
+	ctx := context.Background()
+	var names []string
+	cursor := ""
+	for range 1000 {
+		q := base
+		q.Cursor = cursor
+		page, next, err := store.FindInBoundaryZonePage(ctx, q)
+		if err != nil {
+			t.Fatalf("FindInBoundaryZonePage(sort=%s status=%q unread=%t cursor=%q): %v", base.Sort, base.Status, base.Unread, cursor, err)
+		}
+		names = append(names, appNames(page)...)
+		if next == "" {
+			return names
+		}
+		cursor = next
+	}
+	t.Fatalf("FindInBoundaryZonePage(sort=%s status=%q unread=%t) did not exhaust within the safety bound", base.Sort, base.Status, base.Unread)
+	return nil
+}
+
+// TestPostgresStore_FindInBoundaryZonePage_Distance proves the boundary-scoped
+// sort-aware path reproduces FindInBoundaryPage's nearest-centroid-first
+// ordering and pages without gaps.
+func TestPostgresStore_FindInBoundaryZonePage_Distance(t *testing.T) {
+	store := newAppPGStore(t)
+	sortFixture(t, store)
+
+	want := []string{"A1", "A2", "A3", "A4", "A5", "A6"}
+	if got := pageAllInBoundaryZone(t, store, SortDistance, 100); !reflect.DeepEqual(got, want) {
+		t.Fatalf("distance single page: got %v, want %v", got, want)
+	}
+	if got := pageAllInBoundaryZone(t, store, SortDistance, 2); !reflect.DeepEqual(got, want) {
+		t.Fatalf("distance paged: got %v, want %v", got, want)
+	}
+}
+
+// TestPostgresStore_FindInBoundaryZonePage_Newest proves start_date DESC NULLS
+// LAST with the (authority_code, planit_name) tiebreak, paged to exhaustion
+// with no overlap or gap, matches the single unpaged order -- identical to
+// FindInZonePage's ordering, just polygon-scoped.
+func TestPostgresStore_FindInBoundaryZonePage_Newest(t *testing.T) {
+	store := newAppPGStore(t)
+	sortFixture(t, store)
+
+	want := []string{"A1", "A3", "A4", "A2", "A5", "A6"}
+	if got := pageAllInBoundaryZone(t, store, SortNewest, 100); !reflect.DeepEqual(got, want) {
+		t.Fatalf("newest single page: got %v, want %v", got, want)
+	}
+	if got := pageAllInBoundaryZone(t, store, SortNewest, 2); !reflect.DeepEqual(got, want) {
+		t.Fatalf("newest paged: got %v, want %v", got, want)
+	}
+	if got := pageAllInBoundaryZone(t, store, SortNewest, 1); !reflect.DeepEqual(got, want) {
+		t.Fatalf("newest paged size 1: got %v, want %v", got, want)
+	}
+}
+
+// TestPostgresStore_FindInBoundaryZonePage_Oldest proves start_date ASC NULLS
+// LAST with the same tiebreak, paged to exhaustion, matches the single
+// unpaged order.
+func TestPostgresStore_FindInBoundaryZonePage_Oldest(t *testing.T) {
+	store := newAppPGStore(t)
+	sortFixture(t, store)
+
+	want := []string{"A2", "A3", "A4", "A1", "A5", "A6"}
+	if got := pageAllInBoundaryZone(t, store, SortOldest, 100); !reflect.DeepEqual(got, want) {
+		t.Fatalf("oldest single page: got %v, want %v", got, want)
+	}
+	if got := pageAllInBoundaryZone(t, store, SortOldest, 2); !reflect.DeepEqual(got, want) {
+		t.Fatalf("oldest paged: got %v, want %v", got, want)
+	}
+}
+
+// TestPostgresStore_FindInBoundaryZonePage_Status proves the mixed-direction
+// keyset (app_state ASC NULLS LAST, start_date DESC NULLS LAST, tiebreak)
+// pages to exhaustion with no overlap or gap, matching FindInZonePage's
+// status ordering exactly.
+func TestPostgresStore_FindInBoundaryZonePage_Status(t *testing.T) {
+	store := newAppPGStore(t)
+	statusFixture(t, store)
+
+	want := []string{"P1", "P3", "P4", "P2", "P5", "R1", "R2", "N1", "N2"}
+	if got := pageAllInBoundaryZone(t, store, SortStatus, 100); !reflect.DeepEqual(got, want) {
+		t.Fatalf("status single page: got %v, want %v", got, want)
+	}
+	if got := pageAllInBoundaryZone(t, store, SortStatus, 1); !reflect.DeepEqual(got, want) {
+		t.Fatalf("status paged size 1: got %v, want %v", got, want)
+	}
+	if got := pageAllInBoundaryZone(t, store, SortStatus, 3); !reflect.DeepEqual(got, want) {
+		t.Fatalf("status paged size 3: got %v, want %v", got, want)
+	}
+}
+
+// TestPostgresStore_FindInBoundaryZonePage_RecentActivity proves the
+// GREATEST(start_date, unread.created_at) DESC NULLS LAST ordering, paged to
+// exhaustion, matches the single unpaged order -- the polygon-scoped
+// equivalent of FindInZonePage's headline recent-activity behaviour.
+func TestPostgresStore_FindInBoundaryZonePage_RecentActivity(t *testing.T) {
+	store, pool := newActivityPGStore(t)
+	const userID = "user-boundary-activity"
+	activityFixture(t, store, pool, userID)
+
+	want := []string{"AA", "BB", "CC", "DD", "EE", "FF"}
+	got := pageAllInBoundaryZoneAs(t, store, userID, SortRecentActivity, 100)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("recent-activity single page: got %v, want %v", got, want)
+	}
+	if got := pageAllInBoundaryZoneAs(t, store, userID, SortRecentActivity, 1); !reflect.DeepEqual(got, want) {
+		t.Fatalf("recent-activity paged size 1: got %v, want %v", got, want)
+	}
+}
+
+// TestPostgresStore_FindInBoundaryZonePage_StatusFilter proves ?status=
+// restricts the polygon-scoped candidate set to exactly the matching
+// app_state, composes with every scalar sort, and pages to exhaustion with no
+// overlap or gap.
+func TestPostgresStore_FindInBoundaryZonePage_StatusFilter(t *testing.T) {
+	store := newAppPGStore(t)
+	statusFixture(t, store)
+
+	permittedByDate := []string{"P1", "P3", "P4", "P2", "P5"}
+	permittedByDistance := []string{"P1", "P2", "P3", "P4", "P5"}
+	cases := []struct {
+		sort Sort
+		want []string
+	}{
+		{SortNewest, permittedByDate},
+		{SortStatus, permittedByDate},
+		{SortDistance, permittedByDistance},
+	}
+	for _, tc := range cases {
+		for _, limit := range []int{100, 2, 1} {
+			base := InBoundaryQuery{
+				Latitude: pgCentreLat, Longitude: pgCentreLon, Boundary: generousZoneBoundary(),
+				Sort: tc.sort, Status: "Permitted", Limit: limit,
+			}
+			if got := pageAllBoundaryZoneFiltered(t, store, base); !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("status=Permitted sort=%s limit=%d: got %v, want %v", tc.sort, limit, got, tc.want)
+			}
+		}
+	}
+
+	empty := pageAllBoundaryZoneFiltered(t, store, InBoundaryQuery{
+		Latitude: pgCentreLat, Longitude: pgCentreLon, Boundary: generousZoneBoundary(),
+		Sort: SortNewest, Status: "Withdrawn", Limit: 10,
+	})
+	if len(empty) != 0 {
+		t.Fatalf("status=Withdrawn (no rows): got %v, want empty", empty)
+	}
+}
+
+// TestPostgresStore_FindInBoundaryZonePage_UnreadFilter proves ?unread=true
+// (the INNER JOIN to the caller's unread notifications) keeps only
+// applications with an unread notification, composes with scalar sorts, and
+// pages without gaps -- the polygon-scoped equivalent of FindInZonePage's
+// unread filter.
+func TestPostgresStore_FindInBoundaryZonePage_UnreadFilter(t *testing.T) {
+	store, pool := newActivityPGStore(t)
+	const userID = "user-boundary-unread"
+	unreadFixture(t, store, pool, userID)
+
+	cases := []struct {
+		sort Sort
+		want []string
+	}{
+		{SortNewest, []string{"U4", "U1"}},
+		{SortDistance, []string{"U1", "U4"}},
+	}
+	for _, tc := range cases {
+		for _, limit := range []int{100, 1} {
+			base := InBoundaryQuery{
+				UserID: userID, Latitude: pgCentreLat, Longitude: pgCentreLon, Boundary: generousZoneBoundary(),
+				Sort: tc.sort, Unread: true, Limit: limit,
+			}
+			if got := pageAllBoundaryZoneFiltered(t, store, base); !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("unread=true sort=%s limit=%d: got %v, want %v", tc.sort, limit, got, tc.want)
+			}
+		}
+	}
+}
+
+// TestPostgresStore_FindInBoundaryZonePage_CursorSortMismatch proves a cursor
+// minted under one sort is rejected when replayed under another, and a
+// malformed cursor is reported as ErrCursorInvalid -- identical semantics to
+// FindInZonePage's cursor guard.
+func TestPostgresStore_FindInBoundaryZonePage_CursorSortMismatch(t *testing.T) {
+	ctx := context.Background()
+	store := newAppPGStore(t)
+	sortFixture(t, store)
+
+	_, cursor, err := store.FindInBoundaryZonePage(ctx, boundaryZoneQuery(SortNewest, 1, ""))
+	if err != nil {
+		t.Fatalf("mint newest cursor: %v", err)
+	}
+	if cursor == "" {
+		t.Fatal("expected a continuation cursor after a full page")
+	}
+	if _, _, err := store.FindInBoundaryZonePage(ctx, boundaryZoneQuery(SortOldest, 1, cursor)); !errors.Is(err, ErrCursorSortMismatch) {
+		t.Errorf("replay newest cursor under oldest: got err %v, want ErrCursorSortMismatch", err)
+	}
+	if _, _, err := store.FindInBoundaryZonePage(ctx, boundaryZoneQuery(SortNewest, 1, "!!!not-base64!!!")); !errors.Is(err, ErrCursorInvalid) {
+		t.Errorf("malformed cursor: got err %v, want ErrCursorInvalid", err)
+	}
+}
+
+// TestPostgresStore_FindInBoundaryZonePage_CursorFilterMismatch proves a
+// cursor minted under one filter is rejected when replayed under another --
+// identical semantics to FindInZonePage's filter guard.
+func TestPostgresStore_FindInBoundaryZonePage_CursorFilterMismatch(t *testing.T) {
+	ctx := context.Background()
+	store := newAppPGStore(t)
+	statusFixture(t, store)
+
+	permitted := InBoundaryQuery{
+		Latitude: pgCentreLat, Longitude: pgCentreLon, Boundary: generousZoneBoundary(),
+		Sort: SortNewest, Status: "Permitted", Limit: 1,
+	}
+	_, cursor, err := store.FindInBoundaryZonePage(ctx, permitted)
+	if err != nil {
+		t.Fatalf("mint status=Permitted cursor: %v", err)
+	}
+	if cursor == "" {
+		t.Fatal("expected a continuation cursor after a full filtered page")
+	}
+
+	rejectedReplay := permitted
+	rejectedReplay.Status, rejectedReplay.Cursor = "Rejected", cursor
+	if _, _, err := store.FindInBoundaryZonePage(ctx, rejectedReplay); !errors.Is(err, ErrCursorFilterMismatch) {
+		t.Errorf("replay Permitted cursor under Rejected: got %v, want ErrCursorFilterMismatch", err)
+	}
+
+	unfilteredReplay := InBoundaryQuery{
+		Latitude: pgCentreLat, Longitude: pgCentreLon, Boundary: generousZoneBoundary(),
+		Sort: SortNewest, Cursor: cursor,
+	}
+	if _, _, err := store.FindInBoundaryZonePage(ctx, unfilteredReplay); !errors.Is(err, ErrCursorFilterMismatch) {
+		t.Errorf("replay Permitted cursor unfiltered: got %v, want ErrCursorFilterMismatch", err)
+	}
+}
+
+// TestPostgresStore_FindInBoundaryZonePage_UnsupportedSort proves an
+// out-of-set sort is rejected with ErrUnsupportedSort.
+func TestPostgresStore_FindInBoundaryZonePage_UnsupportedSort(t *testing.T) {
+	ctx := context.Background()
+	store := newAppPGStore(t)
+	sortFixture(t, store)
+
+	if _, _, err := store.FindInBoundaryZonePage(ctx, boundaryZoneQuery(Sort("nonsense"), 10, "")); !errors.Is(err, ErrUnsupportedSort) {
+		t.Errorf("unsupported sort: got err %v, want ErrUnsupportedSort", err)
+	}
+}
+
+// TestPostgresStore_FindInBoundaryZonePage_CoversPolygonNotEnclosingCircle is
+// the honest real-PostGIS proof ADR 0032 requires for the sort/filter-aware
+// path, mirroring boundarypage_integration_test.go's proof for the plain
+// path: a point inside the polygon matches under every sort, and a point
+// inside the polygon's enclosing circle but outside the polygon itself does
+// NOT match -- the exact spatial distinction a fake store cannot model.
+func TestPostgresStore_FindInBoundaryZonePage_CoversPolygonNotEnclosingCircle(t *testing.T) {
+	ctx := context.Background()
+	store := newAppPGStore(t)
+
+	boundary := squareBoundary(0.005)
+
+	inside := pgApp("INSIDE", 100)
+	inside.Longitude = pgPtr(pgCentreLon + 0.001)
+	inside.Latitude = pgPtr(pgCentreLat + 0.001)
+
+	outsideSquareInsideCircle := pgApp("OUTSIDE-SQUARE", 100)
+	outsideSquareInsideCircle.Longitude = pgPtr(pgCentreLon + 0.02)
+	outsideSquareInsideCircle.Latitude = pgPtr(pgCentreLat + 0.02)
+
+	for _, a := range []PlanningApplication{inside, outsideSquareInsideCircle} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	for _, sort := range []Sort{SortDistance, SortNewest, SortStatus} {
+		page, _, err := store.FindInBoundaryZonePage(ctx, InBoundaryQuery{
+			Latitude: pgCentreLat, Longitude: pgCentreLon, Boundary: boundary, Sort: sort, Limit: 10,
+		})
+		if err != nil {
+			t.Fatalf("FindInBoundaryZonePage(%s): %v", sort, err)
+		}
+		if got := appNames(page); !reflect.DeepEqual(got, []string{"INSIDE"}) {
+			t.Errorf("%s: got %v, want [INSIDE] (OUTSIDE-SQUARE is inside the enclosing circle but outside the polygon)", sort, got)
+		}
+	}
+}
+
+// TestPostgresStore_FindInBoundaryZonePage_RespectsBoundary proves the
+// polygon predicate still bounds every sort: a row outside the boundary never
+// appears, even when it would otherwise sort first (e.g. the newest
+// start_date).
+func TestPostgresStore_FindInBoundaryZonePage_RespectsBoundary(t *testing.T) {
+	ctx := context.Background()
+	store := newAppPGStore(t)
+	far := time.Date(2026, 12, 1, 0, 0, 0, 0, time.UTC) // newest of all, but far away
+	for _, a := range []PlanningApplication{
+		withStart(at(pgApp("IN", 100), 100), time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)),
+		withStart(at(pgApp("OUT", 100), 50000), far), // 50 km, well outside the boundary
+	} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+	for _, sort := range []Sort{SortDistance, SortNewest, SortOldest, SortStatus} {
+		got := pageAllInBoundaryZone(t, store, sort, 10)
+		if !reflect.DeepEqual(got, []string{"IN"}) {
+			t.Errorf("%s: got %v, want [IN] (OUT is beyond the boundary)", sort, got)
+		}
+	}
+}

--- a/api-go/internal/applications/store_postgres.go
+++ b/api-go/internal/applications/store_postgres.go
@@ -41,6 +41,7 @@ type Store interface {
 	FindClustersInZone(ctx context.Context, q ClusterQuery) ([]Cluster, error)
 	FindInBoundaryPage(ctx context.Context, latitude, longitude float64, boundary []Coordinate, limit int, cursor string) ([]PlanningApplication, string, error)
 	FindClustersInBoundary(ctx context.Context, q BoundaryClusterQuery) ([]Cluster, error)
+	FindInBoundaryZonePage(ctx context.Context, q InBoundaryQuery) ([]PlanningApplication, string, error)
 	RecentNearestTown(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64, siblings []TownCentroid, cap int) ([]PlanningApplication, error)
 	BreakdownNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64) ([]StateCount, error)
 	Search(ctx context.Context, query, authorityCode string, lat, lon float64, limit int) ([]PlanningApplication, bool, error)

--- a/api-go/internal/watchzones/nearby.go
+++ b/api-go/internal/watchzones/nearby.go
@@ -66,14 +66,18 @@ type authorityResolver interface {
 // FindInBoundaryPage and FindClustersInBoundary (GH#1031, tc-6he3x.5) are the
 // custom-shape counterparts to FindNearbyPage and FindClustersInZone: the
 // containment test is ST_Covers against the zone's polygon rather than
-// ST_DWithin against its circle. See findZonePage and clusters for the
-// zone.IsCustomShape() branch that routes to them.
+// ST_DWithin against its circle. FindInBoundaryZonePage (GH#1031, tc-acbsh) is
+// the custom-shape counterpart to FindInZonePage: the same {distance, newest,
+// oldest, status, recent-activity} sorts and status/unread filters, ST_Covers-
+// scoped. See findZonePage and clusters for the zone.IsCustomShape() branches
+// that route to them.
 type appFinder interface {
 	FindNearbyPage(ctx context.Context, latitude, longitude, radiusMetres float64, limit int, cursor string) ([]applications.PlanningApplication, string, error)
 	FindInZonePage(ctx context.Context, q applications.InZoneQuery) ([]applications.PlanningApplication, string, error)
 	FindClustersInZone(ctx context.Context, q applications.ClusterQuery) ([]applications.Cluster, error)
 	FindInBoundaryPage(ctx context.Context, latitude, longitude float64, boundary []applications.Coordinate, limit int, cursor string) ([]applications.PlanningApplication, string, error)
 	FindClustersInBoundary(ctx context.Context, q applications.BoundaryClusterQuery) ([]applications.Cluster, error)
+	FindInBoundaryZonePage(ctx context.Context, q applications.InBoundaryQuery) ([]applications.PlanningApplication, string, error)
 }
 
 // unreadReader batches the per-application latest-unread lookup (read_at IS NULL,
@@ -502,23 +506,31 @@ func (h *handler) applications(w http.ResponseWriter, r *http.Request) {
 // restricts on. rawLimit is the unparsed ?limit= value; cursor is the
 // transport-unwrapped continuation token.
 //
-// INTERIM (tc-6he3x.4): neither finder is boundary-aware yet. For a
-// custom-shape zone (zone.IsCustomShape()) both branches below run against
-// zone.Latitude/Longitude/RadiusMetres -- the polygon's derived centroid and
-// ENCLOSING radius (see WithBoundary), i.e. a circle no smaller than the true
-// shape, so results are a safe over-fetch, never an under-fetch. A
-// polygon-scoped finder (FindInBoundaryPage) replaces this fallback in
-// tc-6he3x.5.
+// Custom-shape zones (GH#1031, tc-6he3x.5 / tc-acbsh) mirror the circle-zone
+// branching below exactly, one level up: the plain boundary-scoped page
+// (FindInBoundaryPage) for a truly param-less request, and the sort-and-
+// filter-aware boundary page (FindInBoundaryZonePage) as soon as a sort or a
+// filter is requested -- full parity with a circle zone, just ST_Covers
+// against the polygon replacing ST_DWithin against the circle. Circle zones
+// are completely unaffected by either branch.
 func (h *handler) findZonePage(ctx context.Context, userID string, zone WatchZone, sort applications.Sort, sortPresent bool, status string, unread bool, rawLimit, cursor string) ([]applications.PlanningApplication, string, error) {
-	// Custom-shape zones (GH#1031, tc-6he3x.5) always take the plain boundary-
-	// scoped page, regardless of ?sort=/?status=/?unread=: there is no
-	// boundary-aware counterpart to FindInZonePage yet, so those params are a
-	// silent no-op here (escalated and decided 2026-08-01 — option A). Circle
-	// zones are completely unaffected; a follow-up bead tracks the
-	// boundary-aware sort/filter equivalent.
 	if zone.IsCustomShape() {
-		limit := parseLimit(rawLimit, defaultNearbyLimit)
-		return h.apps.FindInBoundaryPage(ctx, zone.Latitude, zone.Longitude, boundaryCoordinates(zone.Boundary), limit, cursor)
+		if !sortPresent && status == "" && !unread {
+			limit := parseLimit(rawLimit, defaultNearbyLimit)
+			return h.apps.FindInBoundaryPage(ctx, zone.Latitude, zone.Longitude, boundaryCoordinates(zone.Boundary), limit, cursor)
+		}
+		limit := parseLimit(rawLimit, defaultSortedLimit)
+		return h.apps.FindInBoundaryZonePage(ctx, applications.InBoundaryQuery{
+			UserID:    userID,
+			Latitude:  zone.Latitude,
+			Longitude: zone.Longitude,
+			Boundary:  boundaryCoordinates(zone.Boundary),
+			Sort:      sort,
+			Status:    status,
+			Unread:    unread,
+			Limit:     limit,
+			Cursor:    cursor,
+		})
 	}
 	if !sortPresent && status == "" && !unread {
 		limit := parseLimit(rawLimit, defaultNearbyLimit)

--- a/api-go/internal/watchzones/nearby_test.go
+++ b/api-go/internal/watchzones/nearby_test.go
@@ -1193,7 +1193,7 @@ func TestApplications_CircleZoneStillUsesLegacyDistancePath(t *testing.T) {
 // FindNearbyPage/FindInZonePage.
 func TestApplications_CustomShapeZoneUsesBoundaryPath(t *testing.T) {
 	t.Parallel()
-	zone := mustCustomShapeZone(t, 471)
+	zone := mustCustomShapeZone(t)
 	apps := &fakeAppFinder{}
 	d := nearbyDeps{
 		store:    &fakeZoneStore{zones: []WatchZone{zone}},
@@ -1242,7 +1242,7 @@ func TestApplications_CustomShapeZoneUsesBoundaryPath(t *testing.T) {
 // to the plain boundary page or the circle-zone FindInZonePage.
 func TestApplications_CustomShapeZoneSortAndFilterRoutesToBoundaryZonePage(t *testing.T) {
 	t.Parallel()
-	zone := mustCustomShapeZone(t, 471)
+	zone := mustCustomShapeZone(t)
 	apps := &fakeAppFinder{}
 	d := nearbyDeps{
 		store:    &fakeZoneStore{zones: []WatchZone{zone}},
@@ -1293,7 +1293,7 @@ func TestApplications_CustomShapeZoneSortAndFilterRoutesToBoundaryZonePage(t *te
 // just ?sort=/?status=.
 func TestApplications_CustomShapeZoneUnreadFilterRoutesToBoundaryZonePage(t *testing.T) {
 	t.Parallel()
-	zone := mustCustomShapeZone(t, 471)
+	zone := mustCustomShapeZone(t)
 	apps := &fakeAppFinder{}
 	d := nearbyDeps{
 		store:    &fakeZoneStore{zones: []WatchZone{zone}},
@@ -1324,7 +1324,7 @@ func TestApplications_CustomShapeZoneUnreadFilterRoutesToBoundaryZonePage(t *tes
 // as 400, exactly like the circle-zone FindInZonePage path.
 func TestApplications_CustomShapeZoneBoundaryZoneCursorMismatchIs400(t *testing.T) {
 	t.Parallel()
-	zone := mustCustomShapeZone(t, 471)
+	zone := mustCustomShapeZone(t)
 	apps := &fakeAppFinder{boundaryZoneErr: applications.ErrCursorSortMismatch}
 	d := nearbyDeps{
 		store:    &fakeZoneStore{zones: []WatchZone{zone}},
@@ -1765,11 +1765,12 @@ func mustZone(t *testing.T, id string, authorityID int) WatchZone {
 
 // mustCustomShapeZone builds a custom-shape zone (londonSquare, from
 // zone_test.go) over the same base fields as mustZone, for the polygon-branch
-// tests in findZonePage and clusters. id is always "zone-1" across callers
-// (unparam), so it is fixed here rather than threaded through.
-func mustCustomShapeZone(t *testing.T, authorityID int) WatchZone {
+// tests in findZonePage and clusters. id and authorityID are always "zone-1"
+// and 471 across callers (unparam), so they are fixed here rather than
+// threaded through.
+func mustCustomShapeZone(t *testing.T) WatchZone {
 	t.Helper()
-	z := mustZone(t, "zone-1", authorityID)
+	z := mustZone(t, "zone-1", 471)
 	z, err := z.WithBoundary(londonSquare(t))
 	if err != nil {
 		t.Fatalf("WithBoundary: %v", err)
@@ -1859,7 +1860,7 @@ func TestClusters_PassesZoneAndParamsToStore(t *testing.T) {
 // circle path -- and never falls through to FindClustersInZone.
 func TestClusters_CustomShapeZoneUsesBoundaryClusterQuery(t *testing.T) {
 	t.Parallel()
-	zone := mustCustomShapeZone(t, 471)
+	zone := mustCustomShapeZone(t)
 	apps := &fakeAppFinder{}
 	d := nearbyDeps{
 		store:    &fakeZoneStore{zones: []WatchZone{zone}},

--- a/api-go/internal/watchzones/nearby_test.go
+++ b/api-go/internal/watchzones/nearby_test.go
@@ -1193,7 +1193,7 @@ func TestApplications_CircleZoneStillUsesLegacyDistancePath(t *testing.T) {
 // FindNearbyPage/FindInZonePage.
 func TestApplications_CustomShapeZoneUsesBoundaryPath(t *testing.T) {
 	t.Parallel()
-	zone := mustCustomShapeZone(t, "zone-1", 471)
+	zone := mustCustomShapeZone(t, 471)
 	apps := &fakeAppFinder{}
 	d := nearbyDeps{
 		store:    &fakeZoneStore{zones: []WatchZone{zone}},
@@ -1242,7 +1242,7 @@ func TestApplications_CustomShapeZoneUsesBoundaryPath(t *testing.T) {
 // to the plain boundary page or the circle-zone FindInZonePage.
 func TestApplications_CustomShapeZoneSortAndFilterRoutesToBoundaryZonePage(t *testing.T) {
 	t.Parallel()
-	zone := mustCustomShapeZone(t, "zone-1", 471)
+	zone := mustCustomShapeZone(t, 471)
 	apps := &fakeAppFinder{}
 	d := nearbyDeps{
 		store:    &fakeZoneStore{zones: []WatchZone{zone}},
@@ -1293,7 +1293,7 @@ func TestApplications_CustomShapeZoneSortAndFilterRoutesToBoundaryZonePage(t *te
 // just ?sort=/?status=.
 func TestApplications_CustomShapeZoneUnreadFilterRoutesToBoundaryZonePage(t *testing.T) {
 	t.Parallel()
-	zone := mustCustomShapeZone(t, "zone-1", 471)
+	zone := mustCustomShapeZone(t, 471)
 	apps := &fakeAppFinder{}
 	d := nearbyDeps{
 		store:    &fakeZoneStore{zones: []WatchZone{zone}},
@@ -1324,7 +1324,7 @@ func TestApplications_CustomShapeZoneUnreadFilterRoutesToBoundaryZonePage(t *tes
 // as 400, exactly like the circle-zone FindInZonePage path.
 func TestApplications_CustomShapeZoneBoundaryZoneCursorMismatchIs400(t *testing.T) {
 	t.Parallel()
-	zone := mustCustomShapeZone(t, "zone-1", 471)
+	zone := mustCustomShapeZone(t, 471)
 	apps := &fakeAppFinder{boundaryZoneErr: applications.ErrCursorSortMismatch}
 	d := nearbyDeps{
 		store:    &fakeZoneStore{zones: []WatchZone{zone}},
@@ -1765,10 +1765,11 @@ func mustZone(t *testing.T, id string, authorityID int) WatchZone {
 
 // mustCustomShapeZone builds a custom-shape zone (londonSquare, from
 // zone_test.go) over the same base fields as mustZone, for the polygon-branch
-// tests in findZonePage and clusters.
-func mustCustomShapeZone(t *testing.T, id string, authorityID int) WatchZone {
+// tests in findZonePage and clusters. id is always "zone-1" across callers
+// (unparam), so it is fixed here rather than threaded through.
+func mustCustomShapeZone(t *testing.T, authorityID int) WatchZone {
 	t.Helper()
-	z := mustZone(t, id, authorityID)
+	z := mustZone(t, "zone-1", authorityID)
 	z, err := z.WithBoundary(londonSquare(t))
 	if err != nil {
 		t.Fatalf("WithBoundary: %v", err)
@@ -1858,7 +1859,7 @@ func TestClusters_PassesZoneAndParamsToStore(t *testing.T) {
 // circle path -- and never falls through to FindClustersInZone.
 func TestClusters_CustomShapeZoneUsesBoundaryClusterQuery(t *testing.T) {
 	t.Parallel()
-	zone := mustCustomShapeZone(t, "zone-1", 471)
+	zone := mustCustomShapeZone(t, 471)
 	apps := &fakeAppFinder{}
 	d := nearbyDeps{
 		store:    &fakeZoneStore{zones: []WatchZone{zone}},

--- a/api-go/internal/watchzones/nearby_test.go
+++ b/api-go/internal/watchzones/nearby_test.go
@@ -71,6 +71,10 @@ type fakeAppFinder struct {
 	lastBoundary             []applications.Coordinate
 	boundaryClustersCalled   bool
 	lastBoundaryClusterQuery applications.BoundaryClusterQuery
+
+	boundaryZoneCalled    bool
+	boundaryZoneErr       error
+	lastBoundaryZoneQuery applications.InBoundaryQuery
 }
 
 func (f *fakeAppFinder) FindNearbyPage(_ context.Context, latitude, longitude, radiusMetres float64, limit int, cursor string) ([]applications.PlanningApplication, string, error) {
@@ -145,6 +149,19 @@ func (f *fakeAppFinder) FindClustersInBoundary(_ context.Context, q applications
 		return nil, f.clusterErr
 	}
 	return f.clusters, nil
+}
+
+func (f *fakeAppFinder) FindInBoundaryZonePage(_ context.Context, q applications.InBoundaryQuery) ([]applications.PlanningApplication, string, error) {
+	f.boundaryZoneCalled = true
+	f.lastBoundaryZoneQuery = q
+	if f.boundaryZoneErr != nil {
+		return nil, "", f.boundaryZoneErr
+	}
+	apps := f.apps
+	if q.Limit > 0 && len(apps) > q.Limit {
+		apps = apps[:q.Limit]
+	}
+	return apps, f.next, nil
 }
 
 type fakeUnread struct {
@@ -1094,75 +1111,17 @@ func TestCreate_Boundary_InvalidShapeIs400(t *testing.T) {
 	}
 }
 
-// TestApplications_CustomShapeZone_UsesEnclosingRadiusInterimFallback pins the
-// documented interim behaviour (tc-6he3x.4, replaced by tc-6he3x.5): a
-// custom-shape zone's applications page still runs through the legacy circle
-// finder (FindNearbyPage) using the polygon's derived centroid and ENCLOSING
-// radius, never a boundary-scoped query.
-func TestApplications_CustomShapeZone_UsesEnclosingRadiusInterimFallback(t *testing.T) {
-	t.Parallel()
-	base := mustZone(t, "zone-1", 471)
-	zone, err := base.WithBoundary(squareVertices(51.5, -0.12, 500))
-	if err != nil {
-		t.Fatalf("WithBoundary: %v", err)
-	}
-	if !zone.IsCustomShape() {
-		t.Fatal("fixture zone must be a custom shape")
-	}
-	apps := &fakeAppFinder{}
-	d := nearbyDeps{
-		store:    &fakeZoneStore{zones: []WatchZone{zone}},
-		apps:     apps,
-		profiles: &fakeProfileReader{},
-		resolver: &fakeResolver{},
-		unread:   &fakeUnread{},
-	}
-	mux := newNearbyMux(t, d)
-
-	rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications", "")
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status: got %d, want 200 (body %s)", rec.Code, rec.Body)
-	}
-	if !apps.called || apps.inZoneCalled {
-		t.Fatalf("a param-less request for a custom-shape zone must still use the legacy FindNearbyPage path: called=%v inZone=%v", apps.called, apps.inZoneCalled)
-	}
-	if apps.lastLatitude != zone.Latitude || apps.lastLongitude != zone.Longitude || apps.lastRadiusMetres != zone.RadiusMetres {
-		t.Errorf("interim fallback must query the polygon's derived centroid/enclosing radius: got (%v,%v,%v), want (%v,%v,%v)",
-			apps.lastLatitude, apps.lastLongitude, apps.lastRadiusMetres, zone.Latitude, zone.Longitude, zone.RadiusMetres)
-	}
-}
-
-// TestClusters_CustomShapeZone_UsesEnclosingRadiusInterimFallback is the
-// clusters-endpoint sibling of the applications test above: the cluster query
-// threads the same polygon-derived centroid/enclosing radius, never a
-// boundary-scoped query (tc-6he3x.5 replaces this).
-func TestClusters_CustomShapeZone_UsesEnclosingRadiusInterimFallback(t *testing.T) {
-	t.Parallel()
-	base := mustZone(t, "zone-1", 471)
-	zone, err := base.WithBoundary(squareVertices(51.5, -0.12, 500))
-	if err != nil {
-		t.Fatalf("WithBoundary: %v", err)
-	}
-	apps := &fakeAppFinder{}
-	d := nearbyDeps{
-		store:    &fakeZoneStore{zones: []WatchZone{zone}},
-		apps:     apps,
-		profiles: &fakeProfileReader{},
-		resolver: &fakeResolver{},
-		unread:   &fakeUnread{},
-	}
-	mux := newNearbyMux(t, d)
-
-	rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications/clusters"+validClusterQuery, "")
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status: got %d, want 200 (body %s)", rec.Code, rec.Body)
-	}
-	q := apps.lastClusterQuery
-	if q.Latitude != zone.Latitude || q.Longitude != zone.Longitude || q.RadiusMetres != zone.RadiusMetres {
-		t.Errorf("interim fallback must query the polygon's derived centroid/enclosing radius: got (%v,%v,%v), want (%v,%v,%v)",
-			q.Latitude, q.Longitude, q.RadiusMetres, zone.Latitude, zone.Longitude, zone.RadiusMetres)
-	}
-}
+// NOTE (tc-grlnc, discovered-from tc-acbsh): two tests used to live here --
+// TestApplications_CustomShapeZone_UsesEnclosingRadiusInterimFallback and
+// TestClusters_CustomShapeZone_UsesEnclosingRadiusInterimFallback -- pinning
+// the tc-6he3x.4 interim behaviour (a param-less custom-shape request routing
+// through the legacy circle finders). tc-6he3x.5 (PR #1047) replaced that
+// routing with FindInBoundaryPage/FindClustersInBoundary but left these two
+// tests asserting the superseded behaviour, so they failed independent of any
+// other change (confirmed via `git stash` before this bead's edits). Deleted
+// as dead, contradicting test code -- TestApplications_CustomShapeZoneUsesBoundaryPath
+// and TestClusters_CustomShapeZoneUsesBoundaryClusterQuery already cover the
+// current (correct) routing.
 
 // sortDeps builds a standard dependency set for the applications-list sort tests:
 // one seeded zone, a configurable finder, no watermark.
@@ -1223,6 +1182,9 @@ func TestApplications_CircleZoneStillUsesLegacyDistancePath(t *testing.T) {
 	if apps.boundaryCalled {
 		t.Error("a circle zone must never route to the boundary-scoped finder")
 	}
+	if apps.boundaryZoneCalled {
+		t.Error("a circle zone must never route to the boundary-scoped sort/filter finder")
+	}
 }
 
 // TestApplications_CustomShapeZoneUsesBoundaryPath proves a custom-shape zone's
@@ -1252,6 +1214,9 @@ func TestApplications_CustomShapeZoneUsesBoundaryPath(t *testing.T) {
 	if apps.called || apps.inZoneCalled {
 		t.Error("a custom-shape zone must never route to FindNearbyPage/FindInZonePage")
 	}
+	if apps.boundaryZoneCalled {
+		t.Error("a param-less custom-shape zone request must not use the sort/filter-aware boundary finder")
+	}
 	if apps.lastBoundaryLatitude != zone.Latitude || apps.lastBoundaryLongitude != zone.Longitude {
 		t.Errorf("boundary centre: got (%v, %v), want the zone's derived centroid (%v, %v)",
 			apps.lastBoundaryLatitude, apps.lastBoundaryLongitude, zone.Latitude, zone.Longitude)
@@ -1270,12 +1235,12 @@ func TestApplications_CustomShapeZoneUsesBoundaryPath(t *testing.T) {
 	}
 }
 
-// TestApplications_CustomShapeZoneIgnoresSortAndFilterParams proves the
-// documented interim gap (tc-6he3x.5; a boundary-aware FindInZonePage
-// equivalent is a follow-up, per the escalated decision): a custom-shape
-// zone's ?sort=/?status=/?unread= are silent no-ops, always serving the plain
-// boundary page rather than erroring or falling through to FindInZonePage.
-func TestApplications_CustomShapeZoneIgnoresSortAndFilterParams(t *testing.T) {
+// TestApplications_CustomShapeZoneSortAndFilterRoutesToBoundaryZonePage proves
+// the gap tc-6he3x.4/tc-6he3x.5 left open is closed (tc-acbsh): a custom-shape
+// zone's ?sort=/?status= now route to the boundary-aware sort/filter finder
+// (FindInBoundaryZonePage), never silently ignored and never falling through
+// to the plain boundary page or the circle-zone FindInZonePage.
+func TestApplications_CustomShapeZoneSortAndFilterRoutesToBoundaryZonePage(t *testing.T) {
 	t.Parallel()
 	zone := mustCustomShapeZone(t, "zone-1", 471)
 	apps := &fakeAppFinder{}
@@ -1292,11 +1257,88 @@ func TestApplications_CustomShapeZoneIgnoresSortAndFilterParams(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
 	}
-	if !apps.boundaryCalled {
-		t.Fatal("a custom-shape zone must still route to FindInBoundaryPage even with ?sort=/?status=")
+	if !apps.boundaryZoneCalled {
+		t.Fatal("a custom-shape zone's ?sort=/?status= must route to FindInBoundaryZonePage")
 	}
-	if apps.inZoneCalled {
-		t.Error("?sort=/?status= must be a no-op for a custom-shape zone, not route to FindInZonePage")
+	if apps.boundaryCalled {
+		t.Error("a custom-shape zone's ?sort=/?status= must never route to the plain FindInBoundaryPage")
+	}
+	if apps.inZoneCalled || apps.called {
+		t.Error("a custom-shape zone must never route to FindNearbyPage/FindInZonePage")
+	}
+	q := apps.lastBoundaryZoneQuery
+	if q.Sort != applications.SortNewest {
+		t.Errorf("sort: got %q, want newest", q.Sort)
+	}
+	if q.Status != "Permitted" {
+		t.Errorf("status: got %q, want Permitted", q.Status)
+	}
+	if q.UserID != testUser {
+		t.Errorf("userID threaded to store: got %q, want %q", q.UserID, testUser)
+	}
+	if q.Latitude != zone.Latitude || q.Longitude != zone.Longitude {
+		t.Errorf("boundary centre: got (%v, %v), want the zone's derived centroid (%v, %v)",
+			q.Latitude, q.Longitude, zone.Latitude, zone.Longitude)
+	}
+	if len(q.Boundary) != len(zone.Boundary) {
+		t.Fatalf("boundary ring length: got %d, want %d", len(q.Boundary), len(zone.Boundary))
+	}
+	if q.Limit != defaultSortedLimit {
+		t.Errorf("boundary sort-aware default limit: got %d, want %d", q.Limit, defaultSortedLimit)
+	}
+}
+
+// TestApplications_CustomShapeZoneUnreadFilterRoutesToBoundaryZonePage proves
+// ?unread=true also routes a custom-shape zone to FindInBoundaryZonePage, not
+// just ?sort=/?status=.
+func TestApplications_CustomShapeZoneUnreadFilterRoutesToBoundaryZonePage(t *testing.T) {
+	t.Parallel()
+	zone := mustCustomShapeZone(t, "zone-1", 471)
+	apps := &fakeAppFinder{}
+	d := nearbyDeps{
+		store:    &fakeZoneStore{zones: []WatchZone{zone}},
+		apps:     apps,
+		profiles: &fakeProfileReader{},
+		resolver: &fakeResolver{},
+		unread:   &fakeUnread{},
+	}
+	mux := newNearbyMux(t, d)
+
+	rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications?unread=true", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if !apps.boundaryZoneCalled {
+		t.Fatal("a custom-shape zone's ?unread=true must route to FindInBoundaryZonePage")
+	}
+	if !apps.lastBoundaryZoneQuery.Unread {
+		t.Error("unread flag must be threaded through to InBoundaryQuery")
+	}
+	if apps.lastBoundaryZoneQuery.Sort != applications.SortDistance {
+		t.Errorf("an omitted ?sort= must still default to distance: got %q", apps.lastBoundaryZoneQuery.Sort)
+	}
+}
+
+// TestApplications_CustomShapeZoneBoundaryZoneCursorMismatchIs400 proves a
+// cursor rejected by FindInBoundaryZonePage (ErrCursorSortMismatch) surfaces
+// as 400, exactly like the circle-zone FindInZonePage path.
+func TestApplications_CustomShapeZoneBoundaryZoneCursorMismatchIs400(t *testing.T) {
+	t.Parallel()
+	zone := mustCustomShapeZone(t, "zone-1", 471)
+	apps := &fakeAppFinder{boundaryZoneErr: applications.ErrCursorSortMismatch}
+	d := nearbyDeps{
+		store:    &fakeZoneStore{zones: []WatchZone{zone}},
+		apps:     apps,
+		profiles: &fakeProfileReader{},
+		resolver: &fakeResolver{},
+		unread:   &fakeUnread{},
+	}
+	mux := newNearbyMux(t, d)
+
+	cursor := base64.RawURLEncoding.EncodeToString([]byte("cursor-from-another-sort"))
+	rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications?sort=oldest&cursor="+cursor, "")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400", rec.Code)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes the gap left by tc-6he3x.5 (#1047): a custom-shape (polygon, paid-tier) watch zone's applications list previously ignored `?sort=`, `?status=`, and `?unread=` and always served the plain nearest-first boundary page, while a circle zone got the full `{distance, newest, oldest, status, recent-activity}` sort surface plus status/unread filters via `FindInZonePage`. This was an explicitly escalated and documented interim state (option A, decided 2026-08-01) with no live-customer impact at the time, tracked as follow-up bead tc-acbsh.

This PR adds `FindInBoundaryZonePage`, the polygon-scoped counterpart to `FindInZonePage`, and wires it into `findZonePage`'s `zone.IsCustomShape()` branch — giving a custom-shape zone full sort/filter parity with a circle zone. Circle zones are unaffected.

- `api-go/internal/applications/boundaryzonepage.go` (new): `InBoundaryQuery` + `FindInBoundaryZonePage`, mirroring `zonepage.go`'s per-sort query construction and keyset cursor semantics (`ErrCursorSortMismatch`, `ErrCursorFilterMismatch`), with `ST_Covers(polygon, location)` replacing `ST_DWithin(circle, location)`. Reuses `zonepage.go`'s shared helpers (`orderByExpr`, `keysetPredicate`, cursor builders) rather than duplicating them.
- `api-go/internal/watchzones/nearby.go`: `findZonePage`'s custom-shape branch now mirrors the circle-zone branch — plain `FindInBoundaryPage` when no sort/status/unread is requested, `FindInBoundaryZonePage` otherwise. Stale doc comments describing the now-closed gap are updated.
- Cluster queries are untouched — out of scope for this bead.

## Side fix (tc-grlnc, discovered-from tc-acbsh)

Found two pre-existing tests in `nearby_test.go` pinning superseded tc-6he3x.4 behaviour, failing independent of this change (confirmed via `git stash`). Deleted as dead/contradicting tests — equivalent correct coverage already existed elsewhere in the same file. Test-only, no production code touched.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` (clean)
- [x] `go test ./...` — full suite green
- [x] `go build/vet -tags=integration ./...` — compiles clean
- [x] New real-DB integration suite added (`boundaryzonepage_integration_test.go`, `//go:build integration`) mirroring `FindInZonePage`'s coverage: per-sort ordering/pagination, status/unread filters, cursor mismatch rejection, and an honest `ST_Covers`-vs-enclosing-circle proof
- [ ] **Not run in this sandbox** — Docker unavailable here, so the new integration tests were compile-checked only, not executed against real Postgres/PostGIS. `pr-gate`'s `Go API Integration tests` check will run them for real; please confirm green before merge.
- [ ] `golangci-lint` not run locally (sandbox's installed binary predates the `go 1.26` toolchain this repo targets, unrelated to this change) — relying on `pr-gate`'s Go API Lint check.

Refs: tc-acbsh, GH#1031 (section 5/6), tc-6he3x.5 (#1047)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFvamf4kxCZGSh78R1s2uy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added paginated application searches within custom boundary shapes.
  * Added sorting by distance, newest, oldest, status, and recent activity.
  * Added status and unread filters, with cursor-based pagination.
  * Improved boundary accuracy to include applications covered by the selected shape.

* **Bug Fixes**
  * Custom boundary searches now correctly preserve filters, sorting, and pagination.
  * Invalid cursor and unsupported sort requests return appropriate errors.
  * Existing circular-area search behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->