### PR TITLE
web: boundary drawing hook, BoundaryMap, ShapeModeToggle wired into create/edit (tc-6he3x.12)

### DIFF
--- a/web/src/features/WatchZones/BoundaryMap.module.css
+++ b/web/src/features/WatchZones/BoundaryMap.module.css
@@ -4,3 +4,30 @@
   height: 320px;
   margin-bottom: var(--tc-space-md);
 }
+
+.controls {
+  display: flex;
+  gap: var(--tc-space-sm);
+  margin-bottom: var(--tc-space-sm);
+}
+
+.controlButton {
+  padding: var(--tc-space-xs) var(--tc-space-sm);
+  font-size: var(--tc-text-caption);
+  font-weight: var(--tc-weight-medium);
+  color: var(--tc-text-primary);
+  background: var(--tc-surface);
+  border: 1px solid var(--tc-border);
+  border-radius: var(--tc-radius-md);
+  cursor: pointer;
+  transition: border-color var(--tc-duration-fast);
+}
+
+.controlButton:hover:not(:disabled) {
+  border-color: var(--tc-text-secondary);
+}
+
+.controlButton:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}

--- a/web/src/features/WatchZones/BoundaryMap.module.css
+++ b/web/src/features/WatchZones/BoundaryMap.module.css
@@ -1,0 +1,6 @@
+.container {
+  border-radius: var(--tc-radius-md);
+  overflow: hidden;
+  height: 320px;
+  margin-bottom: var(--tc-space-md);
+}

