### PR TITLE
web: round radius and label polygon zones "Custom shape" in list (tc-7se1w.6)

### DIFF
--- a/web/src/features/WatchZones/WatchZoneListPage.tsx
+++ b/web/src/features/WatchZones/WatchZoneListPage.tsx
@@ -11,7 +11,11 @@ interface Props {
 }
 
 function formatRadius(metres: number): string {
-  return `${metres / 1000} km`;
+  if (metres >= 1000) {
+    const km = Math.round((metres / 1000) * 10) / 10;
+    return `${km} km`;
+  }
+  return `${Math.round(metres)} m`;
 }
 
 export function WatchZoneListPage({ repository }: Props) {
@@ -86,7 +90,9 @@ export function WatchZoneListPage({ repository }: Props) {
                     </span>
                   )}
                 </div>
-                <p className={styles.zoneRadius}>{formatRadius(zone.radiusMetres)}</p>
+                <p className={styles.zoneRadius}>
+                  {zone.boundary !== null ? 'Custom shape' : formatRadius(zone.radiusMetres)}
+                </p>
               </div>
               <div className={styles.cardActions}>
                 <Link to={`/watch-zones/${zone.id}`} className={styles.editLink}>

--- a/web/src/features/WatchZones/__tests__/WatchZoneListPage.test.tsx
+++ b/web/src/features/WatchZones/__tests__/WatchZoneListPage.test.tsx
@@ -4,7 +4,7 @@ import { MemoryRouter } from 'react-router';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { WatchZoneListPage } from '../WatchZoneListPage';
 import { SpyWatchZoneRepository } from './spies/spy-watch-zone-repository';
-import { aWatchZone, aSecondWatchZone } from './fixtures/watch-zone.fixtures';
+import { aWatchZone, aSecondWatchZone, aWatchZoneBoundary } from './fixtures/watch-zone.fixtures';
 
 function renderWithRouter(ui: React.ReactElement) {
   return render(<MemoryRouter>{ui}</MemoryRouter>);
@@ -137,5 +137,24 @@ describe('WatchZoneListPage', () => {
     await screen.findByText('Home');
 
     expect(screen.queryByText('Paused')).not.toBeInTheDocument();
+  });
+
+  it('rounds an unrounded floating-point radius to a clean km value', async () => {
+    spy.listResult = [aWatchZone({ radiusMetres: 1999.2790775632876 })];
+
+    renderWithRouter(<WatchZoneListPage repository={spy} />);
+
+    expect(await screen.findByText('2 km')).toBeInTheDocument();
+    expect(screen.queryByText(/1\.9992790775632876/)).not.toBeInTheDocument();
+  });
+
+  it('shows "Custom shape" instead of a fabricated radius for a polygon zone', async () => {
+    spy.listResult = [aWatchZone({ boundary: aWatchZoneBoundary() })];
+
+    renderWithRouter(<WatchZoneListPage repository={spy} />);
+
+    expect(await screen.findByText('Custom shape')).toBeInTheDocument();
+    expect(screen.queryByText(/km/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/\bm\b/)).not.toBeInTheDocument();
   });
 });

--- a/web/src/features/WatchZones/__tests__/WatchZoneListPage.test.tsx
+++ b/web/src/features/WatchZones/__tests__/WatchZoneListPage.test.tsx
@@ -140,12 +140,12 @@ describe('WatchZoneListPage', () => {
   });
 
   it('rounds an unrounded floating-point radius to a clean km value', async () => {
-    spy.listResult = [aWatchZone({ radiusMetres: 1999.2790775632876 })];
+    spy.listResult = [aWatchZone({ radiusMetres: 1999.279077563 })];
 
     renderWithRouter(<WatchZoneListPage repository={spy} />);
 
     expect(await screen.findByText('2 km')).toBeInTheDocument();
-    expect(screen.queryByText(/1\.9992790775632876/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/1\.999279077563/)).not.toBeInTheDocument();
   });
 
   it('shows "Custom shape" instead of a fabricated radius for a polygon zone', async () => {


### PR DESCRIPTION
## Summary
- `WatchZoneListPage.tsx`'s watch-zone list showed a raw, unrounded floating-point pseudo-radius for custom-shape (polygon) zones — e.g. `1.9992790775632876 km` — because `formatRadius` did no rounding and `zone.radiusMetres` for a polygon zone is only a server-derived enclosing-radius approximation, not a real radius.
- `formatRadius` now rounds cleanly (1 decimal place in km, whole metres below 1km).
- Zones with a non-null `boundary` (custom shape) now show `"Custom shape"` instead of a fabricated radius, matching the wording already used in `WatchZoneCreatePage.tsx`'s confirm step and `OnboardingPage.tsx`'s confirm step.

Bead: tc-7se1w.6 (child of epic tc-7se1w, follow-up from TestFlight testing of GH#1031 polygon watch zones). Scope is intentionally narrow to `WatchZoneListPage.tsx` and its test file — sibling beads (tc-7se1w.7, .8, .9, .10) cover other web/iOS surfaces with the same underlying epic and are not touched here.

## Test plan
- [x] TDD: added two tests — a circle zone with a float radius (`1999.2790775632876`) renders `'2 km'` (not the raw float), and a zone with a polygon `boundary` renders `'Custom shape'` with no km/m text. Both confirmed failing before the fix (Red), passing after (Green).
- [x] `npx vitest run` — full suite: 143 files / 1400 tests pass.
- [x] `npx tsc --noEmit` — clean, no errors.
- [x] `npm run build` — succeeds.
- [ ] Manual browser verification against dev — not done in this run (presentation-only change verified via automated tests).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnxfUKXDw4CvrChi8xgYVc)_