### PR TITLE
iOS: zoom-to-fit large polygons when reopening watch zone editor (tc-7se1w.2)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/BoundaryDrawingMapView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/BoundaryDrawingMapView.swift
@@ -3,6 +3,66 @@
   import SwiftUI
   import TownCrierDomain
 
+  /// Computes the map region ``BoundaryDrawingMapView`` shows on first
+  /// appearance (GH#1031, bead tc-7se1w.2): a fixed close-in region centred
+  /// on the postcode-geocoded centre when there are no vertices yet (a
+  /// brand-new custom shape — today's behaviour, unchanged), or a region
+  /// that fits the bounding box of the existing vertices with margin when
+  /// re-opening a zone that already has a drawn polygon. Without this, the
+  /// fixed 1000m default clips a large polygon's vertices/edges outside the
+  /// visible map on reopen.
+  ///
+  /// A free-standing, non-generic type (rather than a member of the generic
+  /// `BoundaryDrawingMapView<ViewModel>`) so the zoom-to-fit math is
+  /// directly unit-testable without a concrete `ViewModel` or a
+  /// `UIViewRepresentable` context.
+  enum BoundaryDrawingRegion {
+    /// The fixed region size (metres) used when there are no vertices yet —
+    /// matches the region this view always used before tc-7se1w.2.
+    static let freshDrawRegionMetres: CLLocationDistance = 1000
+
+    /// Extra room around the tightest bounding box of the vertices, as a
+    /// fraction of the box's own span — keeps drawn edges/vertices from
+    /// sitting flush against the map's edge rather than comfortably inside it.
+    static let marginFraction = 0.3
+
+    /// Smallest span (degrees of latitude/longitude) the fitted region is
+    /// allowed to shrink to — stops a single vertex or a tightly clustered
+    /// few vertices from producing an absurdly close-in zoom.
+    static let minimumSpanDegrees = 0.006
+
+    static func fitting(vertices: [Coordinate], initialCentre: Coordinate) -> MKCoordinateRegion {
+      guard !vertices.isEmpty else {
+        return MKCoordinateRegion(
+          center: CLLocationCoordinate2D(
+            latitude: initialCentre.latitude, longitude: initialCentre.longitude),
+          latitudinalMeters: freshDrawRegionMetres,
+          longitudinalMeters: freshDrawRegionMetres
+        )
+      }
+
+      let latitudes = vertices.map(\.latitude)
+      let longitudes = vertices.map(\.longitude)
+      // Force-unwrap-free: `vertices` is non-empty here, so `min()`/`max()`
+      // always succeed; the `??` fallback only guards the type-checker.
+      let minLatitude = latitudes.min() ?? initialCentre.latitude
+      let maxLatitude = latitudes.max() ?? initialCentre.latitude
+      let minLongitude = longitudes.min() ?? initialCentre.longitude
+      let maxLongitude = longitudes.max() ?? initialCentre.longitude
+
+      let centre = CLLocationCoordinate2D(
+        latitude: (minLatitude + maxLatitude) / 2,
+        longitude: (minLongitude + maxLongitude) / 2
+      )
+      let span = MKCoordinateSpan(
+        latitudeDelta: max((maxLatitude - minLatitude) * (1 + marginFraction), minimumSpanDegrees),
+        longitudeDelta: max(
+          (maxLongitude - minLongitude) * (1 + marginFraction), minimumSpanDegrees)
+      )
+      return MKCoordinateRegion(center: centre, span: span)
+    }
+  }
+
   /// A UIKit `MKMapView` wrapped for SwiftUI for drawing a custom-shape watch
   /// zone boundary (GH#1031, bead tc-6he3x.8): tap an empty area to drop a
   /// vertex, drag an existing vertex pin to move it, tap the first vertex
@@ -49,12 +109,8 @@
       mapView.delegate = context.coordinator
       mapView.pointOfInterestFilter = .excludingAll
       mapView.setRegion(
-        MKCoordinateRegion(
-          center: CLLocationCoordinate2D(
-            latitude: initialCentre.latitude, longitude: initialCentre.longitude),
-          latitudinalMeters: 1000,
-          longitudinalMeters: 1000
-        ),
+        BoundaryDrawingRegion.fitting(
+          vertices: viewModel.boundaryVertices, initialCentre: initialCentre),
         animated: false
       )
 

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/BoundaryDrawingMapView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/BoundaryDrawingMapView.swift
@@ -1,67 +1,70 @@
-#if canImport(UIKit)
-  import MapKit
-  import SwiftUI
-  import TownCrierDomain
+import MapKit
+import TownCrierDomain
 