--- a/web/src/features/WatchZones/BoundaryMap.tsx
+++ b/web/src/features/WatchZones/BoundaryMap.tsx
@@ -36,6 +36,10 @@ interface Props {
   onAddVertex: (coordinate: Coordinates) => void;
   onMoveVertex: (index: number, coordinate: Coordinates) => void;
   onCloseRing: () => void;
+  /** Reopens a closed ring, or removes the last vertex while still drawing. */
+  onUndo: () => void;
+  /** Clears the ring entirely so drawing can start over. */
+  onReset: () => void;
 }
 
 interface ClickCatcherProps {
@@ -61,54 +65,77 @@ export function BoundaryMap({
   onAddVertex,
   onMoveVertex,
   onCloseRing,
+  onUndo,
+  onReset,
 }: Props) {
   const positions = useMemo<[number, number][]>(
     () => vertices.map((vertex): [number, number] => [vertex.latitude, vertex.longitude]),
     [vertices],
   );
   const centrePosition: [number, number] = [centre.latitude, centre.longitude];
+  const hasVertices = vertices.length > 0;
 
   return (
-    <div className={styles.container}>
-      <MapContainer
-        center={centrePosition}
-        zoom={15}
-        style={{ height: '100%', width: '100%' }}
-        zoomControl={false}
-        attributionControl={true}
-      >
-        <TileLayer url={OSM_TILE_URL} attribution={OSM_ATTRIBUTION} />
-        <ClickCatcher onAddVertex={onAddVertex} />
+    <div>
+      <div className={styles.controls}>
+        <button
+          type="button"
+          className={styles.controlButton}
+          onClick={onUndo}
+          disabled={!hasVertices}
+        >
+          Undo
+        </button>
+        <button
+          type="button"
+          className={styles.controlButton}
+          onClick={onReset}
+          disabled={!hasVertices}
+        >
+          Start over
+        </button>
+      </div>
+      <div className={styles.container}>
+        <MapContainer
+          center={centrePosition}
+          zoom={15}
+          style={{ height: '100%', width: '100%' }}
+          zoomControl={false}
+          attributionControl={true}
+        >
+          <TileLayer url={OSM_TILE_URL} attribution={OSM_ATTRIBUTION} />
+          <ClickCatcher onAddVertex={onAddVertex} />
 
-        {isClosed && positions.length >= 3 && (
-          <Polygon positions={positions} pathOptions={CLOSED_RING_OPTIONS} />
-        )}
-        {!isClosed && positions.length >= 2 && (
-          <Polyline positions={positions} pathOptions={OPEN_RING_OPTIONS} />
-        )}
+          {isClosed && positions.length >= 3 && (
+            <Polygon positions={positions} pathOptions={CLOSED_RING_OPTIONS} />
+          )}
+          {!isClosed && positions.length >= 2 && (
+            <Polyline positions={positions} pathOptions={OPEN_RING_OPTIONS} />
+          )}
 
-        {vertices.map((vertex, index) => (
-          // Vertices are only ever appended/removed at the tail (drawing
-          // order), never reordered — index is a stable identity here, and
-          // using it (rather than the mutable lat/lng) is what lets a marker
-          // keep its React identity while it's being dragged.
-          <Marker
-            key={index}
-            position={[vertex.latitude, vertex.longitude]}
-            draggable
-            eventHandlers={{
-              dragend: (event: LeafletEvent) => {
-                const marker = event.target as LeafletMarkerInstance;
-                const { lat, lng } = marker.getLatLng();
-                onMoveVertex(index, { latitude: lat, longitude: lng });
-              },
-              // Only the first vertex closes the ring when clicked — every
-              // other marker click is a no-op (dragging is how you adjust it).
-              ...(index === 0 ? { click: () => onCloseRing() } : {}),
-            }}
-          />
-        ))}
-      </MapContainer>
+          {vertices.map((vertex, index) => (
+            // Vertices are only ever appended/removed at the tail (drawing
+            // order), never reordered — index is a stable identity here, and
+            // using it (rather than the mutable lat/lng) is what lets a marker
+            // keep its React identity while it's being dragged.
+            <Marker
+              key={index}
+              position={[vertex.latitude, vertex.longitude]}
+              draggable
+              eventHandlers={{
+                dragend: (event: LeafletEvent) => {
+                  const marker = event.target as LeafletMarkerInstance;
+                  const { lat, lng } = marker.getLatLng();
+                  onMoveVertex(index, { latitude: lat, longitude: lng });
+                },
+                // Only the first vertex closes the ring when clicked — every
+                // other marker click is a no-op (dragging is how you adjust it).
+                ...(index === 0 ? { click: () => onCloseRing() } : {}),
+              }}
+            />
+          ))}
+        </MapContainer>
+      </div>
     </div>
   );
 }

--- a/web/src/features/WatchZones/BoundaryMap.tsx
+++ b/web/src/features/WatchZones/BoundaryMap.tsx
@@ -92,7 +92,6 @@ export function BoundaryMap({
           // order), never reordered — index is a stable identity here, and
           // using it (rather than the mutable lat/lng) is what lets a marker
           // keep its React identity while it's being dragged.
-          // eslint-disable-next-line react/no-array-index-key
           <Marker
             key={index}
             position={[vertex.latitude, vertex.longitude]}

--- a/web/src/features/WatchZones/BoundaryMap.tsx
+++ b/web/src/features/WatchZones/BoundaryMap.tsx
@@ -1,0 +1,115 @@
+import { useMemo } from 'react';
+import { MapContainer, TileLayer, Marker, Polygon, Polyline, useMapEvents } from 'react-leaflet';
+import type { LeafletMouseEvent, LeafletEvent, Marker as LeafletMarkerInstance } from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+import type { Coordinates } from '../../domain/types';
+import styles from './BoundaryMap.module.css';
+
+const OSM_TILE_URL = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+const OSM_ATTRIBUTION =
+  '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
+
+// Leaflet SVG layers accept raw colour values, not CSS custom properties —
+// this hex MUST be kept in sync BY HAND with --tc-amber in tokens.css (dark
+// theme value, #E9A620 / rgb(233, 166, 32)) whenever the palette changes.
+// Mirrors ConfirmMap's convention for the confirm-step circle.
+const CLOSED_RING_OPTIONS = {
+  color: 'rgba(233, 166, 32, 0.8)',
+  fillColor: 'rgb(233, 166, 32)',
+  fillOpacity: 0.1,
+  weight: 2,
+};
+
+// The in-progress (not yet closed) ring is drawn as a dashed line with no
+// fill, so it reads as "still being drawn" rather than a completed shape.
+const OPEN_RING_OPTIONS = {
+  color: 'rgba(233, 166, 32, 0.8)',
+  weight: 2,
+  dashArray: '6 4',
+};
+
+interface Props {
+  /** Initial map centre — the zone's postcode lookup or existing centroid. */
+  centre: Coordinates;
+  vertices: readonly Coordinates[];
+  isClosed: boolean;
+  onAddVertex: (coordinate: Coordinates) => void;
+  onMoveVertex: (index: number, coordinate: Coordinates) => void;
+  onCloseRing: () => void;
+}
+
+interface ClickCatcherProps {
+  onAddVertex: (coordinate: Coordinates) => void;
+}
+
+/** Adds a vertex wherever the map is clicked. Renders nothing itself — it
+ * only exists to host the `useMapEvents` hook, which must run inside the
+ * `MapContainer` tree. */
+function ClickCatcher({ onAddVertex }: ClickCatcherProps) {
+  useMapEvents({
+    click(event: LeafletMouseEvent) {
+      onAddVertex({ latitude: event.latlng.lat, longitude: event.latlng.lng });
+    },
+  });
+  return null;
+}
+
+export function BoundaryMap({
+  centre,
+  vertices,
+  isClosed,
+  onAddVertex,
+  onMoveVertex,
+  onCloseRing,
+}: Props) {
+  const positions = useMemo<[number, number][]>(
+    () => vertices.map((vertex): [number, number] => [vertex.latitude, vertex.longitude]),
+    [vertices],
+  );
+  const centrePosition: [number, number] = [centre.latitude, centre.longitude];
+
+  return (
+    <div className={styles.container}>
+      <MapContainer
+        center={centrePosition}
+        zoom={15}
+        style={{ height: '100%', width: '100%' }}
+        zoomControl={false}
+        attributionControl={true}
+      >
+        <TileLayer url={OSM_TILE_URL} attribution={OSM_ATTRIBUTION} />
+        <ClickCatcher onAddVertex={onAddVertex} />
+
+        {isClosed && positions.length >= 3 && (
+          <Polygon positions={positions} pathOptions={CLOSED_RING_OPTIONS} />
+        )}
+        {!isClosed && positions.length >= 2 && (
+          <Polyline positions={positions} pathOptions={OPEN_RING_OPTIONS} />
+        )}
+
+        {vertices.map((vertex, index) => (
+          // Vertices are only ever appended/removed at the tail (drawing
+          // order), never reordered — index is a stable identity here, and
+          // using it (rather than the mutable lat/lng) is what lets a marker
+          // keep its React identity while it's being dragged.
+          // eslint-disable-next-line react/no-array-index-key
+          <Marker
+            key={index}
+            position={[vertex.latitude, vertex.longitude]}
+            draggable
+            eventHandlers={{
+              dragend: (event: LeafletEvent) => {
+                const marker = event.target as LeafletMarkerInstance;
+                const { lat, lng } = marker.getLatLng();
+                onMoveVertex(index, { latitude: lat, longitude: lng });
+              },
+              // Only the first vertex closes the ring when clicked — every
+              // other marker click is a no-op (dragging is how you adjust it).
+              ...(index === 0 ? { click: () => onCloseRing() } : {}),
+            }}
+          />
+        ))}
+      </MapContainer>
+    </div>
+  );
+}

--- a/web/src/features/WatchZones/ConnectedWatchZoneCreatePage.tsx
+++ b/web/src/features/WatchZones/ConnectedWatchZoneCreatePage.tsx
@@ -2,6 +2,8 @@ import { useMemo } from 'react';
 import { useNavigate } from 'react-router';
 import { useApiClient } from '../../api/useApiClient';
 import { geocodingApi } from '../../api/geocoding';
+import { useProfileRepository } from '../../auth/profile-context';
+import { useFetchData } from '../../hooks/useFetchData';
 import { ApiWatchZoneRepository } from './ApiWatchZoneRepository';
 import type { GeocodingPort } from '../../domain/ports/geocoding-port';
 import { WatchZoneCreatePage } from './WatchZoneCreatePage';
@@ -15,11 +17,18 @@ export function ConnectedWatchZoneCreatePage() {
     [client],
   );
 
+  const profileRepository = useProfileRepository();
+  const { data: profile } = useFetchData(
+    () => profileRepository.fetchProfile(),
+    [profileRepository],
+  );
+
   return (
     <WatchZoneCreatePage
       repository={repository}
       geocodingPort={geocodingPort}
       navigate={navigate}
+      tier={profile?.tier ?? 'Free'}
     />
   );
 }

--- a/web/src/features/WatchZones/ShapeModeToggle.module.css
+++ b/web/src/features/WatchZones/ShapeModeToggle.module.css
@@ -1,0 +1,62 @@
+.fieldset {
+  border: none;
+  margin: 0;
+  padding: 0;
+  margin-bottom: var(--tc-space-md);
+}
+
+.legend {
+  font-size: var(--tc-text-caption);
+  font-weight: var(--tc-weight-medium);
+  color: var(--tc-text-secondary);
+  margin-bottom: var(--tc-space-sm);
+}
+
+.options {
+  display: flex;
+  gap: var(--tc-space-sm);
+}
+
+.option {
+  position: relative;
+  cursor: pointer;
+}
+
+.radio {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.label {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 64px;
+  height: 40px;
+  padding: 0 var(--tc-space-md);
+  border: 1px solid var(--tc-border);
+  border-radius: var(--tc-radius-full);
+  font-size: var(--tc-text-caption);
+  font-weight: var(--tc-weight-medium);
+  color: var(--tc-text-primary);
+  background: var(--tc-surface);
+  transition: border-color var(--tc-duration-fast), background var(--tc-duration-fast);
+}
+
+.radio:checked + .label {
+  border-color: var(--tc-amber);
+  background: var(--tc-amber-muted);
+  color: var(--tc-amber);
+  font-weight: var(--tc-weight-semibold);
+}
+
+.radio:focus-visible + .label {
+  outline: 2px solid var(--tc-border-focused);
+  outline-offset: 2px;
+}
+
+.label:hover {
+  border-color: var(--tc-text-secondary);
+}

--- a/web/src/features/WatchZones/ShapeModeToggle.tsx
+++ b/web/src/features/WatchZones/ShapeModeToggle.tsx
@@ -1,0 +1,40 @@
+import styles from './ShapeModeToggle.module.css';
+
+/**
+ * Whether a zone being created/edited is a plain circle (centre + radius) or
+ * a hand-drawn custom shape. Personal/Pro only — see GH#1031.
+ */
+export type ShapeMode = 'circle' | 'custom';
+
+interface Props {
+  mode: ShapeMode;
+  onSelect: (mode: ShapeMode) => void;
+}
+
+const OPTIONS: ReadonlyArray<{ mode: ShapeMode; label: string }> = [
+  { mode: 'circle', label: 'Circle' },
+  { mode: 'custom', label: 'Custom shape' },
+];
+
+export function ShapeModeToggle({ mode, onSelect }: Props) {
+  return (
+    <fieldset className={styles.fieldset} role="radiogroup" aria-label="Shape">
+      <legend className={styles.legend}>Shape</legend>
+      <div className={styles.options}>
+        {OPTIONS.map((option) => (
+          <label key={option.mode} className={styles.option}>
+            <input
+              type="radio"
+              name="shape-mode"
+              value={option.mode}
+              checked={mode === option.mode}
+              onChange={() => onSelect(option.mode)}
+              className={styles.radio}
+            />
+            <span className={styles.label}>{option.label}</span>
+          </label>
+        ))}
+      </div>
+    </fieldset>
+  );
+}

--- a/web/src/features/WatchZones/WatchZoneCreatePage.tsx
+++ b/web/src/features/WatchZones/WatchZoneCreatePage.tsx
@@ -1,34 +1,52 @@
 import { Link } from 'react-router';
 import type { WatchZoneRepository } from '../../domain/ports/watch-zone-repository';
 import type { GeocodingPort } from '../../domain/ports/geocoding-port';
+import type { SubscriptionTier } from '../../domain/types';
 import { useCreateWatchZone } from './useCreateWatchZone';
+import { useBoundaryDrawing } from './useBoundaryDrawing';
 import { PostcodeInput } from '../../components/PostcodeInput/PostcodeInput';
 import { RadiusPicker } from '../../components/RadiusPicker/RadiusPicker';
 import { LargeRadiusWarning } from '../../components/LargeRadiusWarning/LargeRadiusWarning';
 import { ConfirmMap } from '../../components/ConfirmMap/ConfirmMap';
+import { ShapeModeToggle } from './ShapeModeToggle';
+import { BoundaryMap } from './BoundaryMap';
+import { CustomShapeUpsell } from './CustomShapeUpsell';
 import styles from './WatchZoneCreatePage.module.css';
 
 interface Props {
   repository: WatchZoneRepository;
   geocodingPort: GeocodingPort;
   navigate: (path: string) => void;
+  /**
+   * The current user's subscription tier. Only Personal/Pro can draw a
+   * custom shape (GH#1031) — Free sees the radius picker plus an upsell,
+   * with no drawing affordance. Optional so legacy call sites keep
+   * compiling; defaults to Free.
+   */
+  tier?: SubscriptionTier;
 }
 
-export function WatchZoneCreatePage({ repository, geocodingPort, navigate }: Props) {
+export function WatchZoneCreatePage({ repository, geocodingPort, navigate, tier = 'Free' }: Props) {
   const {
     step,
     name,
     postcode,
     coordinates,
     radiusMetres,
+    shapeMode,
     isSaving,
     error,
     setGeocode,
     setName,
     setRadiusMetres,
+    setShapeMode,
     confirmDetails,
     save,
   } = useCreateWatchZone(repository, navigate);
+
+  const drawing = useBoundaryDrawing();
+  const canDrawCustomShape = tier !== 'Free';
+  const isCustomShape = canDrawCustomShape && shapeMode === 'custom';
 
   return (
     <div className={styles.container}>
@@ -64,9 +82,27 @@ export function WatchZoneCreatePage({ repository, geocodingPort, navigate }: Pro
             />
           </div>
 
-          <RadiusPicker selectedMetres={radiusMetres} onSelect={setRadiusMetres} />
+          {canDrawCustomShape && <ShapeModeToggle mode={shapeMode} onSelect={setShapeMode} />}
 
-          <LargeRadiusWarning radiusMetres={radiusMetres} />
+          {isCustomShape ? (
+            coordinates && (
+              <BoundaryMap
+                centre={coordinates}
+                vertices={drawing.vertices}
+                isClosed={drawing.isClosed}
+                onAddVertex={drawing.addVertex}
+                onMoveVertex={drawing.moveVertex}
+                onCloseRing={drawing.closeRing}
+              />
+            )
+          ) : (
+            <>
+              <RadiusPicker selectedMetres={radiusMetres} onSelect={setRadiusMetres} />
+              <LargeRadiusWarning radiusMetres={radiusMetres} />
+            </>
+          )}
+
+          {!canDrawCustomShape && <CustomShapeUpsell />}
 
           {error && (
             <p className={styles.error} role="alert">
@@ -78,7 +114,7 @@ export function WatchZoneCreatePage({ repository, geocodingPort, navigate }: Pro
             <button
               type="button"
               className={styles.saveButton}
-              onClick={confirmDetails}
+              onClick={() => confirmDetails(drawing.boundary)}
             >
               Next
             </button>
@@ -88,13 +124,24 @@ export function WatchZoneCreatePage({ repository, geocodingPort, navigate }: Pro
 
       {step === 'confirm' && (
         <section className={styles.section}>
-          {coordinates && (
-            <ConfirmMap
-              latitude={coordinates.latitude}
-              longitude={coordinates.longitude}
-              radiusMetres={radiusMetres}
-            />
-          )}
+          {isCustomShape
+            ? coordinates && (
+                <BoundaryMap
+                  centre={coordinates}
+                  vertices={drawing.vertices}
+                  isClosed={drawing.isClosed}
+                  onAddVertex={drawing.addVertex}
+                  onMoveVertex={drawing.moveVertex}
+                  onCloseRing={drawing.closeRing}
+                />
+              )
+            : coordinates && (
+                <ConfirmMap
+                  latitude={coordinates.latitude}
+                  longitude={coordinates.longitude}
+                  radiusMetres={radiusMetres}
+                />
+              )}
           <div className={styles.confirmDetails}>
             <div className={styles.confirmRow}>
               <span className={styles.confirmLabel}>Postcode</span>
@@ -105,11 +152,19 @@ export function WatchZoneCreatePage({ repository, geocodingPort, navigate }: Pro
               <span className={styles.confirmValue}>{name}</span>
             </div>
             <div className={styles.confirmRow}>
-              <span className={styles.confirmLabel}>Radius</span>
+              <span className={styles.confirmLabel}>Shape</span>
               <span className={styles.confirmValue}>
-                {radiusMetres >= 1000 ? `${radiusMetres / 1000} km` : `${radiusMetres} m`}
+                {isCustomShape ? 'Custom shape' : 'Circle'}
               </span>
             </div>
+            {!isCustomShape && (
+              <div className={styles.confirmRow}>
+                <span className={styles.confirmLabel}>Radius</span>
+                <span className={styles.confirmValue}>
+                  {radiusMetres >= 1000 ? `${radiusMetres / 1000} km` : `${radiusMetres} m`}
+                </span>
+              </div>
+            )}
           </div>
           {error && (
             <p className={styles.error} role="alert">
@@ -120,7 +175,7 @@ export function WatchZoneCreatePage({ repository, geocodingPort, navigate }: Pro
             <button
               type="button"
               className={styles.saveButton}
-              onClick={save}
+              onClick={() => save(drawing.boundary)}
               disabled={isSaving}
             >
               {isSaving ? 'Saving...' : 'Confirm'}

--- a/web/src/features/WatchZones/WatchZoneCreatePage.tsx
+++ b/web/src/features/WatchZones/WatchZoneCreatePage.tsx
@@ -93,6 +93,8 @@ export function WatchZoneCreatePage({ repository, geocodingPort, navigate, tier 
                 onAddVertex={drawing.addVertex}
                 onMoveVertex={drawing.moveVertex}
                 onCloseRing={drawing.closeRing}
+                onUndo={drawing.undo}
+                onReset={drawing.reset}
               />
             )
           ) : (
@@ -133,6 +135,8 @@ export function WatchZoneCreatePage({ repository, geocodingPort, navigate, tier 
                   onAddVertex={drawing.addVertex}
                   onMoveVertex={drawing.moveVertex}
                   onCloseRing={drawing.closeRing}
+                  onUndo={drawing.undo}
+                  onReset={drawing.reset}
                 />
               )
             : coordinates && (

--- a/web/src/features/WatchZones/WatchZoneEditPage.module.css
+++ b/web/src/features/WatchZones/WatchZoneEditPage.module.css
@@ -63,6 +63,16 @@
   margin: var(--tc-space-xs) 0 0 0;
 }
 
+.lockedShapeNotice {
+  font-size: var(--tc-text-caption);
+  color: var(--tc-text-secondary);
+  background: var(--tc-background);
+  border: 1px solid var(--tc-border);
+  border-radius: var(--tc-radius-md);
+  padding: var(--tc-space-sm) var(--tc-space-md);
+  margin: 0;
+}
+
 .saveButton {
   display: block;
   width: 100%;

--- a/web/src/features/WatchZones/WatchZoneEditPage.tsx
+++ b/web/src/features/WatchZones/WatchZoneEditPage.tsx
@@ -3,9 +3,13 @@ import type { WatchZoneSummary, SubscriptionTier } from '../../domain/types';
 import type { WatchZoneRepository } from '../../domain/ports/watch-zone-repository';
 import { useZonePreferences } from './useZonePreferences';
 import { useZoneEdit } from './useZoneEdit';
+import { useBoundaryDrawing } from './useBoundaryDrawing';
 import { RadiusPicker } from '../../components/RadiusPicker/RadiusPicker';
 import { LargeRadiusWarning } from '../../components/LargeRadiusWarning/LargeRadiusWarning';
 import { Toggle } from '../../components/Toggle/Toggle';
+import { ShapeModeToggle } from './ShapeModeToggle';
+import { BoundaryMap } from './BoundaryMap';
+import { CustomShapeUpsell } from './CustomShapeUpsell';
 import styles from './WatchZoneEditPage.module.css';
 
 interface Props {
@@ -27,8 +31,11 @@ export function WatchZoneEditPage({ repository, zone, tier = 'Free' }: Props) {
     zone.id,
   );
 
-  const zoneEdit = useZoneEdit(repository, zone);
+  const drawing = useBoundaryDrawing(zone.boundary);
+  const zoneEdit = useZoneEdit(repository, zone, drawing.boundary);
   const showZoneNotificationToggles = tier !== 'Free';
+  const canDrawCustomShape = tier !== 'Free';
+  const isCustomShape = canDrawCustomShape && zoneEdit.shapeMode === 'custom';
 
   type PreferenceField =
     | 'newApplicationPush'
@@ -82,12 +89,34 @@ export function WatchZoneEditPage({ repository, zone, tier = 'Free' }: Props) {
           )}
         </div>
 
-        <RadiusPicker
-          selectedMetres={zoneEdit.radiusMetres}
-          onSelect={zoneEdit.setRadiusMetres}
-        />
+        {canDrawCustomShape && (
+          <ShapeModeToggle mode={zoneEdit.shapeMode} onSelect={zoneEdit.setShapeMode} />
+        )}
 
-        <LargeRadiusWarning radiusMetres={zoneEdit.radiusMetres} />
+        {isCustomShape ? (
+          <BoundaryMap
+            centre={{ latitude: zone.latitude, longitude: zone.longitude }}
+            vertices={drawing.vertices}
+            isClosed={drawing.isClosed}
+            onAddVertex={drawing.addVertex}
+            onMoveVertex={drawing.moveVertex}
+            onCloseRing={drawing.closeRing}
+          />
+        ) : (
+          <>
+            <RadiusPicker
+              selectedMetres={zoneEdit.radiusMetres}
+              onSelect={zoneEdit.setRadiusMetres}
+            />
+            <LargeRadiusWarning radiusMetres={zoneEdit.radiusMetres} />
+          </>
+        )}
+
+        {!canDrawCustomShape && <CustomShapeUpsell />}
+
+        {zoneEdit.boundaryError && (
+          <p className={styles.fieldError}>{zoneEdit.boundaryError}</p>
+        )}
 
         {showZoneNotificationToggles && (
           <div className={styles.zoneNotifications}>

--- a/web/src/features/WatchZones/WatchZoneEditPage.tsx
+++ b/web/src/features/WatchZones/WatchZoneEditPage.tsx
@@ -35,7 +35,15 @@ export function WatchZoneEditPage({ repository, zone, tier = 'Free' }: Props) {
   const zoneEdit = useZoneEdit(repository, zone, drawing.boundary);
   const showZoneNotificationToggles = tier !== 'Free';
   const canDrawCustomShape = tier !== 'Free';
-  const isCustomShape = canDrawCustomShape && zoneEdit.shapeMode === 'custom';
+  // Whether this zone's *saved* shape is a custom polygon, independent of
+  // whether the current tier can still edit it — a zone drawn while paid
+  // keeps its shape after a downgrade (GH#1031: paused, never converted).
+  const zoneHasCustomShape = zoneEdit.shapeMode === 'custom';
+  const isCustomShape = canDrawCustomShape && zoneHasCustomShape;
+  // A downgraded user holding a custom-shape zone: the radius picker would
+  // silently misrepresent the zone's actual coverage, so this case gets its
+  // own locked notice instead of falling through to the circle controls.
+  const shapeLockedByTier = zoneHasCustomShape && !canDrawCustomShape;
 
   type PreferenceField =
     | 'newApplicationPush'
@@ -101,7 +109,13 @@ export function WatchZoneEditPage({ repository, zone, tier = 'Free' }: Props) {
             onAddVertex={drawing.addVertex}
             onMoveVertex={drawing.moveVertex}
             onCloseRing={drawing.closeRing}
+            onUndo={drawing.undo}
+            onReset={drawing.reset}
           />
+        ) : shapeLockedByTier ? (
+          <p className={styles.lockedShapeNotice}>
+            This zone uses a custom shape. Upgrade to Personal or Pro to view or edit it.
+          </p>
         ) : (
           <>
             <RadiusPicker
@@ -112,7 +126,7 @@ export function WatchZoneEditPage({ repository, zone, tier = 'Free' }: Props) {
           </>
         )}
 
-        {!canDrawCustomShape && <CustomShapeUpsell />}
+        {!canDrawCustomShape && !shapeLockedByTier && <CustomShapeUpsell />}
 
         {zoneEdit.boundaryError && (
           <p className={styles.fieldError}>{zoneEdit.boundaryError}</p>

--- a/web/src/features/WatchZones/__tests__/BoundaryMap.test.tsx
+++ b/web/src/features/WatchZones/__tests__/BoundaryMap.test.tsx
@@ -75,6 +75,8 @@ describe('BoundaryMap', () => {
         onAddVertex={() => {}}
         onMoveVertex={() => {}}
         onCloseRing={() => {}}
+        onUndo={() => {}}
+        onReset={() => {}}
       />,
     );
 
@@ -94,6 +96,8 @@ describe('BoundaryMap', () => {
         onAddVertex={() => {}}
         onMoveVertex={() => {}}
         onCloseRing={() => {}}
+        onUndo={() => {}}
+        onReset={() => {}}
       />,
     );
 
@@ -112,6 +116,8 @@ describe('BoundaryMap', () => {
         onAddVertex={() => {}}
         onMoveVertex={() => {}}
         onCloseRing={() => {}}
+        onUndo={() => {}}
+        onReset={() => {}}
       />,
     );
 
@@ -132,6 +138,8 @@ describe('BoundaryMap', () => {
         onAddVertex={() => {}}
         onMoveVertex={() => {}}
         onCloseRing={() => {}}
+        onUndo={() => {}}
+        onReset={() => {}}
       />,
     );
 
@@ -150,6 +158,8 @@ describe('BoundaryMap', () => {
         onAddVertex={onAddVertex}
         onMoveVertex={() => {}}
         onCloseRing={() => {}}
+        onUndo={() => {}}
+        onReset={() => {}}
       />,
     );
 
@@ -173,6 +183,8 @@ describe('BoundaryMap', () => {
         onAddVertex={() => {}}
         onMoveVertex={() => {}}
         onCloseRing={onCloseRing}
+        onUndo={() => {}}
+        onReset={() => {}}
       />,
     );
 
@@ -197,6 +209,8 @@ describe('BoundaryMap', () => {
         onAddVertex={() => {}}
         onMoveVertex={() => {}}
         onCloseRing={onCloseRing}
+        onUndo={() => {}}
+        onReset={() => {}}
       />,
     );
 
@@ -221,6 +235,8 @@ describe('BoundaryMap', () => {
         onAddVertex={() => {}}
         onMoveVertex={onMoveVertex}
         onCloseRing={() => {}}
+        onUndo={() => {}}
+        onReset={() => {}}
       />,
     );
 
@@ -228,5 +244,67 @@ describe('BoundaryMap', () => {
     await user.click(dragButtons[1]!);
 
     expect(onMoveVertex).toHaveBeenCalledWith(1, { latitude: 52.3, longitude: 0.2 });
+  });
+
+  it('disables Undo and Start over when there are no vertices', () => {
+    render(
+      <BoundaryMap
+        centre={centre}
+        vertices={[]}
+        isClosed={false}
+        onAddVertex={() => {}}
+        onMoveVertex={() => {}}
+        onCloseRing={() => {}}
+        onUndo={() => {}}
+        onReset={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Undo' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Start over' })).toBeDisabled();
+  });
+
+  it('calls onUndo when Undo is clicked', async () => {
+    const user = userEvent.setup();
+    const onUndo = vi.fn();
+
+    render(
+      <BoundaryMap
+        centre={centre}
+        vertices={[{ latitude: 52.2, longitude: 0.1 }]}
+        isClosed={false}
+        onAddVertex={() => {}}
+        onMoveVertex={() => {}}
+        onCloseRing={() => {}}
+        onUndo={onUndo}
+        onReset={() => {}}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Undo' }));
+
+    expect(onUndo).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onReset when Start over is clicked', async () => {
+    const user = userEvent.setup();
+    const onReset = vi.fn();
+
+    render(
+      <BoundaryMap
+        centre={centre}
+        vertices={[{ latitude: 52.2, longitude: 0.1 }]}
+        isClosed={false}
+        onAddVertex={() => {}}
+        onMoveVertex={() => {}}
+        onCloseRing={() => {}}
+        onUndo={() => {}}
+        onReset={onReset}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Start over' }));
+
+    expect(onReset).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/src/features/WatchZones/__tests__/BoundaryMap.test.tsx
+++ b/web/src/features/WatchZones/__tests__/BoundaryMap.test.tsx
@@ -1,0 +1,232 @@
+import type { ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { BoundaryMap } from '../BoundaryMap';
+
+interface LatLngPayload {
+  latlng: { lat: number; lng: number };
+}
+
+interface DragEndPayload {
+  target: { getLatLng: () => { lat: number; lng: number } };
+}
+
+interface MockMarkerEventHandlers {
+  click?: () => void;
+  dragend?: (event: DragEndPayload) => void;
+}
+
+interface MockMarkerProps {
+  position: [number, number];
+  eventHandlers?: MockMarkerEventHandlers;
+}
+
+interface PathLayerProps {
+  positions: [number, number][];
+}
+
+const { capturedMapEvents } = vi.hoisted(() => ({
+  capturedMapEvents: { click: undefined as ((event: LatLngPayload) => void) | undefined },
+}));
+
+vi.mock('react-leaflet', () => ({
+  MapContainer: ({ children }: { children: ReactNode }) => (
+    <div data-testid="map-container">{children}</div>
+  ),
+  TileLayer: () => <div data-testid="tile-layer" />,
+  Marker: ({ position, eventHandlers }: MockMarkerProps) => (
+    <div data-testid="vertex-marker" data-lat={position[0]} data-lng={position[1]}>
+      <button type="button" data-testid="marker-click" onClick={() => eventHandlers?.click?.()}>
+        marker
+      </button>
+      <button
+        type="button"
+        data-testid="marker-dragend"
+        onClick={() =>
+          eventHandlers?.dragend?.({ target: { getLatLng: () => ({ lat: 52.3, lng: 0.2 }) } })
+        }
+      >
+        drag
+      </button>
+    </div>
+  ),
+  Polygon: ({ positions }: PathLayerProps) => (
+    <div data-testid="polygon" data-count={positions.length} />
+  ),
+  Polyline: ({ positions }: PathLayerProps) => (
+    <div data-testid="polyline" data-count={positions.length} />
+  ),
+  useMapEvents: (handlers: { click?: (event: LatLngPayload) => void }) => {
+    capturedMapEvents.click = handlers.click;
+    return null;
+  },
+}));
+
+describe('BoundaryMap', () => {
+  const centre = { latitude: 52.2053, longitude: 0.1218 };
+
+  it('renders the map container and tile layer', () => {
+    render(
+      <BoundaryMap
+        centre={centre}
+        vertices={[]}
+        isClosed={false}
+        onAddVertex={() => {}}
+        onMoveVertex={() => {}}
+        onCloseRing={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId('map-container')).toBeInTheDocument();
+    expect(screen.getByTestId('tile-layer')).toBeInTheDocument();
+  });
+
+  it('renders one marker per vertex', () => {
+    render(
+      <BoundaryMap
+        centre={centre}
+        vertices={[
+          { latitude: 52.2, longitude: 0.1 },
+          { latitude: 52.21, longitude: 0.12 },
+        ]}
+        isClosed={false}
+        onAddVertex={() => {}}
+        onMoveVertex={() => {}}
+        onCloseRing={() => {}}
+      />,
+    );
+
+    expect(screen.getAllByTestId('vertex-marker')).toHaveLength(2);
+  });
+
+  it('renders an open dashed line while the ring has 2+ vertices and is not closed', () => {
+    render(
+      <BoundaryMap
+        centre={centre}
+        vertices={[
+          { latitude: 52.2, longitude: 0.1 },
+          { latitude: 52.21, longitude: 0.12 },
+        ]}
+        isClosed={false}
+        onAddVertex={() => {}}
+        onMoveVertex={() => {}}
+        onCloseRing={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId('polyline')).toBeInTheDocument();
+    expect(screen.queryByTestId('polygon')).not.toBeInTheDocument();
+  });
+
+  it('renders a filled polygon once the ring is closed', () => {
+    render(
+      <BoundaryMap
+        centre={centre}
+        vertices={[
+          { latitude: 52.2, longitude: 0.1 },
+          { latitude: 52.2, longitude: 0.12 },
+          { latitude: 52.21, longitude: 0.12 },
+        ]}
+        isClosed={true}
+        onAddVertex={() => {}}
+        onMoveVertex={() => {}}
+        onCloseRing={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId('polygon')).toBeInTheDocument();
+    expect(screen.queryByTestId('polyline')).not.toBeInTheDocument();
+  });
+
+  it('calls onAddVertex when the map is clicked', () => {
+    const onAddVertex = vi.fn();
+
+    render(
+      <BoundaryMap
+        centre={centre}
+        vertices={[]}
+        isClosed={false}
+        onAddVertex={onAddVertex}
+        onMoveVertex={() => {}}
+        onCloseRing={() => {}}
+      />,
+    );
+
+    capturedMapEvents.click?.({ latlng: { lat: 52.25, lng: 0.15 } });
+
+    expect(onAddVertex).toHaveBeenCalledWith({ latitude: 52.25, longitude: 0.15 });
+  });
+
+  it('calls onCloseRing when the first vertex marker is clicked', async () => {
+    const user = userEvent.setup();
+    const onCloseRing = vi.fn();
+
+    render(
+      <BoundaryMap
+        centre={centre}
+        vertices={[
+          { latitude: 52.2, longitude: 0.1 },
+          { latitude: 52.21, longitude: 0.12 },
+        ]}
+        isClosed={false}
+        onAddVertex={() => {}}
+        onMoveVertex={() => {}}
+        onCloseRing={onCloseRing}
+      />,
+    );
+
+    const clickButtons = screen.getAllByTestId('marker-click');
+    await user.click(clickButtons[0]!);
+
+    expect(onCloseRing).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not wire a close handler onto markers after the first', async () => {
+    const user = userEvent.setup();
+    const onCloseRing = vi.fn();
+
+    render(
+      <BoundaryMap
+        centre={centre}
+        vertices={[
+          { latitude: 52.2, longitude: 0.1 },
+          { latitude: 52.21, longitude: 0.12 },
+        ]}
+        isClosed={false}
+        onAddVertex={() => {}}
+        onMoveVertex={() => {}}
+        onCloseRing={onCloseRing}
+      />,
+    );
+
+    const clickButtons = screen.getAllByTestId('marker-click');
+    await user.click(clickButtons[1]!);
+
+    expect(onCloseRing).not.toHaveBeenCalled();
+  });
+
+  it('calls onMoveVertex with the vertex index and new position when a marker is dragged', async () => {
+    const user = userEvent.setup();
+    const onMoveVertex = vi.fn();
+
+    render(
+      <BoundaryMap
+        centre={centre}
+        vertices={[
+          { latitude: 52.2, longitude: 0.1 },
+          { latitude: 52.21, longitude: 0.12 },
+        ]}
+        isClosed={false}
+        onAddVertex={() => {}}
+        onMoveVertex={onMoveVertex}
+        onCloseRing={() => {}}
+      />,
+    );
+
+    const dragButtons = screen.getAllByTestId('marker-dragend');
+    await user.click(dragButtons[1]!);
+
+    expect(onMoveVertex).toHaveBeenCalledWith(1, { latitude: 52.3, longitude: 0.2 });
+  });
+});

--- a/web/src/features/WatchZones/__tests__/ShapeModeToggle.test.tsx
+++ b/web/src/features/WatchZones/__tests__/ShapeModeToggle.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect } from 'vitest';
+import { ShapeModeToggle } from '../ShapeModeToggle';
+
+describe('ShapeModeToggle', () => {
+  it('renders Circle and Custom shape options as a radio group', () => {
+    render(<ShapeModeToggle mode="circle" onSelect={() => {}} />);
+
+    const group = screen.getByRole('radiogroup', { name: /shape/i });
+    expect(group).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /circle/i })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /custom shape/i })).toBeInTheDocument();
+  });
+
+  it('marks the current mode as checked', () => {
+    render(<ShapeModeToggle mode="custom" onSelect={() => {}} />);
+
+    expect(screen.getByRole('radio', { name: /circle/i })).not.toBeChecked();
+    expect(screen.getByRole('radio', { name: /custom shape/i })).toBeChecked();
+  });
+
+  it('calls onSelect with the clicked mode', async () => {
+    const user = userEvent.setup();
+    const selected: string[] = [];
+
+    render(<ShapeModeToggle mode="circle" onSelect={(mode) => selected.push(mode)} />);
+
+    await user.click(screen.getByRole('radio', { name: /custom shape/i }));
+
+    expect(selected).toEqual(['custom']);
+  });
+});

--- a/web/src/features/WatchZones/__tests__/WatchZoneCreatePage.test.tsx
+++ b/web/src/features/WatchZones/__tests__/WatchZoneCreatePage.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
@@ -8,16 +8,55 @@ import { SpyWatchZoneRepository } from './spies/spy-watch-zone-repository';
 import { aWatchZone } from './fixtures/watch-zone.fixtures';
 import type { GeocodingPort } from '../../../domain/ports/geocoding-port';
 
+interface LatLngPayload {
+  latlng: { lat: number; lng: number };
+}
+
+interface MockMarkerEventHandlers {
+  click?: () => void;
+}
+
+interface MockMarkerProps {
+  position: [number, number];
+  eventHandlers?: MockMarkerEventHandlers;
+}
+
+interface PathLayerProps {
+  positions: [number, number][];
+}
+
+const { capturedMapEvents } = vi.hoisted(() => ({
+  capturedMapEvents: { click: undefined as ((event: LatLngPayload) => void) | undefined },
+}));
+
 vi.mock('react-leaflet', () => ({
   MapContainer: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="map-container">{children}</div>
   ),
   TileLayer: () => <div data-testid="tile-layer" />,
-  Marker: () => <div data-testid="map-marker" />,
+  Marker: ({ position, eventHandlers }: MockMarkerProps) => (
+    <div data-testid="map-marker" data-lat={position[0]} data-lng={position[1]}>
+      {eventHandlers?.click && (
+        <button type="button" data-testid="marker-click" onClick={eventHandlers.click}>
+          marker
+        </button>
+      )}
+    </div>
+  ),
   Circle: () => <div data-testid="map-circle" />,
+  Polygon: ({ positions }: PathLayerProps) => (
+    <div data-testid="boundary-polygon" data-count={positions.length} />
+  ),
+  Polyline: ({ positions }: PathLayerProps) => (
+    <div data-testid="boundary-polyline" data-count={positions.length} />
+  ),
   useMap: () => ({
     fitBounds: vi.fn(),
   }),
+  useMapEvents: (handlers: { click?: (event: LatLngPayload) => void }) => {
+    capturedMapEvents.click = handlers.click;
+    return null;
+  },
 }));
 
 vi.mock('leaflet', () => ({
@@ -216,5 +255,95 @@ describe('WatchZoneCreatePage', () => {
 
     const cancelLink = screen.getByRole('link', { name: /cancel/i });
     expect(cancelLink).toHaveAttribute('href', '/watch-zones');
+  });
+
+  describe('shape mode', () => {
+    async function reachDetailsStep(tier?: 'Free' | 'Personal' | 'Pro') {
+      const user = userEvent.setup();
+      renderWithRouter(
+        <WatchZoneCreatePage
+          repository={repoSpy}
+          geocodingPort={geocodingSpy}
+          navigate={navigate}
+          tier={tier}
+        />,
+      );
+
+      await user.type(screen.getByRole('textbox', { name: /postcode/i }), 'CB1 2AD');
+      await user.click(screen.getByRole('button', { name: /look up/i }));
+      await screen.findByLabelText(/zone name/i);
+
+      return user;
+    }
+
+    it('shows RadiusPicker and the custom-shape upsell, with no shape toggle, for Free tier', async () => {
+      await reachDetailsStep('Free');
+
+      expect(screen.getByRole('radiogroup', { name: /radius/i })).toBeInTheDocument();
+      expect(screen.queryByRole('radiogroup', { name: /shape/i })).not.toBeInTheDocument();
+      expect(
+        screen.getByRole('heading', { name: /draw any shape/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('shows the shape toggle for Personal/Pro tier', async () => {
+      await reachDetailsStep('Pro');
+
+      expect(screen.getByRole('radiogroup', { name: /shape/i })).toBeInTheDocument();
+      // Defaults to circle mode, so the radius picker is still visible.
+      expect(screen.getByRole('radiogroup', { name: /radius/i })).toBeInTheDocument();
+      expect(
+        screen.queryByRole('heading', { name: /draw any shape/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('switching to custom shape hides the radius picker and shows the drawing map', async () => {
+      const user = await reachDetailsStep('Personal');
+
+      await user.click(screen.getByRole('radio', { name: /^custom shape$/i }));
+
+      expect(screen.queryByRole('radiogroup', { name: /radius/i })).not.toBeInTheDocument();
+      expect(screen.getByTestId('map-container')).toBeInTheDocument();
+    });
+
+    it('draws a polygon, closes it, and saves the zone with the boundary', async () => {
+      const user = await reachDetailsStep('Pro');
+      repoSpy.createResult = aWatchZone();
+
+      await user.type(screen.getByLabelText(/zone name/i), 'Home');
+      await user.click(screen.getByRole('radio', { name: /^custom shape$/i }));
+
+      act(() => {
+        capturedMapEvents.click?.({ latlng: { lat: 52.2, lng: 0.1 } });
+      });
+      act(() => {
+        capturedMapEvents.click?.({ latlng: { lat: 52.2, lng: 0.12 } });
+      });
+      act(() => {
+        capturedMapEvents.click?.({ latlng: { lat: 52.21, lng: 0.12 } });
+      });
+
+      const firstVertexClose = screen.getAllByTestId('marker-click')[0];
+      await user.click(firstVertexClose!);
+
+      expect(screen.getByTestId('boundary-polygon')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: /next/i }));
+      await user.click(screen.getByRole('button', { name: /confirm/i }));
+
+      expect(repoSpy.createCalls).toHaveLength(1);
+      expect(repoSpy.createCalls[0]?.boundary).toEqual({
+        type: 'Polygon',
+        coordinates: [
+          [
+            [0.1, 52.2],
+            [0.12, 52.2],
+            [0.12, 52.21],
+            [0.1, 52.2],
+          ],
+        ],
+      });
+      expect(navigatedTo).toBe('/watch-zones');
+    });
   });
 });

--- a/web/src/features/WatchZones/__tests__/WatchZoneCreatePage.test.tsx
+++ b/web/src/features/WatchZones/__tests__/WatchZoneCreatePage.test.tsx
@@ -306,6 +306,25 @@ describe('WatchZoneCreatePage', () => {
       expect(screen.getByTestId('map-container')).toBeInTheDocument();
     });
 
+    it('undoes the last misplaced vertex without losing the earlier ones', async () => {
+      const user = await reachDetailsStep('Personal');
+
+      await user.click(screen.getByRole('radio', { name: /^custom shape$/i }));
+
+      act(() => {
+        capturedMapEvents.click?.({ latlng: { lat: 52.2, lng: 0.1 } });
+      });
+      act(() => {
+        capturedMapEvents.click?.({ latlng: { lat: 52.2, lng: 0.12 } });
+      });
+
+      expect(screen.getAllByTestId('map-marker')).toHaveLength(2);
+
+      await user.click(screen.getByRole('button', { name: 'Undo' }));
+
+      expect(screen.getAllByTestId('map-marker')).toHaveLength(1);
+    });
+
     it('draws a polygon, closes it, and saves the zone with the boundary', async () => {
       const user = await reachDetailsStep('Pro');
       repoSpy.createResult = aWatchZone();

--- a/web/src/features/WatchZones/__tests__/WatchZoneEditPage.test.tsx
+++ b/web/src/features/WatchZones/__tests__/WatchZoneEditPage.test.tsx
@@ -448,6 +448,22 @@ describe('WatchZoneEditPage', () => {
       expect(screen.getByRole('heading', { name: /draw any shape/i })).toBeInTheDocument();
     });
 
+    it('surfaces a locked notice, not the radius picker, for a Free-tier user holding a pre-existing custom-shape zone', () => {
+      spy.getPreferencesResult = zonePreferences();
+      const boundary = aWatchZoneBoundary();
+
+      renderWithRouter(
+        <WatchZoneEditPage repository={spy} zone={aWatchZone({ boundary })} tier="Free" />,
+      );
+
+      expect(screen.getByText(/this zone uses a custom shape/i)).toBeInTheDocument();
+      expect(screen.queryByRole('radiogroup', { name: /radius/i })).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('heading', { name: /draw any shape/i }),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByTestId('boundary-polygon')).not.toBeInTheDocument();
+    });
+
     it('shows the shape toggle in circle mode for a paid tier with a plain circle zone', () => {
       spy.getPreferencesResult = zonePreferences();
 

--- a/web/src/features/WatchZones/__tests__/WatchZoneEditPage.test.tsx
+++ b/web/src/features/WatchZones/__tests__/WatchZoneEditPage.test.tsx
@@ -1,10 +1,58 @@
-import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { WatchZoneEditPage } from '../WatchZoneEditPage';
 import { SpyWatchZoneRepository } from './spies/spy-watch-zone-repository';
-import { aWatchZone, zonePreferences } from './fixtures/watch-zone.fixtures';
+import { aWatchZone, aWatchZoneBoundary, zonePreferences } from './fixtures/watch-zone.fixtures';
+
+interface LatLngPayload {
+  latlng: { lat: number; lng: number };
+}
+
+interface MockMarkerEventHandlers {
+  click?: () => void;
+}
+
+interface MockMarkerProps {
+  position: [number, number];
+  eventHandlers?: MockMarkerEventHandlers;
+}
+
+interface PathLayerProps {
+  positions: [number, number][];
+}
+
+const { capturedMapEvents } = vi.hoisted(() => ({
+  capturedMapEvents: { click: undefined as ((event: LatLngPayload) => void) | undefined },
+}));
+
+vi.mock('react-leaflet', () => ({
+  MapContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="map-container">{children}</div>
+  ),
+  TileLayer: () => <div data-testid="tile-layer" />,
+  Marker: ({ position, eventHandlers }: MockMarkerProps) => (
+    <div data-testid="map-marker" data-lat={position[0]} data-lng={position[1]}>
+      {eventHandlers?.click && (
+        <button type="button" data-testid="marker-click" onClick={eventHandlers.click}>
+          marker
+        </button>
+      )}
+    </div>
+  ),
+  Polygon: ({ positions }: PathLayerProps) => (
+    <div data-testid="boundary-polygon" data-count={positions.length} />
+  ),
+  Polyline: ({ positions }: PathLayerProps) => (
+    <div data-testid="boundary-polyline" data-count={positions.length} />
+  ),
+  useMapEvents: (handlers: { click?: (event: LatLngPayload) => void }) => {
+    capturedMapEvents.click = handlers.click;
+    return null;
+  },
+}));
 
 function renderWithRouter(ui: React.ReactElement) {
   return render(<MemoryRouter>{ui}</MemoryRouter>);
@@ -384,6 +432,116 @@ describe('WatchZoneEditPage', () => {
 
       expect(spy.updateZoneCalls).toHaveLength(1);
       expect(spy.updateZoneCalls[0]?.data).toEqual({ emailInstantEnabled: false });
+    });
+  });
+
+  describe('shape mode', () => {
+    it('shows RadiusPicker and the custom-shape upsell, with no shape toggle, for Free tier', () => {
+      spy.getPreferencesResult = zonePreferences();
+
+      renderWithRouter(
+        <WatchZoneEditPage repository={spy} zone={aWatchZone()} tier="Free" />,
+      );
+
+      expect(screen.getByRole('radiogroup', { name: /radius/i })).toBeInTheDocument();
+      expect(screen.queryByRole('radiogroup', { name: /shape/i })).not.toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: /draw any shape/i })).toBeInTheDocument();
+    });
+
+    it('shows the shape toggle in circle mode for a paid tier with a plain circle zone', () => {
+      spy.getPreferencesResult = zonePreferences();
+
+      renderWithRouter(
+        <WatchZoneEditPage repository={spy} zone={aWatchZone({ boundary: null })} tier="Pro" />,
+      );
+
+      const toggle = screen.getByRole('radiogroup', { name: /shape/i });
+      expect(toggle).toBeInTheDocument();
+      expect(screen.getByRole('radio', { name: /^circle$/i })).toBeChecked();
+      expect(screen.getByRole('radiogroup', { name: /radius/i })).toBeInTheDocument();
+      expect(
+        screen.queryByRole('heading', { name: /draw any shape/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('initialises custom mode and renders the existing boundary for a custom-shape zone', () => {
+      spy.getPreferencesResult = zonePreferences();
+      const boundary = aWatchZoneBoundary();
+
+      renderWithRouter(
+        <WatchZoneEditPage repository={spy} zone={aWatchZone({ boundary })} tier="Personal" />,
+      );
+
+      expect(screen.getByRole('radio', { name: /^custom shape$/i })).toBeChecked();
+      expect(screen.queryByRole('radiogroup', { name: /radius/i })).not.toBeInTheDocument();
+      expect(screen.getByTestId('boundary-polygon')).toBeInTheDocument();
+      expect(screen.getAllByTestId('map-marker')).toHaveLength(4);
+    });
+
+    it('sends an explicit null boundary when switching a custom zone back to circle', async () => {
+      const user = userEvent.setup();
+      spy.getPreferencesResult = zonePreferences();
+      const boundary = aWatchZoneBoundary();
+      spy.updateZoneResult = aWatchZone({ boundary: null });
+
+      renderWithRouter(
+        <WatchZoneEditPage repository={spy} zone={aWatchZone({ boundary })} tier="Personal" />,
+      );
+
+      await user.click(screen.getByRole('radio', { name: /^circle$/i }));
+
+      const saveButton = screen.getByRole('button', { name: /save/i });
+      await user.click(saveButton);
+
+      expect(spy.updateZoneCalls).toHaveLength(1);
+      expect(spy.updateZoneCalls[0]?.data).toEqual({ boundary: null });
+    });
+
+    it('draws a polygon and saves the zone with the new boundary', async () => {
+      const user = userEvent.setup();
+      spy.getPreferencesResult = zonePreferences();
+      spy.updateZoneResult = aWatchZone({ boundary: aWatchZoneBoundary() });
+
+      renderWithRouter(
+        <WatchZoneEditPage
+          repository={spy}
+          zone={aWatchZone({ boundary: null })}
+          tier="Personal"
+        />,
+      );
+
+      await user.click(screen.getByRole('radio', { name: /^custom shape$/i }));
+
+      act(() => {
+        capturedMapEvents.click?.({ latlng: { lat: 52.2, lng: 0.1 } });
+      });
+      act(() => {
+        capturedMapEvents.click?.({ latlng: { lat: 52.2, lng: 0.12 } });
+      });
+      act(() => {
+        capturedMapEvents.click?.({ latlng: { lat: 52.21, lng: 0.12 } });
+      });
+
+      const closeButton = screen.getAllByTestId('marker-click')[0];
+      await user.click(closeButton!);
+
+      const saveButton = screen.getByRole('button', { name: /save/i });
+      await user.click(saveButton);
+
+      expect(spy.updateZoneCalls).toHaveLength(1);
+      expect(spy.updateZoneCalls[0]?.data).toEqual({
+        boundary: {
+          type: 'Polygon',
+          coordinates: [
+            [
+              [0.1, 52.2],
+              [0.12, 52.2],
+              [0.12, 52.21],
+              [0.1, 52.2],
+            ],
+          ],
+        },
+      });
     });
   });
 });

--- a/web/src/features/WatchZones/__tests__/useBoundaryDrawing.test.ts
+++ b/web/src/features/WatchZones/__tests__/useBoundaryDrawing.test.ts
@@ -1,0 +1,180 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { useBoundaryDrawing } from '../useBoundaryDrawing';
+import { aWatchZoneBoundary } from './fixtures/watch-zone.fixtures';
+
+describe('useBoundaryDrawing', () => {
+  it('starts with no vertices and an open ring', () => {
+    const { result } = renderHook(() => useBoundaryDrawing());
+
+    expect(result.current.vertices).toEqual([]);
+    expect(result.current.isClosed).toBe(false);
+    expect(result.current.canClose).toBe(false);
+    expect(result.current.boundary).toBeNull();
+  });
+
+  it('adds a vertex on addVertex', () => {
+    const { result } = renderHook(() => useBoundaryDrawing());
+
+    act(() => {
+      result.current.addVertex({ latitude: 52.2, longitude: 0.1 });
+    });
+
+    expect(result.current.vertices).toEqual([{ latitude: 52.2, longitude: 0.1 }]);
+  });
+
+  it('does not close the ring with fewer than 3 vertices (minimum-vertex guard)', () => {
+    const { result } = renderHook(() => useBoundaryDrawing());
+
+    act(() => {
+      result.current.addVertex({ latitude: 52.2, longitude: 0.1 });
+      result.current.addVertex({ latitude: 52.21, longitude: 0.12 });
+    });
+
+    expect(result.current.canClose).toBe(false);
+
+    act(() => {
+      result.current.closeRing();
+    });
+
+    expect(result.current.isClosed).toBe(false);
+    expect(result.current.boundary).toBeNull();
+  });
+
+  it('closes the ring after 3 vertices via closeRing (clicking the first vertex)', () => {
+    const { result } = renderHook(() => useBoundaryDrawing());
+
+    act(() => {
+      result.current.addVertex({ latitude: 52.2, longitude: 0.1 });
+      result.current.addVertex({ latitude: 52.2, longitude: 0.12 });
+      result.current.addVertex({ latitude: 52.21, longitude: 0.12 });
+    });
+
+    expect(result.current.canClose).toBe(true);
+
+    act(() => {
+      result.current.closeRing();
+    });
+
+    expect(result.current.isClosed).toBe(true);
+    expect(result.current.boundary).toEqual({
+      type: 'Polygon',
+      coordinates: [
+        [
+          [0.1, 52.2],
+          [0.12, 52.2],
+          [0.12, 52.21],
+          [0.1, 52.2],
+        ],
+      ],
+    });
+  });
+
+  it('ignores addVertex once the ring is closed', () => {
+    const { result } = renderHook(() => useBoundaryDrawing());
+
+    act(() => {
+      result.current.addVertex({ latitude: 52.2, longitude: 0.1 });
+      result.current.addVertex({ latitude: 52.2, longitude: 0.12 });
+      result.current.addVertex({ latitude: 52.21, longitude: 0.12 });
+      result.current.closeRing();
+    });
+
+    act(() => {
+      result.current.addVertex({ latitude: 53, longitude: 1 });
+    });
+
+    expect(result.current.vertices).toHaveLength(3);
+  });
+
+  it('moves a vertex via moveVertex (drag to adjust)', () => {
+    const { result } = renderHook(() => useBoundaryDrawing());
+
+    act(() => {
+      result.current.addVertex({ latitude: 52.2, longitude: 0.1 });
+      result.current.addVertex({ latitude: 52.21, longitude: 0.12 });
+    });
+
+    act(() => {
+      result.current.moveVertex(0, { latitude: 52.25, longitude: 0.15 });
+    });
+
+    expect(result.current.vertices).toEqual([
+      { latitude: 52.25, longitude: 0.15 },
+      { latitude: 52.21, longitude: 0.12 },
+    ]);
+  });
+
+  it('undo removes the last vertex when the ring is open', () => {
+    const { result } = renderHook(() => useBoundaryDrawing());
+
+    act(() => {
+      result.current.addVertex({ latitude: 52.2, longitude: 0.1 });
+      result.current.addVertex({ latitude: 52.21, longitude: 0.12 });
+    });
+
+    act(() => {
+      result.current.undo();
+    });
+
+    expect(result.current.vertices).toEqual([{ latitude: 52.2, longitude: 0.1 }]);
+  });
+
+  it('undo reopens the ring when closed, without removing a vertex', () => {
+    const { result } = renderHook(() => useBoundaryDrawing());
+
+    act(() => {
+      result.current.addVertex({ latitude: 52.2, longitude: 0.1 });
+      result.current.addVertex({ latitude: 52.2, longitude: 0.12 });
+      result.current.addVertex({ latitude: 52.21, longitude: 0.12 });
+      result.current.closeRing();
+    });
+
+    act(() => {
+      result.current.undo();
+    });
+
+    expect(result.current.isClosed).toBe(false);
+    expect(result.current.vertices).toHaveLength(3);
+    expect(result.current.boundary).toBeNull();
+  });
+
+  it('reset clears the vertices and reopens the ring', () => {
+    const { result } = renderHook(() => useBoundaryDrawing());
+
+    act(() => {
+      result.current.addVertex({ latitude: 52.2, longitude: 0.1 });
+      result.current.addVertex({ latitude: 52.2, longitude: 0.12 });
+      result.current.addVertex({ latitude: 52.21, longitude: 0.12 });
+      result.current.closeRing();
+    });
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.vertices).toEqual([]);
+    expect(result.current.isClosed).toBe(false);
+    expect(result.current.boundary).toBeNull();
+  });
+
+  it('initialises vertices and closed state from an existing boundary', () => {
+    const { result } = renderHook(() => useBoundaryDrawing(aWatchZoneBoundary()));
+
+    expect(result.current.isClosed).toBe(true);
+    expect(result.current.vertices).toEqual([
+      { latitude: 52.2, longitude: 0.1 },
+      { latitude: 52.2, longitude: 0.12 },
+      { latitude: 52.21, longitude: 0.12 },
+      { latitude: 52.21, longitude: 0.1 },
+    ]);
+    expect(result.current.boundary).toEqual(aWatchZoneBoundary());
+  });
+
+  it('treats a null initial boundary the same as no boundary', () => {
+    const { result } = renderHook(() => useBoundaryDrawing(null));
+
+    expect(result.current.isClosed).toBe(false);
+    expect(result.current.vertices).toEqual([]);
+  });
+});

--- a/web/src/features/WatchZones/__tests__/useCreateWatchZone.test.ts
+++ b/web/src/features/WatchZones/__tests__/useCreateWatchZone.test.ts
@@ -2,7 +2,7 @@ import { renderHook, act } from '@testing-library/react';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { useCreateWatchZone } from '../useCreateWatchZone';
 import { SpyWatchZoneRepository } from './spies/spy-watch-zone-repository';
-import { aWatchZone } from './fixtures/watch-zone.fixtures';
+import { aWatchZone, aWatchZoneBoundary } from './fixtures/watch-zone.fixtures';
 
 describe('useCreateWatchZone', () => {
   let spy: SpyWatchZoneRepository;
@@ -129,5 +129,126 @@ describe('useCreateWatchZone', () => {
 
     expect(result.current.step).toBe('details');
     expect(result.current.error).toBe('Please enter a name for this watch zone');
+  });
+
+  describe('shape mode', () => {
+    it('starts in circle shape mode', () => {
+      const { result } = renderHook(() => useCreateWatchZone(spy, navigate));
+
+      expect(result.current.shapeMode).toBe('circle');
+    });
+
+    it('allows switching to custom shape mode', () => {
+      const { result } = renderHook(() => useCreateWatchZone(spy, navigate));
+
+      act(() => {
+        result.current.setShapeMode('custom');
+      });
+
+      expect(result.current.shapeMode).toBe('custom');
+    });
+
+    it('does not advance to confirm in custom mode without a closed boundary', () => {
+      const { result } = renderHook(() => useCreateWatchZone(spy, navigate));
+
+      act(() => {
+        result.current.setGeocode({ latitude: 52.2053, longitude: 0.1218 }, 'CB1 2AD');
+        result.current.setName('Home');
+        result.current.setShapeMode('custom');
+      });
+
+      act(() => {
+        result.current.confirmDetails(null);
+      });
+
+      expect(result.current.step).toBe('details');
+      expect(result.current.error).toBe(
+        'Draw a shape with at least 3 points, then close it by clicking the first point again.',
+      );
+    });
+
+    it('advances to confirm in custom mode once a boundary is provided', () => {
+      const { result } = renderHook(() => useCreateWatchZone(spy, navigate));
+      const boundary = aWatchZoneBoundary();
+
+      act(() => {
+        result.current.setGeocode({ latitude: 52.2053, longitude: 0.1218 }, 'CB1 2AD');
+        result.current.setName('Home');
+        result.current.setShapeMode('custom');
+      });
+
+      act(() => {
+        result.current.confirmDetails(boundary);
+      });
+
+      expect(result.current.step).toBe('confirm');
+      expect(result.current.error).toBeNull();
+    });
+
+    it('includes the boundary in the create request in custom mode', async () => {
+      const boundary = aWatchZoneBoundary();
+      spy.createResult = aWatchZone({ boundary });
+
+      const { result } = renderHook(() => useCreateWatchZone(spy, navigate));
+
+      act(() => {
+        result.current.setGeocode({ latitude: 52.2053, longitude: 0.1218 }, 'CB1 2AD');
+        result.current.setName('Home');
+        result.current.setShapeMode('custom');
+      });
+
+      await act(async () => {
+        await result.current.save(boundary);
+      });
+
+      expect(spy.createCalls).toHaveLength(1);
+      expect(spy.createCalls[0]).toEqual({
+        name: 'Home',
+        latitude: 52.2053,
+        longitude: 0.1218,
+        radiusMetres: 2000,
+        boundary,
+      });
+      expect(navigatedTo).toBe('/watch-zones');
+    });
+
+    it('omits the boundary from the create request while in circle mode', async () => {
+      spy.createResult = aWatchZone();
+      const boundary = aWatchZoneBoundary();
+
+      const { result } = renderHook(() => useCreateWatchZone(spy, navigate));
+
+      act(() => {
+        result.current.setGeocode({ latitude: 52.2053, longitude: 0.1218 }, 'CB1 2AD');
+        result.current.setName('Home');
+      });
+
+      await act(async () => {
+        // Even if a stale boundary value is passed in, circle mode ignores it.
+        await result.current.save(boundary);
+      });
+
+      const call = spy.createCalls[0] as Record<string, unknown>;
+      expect('boundary' in call).toBe(false);
+    });
+
+    it('does not save a custom-mode zone without a boundary', async () => {
+      const { result } = renderHook(() => useCreateWatchZone(spy, navigate));
+
+      act(() => {
+        result.current.setGeocode({ latitude: 52.2053, longitude: 0.1218 }, 'CB1 2AD');
+        result.current.setName('Home');
+        result.current.setShapeMode('custom');
+      });
+
+      await act(async () => {
+        await result.current.save(null);
+      });
+
+      expect(spy.createCalls).toHaveLength(0);
+      expect(result.current.error).toBe(
+        'Draw a shape with at least 3 points, then close it by clicking the first point again.',
+      );
+    });
   });
 });

--- a/web/src/features/WatchZones/__tests__/useZoneEdit.test.ts
+++ b/web/src/features/WatchZones/__tests__/useZoneEdit.test.ts
@@ -2,7 +2,7 @@ import { renderHook, act } from '@testing-library/react';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { useZoneEdit } from '../useZoneEdit';
 import { SpyWatchZoneRepository } from './spies/spy-watch-zone-repository';
-import { aWatchZone } from './fixtures/watch-zone.fixtures';
+import { aWatchZone, aWatchZoneBoundary } from './fixtures/watch-zone.fixtures';
 
 describe('useZoneEdit', () => {
   let spy: SpyWatchZoneRepository;
@@ -333,6 +333,168 @@ describe('useZoneEdit', () => {
 
       expect(result.current.isDirty).toBe(false);
       expect(result.current.pushEnabled).toBe(false);
+    });
+  });
+
+  describe('shape mode / boundary', () => {
+    it('initialises shapeMode as circle for a plain circle zone', () => {
+      const zone = aWatchZone({ boundary: null });
+
+      const { result } = renderHook(() => useZoneEdit(spy, zone));
+
+      expect(result.current.shapeMode).toBe('circle');
+      expect(result.current.isDirty).toBe(false);
+    });
+
+    it('initialises shapeMode as custom for a zone with an existing boundary', () => {
+      const boundary = aWatchZoneBoundary();
+      const zone = aWatchZone({ boundary });
+
+      const { result } = renderHook(() => useZoneEdit(spy, zone, boundary));
+
+      expect(result.current.shapeMode).toBe('custom');
+      expect(result.current.isDirty).toBe(false);
+    });
+
+    it('marks the form dirty when switching shape mode', () => {
+      const zone = aWatchZone({ boundary: null });
+
+      const { result } = renderHook(() => useZoneEdit(spy, zone));
+
+      act(() => {
+        result.current.setShapeMode('custom');
+      });
+
+      expect(result.current.isDirty).toBe(true);
+    });
+
+    it('blocks save with a boundaryError when custom mode has no boundary yet', () => {
+      const zone = aWatchZone({ boundary: null });
+
+      const { result } = renderHook(() => useZoneEdit(spy, zone));
+
+      act(() => {
+        result.current.setShapeMode('custom');
+      });
+
+      expect(result.current.boundaryError).toBe(
+        'Draw a shape with at least 3 points, then close it by clicking the first point again.',
+      );
+      expect(result.current.canSave).toBe(false);
+    });
+
+    it('sends an explicit null boundary when switching a custom zone back to circle', async () => {
+      const boundary = aWatchZoneBoundary();
+      const zone = aWatchZone({ boundary });
+      spy.updateZoneResult = aWatchZone({ boundary: null });
+
+      const { result } = renderHook(() => useZoneEdit(spy, zone, boundary));
+
+      act(() => {
+        result.current.setShapeMode('circle');
+      });
+
+      await act(async () => {
+        await result.current.save();
+      });
+
+      expect(spy.updateZoneCalls).toHaveLength(1);
+      expect(spy.updateZoneCalls[0]?.data).toEqual({ boundary: null });
+    });
+
+    it('sends the new boundary when switching a circle zone to custom', async () => {
+      const boundary = aWatchZoneBoundary();
+      const zone = aWatchZone({ boundary: null });
+      spy.updateZoneResult = aWatchZone({ boundary });
+
+      const { result, rerender } = renderHook(
+        ({ currentBoundary }) => useZoneEdit(spy, zone, currentBoundary),
+        { initialProps: { currentBoundary: null as typeof boundary | null } },
+      );
+
+      act(() => {
+        result.current.setShapeMode('custom');
+      });
+      rerender({ currentBoundary: boundary });
+
+      await act(async () => {
+        await result.current.save();
+      });
+
+      expect(spy.updateZoneCalls).toHaveLength(1);
+      expect(spy.updateZoneCalls[0]?.data).toEqual({ boundary });
+    });
+
+    it('omits boundary from the patch when shape mode and boundary are both unchanged', async () => {
+      const boundary = aWatchZoneBoundary();
+      const zone = aWatchZone({ name: 'Home', boundary });
+      spy.updateZoneResult = aWatchZone({ name: 'Office', boundary });
+
+      const { result } = renderHook(() => useZoneEdit(spy, zone, boundary));
+
+      act(() => {
+        result.current.setName('Office');
+      });
+
+      await act(async () => {
+        await result.current.save();
+      });
+
+      expect(spy.updateZoneCalls[0]?.data).toEqual({ name: 'Office' });
+    });
+
+    it('sends an updated boundary when a custom zone is redrawn', async () => {
+      const originalBoundary = aWatchZoneBoundary();
+      const redrawnBoundary = aWatchZoneBoundary({
+        coordinates: [
+          [
+            [0.2, 52.3],
+            [0.22, 52.3],
+            [0.22, 52.31],
+            [0.2, 52.3],
+          ],
+        ],
+      });
+      const zone = aWatchZone({ boundary: originalBoundary });
+      spy.updateZoneResult = aWatchZone({ boundary: redrawnBoundary });
+
+      const { result, rerender } = renderHook(
+        ({ currentBoundary }) => useZoneEdit(spy, zone, currentBoundary),
+        { initialProps: { currentBoundary: originalBoundary } },
+      );
+
+      expect(result.current.isDirty).toBe(false);
+
+      rerender({ currentBoundary: redrawnBoundary });
+
+      expect(result.current.isDirty).toBe(true);
+
+      await act(async () => {
+        await result.current.save();
+      });
+
+      expect(spy.updateZoneCalls[0]?.data).toEqual({ boundary: redrawnBoundary });
+    });
+
+    it('resets baseline shape state after a successful save', async () => {
+      const boundary = aWatchZoneBoundary();
+      const zone = aWatchZone({ boundary });
+      spy.updateZoneResult = aWatchZone({ boundary: null });
+
+      const { result } = renderHook(() => useZoneEdit(spy, zone, boundary));
+
+      act(() => {
+        result.current.setShapeMode('circle');
+      });
+
+      expect(result.current.isDirty).toBe(true);
+
+      await act(async () => {
+        await result.current.save();
+      });
+
+      expect(result.current.isDirty).toBe(false);
+      expect(result.current.shapeMode).toBe('circle');
     });
   });
 });

--- a/web/src/features/WatchZones/useBoundaryDrawing.ts
+++ b/web/src/features/WatchZones/useBoundaryDrawing.ts
@@ -1,0 +1,124 @@
+import { useState, useCallback, useMemo } from 'react';
+import type { Coordinates, WatchZoneBoundary } from '../../domain/types';
+
+/**
+ * 3 is the geometric minimum for a polygon — matches the server-side
+ * validation range (3 to 50 vertices) in GH#1031.
+ */
+const MIN_VERTICES = 3;
+
+export interface BoundaryDrawingState {
+  /** The in-progress or completed ring, in draw order. Never includes the
+   * GeoJSON closing duplicate of the first vertex — that is added only when
+   * computing `boundary`. */
+  readonly vertices: readonly Coordinates[];
+  /** True once the ring has been closed (first vertex clicked again). */
+  readonly isClosed: boolean;
+  /** True once there are enough vertices to legally close the ring. */
+  readonly canClose: boolean;
+  /**
+   * The GeoJSON `Polygon` for the completed ring, or `null` while the ring
+   * is still open or has too few vertices.
+   */
+  readonly boundary: WatchZoneBoundary | null;
+  /** Click to add a vertex. Ignored once the ring is closed. */
+  addVertex: (coordinate: Coordinates) => void;
+  /** Drag a vertex marker to a new position. */
+  moveVertex: (index: number, coordinate: Coordinates) => void;
+  /** Click the first vertex again to close the ring. No-op below the minimum. */
+  closeRing: () => void;
+  /** Undo the last action: reopens a closed ring, or removes the last vertex. */
+  undo: () => void;
+  /** Clear all vertices and reopen the ring. */
+  reset: () => void;
+}
+
+interface DrawingState {
+  vertices: Coordinates[];
+  isClosed: boolean;
+}
+
+function initialDrawingState(initialBoundary?: WatchZoneBoundary | null): DrawingState {
+  if (!initialBoundary) {
+    return { vertices: [], isClosed: false };
+  }
+  const ring = initialBoundary.coordinates[0] ?? [];
+  // GeoJSON repeats the first vertex at the end to close the ring; drop it
+  // since `vertices` always holds the open, de-duplicated point list.
+  const openRing = ring.length > 1 ? ring.slice(0, -1) : ring;
+  return {
+    vertices: openRing.map(([longitude, latitude]) => ({ latitude, longitude })),
+    isClosed: true,
+  };
+}
+
+export function useBoundaryDrawing(
+  initialBoundary?: WatchZoneBoundary | null,
+): BoundaryDrawingState {
+  const [state, setState] = useState<DrawingState>(() => initialDrawingState(initialBoundary));
+
+  const addVertex = useCallback((coordinate: Coordinates) => {
+    setState((prev) => {
+      if (prev.isClosed) {
+        return prev;
+      }
+      return { ...prev, vertices: [...prev.vertices, coordinate] };
+    });
+  }, []);
+
+  const moveVertex = useCallback((index: number, coordinate: Coordinates) => {
+    setState((prev) => ({
+      ...prev,
+      vertices: prev.vertices.map((vertex, i) => (i === index ? coordinate : vertex)),
+    }));
+  }, []);
+
+  const closeRing = useCallback(() => {
+    setState((prev) => {
+      if (prev.isClosed || prev.vertices.length < MIN_VERTICES) {
+        return prev;
+      }
+      return { ...prev, isClosed: true };
+    });
+  }, []);
+
+  const undo = useCallback(() => {
+    setState((prev) => {
+      if (prev.isClosed) {
+        return { ...prev, isClosed: false };
+      }
+      return { ...prev, vertices: prev.vertices.slice(0, -1) };
+    });
+  }, []);
+
+  const reset = useCallback(() => {
+    setState({ vertices: [], isClosed: false });
+  }, []);
+
+  const { vertices, isClosed } = state;
+  const canClose = vertices.length >= MIN_VERTICES;
+
+  const boundary = useMemo<WatchZoneBoundary | null>(() => {
+    const firstVertex = vertices[0];
+    if (!isClosed || !firstVertex || vertices.length < MIN_VERTICES) {
+      return null;
+    }
+    const ring: (readonly [number, number])[] = vertices.map(
+      (vertex) => [vertex.longitude, vertex.latitude] as const,
+    );
+    ring.push([firstVertex.longitude, firstVertex.latitude]);
+    return { type: 'Polygon', coordinates: [ring] };
+  }, [vertices, isClosed]);
+
+  return {
+    vertices,
+    isClosed,
+    canClose,
+    boundary,
+    addVertex,
+    moveVertex,
+    closeRing,
+    undo,
+    reset,
+  };
+}

--- a/web/src/features/WatchZones/useCreateWatchZone.ts
+++ b/web/src/features/WatchZones/useCreateWatchZone.ts
@@ -1,9 +1,13 @@
 import { useState, useCallback } from 'react';
-import type { GeocodeResult } from '../../domain/types';
+import type { GeocodeResult, WatchZoneBoundary } from '../../domain/types';
 import type { WatchZoneRepository } from '../../domain/ports/watch-zone-repository';
+import type { ShapeMode } from './ShapeModeToggle';
 import { extractErrorMessage } from '../../utils/extractErrorMessage';
 
 type CreateStep = 'postcode' | 'details' | 'confirm';
+
+const MISSING_BOUNDARY_ERROR =
+  'Draw a shape with at least 3 points, then close it by clicking the first point again.';
 
 interface CreateWatchZoneState {
   step: CreateStep;
@@ -11,6 +15,7 @@ interface CreateWatchZoneState {
   postcode: string;
   coordinates: GeocodeResult | null;
   radiusMetres: number;
+  shapeMode: ShapeMode;
   isSaving: boolean;
   error: string | null;
 }
@@ -25,6 +30,7 @@ export function useCreateWatchZone(
     postcode: '',
     coordinates: null,
     radiusMetres: 2000,
+    shapeMode: 'circle',
     isSaving: false,
     error: null,
   });
@@ -47,34 +53,53 @@ export function useCreateWatchZone(
     setState(prev => ({ ...prev, radiusMetres }));
   }, []);
 
-  const confirmDetails = useCallback(() => {
-    if (!state.name.trim()) {
-      setState(prev => ({ ...prev, error: 'Please enter a name for this watch zone' }));
-      return;
-    }
-    setState(prev => ({ ...prev, step: 'confirm', error: null }));
-  }, [state.name]);
+  const setShapeMode = useCallback((shapeMode: ShapeMode) => {
+    setState(prev => ({ ...prev, shapeMode, error: null }));
+  }, []);
 
-  const save = useCallback(async () => {
-    if (!state.coordinates) {
-      setState(prev => ({ ...prev, error: 'Please look up a postcode first' }));
-      return;
-    }
+  const confirmDetails = useCallback(
+    (boundary?: WatchZoneBoundary | null) => {
+      if (!state.name.trim()) {
+        setState(prev => ({ ...prev, error: 'Please enter a name for this watch zone' }));
+        return;
+      }
+      if (state.shapeMode === 'custom' && !boundary) {
+        setState(prev => ({ ...prev, error: MISSING_BOUNDARY_ERROR }));
+        return;
+      }
+      setState(prev => ({ ...prev, step: 'confirm', error: null }));
+    },
+    [state.name, state.shapeMode],
+  );
 
-    setState(prev => ({ ...prev, isSaving: true, error: null }));
-    try {
-      await repository.create({
-        name: state.name.trim(),
-        latitude: state.coordinates.latitude,
-        longitude: state.coordinates.longitude,
-        radiusMetres: state.radiusMetres,
-      });
-      navigate('/watch-zones');
-    } catch (err: unknown) {
-      const message = extractErrorMessage(err);
-      setState(prev => ({ ...prev, isSaving: false, error: message }));
-    }
-  }, [state.coordinates, state.name, state.radiusMetres, repository, navigate]);
+  const save = useCallback(
+    async (boundary?: WatchZoneBoundary | null) => {
+      if (!state.coordinates) {
+        setState(prev => ({ ...prev, error: 'Please look up a postcode first' }));
+        return;
+      }
+      if (state.shapeMode === 'custom' && !boundary) {
+        setState(prev => ({ ...prev, error: MISSING_BOUNDARY_ERROR }));
+        return;
+      }
+
+      setState(prev => ({ ...prev, isSaving: true, error: null }));
+      try {
+        await repository.create({
+          name: state.name.trim(),
+          latitude: state.coordinates.latitude,
+          longitude: state.coordinates.longitude,
+          radiusMetres: state.radiusMetres,
+          ...(state.shapeMode === 'custom' && boundary ? { boundary } : {}),
+        });
+        navigate('/watch-zones');
+      } catch (err: unknown) {
+        const message = extractErrorMessage(err);
+        setState(prev => ({ ...prev, isSaving: false, error: message }));
+      }
+    },
+    [state.coordinates, state.name, state.radiusMetres, state.shapeMode, repository, navigate],
+  );
 
   return {
     step: state.step,
@@ -82,11 +107,13 @@ export function useCreateWatchZone(
     postcode: state.postcode,
     coordinates: state.coordinates,
     radiusMetres: state.radiusMetres,
+    shapeMode: state.shapeMode,
     isSaving: state.isSaving,
     error: state.error,
     setGeocode,
     setName,
     setRadiusMetres,
+    setShapeMode,
     confirmDetails,
     save,
   };

--- a/web/src/features/WatchZones/useZoneEdit.ts
+++ b/web/src/features/WatchZones/useZoneEdit.ts
@@ -1,19 +1,43 @@
 import { useState, useCallback, useMemo } from 'react';
-import type { WatchZoneSummary, UpdateWatchZoneRequest } from '../../domain/types';
+import type { WatchZoneSummary, UpdateWatchZoneRequest, WatchZoneBoundary } from '../../domain/types';
 import type { WatchZoneRepository } from '../../domain/ports/watch-zone-repository';
+import type { ShapeMode } from './ShapeModeToggle';
 import { extractErrorMessage } from '../../utils/extractErrorMessage';
 
-export function useZoneEdit(repository: WatchZoneRepository, zone: WatchZoneSummary) {
+const MISSING_BOUNDARY_ERROR =
+  'Draw a shape with at least 3 points, then close it by clicking the first point again.';
+
+function shapeModeOf(boundary: WatchZoneBoundary | null): ShapeMode {
+  return boundary ? 'custom' : 'circle';
+}
+
+/** Structural equality for a GeoJSON boundary — good enough here since
+ * both sides always come from the same wire shape (no extra keys, no
+ * `NaN`s), and a byte-for-byte compare is exactly what "has this shape
+ * been redrawn" means. */
+function boundariesEqual(a: WatchZoneBoundary | null, b: WatchZoneBoundary | null): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+export function useZoneEdit(
+  repository: WatchZoneRepository,
+  zone: WatchZoneSummary,
+  currentBoundary?: WatchZoneBoundary | null,
+) {
   const [baselineName, setBaselineName] = useState(zone.name);
   const [baselineRadius, setBaselineRadius] = useState(zone.radiusMetres);
   const [baselinePushEnabled, setBaselinePushEnabled] = useState(zone.pushEnabled);
   const [baselineEmailInstantEnabled, setBaselineEmailInstantEnabled] = useState(
     zone.emailInstantEnabled,
   );
+  const [baselineBoundary, setBaselineBoundary] = useState<WatchZoneBoundary | null>(
+    zone.boundary,
+  );
   const [name, setName] = useState(zone.name);
   const [radiusMetres, setRadiusMetres] = useState(zone.radiusMetres);
   const [pushEnabled, setPushEnabled] = useState(zone.pushEnabled);
   const [emailInstantEnabled, setEmailInstantEnabled] = useState(zone.emailInstantEnabled);
+  const [shapeMode, setShapeMode] = useState<ShapeMode>(() => shapeModeOf(zone.boundary));
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -24,16 +48,35 @@ export function useZoneEdit(repository: WatchZoneRepository, zone: WatchZoneSumm
     return null;
   }, [name]);
 
+  // The boundary actually in play right now: `null` in circle mode
+  // regardless of what's being drawn, otherwise whatever the caller passed
+  // (the live value from `useBoundaryDrawing`, or `null`/undefined while
+  // nothing has been drawn yet).
+  const effectiveBoundary = shapeMode === 'custom' ? (currentBoundary ?? null) : null;
+
+  const boundaryError = useMemo(() => {
+    if (shapeMode === 'custom' && effectiveBoundary === null) {
+      return MISSING_BOUNDARY_ERROR;
+    }
+    return null;
+  }, [shapeMode, effectiveBoundary]);
+
+  const baselineShapeMode = shapeModeOf(baselineBoundary);
+  const boundaryDirty =
+    shapeMode !== baselineShapeMode ||
+    (shapeMode === 'custom' && !boundariesEqual(effectiveBoundary, baselineBoundary));
+
   const isDirty =
     name !== baselineName ||
     radiusMetres !== baselineRadius ||
     pushEnabled !== baselinePushEnabled ||
-    emailInstantEnabled !== baselineEmailInstantEnabled;
+    emailInstantEnabled !== baselineEmailInstantEnabled ||
+    boundaryDirty;
 
-  const canSave = isDirty && nameError === null;
+  const canSave = isDirty && nameError === null && boundaryError === null;
 
   const save = useCallback(async () => {
-    if (!isDirty) return;
+    if (!isDirty || boundaryError !== null) return;
 
     const data: UpdateWatchZoneRequest = {};
     const mutableData = data as Record<string, unknown>;
@@ -49,6 +92,11 @@ export function useZoneEdit(repository: WatchZoneRepository, zone: WatchZoneSumm
     if (emailInstantEnabled !== baselineEmailInstantEnabled) {
       mutableData['emailInstantEnabled'] = emailInstantEnabled;
     }
+    if (boundaryDirty) {
+      // Tri-state: omitted entirely above when unchanged, explicit `null`
+      // to revert to a circle, or the new/redrawn shape.
+      mutableData['boundary'] = effectiveBoundary;
+    }
 
     setIsSaving(true);
     setError(null);
@@ -58,10 +106,12 @@ export function useZoneEdit(repository: WatchZoneRepository, zone: WatchZoneSumm
       setBaselineRadius(updated.radiusMetres);
       setBaselinePushEnabled(updated.pushEnabled);
       setBaselineEmailInstantEnabled(updated.emailInstantEnabled);
+      setBaselineBoundary(updated.boundary);
       setName(updated.name);
       setRadiusMetres(updated.radiusMetres);
       setPushEnabled(updated.pushEnabled);
       setEmailInstantEnabled(updated.emailInstantEnabled);
+      setShapeMode(shapeModeOf(updated.boundary));
       setIsSaving(false);
     } catch (err: unknown) {
       setIsSaving(false);
@@ -69,10 +119,13 @@ export function useZoneEdit(repository: WatchZoneRepository, zone: WatchZoneSumm
     }
   }, [
     isDirty,
+    boundaryError,
     name,
     radiusMetres,
     pushEnabled,
     emailInstantEnabled,
+    boundaryDirty,
+    effectiveBoundary,
     baselineName,
     baselineRadius,
     baselinePushEnabled,
@@ -90,10 +143,13 @@ export function useZoneEdit(repository: WatchZoneRepository, zone: WatchZoneSumm
     setPushEnabled,
     emailInstantEnabled,
     setEmailInstantEnabled,
+    shapeMode,
+    setShapeMode,
     isDirty,
     isSaving,
     error,
     nameError,
+    boundaryError,
     canSave,
     save,
   };


### PR DESCRIPTION
## Summary
- Implements GH#1031 section 8 (Web) — custom-shape (polygon) watch zone drawing on the web app, following on from `tc-6he3x.11` (#1049, merged) which wired the `boundary` field through the domain types and `ApiWatchZoneRepository`.
- New `useBoundaryDrawing.ts` hand-rolled hook over `react-leaflet` (no new dependency): click to add a vertex, drag to move, click the first vertex to close the ring, undo the last point.
- New `BoundaryMap.tsx` (drawing surface) and `ShapeModeToggle.tsx` (Circle / Custom shape control), wired into `WatchZoneCreatePage` and `WatchZoneEditPage`.
- Personal/Pro tiers see the shape toggle and can draw a custom boundary; Free tier still gets `RadiusPicker` plus the existing `CustomShapeUpsell` (from `tc-6he3x.13`), with no drawing affordance.
- `useCreateWatchZone` and `useZoneEdit` gained boundary-aware state, including tri-state PATCH semantics on edit (omit when unchanged, explicit `null` to convert a custom shape back to a circle, new value on redraw).

## Out of scope (by design)
- Onboarding upsell / mid-flow drawing step — that's `tc-6he3x.14`, blocked on this PR.
- iOS, Android, Go API — already shipped or tracked separately in the epic.
- No upgrade/billing CTA is wired into `CustomShapeUpsell` yet since no upgrade route exists in `web/` — flagged as a possible follow-up, not built here.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 143 files / 1384 tests passing, including new `useBoundaryDrawing`, `BoundaryMap`, `ShapeModeToggle`, and updated `WatchZoneCreatePage`/`WatchZoneEditPage`/`useCreateWatchZone`/`useZoneEdit` suites (add/close/drag/undo/guard, tier gating, tri-state patch)
- [x] `npm run build` — succeeds, no new runtime dependency in `package.json`
- [ ] Live browser verification (agent-browser) — not run in this session; recommend before merge

Bead: tc-6he3x.12

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eqj4c9pvivrVBSFnETCQEV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added custom boundary shapes for eligible watch-zone plans.
  * Draw, edit, move, close, undo, and reset polygon boundaries on an interactive map.
  * Added shape selection between circular radius and custom boundary modes.
  * Displayed selected shapes during confirmation and editing.
  * Added upgrade messaging for Free users.

* **Bug Fixes**
  * Added validation preventing custom zones from being saved without a boundary.

* **Tests**
  * Expanded coverage for boundary drawing, shape selection, creation, editing, validation, and saving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->