### PR TITLE
feat(ios): watch zone editor shape mode, vertex editing, boundary drawing map (tc-6he3x.8)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/BoundaryDrawingMapView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/BoundaryDrawingMapView.swift
@@ -122,8 +122,8 @@
           self.shapeOverlay = nil
         }
         guard desired.count >= 2 else { return }
-        let points = desired.map {
-          CLLocationCoordinate2D(latitude: $0.latitude, longitude: $0.longitude)
+        let points = desired.map { vertex in
+          CLLocationCoordinate2D(latitude: vertex.latitude, longitude: vertex.longitude)
         }
         let overlay: MKOverlay =
           desired.count >= 3
@@ -165,7 +165,7 @@
         var closestIndex: Int?
         var closestDistance = BoundaryDrawingMapView.vertexHitTestTolerance
         for vertex in vertices {
-          let vertexPoint = mapView.convert(vertex.coordinate, toPointIn: mapView)
+          let vertexPoint = mapView.convert(vertex.coordinate, toPointTo: mapView)
           let distance = hypot(vertexPoint.x - point.x, vertexPoint.y - point.y)
           if distance <= closestDistance {
             closestDistance = distance

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/BoundaryDrawingMapView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/BoundaryDrawingMapView.swift
@@ -1,0 +1,243 @@
+#if canImport(UIKit)
+  import MapKit
+  import SwiftUI
+  import TownCrierDomain
+
+  /// A UIKit `MKMapView` wrapped for SwiftUI for drawing a custom-shape watch
+  /// zone boundary (GH#1031, bead tc-6he3x.8): tap an empty area to drop a
+  /// vertex, drag an existing vertex pin to move it, tap the first vertex
+  /// (once at least 3 exist) to close the ring.
+  ///
+  /// The representable is a thin adapter (MVVM-C): all vertex state lives on
+  /// ``WatchZoneEditorViewModel``; this view translates taps/drags into
+  /// ViewModel calls and renders the vertex pins plus a preview
+  /// polygon/polyline overlay. Structure mirrors `ClusteredMapView`.
+  @MainActor
+  struct BoundaryDrawingMapView: UIViewRepresentable {
+    /// Observed so `updateUIView` re-runs to re-diff vertices whenever the
+    /// ViewModel publishes a change (add/move/remove/undo) — a plain stored
+    /// reference is NOT enough: SwiftUI treats the representable as
+    /// unchanged when its only stored property is the same
+    /// `WatchZoneEditorViewModel` instance, so it skips `updateUIView` and
+    /// new vertices never reach the map (mirrors `ClusteredMapView`).
+    @ObservedObject var viewModel: WatchZoneEditorViewModel
+
+    /// Where the map centres on first appearance — the postcode-geocoded
+    /// coordinate the user already entered before switching to Custom.
+    let initialCentre: Coordinate
+
+    /// Screen-point tolerance for treating a tap as "on an existing vertex"
+    /// (closes the ring, if it's the first one, or is otherwise ignored —
+    /// moving a vertex is a drag) rather than "add a new vertex here".
+    static let vertexHitTestTolerance: CGFloat = 22
+
+    func makeCoordinator() -> Coordinator {
+      Coordinator(viewModel: viewModel)
+    }
+
+    func makeUIView(context: Context) -> MKMapView {
+      let mapView = MKMapView()
+      mapView.delegate = context.coordinator
+      mapView.pointOfInterestFilter = .excludingAll
+      mapView.setRegion(
+        MKCoordinateRegion(
+          center: CLLocationCoordinate2D(
+            latitude: initialCentre.latitude, longitude: initialCentre.longitude),
+          latitudinalMeters: 1000,
+          longitudinalMeters: 1000
+        ),
+        animated: false
+      )
+
+      let tapRecognizer = UITapGestureRecognizer(
+        target: context.coordinator, action: #selector(Coordinator.handleTap(_:)))
+      mapView.addGestureRecognizer(tapRecognizer)
+
+      context.coordinator.applyVertices(on: mapView, desired: viewModel.boundaryVertices)
+      return mapView
+    }
+
+    func updateUIView(_ mapView: MKMapView, context: Context) {
+      context.coordinator.applyVertices(on: mapView, desired: viewModel.boundaryVertices)
+    }
+  }
+
+  extension BoundaryDrawingMapView {
+    /// `MKMapViewDelegate` + tap-gesture target for ``BoundaryDrawingMapView``.
+    /// Holds no business logic of its own beyond translating a screen tap or
+    /// a pin drag into the corresponding ``WatchZoneEditorViewModel`` call —
+    /// all validation (minimum vertices, self-intersection, UK bounds) stays
+    /// in the domain/ViewModel layer.
+    @MainActor
+    final class Coordinator: NSObject, MKMapViewDelegate {
+      static let vertexReuseIdentifier = "watch-zone-boundary-vertex"
+
+      private let viewModel: WatchZoneEditorViewModel
+
+      /// The shape preview overlay currently on the map (a polygon once at
+      /// least 3 vertices exist, otherwise an open polyline), so it can be
+      /// swapped rather than left to accumulate stale overlays.
+      private var shapeOverlay: MKOverlay?
+
+      init(viewModel: WatchZoneEditorViewModel) {
+        self.viewModel = viewModel
+      }
+
+      // MARK: - Vertex + overlay diffing
+
+      /// Applies only the delta between the displayed vertex pins and
+      /// `desired`, keyed by ordinal position (a vertex's identity is its
+      /// index in the ring, not its coordinate — two vertices may
+      /// legitimately sit close together while drawing), then redraws the
+      /// preview shape overlay.
+      func applyVertices(on mapView: MKMapView, desired: [Coordinate]) {
+        let current = mapView.annotations
+          .compactMap { $0 as? BoundaryVertexAnnotation }
+          .sorted { $0.index < $1.index }
+
+        if current.count > desired.count {
+          mapView.removeAnnotations(Array(current[desired.count...]))
+        }
+
+        for (index, coordinate) in desired.enumerated() {
+          let clCoordinate = CLLocationCoordinate2D(
+            latitude: coordinate.latitude, longitude: coordinate.longitude)
+          if index < current.count {
+            let existing = current[index]
+            if existing.coordinate.latitude != clCoordinate.latitude
+              || existing.coordinate.longitude != clCoordinate.longitude {
+              existing.coordinate = clCoordinate
+            }
+          } else {
+            mapView.addAnnotation(BoundaryVertexAnnotation(index: index, coordinate: clCoordinate))
+          }
+        }
+
+        applyShapeOverlay(on: mapView, desired: desired)
+      }
+
+      private func applyShapeOverlay(on mapView: MKMapView, desired: [Coordinate]) {
+        if let shapeOverlay {
+          mapView.removeOverlay(shapeOverlay)
+          self.shapeOverlay = nil
+        }
+        guard desired.count >= 2 else { return }
+        let points = desired.map {
+          CLLocationCoordinate2D(latitude: $0.latitude, longitude: $0.longitude)
+        }
+        let overlay: MKOverlay =
+          desired.count >= 3
+          ? MKPolygon(coordinates: points, count: points.count)
+          : MKPolyline(coordinates: points, count: points.count)
+        mapView.addOverlay(overlay, level: .aboveRoads)
+        shapeOverlay = overlay
+      }
+
+      // MARK: - Tap gesture (add vertex / close ring)
+
+      @objc func handleTap(_ recognizer: UITapGestureRecognizer) {
+        guard recognizer.state == .ended, let mapView = recognizer.view as? MKMapView else {
+          return
+        }
+        let point = recognizer.location(in: mapView)
+
+        if let hitIndex = nearestVertexIndex(to: point, on: mapView) {
+          if hitIndex == 0, viewModel.boundaryVertices.count >= 3 {
+            viewModel.finishDrawing()
+          }
+          // A tap on any other existing vertex is a no-op here — moving one
+          // is a drag, handled by `mapView(_:annotationView:didChange:...)`.
+          return
+        }
+
+        let tapped = mapView.convert(point, toCoordinateFrom: mapView)
+        guard
+          let coordinate = try? Coordinate(latitude: tapped.latitude, longitude: tapped.longitude)
+        else { return }
+        viewModel.addVertex(coordinate)
+      }
+
+      /// The index of the displayed vertex nearest `point`, if any lies
+      /// within `BoundaryDrawingMapView.vertexHitTestTolerance` screen
+      /// points of it.
+      private func nearestVertexIndex(to point: CGPoint, on mapView: MKMapView) -> Int? {
+        let vertices = mapView.annotations.compactMap { $0 as? BoundaryVertexAnnotation }
+        var closestIndex: Int?
+        var closestDistance = BoundaryDrawingMapView.vertexHitTestTolerance
+        for vertex in vertices {
+          let vertexPoint = mapView.convert(vertex.coordinate, toPointIn: mapView)
+          let distance = hypot(vertexPoint.x - point.x, vertexPoint.y - point.y)
+          if distance <= closestDistance {
+            closestDistance = distance
+            closestIndex = vertex.index
+          }
+        }
+        return closestIndex
+      }
+
+      // MARK: - MKMapViewDelegate
+
+      func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
+        guard let vertex = annotation as? BoundaryVertexAnnotation else { return nil }
+        let view =
+          (mapView.dequeueReusableAnnotationView(withIdentifier: Self.vertexReuseIdentifier)
+            as? MKMarkerAnnotationView)
+          ?? MKMarkerAnnotationView(annotation: vertex, reuseIdentifier: Self.vertexReuseIdentifier)
+        view.annotation = vertex
+        view.canShowCallout = false
+        view.isDraggable = true
+        view.markerTintColor =
+          vertex.index == 0 ? UIColor(Color.tcAmber) : UIColor(Color.tcAmberMuted)
+        view.glyphText = "\(vertex.index + 1)"
+        return view
+      }
+
+      func mapView(
+        _ mapView: MKMapView,
+        annotationView view: MKAnnotationView,
+        didChange newState: MKAnnotationView.DragState,
+        fromOldState oldState: MKAnnotationView.DragState
+      ) {
+        guard newState == .ending || newState == .canceling else { return }
+        defer { view.dragState = .none }
+        guard newState == .ending, let vertex = view.annotation as? BoundaryVertexAnnotation
+        else { return }
+        let moved = vertex.coordinate
+        if let coordinate = try? Coordinate(latitude: moved.latitude, longitude: moved.longitude) {
+          viewModel.moveVertex(at: vertex.index, to: coordinate)
+        }
+      }
+
+      func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
+        if let polygon = overlay as? MKPolygon {
+          let renderer = MKPolygonRenderer(polygon: polygon)
+          renderer.strokeColor = UIColor(Color.tcAmber)
+          renderer.fillColor = UIColor(Color.tcAmber.opacity(0.15))
+          renderer.lineWidth = 2
+          return renderer
+        }
+        if let polyline = overlay as? MKPolyline {
+          let renderer = MKPolylineRenderer(polyline: polyline)
+          renderer.strokeColor = UIColor(Color.tcAmber)
+          renderer.lineWidth = 2
+          return renderer
+        }
+        return MKOverlayRenderer(overlay: overlay)
+      }
+    }
+  }
+
+  /// A reference-type `MKAnnotation` for a single boundary vertex pin,
+  /// carrying its ordinal position in the ring so the coordinator can route
+  /// a drag, or a "tap first vertex to close", back to the right index in
+  /// ``WatchZoneEditorViewModel/boundaryVertices``.
+  final class BoundaryVertexAnnotation: NSObject, MKAnnotation {
+    let index: Int
+    @objc dynamic var coordinate: CLLocationCoordinate2D
+
+    init(index: Int, coordinate: CLLocationCoordinate2D) {
+      self.index = index
+      self.coordinate = coordinate
+    }
+  }
+#endif

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorView.swift
@@ -18,8 +18,13 @@ public struct WatchZoneEditorView: View {
           postcodeSection
         }
         if viewModel.geocodedCoordinate != nil {
-          radiusSection
-          mapPreviewSection
+          shapeModeSection
+          if viewModel.shapeMode == .circle {
+            radiusSection
+            mapPreviewSection
+          } else {
+            boundaryDrawingSection
+          }
         }
         if viewModel.areNotificationTogglesVisible {
           notificationsSection
@@ -53,6 +58,7 @@ public struct WatchZoneEditorView: View {
           .disabled(
             viewModel.geocodedCoordinate == nil || viewModel.isLoading
               || viewModel.nameInput.trimmingCharacters(in: .whitespaces).isEmpty
+              || (viewModel.shapeMode == .custom && !viewModel.canFinishCustomShape)
           )
         }
       }
@@ -141,6 +147,114 @@ public struct WatchZoneEditorView: View {
         }
       }
     }