-  /// Computes the map region ``BoundaryDrawingMapView`` shows on first
-  /// appearance (GH#1031, bead tc-7se1w.2): a fixed close-in region centred
-  /// on the postcode-geocoded centre when there are no vertices yet (a
-  /// brand-new custom shape — today's behaviour, unchanged), or a region
-  /// that fits the bounding box of the existing vertices with margin when
-  /// re-opening a zone that already has a drawn polygon. Without this, the
-  /// fixed 1000m default clips a large polygon's vertices/edges outside the
-  /// visible map on reopen.
-  ///
-  /// A free-standing, non-generic type (rather than a member of the generic
-  /// `BoundaryDrawingMapView<ViewModel>`) so the zoom-to-fit math is
-  /// directly unit-testable without a concrete `ViewModel` or a
-  /// `UIViewRepresentable` context.
-  enum BoundaryDrawingRegion {
-    /// The fixed region size (metres) used when there are no vertices yet —
-    /// matches the region this view always used before tc-7se1w.2.
-    static let freshDrawRegionMetres: CLLocationDistance = 1000
+/// Computes the map region ``BoundaryDrawingMapView`` shows on first
+/// appearance (GH#1031, bead tc-7se1w.2): a fixed close-in region centred
+/// on the postcode-geocoded centre when there are no vertices yet (a
+/// brand-new custom shape — today's behaviour, unchanged), or a region
+/// that fits the bounding box of the existing vertices with margin when
+/// re-opening a zone that already has a drawn polygon. Without this, the
+/// fixed 1000m default clips a large polygon's vertices/edges outside the
+/// visible map on reopen.
+///
+/// A free-standing, non-generic type (rather than a member of the generic
+/// `BoundaryDrawingMapView<ViewModel>`) so the zoom-to-fit math is
+/// directly unit-testable without a concrete `ViewModel` or a
+/// `UIViewRepresentable` context. Deliberately outside the `canImport(UIKit)`
+/// guard below — it only needs `MapKit`/`CoreLocation`, both available on
+/// macOS, so `swift test`'s bare-macOS build (no UIKit) can still see it.
+enum BoundaryDrawingRegion {
+  /// The fixed region size (metres) used when there are no vertices yet —
+  /// matches the region this view always used before tc-7se1w.2.
+  static let freshDrawRegionMetres: CLLocationDistance = 1000
 
-    /// Extra room around the tightest bounding box of the vertices, as a
-    /// fraction of the box's own span — keeps drawn edges/vertices from
-    /// sitting flush against the map's edge rather than comfortably inside it.
-    static let marginFraction = 0.3
+  /// Extra room around the tightest bounding box of the vertices, as a
+  /// fraction of the box's own span — keeps drawn edges/vertices from
+  /// sitting flush against the map's edge rather than comfortably inside it.
+  static let marginFraction = 0.3
 
-    /// Smallest span (degrees of latitude/longitude) the fitted region is
-    /// allowed to shrink to — stops a single vertex or a tightly clustered
-    /// few vertices from producing an absurdly close-in zoom.
-    static let minimumSpanDegrees = 0.006
+  /// Smallest span (degrees of latitude/longitude) the fitted region is
+  /// allowed to shrink to — stops a single vertex or a tightly clustered
+  /// few vertices from producing an absurdly close-in zoom.
+  static let minimumSpanDegrees = 0.006
 
-    static func fitting(vertices: [Coordinate], initialCentre: Coordinate) -> MKCoordinateRegion {
-      guard !vertices.isEmpty else {
-        return MKCoordinateRegion(
-          center: CLLocationCoordinate2D(
-            latitude: initialCentre.latitude, longitude: initialCentre.longitude),
-          latitudinalMeters: freshDrawRegionMetres,
-          longitudinalMeters: freshDrawRegionMetres
-        )
-      }
-
-      let latitudes = vertices.map(\.latitude)
-      let longitudes = vertices.map(\.longitude)
-      // Force-unwrap-free: `vertices` is non-empty here, so `min()`/`max()`
-      // always succeed; the `??` fallback only guards the type-checker.
-      let minLatitude = latitudes.min() ?? initialCentre.latitude
-      let maxLatitude = latitudes.max() ?? initialCentre.latitude
-      let minLongitude = longitudes.min() ?? initialCentre.longitude
-      let maxLongitude = longitudes.max() ?? initialCentre.longitude
-
-      let centre = CLLocationCoordinate2D(
-        latitude: (minLatitude + maxLatitude) / 2,
-        longitude: (minLongitude + maxLongitude) / 2
+  static func fitting(vertices: [Coordinate], initialCentre: Coordinate) -> MKCoordinateRegion {
+    guard !vertices.isEmpty else {
+      return MKCoordinateRegion(
+        center: CLLocationCoordinate2D(
+          latitude: initialCentre.latitude, longitude: initialCentre.longitude),
+        latitudinalMeters: freshDrawRegionMetres,
+        longitudinalMeters: freshDrawRegionMetres
       )
-      let span = MKCoordinateSpan(
-        latitudeDelta: max((maxLatitude - minLatitude) * (1 + marginFraction), minimumSpanDegrees),
-        longitudeDelta: max(
-          (maxLongitude - minLongitude) * (1 + marginFraction), minimumSpanDegrees)
-      )
-      return MKCoordinateRegion(center: centre, span: span)
     }
+
+    let latitudes = vertices.map(\.latitude)
+    let longitudes = vertices.map(\.longitude)
+    // Force-unwrap-free: `vertices` is non-empty here, so `min()`/`max()`
+    // always succeed; the `??` fallback only guards the type-checker.
+    let minLatitude = latitudes.min() ?? initialCentre.latitude
+    let maxLatitude = latitudes.max() ?? initialCentre.latitude
+    let minLongitude = longitudes.min() ?? initialCentre.longitude
+    let maxLongitude = longitudes.max() ?? initialCentre.longitude
+
+    let centre = CLLocationCoordinate2D(
+      latitude: (minLatitude + maxLatitude) / 2,
+      longitude: (minLongitude + maxLongitude) / 2
+    )
+    let span = MKCoordinateSpan(
+      latitudeDelta: max((maxLatitude - minLatitude) * (1 + marginFraction), minimumSpanDegrees),
+      longitudeDelta: max(
+        (maxLongitude - minLongitude) * (1 + marginFraction), minimumSpanDegrees)
+    )
+    return MKCoordinateRegion(center: centre, span: span)
   }
+}
+
+#if canImport(UIKit)
+  import SwiftUI
 
   /// A UIKit `MKMapView` wrapped for SwiftUI for drawing a custom-shape watch
   /// zone boundary (GH#1031, bead tc-6he3x.8): tap an empty area to drop a

--- a/mobile/ios/town-crier-tests/Sources/Features/BoundaryDrawingRegionTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/BoundaryDrawingRegionTests.swift
@@ -1,0 +1,96 @@
+import MapKit
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+/// `BoundaryDrawingRegion.fitting(vertices:initialCentre:)` — the initial
+/// map region `BoundaryDrawingMapView` shows on first appearance (GH#1031,
+/// bead tc-7se1w.2). Extracted as a pure function so the zoom-to-fit math
+/// is testable without standing up a `UIViewRepresentable`.
+@Suite("BoundaryDrawingRegion")
+struct BoundaryDrawingRegionTests {
+  private func coordinate(_ latitude: Double, _ longitude: Double) throws -> Coordinate {
+    try Coordinate(latitude: latitude, longitude: longitude)
+  }
+
+  // MARK: - No vertices yet (fresh draw) — unchanged fixed-region behaviour
+
+  @Test func noVertices_returnsFixedRegionCentredOnInitialCentre() throws {
+    let centre = try coordinate(52.2053, 0.1218)
+
+    let region = BoundaryDrawingRegion.fitting(vertices: [], initialCentre: centre)
+
+    let expected = MKCoordinateRegion(
+      center: CLLocationCoordinate2D(latitude: centre.latitude, longitude: centre.longitude),
+      latitudinalMeters: BoundaryDrawingRegion.freshDrawRegionMetres,
+      longitudinalMeters: BoundaryDrawingRegion.freshDrawRegionMetres
+    )
+    #expect(region.center.latitude == expected.center.latitude)
+    #expect(region.center.longitude == expected.center.longitude)
+    #expect(region.span.latitudeDelta == expected.span.latitudeDelta)
+    #expect(region.span.longitudeDelta == expected.span.longitudeDelta)
+  }
+
+  // MARK: - A large polygon — must fit the whole bounding box, with margin
+
+  @Test func largePolygon_fitsBoundingBoxWithMargin() throws {
+    // A ~1.1km x 1.1km box around Cambridge — bigger than the old fixed
+    // 1000m default, so the old behaviour would clip it.
+    let vertices = try [
+      coordinate(51.50, -0.10),
+      coordinate(51.51, -0.10),
+      coordinate(51.51, -0.09),
+      coordinate(51.50, -0.09),
+    ]
+
+    let region = BoundaryDrawingRegion.fitting(
+      vertices: vertices, initialCentre: try coordinate(51.505, -0.095))
+
+    // Centred on the bounding box, not `initialCentre`.
+    #expect(abs(region.center.latitude - 51.505) < 0.0001)
+    #expect(abs(region.center.longitude - (-0.095)) < 0.0001)
+
+    // Every vertex must lie strictly inside the region (with margin, not
+    // flush against the edge).
+    for vertex in vertices {
+      let latHalfSpan = region.span.latitudeDelta / 2
+      let lonHalfSpan = region.span.longitudeDelta / 2
+      #expect(abs(vertex.latitude - region.center.latitude) < latHalfSpan)
+      #expect(abs(vertex.longitude - region.center.longitude) < lonHalfSpan)
+    }
+
+    // Margin actually widens the span beyond the raw bounding box (0.01 deg
+    // in both directions here) rather than fitting it exactly flush.
+    #expect(region.span.latitudeDelta > 0.01)
+    #expect(region.span.longitudeDelta > 0.01)
+  }
+
+  // MARK: - A single vertex / tight cluster — minimum span, not absurd zoom
+
+  @Test func singleVertex_appliesMinimumSpanRatherThanZoomingToNothing() throws {
+    let vertex = try coordinate(51.50, -0.10)
+
+    let region = BoundaryDrawingRegion.fitting(
+      vertices: [vertex], initialCentre: try coordinate(51.60, -0.20))
+
+    #expect(region.center.latitude == vertex.latitude)
+    #expect(region.center.longitude == vertex.longitude)
+    #expect(region.span.latitudeDelta == BoundaryDrawingRegion.minimumSpanDegrees)
+    #expect(region.span.longitudeDelta == BoundaryDrawingRegion.minimumSpanDegrees)
+  }
+
+  @Test func tightCluster_appliesMinimumSpanWhenBoundingBoxIsSmallerThanMinimum() throws {
+    // Two vertices a few metres apart — a real but tiny polygon.
+    let vertices = try [
+      coordinate(51.50000, -0.10000),
+      coordinate(51.50002, -0.10002),
+    ]
+
+    let region = BoundaryDrawingRegion.fitting(
+      vertices: vertices, initialCentre: try coordinate(51.60, -0.20))
+
+    #expect(region.span.latitudeDelta == BoundaryDrawingRegion.minimumSpanDegrees)
+    #expect(region.span.longitudeDelta == BoundaryDrawingRegion.minimumSpanDegrees)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/BoundaryDrawingRegionTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/BoundaryDrawingRegionTests.swift
@@ -60,10 +60,12 @@ struct BoundaryDrawingRegionTests {
       #expect(abs(vertex.longitude - region.center.longitude) < lonHalfSpan)
     }
 
-    // Margin actually widens the span beyond the raw bounding box (0.01 deg
-    // in both directions here) rather than fitting it exactly flush.
-    #expect(region.span.latitudeDelta > 0.01)
-    #expect(region.span.longitudeDelta > 0.01)
+    // Margin actually applies the expected 30% widening (0.01deg raw box *
+    // 1.3 = 0.013deg) rather than merely exceeding the raw bounding box — a
+    // bare `> 0.01` check would still pass if marginFraction regressed to
+    // something far smaller than 0.3.
+    #expect(abs(region.span.latitudeDelta - 0.013) < 0.0001)
+    #expect(abs(region.span.longitudeDelta - 0.013) < 0.0001)
   }
 
   // MARK: - A single vertex / tight cluster — minimum span, not absurd zoom


### PR DESCRIPTION
## Summary
- Fixes `BoundaryDrawingMapView` always opening a fixed 1000m×1000m region regardless of the existing polygon's extent, which clipped large custom-shape watch zones outside the visible map on reopen.
- Adds `BoundaryDrawingRegion.fitting(vertices:initialCentre:)`, a pure, unit-testable function: empty vertices keep today's fixed 1000m region (fresh-draw case); non-empty vertices get a region fit to the vertices' bounding box with a 30% margin and a minimum-span floor so a single vertex or tight cluster doesn't zoom in absurdly close.
- `makeUIView` now calls this function instead of hardcoding the region.

Bead: tc-7se1w.2 (child of epic tc-7se1w, GH#1031). Scope is intentionally narrow to this one file + its test — sibling beads cover the same problem on web (tc-7se1w.7) and the map-page circle-vs-polygon overlay bug (tc-7se1w.3); neither is touched here.

## Test plan
- [x] New `BoundaryDrawingRegionTests.swift` covers: no-vertices fixed region, large-polygon bounding-box-with-margin fit (every vertex inside the region, span wider than the raw bounding box), single-vertex minimum span, tight-cluster minimum span.
- [ ] **CI verification needed** — this session's sandbox has no Swift toolchain (`swift`, `xcodebuild`, `swiftlint` are all unavailable), so `swift build`, `swift test`, and `swiftlint lint --strict` could not be run locally. Please confirm the `pr-gate` check (which runs these on a macOS runner) is green before merging.
- [ ] Manual/simulator verification of the actual reopen-a-large-polygon UX is outstanding — not done in this run.

---
_Generated by [Claude Code](https://claude.ai/code/session_0183iBceeN9d6Y2sww1ywaCG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Map boundary drawing now opens to a more appropriate starting view based on existing boundary points.
  * Empty drawings still use the same fixed map area as before.
* **Bug Fixes**
  * Improved map fitting so large, small, or clustered boundaries are easier to view and edit without manual zooming.
  * Added consistent spacing around existing boundaries and a minimum viewing area for very small boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->