### PR TITLE
web: reword SEO freshness line to "Last application update"

### DIFF
--- a/web/scripts/lib/__tests__/format.test.mjs
+++ b/web/scripts/lib/__tests__/format.test.mjs
@@ -157,14 +157,14 @@ describe('aggregateStatusSummary (tc-r4n9.3: compact Granted/Refused/Undecided s
   });
 });
 
-describe('dataUpdatedLine (tc-r4n9.3: single "Data updated" line replacing the per-card repetition)', () => {
+describe('dataUpdatedLine (tc-r4n9.3: single "Last application update" line replacing the per-card repetition)', () => {
   it('reports the freshest lastDifferent among the applications shown, formatted en-GB', () => {
     const applications = [
       { lastDifferent: '2026-06-12T09:30:00+00:00' },
       { lastDifferent: '2026-06-15T10:00:00+00:00' },
       { lastDifferent: '2026-06-09T08:00:00+00:00' },
     ];
-    expect(dataUpdatedLine(applications)).toBe('Data updated 15 Jun 2026');
+    expect(dataUpdatedLine(applications)).toBe('Last application update 15 Jun 2026');
   });
 
   it('ignores applications with no parseable lastDifferent when finding the max', () => {
@@ -173,7 +173,7 @@ describe('dataUpdatedLine (tc-r4n9.3: single "Data updated" line replacing the p
       { lastDifferent: '2026-06-01T08:00:00+00:00' },
       { lastDifferent: '' },
     ];
-    expect(dataUpdatedLine(applications)).toBe('Data updated 1 Jun 2026');
+    expect(dataUpdatedLine(applications)).toBe('Last application update 1 Jun 2026');
   });
 
   it('returns an empty string when no application carries a parseable date', () => {

--- a/web/scripts/lib/__tests__/prerender-snapshot.test.mjs
+++ b/web/scripts/lib/__tests__/prerender-snapshot.test.mjs
@@ -366,7 +366,7 @@ describe('runRender — offline mode', () => {
     expect(authorityHtml).toContain(
       '<h1>Planning applications in Basingstoke and Deane</h1>',
     );
-    expect(authorityHtml).toContain('Data updated 15 Jun 2026');
+    expect(authorityHtml).toContain('Last application update 15 Jun 2026');
 
     // The nested town page renders, with the parent-authority slug resolved
     // offline from the embedded authority list (Cornwall id 52 -> "cornwall").

--- a/web/scripts/lib/__tests__/prerender-towns.test.mjs
+++ b/web/scripts/lib/__tests__/prerender-towns.test.mjs
@@ -300,9 +300,9 @@ describe('runPrerender — town live mode', () => {
     expect(html.indexOf('First In API Order, Truro')).toBeLessThan(
       html.indexOf('Second In API Order, Truro'),
     );
-    // The page-level "Data updated" line is unaffected by render order — still
-    // the freshest lastDifferent among the shown set.
-    expect(html).toContain('Data updated 20 Jun 2026');
+    // The page-level "Last application update" line is unaffected by render
+    // order — still the freshest lastDifferent among the shown set.
+    expect(html).toContain('Last application update 20 Jun 2026');
 
     // The sitemap lastmod is likewise the freshest shown app's lastDifferent,
     // independent of render order.

--- a/web/scripts/lib/__tests__/prerender.test.mjs
+++ b/web/scripts/lib/__tests__/prerender.test.mjs
@@ -69,8 +69,8 @@ describe('runPrerender — fixture mode', () => {
     expect(html).toContain('PlanIt');
     expect(html).toContain('Get push alerts for Basingstoke and Deane');
     // The freshest shown lastDifferent threads through to the single
-    // "Data updated" line near the H1 (tc-r4n9.3), not a per-card repeat.
-    expect(html).toContain('Data updated 15 Jun 2026');
+    // "Last application update" line near the H1 (tc-r4n9.3), not a per-card repeat.
+    expect(html).toContain('Last application update 15 Jun 2026');
     // The server breakdown (20 Granted) is threaded through and exceeds the three
     // cards rendered — proving the stats are server-driven, not card-counted.
     expect(html).toMatch(/20[\s\S]{0,20}Granted/);

--- a/web/scripts/lib/__tests__/render-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-page.test.mjs
@@ -251,12 +251,12 @@ describe('renderPlanningPage', () => {
     );
   });
 
-  describe('single "Data updated" line (tc-r4n9.3, replacing the per-card repetition)', () => {
-    it('renders exactly one "Data updated" line, near the H1, from the freshest shown application date', () => {
+  describe('single "Last application update" line (tc-r4n9.3, replacing the per-card repetition)', () => {
+    it('renders exactly one "Last application update" line, near the H1, from the freshest shown application date', () => {
       const html = renderPlanningPage(pageData());
       const occurrences = (html.match(/class="dataUpdated"/g) ?? []).length;
       expect(occurrences).toBe(1);
-      expect(html).toContain('<p class="dataUpdated">Data updated 12 Jun 2026</p>');
+      expect(html).toContain('<p class="dataUpdated">Last application update 12 Jun 2026</p>');
       expect(html.indexOf('<h1>')).toBeLessThan(html.indexOf('class="dataUpdated"'));
       expect(html.indexOf('class="dataUpdated"')).toBeLessThan(html.indexOf('class="lead"'));
     });

--- a/web/scripts/lib/__tests__/render-shared.test.mjs
+++ b/web/scripts/lib/__tests__/render-shared.test.mjs
@@ -337,12 +337,12 @@ describe('renderStatusSummary (tc-r4n9.3: compact Granted/Refused/Undecided stri
 });
 
 describe('renderDataUpdated (tc-r4n9.3: single line replacing per-card repetition)', () => {
-  it('renders one "Data updated" line from the freshest application date', () => {
+  it('renders one "Last application update" line from the freshest application date', () => {
     const html = renderDataUpdated([
       { lastDifferent: '2026-06-12T09:30:00+00:00' },
       { lastDifferent: '2026-06-15T10:00:00+00:00' },
     ]);
-    expect(html).toBe('<p class="dataUpdated">Data updated 15 Jun 2026</p>');
+    expect(html).toBe('<p class="dataUpdated">Last application update 15 Jun 2026</p>');
   });
 
   it('renders nothing when no application carries a parseable date', () => {

--- a/web/scripts/lib/__tests__/render-town-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-town-page.test.mjs
@@ -241,12 +241,12 @@ describe('renderTownPage', () => {
     );
   });
 
-  describe('single "Data updated" line (tc-r4n9.3, replacing the per-card repetition)', () => {
-    it('renders exactly one "Data updated" line, near the H1, from the freshest shown application date', () => {
+  describe('single "Last application update" line (tc-r4n9.3, replacing the per-card repetition)', () => {
+    it('renders exactly one "Last application update" line, near the H1, from the freshest shown application date', () => {
       const html = renderTownPage(townData());
       const occurrences = (html.match(/class="dataUpdated"/g) ?? []).length;
       expect(occurrences).toBe(1);
-      expect(html).toContain('<p class="dataUpdated">Data updated 12 Jun 2026</p>');
+      expect(html).toContain('<p class="dataUpdated">Last application update 12 Jun 2026</p>');
       expect(html.indexOf('<h1>')).toBeLessThan(html.indexOf('class="dataUpdated"'));
       expect(html.indexOf('class="dataUpdated"')).toBeLessThan(html.indexOf('class="lead"'));
     });

--- a/web/scripts/lib/format.mjs
+++ b/web/scripts/lib/format.mjs
@@ -157,12 +157,15 @@ export function aggregateStatusSummary(statusBreakdown) {
 
 /**
  * Find the most recent (max) `lastDifferent` among the applications actually
- * shown on a page and render it as the single "Data updated" line that
- * replaces the old per-card "Last updated {date}" repetition (tc-r4n9.3):
- * the same honest freshness signal the sitemap's lastmod uses (derived from
- * what's shown, not the build clock), surfaced once near the H1 instead of
- * once per card. Returns '' when no shown application carries a parseable
- * date, so the caller can omit the line rather than show a broken one.
+ * shown on a page and render it as the single "Last application update" line
+ * that replaces the old per-card "Last updated {date}" repetition
+ * (tc-r4n9.3): the same honest freshness signal the sitemap's lastmod uses
+ * (derived from what's shown, not the build clock), surfaced once near the
+ * H1 instead of once per card. Worded around the application rather than
+ * the page, so it reads as "nothing's changed" rather than "this site is
+ * stale" during a quiet week. Returns '' when no shown application carries a
+ * parseable date, so the caller can omit the line rather than show a broken
+ * one.
  *
  * @param {ReadonlyArray<{ lastDifferent?: string | null }>} applications
  * @returns {string}
@@ -184,7 +187,7 @@ export function dataUpdatedLine(applications) {
   if (maxIso === undefined) {
     return '';
   }
-  return `Data updated ${formatDate(maxIso)}`;
+  return `Last application update ${formatDate(maxIso)}`;
 }
 
 /**

--- a/web/scripts/lib/render-shared.mjs
+++ b/web/scripts/lib/render-shared.mjs
@@ -294,7 +294,7 @@ ${other
 }
 
 /**
- * Render the single "Data updated {date}" line (tc-r4n9.3, punch-list #794
+ * Render the single "Last application update {date}" line (tc-r4n9.3, punch-list #794
  * Phase 3) that replaces the old per-card "Last updated {date}" line, which
  * repeated the same handful of snapshot dates once per card (up to 30 times
  * on a full page) under a "Recent applications" heading — reading as


### PR DESCRIPTION
## Changes
- Reword the per-authority/per-town SEO page freshness line from "Data updated {date}" to "Last application update {date}" (`web/scripts/lib/format.mjs`, `render-shared.mjs`)
- The line still reflects the freshest `lastDifferent` among shown applications, unchanged (tc-r4n9.3) — only the copy changes, to make clear it tracks application activity, not page/build freshness
- Update the 7 test files asserting the exact string

---
*Auto-shipped via ship skill*