### PR TITLE
Fix admin subscription grant: deterministic email lookup, sync-then-save (tc-i0t8e)

### DIFF
--- a/api-go/internal/admin/handler_test.go
+++ b/api-go/internal/admin/handler_test.go
@@ -88,6 +88,11 @@ type fakeAdminStore struct {
 	gotSearch   string
 	gotPageSize int
 	gotToken    string
+
+	// order, when non-nil, has "save" appended on every Save call — shared with
+	// a fakeTierSync's order slice so a test can assert call ordering between
+	// the two collaborators (see TestGrant_Auth0FailureLeavesProfileUnsaved).
+	order *[]string
 }
 
 func (f *fakeAdminStore) PaidCandidates(_ context.Context) ([]*profiles.UserProfile, error) {
@@ -107,6 +112,9 @@ func (f *fakeAdminStore) GetByEmail(_ context.Context, email string) (*profiles.
 }
 
 func (f *fakeAdminStore) Save(_ context.Context, p *profiles.UserProfile) error {
+	if f.order != nil {
+		*f.order = append(*f.order, "save")
+	}
 	f.saved = p
 	return nil
 }
@@ -121,11 +129,22 @@ func (f *fakeAdminStore) List(_ context.Context, emailSearch string, pageSize in
 type fakeTierSync struct {
 	gotTier string
 	calls   int
+	err     error
+
+	// order, when non-nil, has "auth0" appended on every UpdateSubscriptionTier
+	// call — shared with a fakeAdminStore's order slice, see fakeAdminStore.order.
+	order *[]string
 }
 
 func (f *fakeTierSync) UpdateSubscriptionTier(_ context.Context, _, tier string) error {
 	f.calls++
 	f.gotTier = tier
+	if f.order != nil {
+		*f.order = append(*f.order, "auth0")
+	}
+	if f.err != nil {
+		return f.err
+	}
 	return nil
 }
 
@@ -264,6 +283,27 @@ func TestGrant_FreeExpiresSubscription(t *testing.T) {
 	}
 	if store.saved.Tier != profiles.TierFree || store.saved.SubscriptionExpiry != nil {
 		t.Errorf("subscription not expired: %+v", store.saved)
+	}
+}
+
+func TestGrant_Auth0FailureLeavesProfileUnsaved(t *testing.T) {
+	t.Parallel()
+
+	var order []string
+	store := &fakeAdminStore{byEmail: map[string]*profiles.UserProfile{"u@example.com": freeProfile(t)}, order: &order}
+	auth0 := &fakeTierSync{err: errBoom, order: &order}
+	h := newTestHandler(store, &fakeNotifCounts{}, auth0, &fakeOfferStore{}, &fakeGenerator{}, time.Now())
+
+	rec := serve(t, h.grantSubscription, http.MethodPut, "/v1/admin/subscriptions", `{"email":"u@example.com","tier":"Pro"}`)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+	if store.saved != nil {
+		t.Errorf("profile saved despite auth0 sync failure: %+v", store.saved)
+	}
+	if len(order) != 1 || order[0] != "auth0" {
+		t.Errorf("call order = %v, want [auth0] (save must never run after a failed sync)", order)
 	}
 }
 

--- a/api-go/internal/admin/subscriptions.go
+++ b/api-go/internal/admin/subscriptions.go
@@ -57,12 +57,16 @@ func (h *handler) grantSubscription(w http.ResponseWriter, r *http.Request) {
 		profile.ActivateSubscription(tier, farFutureExpiry)
 	}
 
-	if err := h.profiles.Save(r.Context(), profile); err != nil {
-		h.serverError(w, r, "save profile", err)
-		return
-	}
+	// Sync Auth0 before writing Postgres: a failed sync then leaves no stray
+	// committed tier change behind for the caller to silently lose track of.
+	// There is no transaction/rollback here (see tc-i0t8e) — sync-then-save is
+	// the deliberate mitigation instead.
 	if err := h.auth0.UpdateSubscriptionTier(r.Context(), profile.UserID, profile.Tier.String()); err != nil {
 		h.serverError(w, r, "sync auth0 tier", err)
+		return
+	}
+	if err := h.profiles.Save(r.Context(), profile); err != nil {
+		h.serverError(w, r, "save profile", err)
 		return
 	}
 

--- a/api-go/internal/profiles/admin_store_postgres.go
+++ b/api-go/internal/profiles/admin_store_postgres.go
@@ -53,9 +53,13 @@ const pgAdminSelectCols = "SELECT " + userSelectCols + " FROM users "
 // recreated can leave a stale row behind), so the query orders by created_at
 // descending to deterministically pick the most-recently-created row — the
 // live account — rather than letting Postgres return an arbitrary match.
+// created_at alone is not a unique tiebreak: the 0016 backfill stamped every
+// pre-existing row with the same migration-run timestamp, so two duplicate
+// rows from before that migration can tie on created_at. user_id (the primary
+// key) breaks the tie deterministically, same as List's compound sort.
 // Mirrors AdminStore.GetByEmail.
 func (s *PostgresAdminStore) GetByEmail(ctx context.Context, email string) (*UserProfile, error) {
-	rows, err := s.db.Query(ctx, pgAdminSelectCols+"WHERE email = $1 ORDER BY created_at DESC LIMIT 1", email)
+	rows, err := s.db.Query(ctx, pgAdminSelectCols+"WHERE email = $1 ORDER BY created_at DESC, user_id DESC LIMIT 1", email)
 	if err != nil {
 		return nil, fmt.Errorf("query profile by email: %w", err)
 	}

--- a/api-go/internal/profiles/admin_store_postgres.go
+++ b/api-go/internal/profiles/admin_store_postgres.go
@@ -48,10 +48,14 @@ func collectUsers(rows pgx.Rows) ([]*UserProfile, error) {
 
 const pgAdminSelectCols = "SELECT " + userSelectCols + " FROM users "
 
-// GetByEmail returns the first profile whose email matches exactly, or
-// ErrNotFound. Mirrors AdminStore.GetByEmail.
+// GetByEmail returns the profile whose email matches exactly, or ErrNotFound.
+// Email is not unique at the schema level (e.g. an account deleted and
+// recreated can leave a stale row behind), so the query orders by created_at
+// descending to deterministically pick the most-recently-created row — the
+// live account — rather than letting Postgres return an arbitrary match.
+// Mirrors AdminStore.GetByEmail.
 func (s *PostgresAdminStore) GetByEmail(ctx context.Context, email string) (*UserProfile, error) {
-	rows, err := s.db.Query(ctx, pgAdminSelectCols+"WHERE email = $1 LIMIT 1", email)
+	rows, err := s.db.Query(ctx, pgAdminSelectCols+"WHERE email = $1 ORDER BY created_at DESC LIMIT 1", email)
 	if err != nil {
 		return nil, fmt.Errorf("query profile by email: %w", err)
 	}

--- a/api-go/internal/profiles/store_postgres_integration_test.go
+++ b/api-go/internal/profiles/store_postgres_integration_test.go
@@ -331,6 +331,38 @@ func TestPostgresAdminStore_GetByEmail(t *testing.T) {
 	}
 }
 
+// TestPostgresAdminStore_GetByEmail_DuplicateEmailPicksNewest verifies GetByEmail
+// is deterministic when two rows share an email — e.g. an account deleted and
+// recreated, where the old row was never cleaned up (tc-i0t8e). Without an
+// ORDER BY, Postgres can return either row nondeterministically, and which one
+// it returns can change between calls. The fix orders by created_at DESC so the
+// most-recently-created row (the live account) always wins.
+func TestPostgresAdminStore_GetByEmail_DuplicateEmailPicksNewest(t *testing.T) {
+	store, admin := newUserPGStore(t)
+	ctx := context.Background()
+
+	older := pgProfile(t, "auth0|dup-old", "dup@example.com")
+	if err := store.Save(ctx, older); err != nil {
+		t.Fatalf("Save older: %v", err)
+	}
+	// created_at is DB-stamped (DEFAULT CURRENT_TIMESTAMP, not written by Go) —
+	// sleep so the second insert's timestamp is unambiguously later than the
+	// first's.
+	time.Sleep(10 * time.Millisecond)
+	newer := pgProfile(t, "auth0|dup-new", "dup@example.com")
+	if err := store.Save(ctx, newer); err != nil {
+		t.Fatalf("Save newer: %v", err)
+	}
+
+	got, err := admin.GetByEmail(ctx, "dup@example.com")
+	if err != nil {
+		t.Fatalf("GetByEmail: %v", err)
+	}
+	if got.UserID != newer.UserID {
+		t.Errorf("GetByEmail with duplicate emails: got userID %q, want %q (the newest row)", got.UserID, newer.UserID)
+	}
+}
+
 // TestPostgresAdminStore_GetByOriginalTransactionID verifies lookup by Apple
 // transaction id and ErrNotFound for a missing id.
 func TestPostgresAdminStore_GetByOriginalTransactionID(t *testing.T) {

--- a/api-go/internal/profiles/store_postgres_integration_test.go
+++ b/api-go/internal/profiles/store_postgres_integration_test.go
@@ -363,6 +363,51 @@ func TestPostgresAdminStore_GetByEmail_DuplicateEmailPicksNewest(t *testing.T) {
 	}
 }
 
+// TestPostgresAdminStore_GetByEmail_TiedCreatedAtPicksDeterministically verifies
+// GetByEmail stays deterministic across repeated calls even when two duplicate
+// rows share the exact same created_at — the case left open by ordering on
+// created_at alone (tc-i0t8e review follow-up). This is not hypothetical: the
+// 0016 migration backfilled every pre-existing row with the same migration-run
+// timestamp, so two old duplicate rows can tie. user_id is the tiebreak, so the
+// query result must stay pinned to the same row across repeated calls.
+func TestPostgresAdminStore_GetByEmail_TiedCreatedAtPicksDeterministically(t *testing.T) {
+	pool := pgtest.New(t)
+	pgtest.Truncate(t, pool, "users")
+	store := NewPostgresStore(pool)
+	admin := NewPostgresAdminStore(pool)
+	ctx := context.Background()
+
+	a := pgProfile(t, "auth0|dup-tied-a", "tied@example.com")
+	if err := store.Save(ctx, a); err != nil {
+		t.Fatalf("Save a: %v", err)
+	}
+	b := pgProfile(t, "auth0|dup-tied-b", "tied@example.com")
+	if err := store.Save(ctx, b); err != nil {
+		t.Fatalf("Save b: %v", err)
+	}
+	// Force an exact tie: pin both rows to the same created_at, reproducing the
+	// 0016 backfill scenario where the column has no natural distinguishing value.
+	tied := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	if _, err := pool.Exec(ctx, "UPDATE users SET created_at = $1 WHERE user_id IN ($2, $3)", tied, a.UserID, b.UserID); err != nil {
+		t.Fatalf("force tied created_at: %v", err)
+	}
+
+	want := a.UserID
+	if b.UserID > a.UserID {
+		want = b.UserID
+	}
+
+	for i := 0; i < 5; i++ {
+		got, err := admin.GetByEmail(ctx, "tied@example.com")
+		if err != nil {
+			t.Fatalf("GetByEmail call %d: %v", i, err)
+		}
+		if got.UserID != want {
+			t.Errorf("GetByEmail call %d with tied created_at: got userID %q, want %q (user_id DESC tiebreak)", i, got.UserID, want)
+		}
+	}
+}
+
 // TestPostgresAdminStore_GetByOriginalTransactionID verifies lookup by Apple
 // transaction id and ErrNotFound for a missing id.
 func TestPostgresAdminStore_GetByOriginalTransactionID(t *testing.T) {


### PR DESCRIPTION
## Summary

`PUT /v1/admin/subscriptions` had two related safety bugs, both reproduced live in dev against an account with a duplicate-email row (tc-i0t8e):

1. **Non-deterministic lookup** — `PostgresAdminStore.GetByEmail` used `WHERE email = $1 LIMIT 1` with no `ORDER BY`. When two rows share an email (e.g. a deleted/recreated account whose old row was never cleaned up), Postgres could return either row nondeterministically — and which one it returned could even change between identical calls (MVCC tuple reordering). Now orders by `created_at DESC` so the most-recently-created (live) row always wins.
2. **Unsafe write ordering** — `grantSubscription` wrote Postgres *before* syncing Auth0, with no rollback if the Auth0 call failed. A failed request could silently leave a committed tier change in Postgres that Auth0 never learned about, while the caller saw a 500 with no way to tell a write had happened. Reordered to sync-then-save: Auth0 is updated first, and Postgres is only written once that succeeds.

## Changes

- `api-go/internal/profiles/admin_store_postgres.go` — `GetByEmail` query gains `ORDER BY created_at DESC`.
- `api-go/internal/admin/subscriptions.go` — `grantSubscription` reordered to call `h.auth0.UpdateSubscriptionTier` before `h.profiles.Save`.
- `api-go/internal/admin/handler_test.go` — new `TestGrant_Auth0FailureLeavesProfileUnsaved` asserting `Save` is never called when the Auth0 sync fails.
- `api-go/internal/profiles/store_postgres_integration_test.go` — new `TestPostgresAdminStore_GetByEmail_DuplicateEmailPicksNewest`, seeding two same-email rows with different `created_at` and asserting the newest wins (real-Postgres integration test; runs under the PR gate).

Deliberately no database transaction/compensating-rollback mechanism — sync-then-save is the scoped fix for this bead; a transaction across Postgres and an external Auth0 call would be a bigger change than this bug needs.

## Test plan

- [x] `gofmt -l .` — clean
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `go test ./...` — all packages pass
- [x] `go test -race ./...` — all packages pass
- [ ] Real-Postgres integration test (`TestPostgresAdminStore_GetByEmail_DuplicateEmailPicksNewest`) — could not run locally (no Docker in this environment); will run under the PR gate's real-Postgres suite.

Bead: tc-i0t8e

---
_Generated by [Claude Code](https://claude.ai/code/session_01QweJ26ixAAr53MbJu6Vyhk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Subscription changes now update account access before being saved.
  * Failed access synchronization no longer saves incomplete profile changes.
  * Profile lookups with duplicate email addresses now return the most recently created profile.

* **Tests**
  * Added coverage for synchronization failures and duplicate-profile selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->