### PR TITLE
chore(ios): bump MARKETING_VERSION 1.2.9 -> 1.2.10 (tc-tq8nj)

### DIFF
--- a/mobile/ios/project.yml
+++ b/mobile/ios/project.yml
@@ -26,7 +26,7 @@ targets:
         DEVELOPMENT_TEAM: 4574VQ7N2X
         TARGETED_DEVICE_FAMILY: "1"
         INFOPLIST_GENERATION_MODE: GeneratedFile
-        MARKETING_VERSION: "1.2.9"
+        MARKETING_VERSION: "1.2.10"
         CURRENT_PROJECT_VERSION: "1"
         GENERATE_INFOPLIST_FILE: "YES"
         INFOPLIST_KEY_UIApplicationSceneManifest_Generation: "YES"


### PR DESCRIPTION
## Summary
- Pre-release train for `1.2.9` closed after it shipped to the App Store on 2026-07-13.
- Manual `workflow_dispatch` of `cd-ios-testflight` on `main` failed at `upload_to_testflight` with altool errors 90186 (train closed) and 90062 (CFBundleShortVersionString must exceed the last approved version).
- Bumps `MARKETING_VERSION` in `mobile/ios/project.yml` from `1.2.9` to `1.2.10` per the documented playbook in CLAUDE.md's Release Process section.

## Test plan
- [x] `xcodegen generate` not required for this change (build-setting-only YAML edit)
- [ ] CI: PR Gate (SwiftLint + swift test) passes
- [ ] Post-merge: re-dispatch `cd-ios-testflight` on `main` and confirm upload succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the iOS app’s marketing version to 1.2.10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->