+  }
+
+  // MARK: - Shape mode (GH#1031)
+
+  /// The Circle/Custom shape control, shown only once a coordinate exists
+  /// (mirrors `radiusSection`/`mapPreviewSection`'s visibility gate). Paid
+  /// tiers get the segmented control; Free tier sees a minimal upsell
+  /// affordance instead (the full onboarding graphic, `CustomShapeUpsellGraphic`,
+  /// is a separate bead — tc-6he3x.10 — this is deliberately a plain-text
+  /// extension point, not that graphic).
+  @ViewBuilder
+  private var shapeModeSection: some View {
+    Section {
+      if viewModel.canDrawCustomShape {
+        Picker(
+          "Shape",
+          selection: Binding(
+            get: { viewModel.shapeMode },
+            set: { viewModel.selectShapeMode($0) }
+          )
+        ) {
+          Text("Circle").tag(WatchZoneShapeMode.circle)
+          Text("Custom").tag(WatchZoneShapeMode.custom)
+        }
+        .pickerStyle(.segmented)
+        .accessibilityLabel("Zone shape")
+      } else {
+        customShapeUpsellPlaceholder
+      }
+    }
+  }
+
+  /// Minimal upsell affordance for Free-tier users — text plus a "View
+  /// Plans" tap-through, not the richer onboarding graphic (tc-6he3x.10).
+  private var customShapeUpsellPlaceholder: some View {
+    Button {
+      viewModel.viewPlans()
+    } label: {
+      HStack(spacing: TCSpacing.small) {
+        Image(systemName: "hexagon.fill")
+          .foregroundStyle(Color.tcAmber)
+          .accessibilityHidden(true)
+        Text("Draw a custom shape on Personal or Pro, instead of just a circle.")
+          .font(TCTypography.caption)
+          .foregroundStyle(Color.tcTextSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+        Spacer(minLength: 0)
+        Image(systemName: "chevron.right")
+          .font(TCTypography.caption)
+          .foregroundStyle(Color.tcTextSecondary)
+          .accessibilityHidden(true)
+      }
+    }
+    .buttonStyle(.plain)
+    .accessibilityLabel("Draw a custom shape on Personal or Pro, instead of just a circle.")
+    .accessibilityHint("Opens subscription plans")
+  }
+
+  @ViewBuilder
+  private var boundaryDrawingSection: some View {
+    if let coordinate = viewModel.geocodedCoordinate {
+      Section {
+        #if canImport(UIKit)
+          BoundaryDrawingMapView(viewModel: viewModel, initialCentre: coordinate)
+            .frame(height: 260)
+            .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.medium))
+            .listRowInsets(
+              EdgeInsets(
+                top: TCSpacing.small,
+                leading: TCSpacing.medium,
+                bottom: TCSpacing.small,
+                trailing: TCSpacing.medium
+              ))
+        #else
+          // BoundaryDrawingMapView wraps UIKit's MKMapView and is
+          // unavailable on this SPM compile-time-only macOS target (the app
+          // ships on iOS; macOS here exists only so `swift build`/`swift
+          // test` can exercise the shared code without Xcode).
+          Text("Custom-shape drawing is available on iOS.")
+            .font(TCTypography.body)
+            .foregroundStyle(Color.tcTextSecondary)
+        #endif
+        HStack {
+          Text(vertexCountLabel)
+            .font(TCTypography.caption)
+            .foregroundStyle(Color.tcTextSecondary)
+          Spacer()
+          Button("Undo") {
+            viewModel.undoLastVertex()
+          }
+          .disabled(viewModel.boundaryVertices.isEmpty)
+        }
+      } header: {
+        Text("Custom Shape")
+      } footer: {
+        Text("Tap the map to add points. Drag a point to move it, and tap the first point again to finish.")
+          .font(TCTypography.caption)
+          .foregroundStyle(Color.tcTextSecondary)
+      }
+    }
+  }
+
+  private var vertexCountLabel: String {
+    let count = viewModel.boundaryVertices.count
+    if count < 3 {
+      return "\(count) of at least 3 points"
+    }
+    return "\(count) points"
   }
 
   private var notificationsSection: some View {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorView.swift
@@ -22,8 +22,10 @@ public struct WatchZoneEditorView: View {
           if viewModel.shapeMode == .circle {
             radiusSection
             mapPreviewSection
-          } else {
+          } else if viewModel.canDrawCustomShape {
             boundaryDrawingSection
+          } else {
+            lockedCustomShapeSection
           }
         }
         if viewModel.areNotificationTogglesVisible {
@@ -156,11 +158,14 @@ public struct WatchZoneEditorView: View {
   /// tiers get the segmented control; Free tier sees a minimal upsell
   /// affordance instead (the full onboarding graphic, `CustomShapeUpsellGraphic`,
   /// is a separate bead — tc-6he3x.10 — this is deliberately a plain-text
-  /// extension point, not that graphic).
+  /// extension point, not that graphic). Free tier editing an existing
+  /// locked custom shape (``WatchZoneEditorViewModel/isCustomShapeLocked``)
+  /// gets nothing here — ``lockedCustomShapeSection`` below is the sole,
+  /// non-duplicated explanation for that state.
   @ViewBuilder
   private var shapeModeSection: some View {
-    Section {
-      if viewModel.canDrawCustomShape {
+    if viewModel.canDrawCustomShape {
+      Section {
         Picker(
           "Shape",
           selection: Binding(
@@ -173,14 +178,17 @@ public struct WatchZoneEditorView: View {
         }
         .pickerStyle(.segmented)
         .accessibilityLabel("Zone shape")
-      } else {
+      }
+    } else if !viewModel.isCustomShapeLocked {
+      Section {
         customShapeUpsellPlaceholder
       }
     }
   }
 
-  /// Minimal upsell affordance for Free-tier users — text plus a "View
-  /// Plans" tap-through, not the richer onboarding graphic (tc-6he3x.10).
+  /// Minimal upsell affordance for a Free-tier user who hasn't drawn a
+  /// custom shape yet — text plus a "View Plans" tap-through, not the
+  /// richer onboarding graphic (tc-6he3x.10).
   private var customShapeUpsellPlaceholder: some View {
     Button {
       viewModel.viewPlans()
@@ -255,6 +263,39 @@ public struct WatchZoneEditorView: View {
       return "\(count) of at least 3 points"
     }
     return "\(count) points"
+  }
+
+  /// Shown instead of ``boundaryDrawingSection`` when editing an existing
+  /// custom-shape zone on a tier that can no longer draw one
+  /// (``WatchZoneEditorViewModel/isCustomShapeLocked``) — a static preview
+  /// with no drawing affordance, so a downgraded Free-tier user has no path
+  /// to the vertex editor while the zone's shape stays untouched.
+  @ViewBuilder
+  private var lockedCustomShapeSection: some View {
+    if let coordinate = viewModel.geocodedCoordinate {
+      Section {
+        ZoneMapPreview(
+          centre: coordinate,
+          radiusMetres: viewModel.selectedRadiusMetres,
+          strokeWidth: 2
+        )
+        .frame(height: 220)
+        .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.medium))
+        .listRowInsets(
+          EdgeInsets(
+            top: TCSpacing.small,
+            leading: TCSpacing.medium,
+            bottom: TCSpacing.small,
+            trailing: TCSpacing.medium
+          ))
+      } header: {
+        Text("Custom Shape")
+      } footer: {
+        Text("This zone's custom shape is locked. Upgrade to Personal or Pro to edit it.")
+          .font(TCTypography.caption)
+          .foregroundStyle(Color.tcTextSecondary)
+      }
+    }
   }
 
   private var notificationsSection: some View {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorViewModel.swift
@@ -162,6 +162,17 @@ public final class WatchZoneEditorViewModel: ObservableObject, EntitlementGating
     boundaryVertices.count >= Self.minimumBoundaryVertexCount
   }
 
+  /// True when editing an existing custom-shape zone on a tier that can no
+  /// longer draw one (a Free-tier user who downgraded after saving a
+  /// polygon zone — GH#1031's paused-zone posture keeps the zone editable,
+  /// never silently converted). ``shapeMode`` is `.custom` here because it
+  /// reflects the zone's actual stored shape, not the tier's entitlement —
+  /// see the `editing:` initializer — so the View must check this
+  /// separately to keep the drawing UI out of a Free tier's reach.
+  public var isCustomShapeLocked: Bool {
+    shapeMode == .custom && !canDrawCustomShape
+  }
+
   /// Switches between Circle and Custom. A request to switch to `.custom`
   /// on a tier that doesn't allow it (``canDrawCustomShape`` is `false`) is
   /// silently ignored — defense in depth behind the View only offering the

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorViewModel.swift
@@ -2,6 +2,15 @@ import Combine
 import Foundation
 import TownCrierDomain
 
+/// Whether a watch zone is drawn as a circle (radius-based, the default) or a
+/// custom polygon shape (GH#1031). Free tier is locked to `.circle`;
+/// Personal/Pro may switch to `.custom` — see
+/// ``WatchZoneEditorViewModel/canDrawCustomShape``.
+public enum WatchZoneShapeMode: Hashable, Sendable {
+  case circle
+  case custom
+}
+
 /// Drives create/edit of a single watch zone with postcode geocoding and tier-based radius limits.
 @MainActor
 public final class WatchZoneEditorViewModel: ObservableObject, EntitlementGatingViewModel {
@@ -13,6 +22,23 @@ public final class WatchZoneEditorViewModel: ObservableObject, EntitlementGating
   @Published public private(set) var geocodedCoordinate: Coordinate?
   @Published public private(set) var isLoading = false
   @Published public internal(set) var error: DomainError?
+
+  /// Circle (radius-based) vs. custom polygon shape (GH#1031). Defaults to
+  /// `.circle`; populated from the edited zone's `boundary` when present.
+  @Published public private(set) var shapeMode: WatchZoneShapeMode = .circle
+
+  /// The custom-shape ring being drawn, as an OPEN sequence of vertices in
+  /// drop order — NOT closed (the first vertex is not repeated at the end).
+  /// ``BoundaryDrawingMapView`` renders these as pins plus a preview
+  /// polygon/polyline; ``save()`` closes and validates the ring via
+  /// `WatchZoneBoundary.init` when ``shapeMode`` is `.custom`.
+  @Published public private(set) var boundaryVertices: [Coordinate] = []
+
+  /// Mirrors `WatchZoneBoundary`'s geometric minimum (3 distinct vertices
+  /// are required to form a polygon) so the UI can gate "finish drawing"
+  /// without constructing (and discarding) a throwaway boundary just to
+  /// check the count.
+  private static let minimumBoundaryVertexCount = 3
 
   /// Drives the in-editor subscription upsell sheet. Non-nil while the gate is
   /// presented for the given entitlement; cleared when the sheet dismisses.
@@ -52,6 +78,12 @@ public final class WatchZoneEditorViewModel: ObservableObject, EntitlementGating
       self.geocodedCoordinate = zone.centre
       self.pushEnabled = zone.pushEnabled
       self.emailInstantEnabled = zone.emailInstantEnabled
+      if let boundary = zone.boundary {
+        self.shapeMode = .custom
+        // The ring is closed (last vertex repeats the first); the editor
+        // works with the open sequence and re-closes on save.
+        self.boundaryVertices = Array(boundary.vertices.dropLast())
+      }
     }
   }
 
@@ -113,6 +145,73 @@ public final class WatchZoneEditorViewModel: ObservableObject, EntitlementGating
     selectedRadiusMetres >= LargeRadiusWarning.thresholdMetres
   }
 
+  // MARK: - Shape mode (GH#1031)
+
+  /// Whether the current tier may draw a custom-shape zone at all — gates
+  /// showing the Circle/Custom segmented control in the View. Free tier is
+  /// always `false`; Personal/Pro are `true`. Mirrors the server's
+  /// `SubscriptionTier.AllowsCustomBoundary()` via `WatchZoneLimits`.
+  public var canDrawCustomShape: Bool {
+    limits.allowsCustomBoundary
+  }
+
+  /// Whether ``boundaryVertices`` currently has enough points to form a
+  /// valid polygon (the domain layer's geometric minimum of 3). Drives the
+  /// Save button's enabled state while ``shapeMode`` is `.custom`.
+  public var canFinishCustomShape: Bool {
+    boundaryVertices.count >= Self.minimumBoundaryVertexCount
+  }
+
+  /// Switches between Circle and Custom. A request to switch to `.custom`
+  /// on a tier that doesn't allow it (``canDrawCustomShape`` is `false`) is
+  /// silently ignored — defense in depth behind the View only offering the
+  /// control on paid tiers.
+  public func selectShapeMode(_ mode: WatchZoneShapeMode) {
+    guard mode != .custom || canDrawCustomShape else { return }
+    shapeMode = mode
+  }
+
+  /// Appends a new vertex at the end of the ring being drawn.
+  public func addVertex(_ coordinate: Coordinate) {
+    boundaryVertices.append(coordinate)
+  }
+
+  /// Moves the vertex at `index` to `coordinate` (e.g. after a drag). A
+  /// stale or out-of-range index is a no-op rather than a crash.
+  public func moveVertex(at index: Int, to coordinate: Coordinate) {
+    guard boundaryVertices.indices.contains(index) else { return }
+    boundaryVertices[index] = coordinate
+  }
+
+  /// Removes the vertex at `index`. A stale or out-of-range index is a
+  /// no-op rather than a crash.
+  public func removeVertex(at index: Int) {
+    guard boundaryVertices.indices.contains(index) else { return }
+    boundaryVertices.remove(at: index)
+  }
+
+  /// Removes the most recently added vertex. A no-op on an empty ring.
+  public func undoLastVertex() {
+    guard !boundaryVertices.isEmpty else { return }
+    boundaryVertices.removeLast()
+  }
+
+  /// Validates the current vertices as a closed ring without saving —
+  /// invoked when the user taps the first vertex to close the shape while
+  /// drawing (``BoundaryDrawingMapView``). Surfaces problems (self-
+  /// intersection, an out-of-UK vertex, a duplicate point) immediately via
+  /// ``error`` rather than waiting for Save; below the minimum vertex count
+  /// this is a silent no-op since there's nothing yet to validate.
+  public func finishDrawing() {
+    guard canFinishCustomShape else { return }
+    do {
+      _ = try WatchZoneBoundary(vertices: boundaryVertices)
+      error = nil
+    } catch {
+      handleError(error)
+    }
+  }
+
   public func submitPostcode() async {
     isLoading = true
     error = nil
@@ -141,25 +240,55 @@ public final class WatchZoneEditorViewModel: ObservableObject, EntitlementGating
   /// Persists the zone. Returns `true` on success so the View dismisses only
   /// when the save actually succeeded.
   ///
+  /// In `.circle` mode, behaves exactly as before: the geocoded coordinate
+  /// and (clamped) radius drive a circular zone with no boundary. In
+  /// `.custom` mode, ``boundaryVertices`` is closed and validated into a
+  /// `WatchZoneBoundary`, and the zone's `centre`/`radiusMetres` are derived
+  /// from the boundary's centroid/enclosing radius (per `WatchZone.boundary`'s
+  /// doc comment) so every existing circle-shaped read path keeps working.
+  ///
   /// On a quota breach (`DomainError.insufficientEntitlement`) the editor routes
   /// to the subscription paywall via `onUpgradeRequired` and leaves `error`
-  /// unset — the coordinator closes the sheet. All other failures set `error`
-  /// so the inline error section is shown and the editor stays open.
+  /// unset — the coordinator closes the sheet. All other failures (including an
+  /// invalid custom shape) set `error` so the inline error section is shown and
+  /// the editor stays open.
   @discardableResult
   public func save() async -> Bool {
-    guard let coordinate = geocodedCoordinate else { return false }
     error = nil
 
-    let clampedRadius = limits.clampRadius(selectedRadiusMetres)
+    let boundary: WatchZoneBoundary?
+    let centre: Coordinate
+    let radius: Double
+
+    switch shapeMode {
+    case .circle:
+      guard let coordinate = geocodedCoordinate else { return false }
+      boundary = nil
+      centre = coordinate
+      radius = limits.clampRadius(selectedRadiusMetres)
+    case .custom:
+      guard canFinishCustomShape else { return false }
+      do {
+        let builtBoundary = try WatchZoneBoundary(vertices: boundaryVertices)
+        let centroid = builtBoundary.centroid
+        centre = try Coordinate(latitude: centroid.latitude, longitude: centroid.longitude)
+        radius = builtBoundary.enclosingRadiusMetres
+        boundary = builtBoundary
+      } catch {
+        handleError(error)
+        return false
+      }
+    }
 
     do {
       let zone = try WatchZone(
         id: existingId ?? WatchZoneId(),
         name: nameInput,
-        centre: coordinate,
-        radiusMetres: clampedRadius,
+        centre: centre,
+        radiusMetres: radius,
         pushEnabled: pushEnabled,
-        emailInstantEnabled: emailInstantEnabled
+        emailInstantEnabled: emailInstantEnabled,
+        boundary: boundary
       )
       if isEditing {
         try await repository.update(zone)

--- a/mobile/ios/town-crier-tests/Sources/Features/WatchZoneEditorViewModelShapeModeTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WatchZoneEditorViewModelShapeModeTests.swift
@@ -1,0 +1,350 @@
+import Foundation
+import Testing
+
+@testable import TownCrierDomain
+@testable import TownCrierPresentation
+
+/// Circle/Custom shape mode, vertex editing, and the custom-shape entitlement
+/// gate on `WatchZoneEditorViewModel` (GH#1031, bead tc-6he3x.8).
+@MainActor
+@Suite("WatchZoneEditorViewModel — shape mode")
+struct WatchZoneEditorViewModelShapeModeTests {
+  private var spyGeocoder: SpyPostcodeGeocoder!
+  private var spyRepository: SpyWatchZoneRepository!
+
+  init() {
+    spyGeocoder = SpyPostcodeGeocoder()
+    spyRepository = SpyWatchZoneRepository()
+  }
+
+  private func makeSUT(
+    tier: SubscriptionTier = .personal,
+    editing zone: WatchZone? = nil
+  ) -> WatchZoneEditorViewModel {
+    WatchZoneEditorViewModel(
+      geocoder: spyGeocoder,
+      repository: spyRepository,
+      tier: tier,
+      editing: zone
+    )
+  }
+
+  /// A valid, UK-bounded triangle — mirrors the fixture used by
+  /// `WatchZoneBoundaryTests`.
+  private func triangle() throws -> [Coordinate] {
+    try [
+      Coordinate(latitude: 51.50, longitude: -0.10),
+      Coordinate(latitude: 51.51, longitude: -0.09),
+      Coordinate(latitude: 51.50, longitude: -0.09),
+    ]
+  }
+
+  /// Four taps where the second vertex is accidentally re-tapped as the
+  /// fourth — a non-adjacent duplicate distinct from the vertex-count case
+  /// (`WatchZoneBoundaryTests.init_fewerThanThreeVertices_throws` covers
+  /// that one). Once auto-closed this hits `WatchZoneBoundary`'s duplicate
+  /// check (position 1 vs. position 3), not its vertex-count check.
+  private func ringWithNonAdjacentDuplicate() throws -> [Coordinate] {
+    let repeated = try Coordinate(latitude: 51.51, longitude: -0.09)
+    return try [
+      Coordinate(latitude: 51.50, longitude: -0.10),
+      repeated,
+      Coordinate(latitude: 51.52, longitude: -0.08),
+      repeated,
+    ]
+  }
+
+  // MARK: - Initial state
+
+  @Test func initialState_shapeModeIsCircle() {
+    let sut = makeSUT()
+    #expect(sut.shapeMode == .circle)
+  }
+
+  @Test func initialState_boundaryVerticesIsEmpty() {
+    let sut = makeSUT()
+    #expect(sut.boundaryVertices.isEmpty)
+  }
+
+  @Test func initialState_editingCustomShapeZone_populatesShapeModeAndVertices() throws {
+    let boundary = try WatchZoneBoundary(vertices: triangle())
+    let zone = try WatchZone(
+      id: WatchZoneId("zone-custom"),
+      name: "Custom Area",
+      centre: Coordinate(latitude: 51.5033, longitude: -0.0933),
+      radiusMetres: 500,
+      boundary: boundary
+    )
+
+    let sut = makeSUT(editing: zone)
+
+    #expect(sut.shapeMode == .custom)
+    // The open sequence — the closing repeat of the first vertex is dropped.
+    #expect(sut.boundaryVertices == Array(boundary.vertices.dropLast()))
+  }
+
+  @Test func initialState_editingCircleZone_staysCircleWithNoVertices() {
+    let sut = makeSUT(editing: .cambridge)
+
+    #expect(sut.shapeMode == .circle)
+    #expect(sut.boundaryVertices.isEmpty)
+  }
+
+  // MARK: - canDrawCustomShape (tier gating)
+
+  @Test func canDrawCustomShape_falseOnFreeTier() {
+    #expect(!makeSUT(tier: .free).canDrawCustomShape)
+  }
+
+  @Test func canDrawCustomShape_trueOnPersonalTier() {
+    #expect(makeSUT(tier: .personal).canDrawCustomShape)
+  }
+
+  @Test func canDrawCustomShape_trueOnProTier() {
+    #expect(makeSUT(tier: .pro).canDrawCustomShape)
+  }
+
+  // MARK: - selectShapeMode
+
+  @Test func selectShapeMode_custom_allowedOnPersonalTier() {
+    let sut = makeSUT(tier: .personal)
+
+    sut.selectShapeMode(.custom)
+
+    #expect(sut.shapeMode == .custom)
+  }
+
+  @Test func selectShapeMode_custom_allowedOnProTier() {
+    let sut = makeSUT(tier: .pro)
+
+    sut.selectShapeMode(.custom)
+
+    #expect(sut.shapeMode == .custom)
+  }
+
+  @Test func selectShapeMode_custom_ignoredOnFreeTier() {
+    let sut = makeSUT(tier: .free)
+
+    sut.selectShapeMode(.custom)
+
+    #expect(sut.shapeMode == .circle)
+  }
+
+  @Test func selectShapeMode_backToCircle_alwaysAllowed() {
+    let sut = makeSUT(tier: .personal)
+    sut.selectShapeMode(.custom)
+
+    sut.selectShapeMode(.circle)
+
+    #expect(sut.shapeMode == .circle)
+  }
+
+  // MARK: - Vertex operations
+
+  @Test func addVertex_appendsCoordinate() throws {
+    let sut = makeSUT()
+    let coordinate = try Coordinate(latitude: 51.50, longitude: -0.10)
+
+    sut.addVertex(coordinate)
+
+    #expect(sut.boundaryVertices == [coordinate])
+  }
+
+  @Test func addVertex_multipleAppendsInOrder() throws {
+    let sut = makeSUT()
+    let vertices = try triangle()
+
+    for vertex in vertices {
+      sut.addVertex(vertex)
+    }
+
+    #expect(sut.boundaryVertices == vertices)
+  }
+
+  @Test func moveVertex_updatesCoordinateAtIndex() throws {
+    let sut = makeSUT()
+    let vertices = try triangle()
+    for vertex in vertices { sut.addVertex(vertex) }
+    let moved = try Coordinate(latitude: 51.52, longitude: -0.08)
+
+    sut.moveVertex(at: 1, to: moved)
+
+    #expect(sut.boundaryVertices[1] == moved)
+    #expect(sut.boundaryVertices.count == 3)
+  }
+
+  @Test func moveVertex_outOfRangeIndex_isNoOp() throws {
+    let sut = makeSUT()
+    let vertices = try triangle()
+    for vertex in vertices { sut.addVertex(vertex) }
+    let moved = try Coordinate(latitude: 51.52, longitude: -0.08)
+
+    sut.moveVertex(at: 99, to: moved)
+
+    #expect(sut.boundaryVertices == vertices)
+  }
+
+  @Test func removeVertex_removesAtIndex() throws {
+    let sut = makeSUT()
+    let vertices = try triangle()
+    for vertex in vertices { sut.addVertex(vertex) }
+
+    sut.removeVertex(at: 1)
+
+    #expect(sut.boundaryVertices == [vertices[0], vertices[2]])
+  }
+
+  @Test func removeVertex_outOfRangeIndex_isNoOp() throws {
+    let sut = makeSUT()
+    let vertices = try triangle()
+    for vertex in vertices { sut.addVertex(vertex) }
+
+    sut.removeVertex(at: 99)
+
+    #expect(sut.boundaryVertices == vertices)
+  }
+
+  @Test func undoLastVertex_removesLast() throws {
+    let sut = makeSUT()
+    let vertices = try triangle()
+    for vertex in vertices { sut.addVertex(vertex) }
+
+    sut.undoLastVertex()
+
+    #expect(sut.boundaryVertices == [vertices[0], vertices[1]])
+  }
+
+  @Test func undoLastVertex_onEmpty_isNoOp() {
+    let sut = makeSUT()
+
+    sut.undoLastVertex()
+
+    #expect(sut.boundaryVertices.isEmpty)
+  }
+
+  // MARK: - canFinishCustomShape (minimum vertex guard)
+
+  @Test func canFinishCustomShape_falseWithZeroVertices() {
+    #expect(!makeSUT().canFinishCustomShape)
+  }
+
+  @Test func canFinishCustomShape_falseWithTwoVertices() throws {
+    let sut = makeSUT()
+    sut.addVertex(try Coordinate(latitude: 51.50, longitude: -0.10))
+    sut.addVertex(try Coordinate(latitude: 51.51, longitude: -0.09))
+
+    #expect(!sut.canFinishCustomShape)
+  }
+
+  @Test func canFinishCustomShape_trueAtThreeVertices() throws {
+    let sut = makeSUT()
+    for vertex in try triangle() { sut.addVertex(vertex) }
+
+    #expect(sut.canFinishCustomShape)
+  }
+
+  // MARK: - finishDrawing
+
+  @Test func finishDrawing_belowMinimum_doesNothing() throws {
+    let sut = makeSUT()
+    sut.addVertex(try Coordinate(latitude: 51.50, longitude: -0.10))
+
+    sut.finishDrawing()
+
+    #expect(sut.error == nil)
+  }
+
+  @Test func finishDrawing_validRing_leavesErrorNil() throws {
+    let sut = makeSUT()
+    for vertex in try triangle() { sut.addVertex(vertex) }
+
+    sut.finishDrawing()
+
+    #expect(sut.error == nil)
+  }
+
+  @Test func finishDrawing_duplicateVertex_setsError() throws {
+    let sut = makeSUT()
+    for vertex in try ringWithNonAdjacentDuplicate() { sut.addVertex(vertex) }
+
+    sut.finishDrawing()
+
+    #expect(sut.error == .invalidWatchZoneBoundaryDuplicateVertex)
+  }
+
+  // MARK: - save() in custom mode
+
+  private func geocode(_ sut: WatchZoneEditorViewModel) async {
+    sut.postcodeInput = "CB1 2AD"
+    spyGeocoder.geocodeResult = .success(.cambridge)
+    await sut.submitPostcode()
+  }
+
+  @Test func save_customMode_belowMinimumVertices_returnsFalseWithoutCallingRepository() async throws {
+    let sut = makeSUT()
+    await geocode(sut)
+    sut.selectShapeMode(.custom)
+    sut.addVertex(try Coordinate(latitude: 51.50, longitude: -0.10))
+
+    let didSave = await sut.save()
+
+    #expect(!didSave)
+    #expect(spyRepository.saveCalls.isEmpty)
+  }
+
+  @Test func save_customMode_buildsBoundaryAndSaves() async throws {
+    let sut = makeSUT()
+    await geocode(sut)
+    sut.selectShapeMode(.custom)
+    for vertex in try triangle() { sut.addVertex(vertex) }
+
+    let didSave = await sut.save()
+
+    #expect(didSave)
+    let saved = try #require(spyRepository.saveCalls.first)
+    #expect(saved.isCustomShape)
+    #expect(saved.boundary?.vertices.dropLast().elementsEqual(try triangle()) == true)
+  }
+
+  @Test func save_customMode_derivesCentreAndRadiusFromBoundary() async throws {
+    let sut = makeSUT()
+    await geocode(sut)
+    sut.selectShapeMode(.custom)
+    let vertices = try triangle()
+    for vertex in vertices { sut.addVertex(vertex) }
+    let expectedBoundary = try WatchZoneBoundary(vertices: vertices)
+
+    _ = await sut.save()
+
+    let saved = try #require(spyRepository.saveCalls.first)
+    let expectedCentroid = expectedBoundary.centroid
+    #expect(saved.centre.latitude == expectedCentroid.latitude)
+    #expect(saved.centre.longitude == expectedCentroid.longitude)
+    #expect(saved.radiusMetres == expectedBoundary.enclosingRadiusMetres)
+  }
+
+  @Test func save_customMode_invalidRing_setsErrorAndDoesNotCallRepository() async throws {
+    let sut = makeSUT()
+    await geocode(sut)
+    sut.selectShapeMode(.custom)
+    for vertex in try ringWithNonAdjacentDuplicate() { sut.addVertex(vertex) }
+
+    let didSave = await sut.save()
+
+    #expect(!didSave)
+    #expect(sut.error == .invalidWatchZoneBoundaryDuplicateVertex)
+    #expect(spyRepository.saveCalls.isEmpty)
+  }
+
+  @Test func save_circleMode_stillOmitsBoundary() async {
+    let sut = makeSUT()
+    await geocode(sut)
+
+    let didSave = await sut.save()
+
+    #expect(didSave)
+    let saved = spyRepository.saveCalls.first
+    #expect(saved?.boundary == nil)
+    #expect(saved?.isCustomShape == false)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/WatchZoneEditorViewModelShapeModeTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WatchZoneEditorViewModelShapeModeTests.swift
@@ -104,6 +104,52 @@ struct WatchZoneEditorViewModelShapeModeTests {
     #expect(makeSUT(tier: .pro).canDrawCustomShape)
   }
 
+  // MARK: - isCustomShapeLocked (downgraded Free tier holding a custom-shape zone)
+
+  @Test func isCustomShapeLocked_falseByDefault() {
+    #expect(!makeSUT().isCustomShapeLocked)
+  }
+
+  @Test func isCustomShapeLocked_falseOnPersonalTier_editingCustomShapeZone() throws {
+    let boundary = try WatchZoneBoundary(vertices: triangle())
+    let zone = try WatchZone(
+      id: WatchZoneId("zone-custom"),
+      name: "Custom Area",
+      centre: Coordinate(latitude: 51.5033, longitude: -0.0933),
+      radiusMetres: 500,
+      boundary: boundary
+    )
+
+    let sut = makeSUT(tier: .personal, editing: zone)
+
+    #expect(!sut.isCustomShapeLocked)
+  }
+
+  @Test func isCustomShapeLocked_trueOnFreeTier_editingCustomShapeZone() throws {
+    let boundary = try WatchZoneBoundary(vertices: triangle())
+    let zone = try WatchZone(
+      id: WatchZoneId("zone-custom"),
+      name: "Custom Area",
+      centre: Coordinate(latitude: 51.5033, longitude: -0.0933),
+      radiusMetres: 500,
+      boundary: boundary
+    )
+
+    // A downgraded Free-tier user reopening the editor for a polygon zone
+    // they drew before downgrading (GH#1031's paused-zone posture: the zone
+    // stays listed and editable, never silently converted).
+    let sut = makeSUT(tier: .free, editing: zone)
+
+    #expect(sut.shapeMode == .custom)
+    #expect(sut.isCustomShapeLocked)
+  }
+
+  @Test func isCustomShapeLocked_falseOnFreeTier_editingCircleZone() {
+    let sut = makeSUT(tier: .free, editing: .cambridge)
+
+    #expect(!sut.isCustomShapeLocked)
+  }
+
   // MARK: - selectShapeMode
 
   @Test func selectShapeMode_custom_allowedOnPersonalTier() {

--- a/mobile/ios/town-crier-tests/Sources/Features/WatchZoneEditorViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WatchZoneEditorViewTests.swift
@@ -160,4 +160,82 @@ struct WatchZoneEditorViewTests {
     let sut = WatchZoneEditorView(viewModel: vm)
     _ = sut.body
   }
+
+  // MARK: - Circle/Custom shape mode (GH#1031, tc-6he3x.8)
+
+  /// A paid tier with a geocoded coordinate must render the segmented
+  /// Circle/Custom control without crashing.
+  @Test func body_renders_personalTier_inCircleMode() {
+    let vm = makeViewModel(tier: .personal, editing: .cambridge)
+    #expect(vm.shapeMode == .circle)
+    let sut = WatchZoneEditorView(viewModel: vm)
+    _ = sut.body
+  }
+
+  /// Switching to Custom swaps the radius slider/map preview for the
+  /// boundary-drawing map; the View must still render.
+  @Test func body_renders_personalTier_inCustomMode() {
+    let vm = makeViewModel(tier: .personal, editing: .cambridge)
+    vm.selectShapeMode(.custom)
+    #expect(vm.shapeMode == .custom)
+    let sut = WatchZoneEditorView(viewModel: vm)
+    _ = sut.body
+  }
+
+  @Test func body_renders_proTier_inCustomMode() {
+    let vm = makeViewModel(tier: .pro, editing: .cambridge)
+    vm.selectShapeMode(.custom)
+    let sut = WatchZoneEditorView(viewModel: vm)
+    _ = sut.body
+  }
+
+  /// Free tier never offers the segmented control — it must render the
+  /// upsell placeholder instead, without crashing.
+  @Test func body_renders_freeTier_showsUpsellPlaceholderInsteadOfShapeToggle() {
+    let vm = makeViewModel(tier: .free, editing: .cambridge)
+    #expect(!vm.canDrawCustomShape)
+    let sut = WatchZoneEditorView(viewModel: vm)
+    _ = sut.body
+  }
+
+  /// A free-tier attempt to select Custom is ignored by the ViewModel, so
+  /// the View stays on the circle layout.
+  @Test func selectShapeMode_custom_onFreeTier_staysCircle() {
+    let vm = makeViewModel(tier: .free, editing: .cambridge)
+
+    vm.selectShapeMode(.custom)
+
+    #expect(vm.shapeMode == .circle)
+  }
+
+  /// Editing an existing custom-shape zone must open the editor already in
+  /// Custom mode with its vertices populated, and render.
+  @Test func body_renders_editingCustomShapeZone() throws {
+    let boundary = try WatchZoneBoundary(vertices: [
+      Coordinate(latitude: 51.50, longitude: -0.10),
+      Coordinate(latitude: 51.51, longitude: -0.09),
+      Coordinate(latitude: 51.50, longitude: -0.09),
+    ])
+    let zone = try WatchZone(
+      id: WatchZoneId("zone-custom"),
+      name: "Custom Area",
+      centre: Coordinate(latitude: 51.5033, longitude: -0.0933),
+      radiusMetres: 500,
+      boundary: boundary
+    )
+    let vm = makeViewModel(tier: .personal, editing: zone)
+    #expect(vm.shapeMode == .custom)
+    #expect(vm.boundaryVertices.count == 3)
+
+    let sut = WatchZoneEditorView(viewModel: vm)
+    _ = sut.body
+  }
+
+  /// Save stays disabled in Custom mode until the minimum vertex count is met.
+  @Test func saveDisabledCondition_customMode_belowMinimumVertices() {
+    let vm = makeViewModel(tier: .personal, editing: .cambridge)
+    vm.selectShapeMode(.custom)
+
+    #expect(!vm.canFinishCustomShape)
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/WatchZoneEditorViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WatchZoneEditorViewTests.swift
@@ -238,4 +238,57 @@ struct WatchZoneEditorViewTests {
 
     #expect(!vm.canFinishCustomShape)
   }
+
+  // MARK: - Locked custom shape (downgraded Free tier, GH#1031)
+
+  /// A Free-tier user reopening the editor for a polygon zone they drew
+  /// before downgrading (GH#1031's paused-zone posture: stays listed and
+  /// editable, never silently converted) must render without crashing, and
+  /// — the entitlement gap this covers — must not reach the boundary-
+  /// drawing UI: `shapeMode` is `.custom` (it reflects the zone's actual
+  /// stored shape) but `canDrawCustomShape` is `false`, so the View takes
+  /// the locked branch, not `boundaryDrawingSection`.
+  @Test func body_renders_freeTier_editingCustomShapeZone_locked() throws {
+    let boundary = try WatchZoneBoundary(vertices: [
+      Coordinate(latitude: 51.50, longitude: -0.10),
+      Coordinate(latitude: 51.51, longitude: -0.09),
+      Coordinate(latitude: 51.50, longitude: -0.09),
+    ])
+    let zone = try WatchZone(
+      id: WatchZoneId("zone-custom-downgraded"),
+      name: "Custom Area",
+      centre: Coordinate(latitude: 51.5033, longitude: -0.0933),
+      radiusMetres: 500,
+      boundary: boundary
+    )
+    let vm = makeViewModel(tier: .free, editing: zone)
+    #expect(vm.shapeMode == .custom)
+    #expect(!vm.canDrawCustomShape)
+    #expect(vm.isCustomShapeLocked)
+
+    let sut = WatchZoneEditorView(viewModel: vm)
+    _ = sut.body
+  }
+
+  /// Save must stay reachable for a locked custom-shape zone (renaming or
+  /// toggling notifications on a paused zone is still allowed — only the
+  /// shape itself is locked) since `boundaryVertices` is untouched and
+  /// already meets the minimum.
+  @Test func saveDisabledCondition_lockedCustomShape_notBlockedByVertexCount() throws {
+    let boundary = try WatchZoneBoundary(vertices: [
+      Coordinate(latitude: 51.50, longitude: -0.10),
+      Coordinate(latitude: 51.51, longitude: -0.09),
+      Coordinate(latitude: 51.50, longitude: -0.09),
+    ])
+    let zone = try WatchZone(
+      id: WatchZoneId("zone-custom-downgraded"),
+      name: "Custom Area",
+      centre: Coordinate(latitude: 51.5033, longitude: -0.0933),
+      radiusMetres: 500,
+      boundary: boundary
+    )
+    let vm = makeViewModel(tier: .free, editing: zone)
+
+    #expect(vm.canFinishCustomShape)
+  }
 }


### PR DESCRIPTION
## Summary

Adds the iOS presentation-layer pieces for switching a watch zone between a circle and a hand-drawn custom shape — section 7 of [GH#1031](https://github.com/AmyDe/town-crier/issues/1031), bead `tc-6he3x.8`. Builds on the domain + repository layer merged in `tc-6he3x.7` (#1048).

- `WatchZoneEditorViewModel`: `shapeMode` (`.circle`/`.custom`), `boundaryVertices` (open ring), add/move/remove/undo vertex operations, `canDrawCustomShape` (gated by `WatchZoneLimits.allowsCustomBoundary`), `canFinishCustomShape` (3-vertex minimum), `finishDrawing()` (eager ring validation while drawing), and a `save()` that derives `centre`/`radiusMetres` from the boundary's centroid/enclosing radius in custom mode.
- `BoundaryDrawingMapView`: new `UIViewRepresentable` over `MKMapView` (UIKit-only, mirrors `ClusteredMapView`'s structure and its `@ObservedObject`/`updateUIView` trap) — tap to add a vertex, drag a pin to move it, tap the first vertex to close/validate the ring.
- `WatchZoneEditorView`: Circle/Custom segmented control shown for paid tiers; a minimal text upsell placeholder for Free tier (the richer onboarding graphic, `CustomShapeUpsellGraphic`, already shipped separately via `tc-6he3x.9` and is wired up by the onboarding bead `tc-6he3x.10`, which depends on this one).

Out of scope for this PR (per the issue's section split): onboarding (`tc-6he3x.10`), the Go API, web, and Android.

## Test plan

- [x] New Swift Testing suite `WatchZoneEditorViewModelShapeModeTests.swift`: shape-mode switching and tier gating, vertex add/move/undo (incl. out-of-range no-ops), minimum-vertex guard, ring validation (vertex-count vs. non-adjacent-duplicate cases), `save()` in both circle and custom modes, populating from an existing custom-shape zone.
- [x] `WatchZoneEditorViewTests.swift`: new body-render/gating smoke tests for the shape-mode section.
- [ ] **Visual verification is outstanding.** This sandbox has no Swift toolchain (no `swift`/`swiftc`, no working Docker, and `swift.org` is proxy-blocked), so `swift build`, `swift test`, and `swiftlint lint --strict` could not be run locally — the diff was hand-audited line-by-line against the merged `tc-6he3x.7` domain API and existing sibling patterns (`ClusteredMapView`, design tokens) instead. **CI's `pr-gate` (iOS Build & test, SwiftLint) is the first real compile of this code — please don't merge until it's green.** Simulator screenshots for the new Circle/Custom toggle and boundary-drawing map were not taken.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01CUcVF3NjmRmmHrpCu1dC15

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUcVF3NjmRmmHrpCu1dC15)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added custom watch-zone boundaries drawn directly on the map.
  * Added Circle and Custom shape modes for watch zones.
  * Added draggable vertices, undo controls, boundary validation, and completion guidance.
  * Existing custom boundaries are restored when editing.
  * Added plan-based access controls and upgrade messaging for custom shapes.

* **Bug Fixes**
  * Prevented saving custom watch zones until a valid boundary with at least three vertices is completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->