### PR TITLE
web: zoom-to-fit large polygons when reopening watch zone editor (tc-7se1w.7)

### DIFF
--- a/web/src/components/BoundaryMap/BoundaryMap.tsx
+++ b/web/src/components/BoundaryMap/BoundaryMap.tsx
@@ -1,8 +1,14 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { MapContainer, TileLayer, Marker, Polygon, Polyline, useMapEvents } from 'react-leaflet';
-import type { LeafletMouseEvent, LeafletEvent, Marker as LeafletMarkerInstance } from 'leaflet';
+import type {
+  LeafletMouseEvent,
+  LeafletEvent,
+  Marker as LeafletMarkerInstance,
+  LatLngBoundsExpression,
+} from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import type { Coordinates } from '../../domain/types';
+import { computeBoundaryMapView } from './boundaryMapView';
 import styles from './BoundaryMap.module.css';
 
 const OSM_TILE_URL = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
@@ -72,8 +78,27 @@ export function BoundaryMap({
     () => vertices.map((vertex): [number, number] => [vertex.latitude, vertex.longitude]),
     [vertices],
   );
-  const centrePosition: [number, number] = [centre.latitude, centre.longitude];
   const hasVertices = vertices.length > 0;
+
+  // Computed once from the vertices present when this component first
+  // mounts (the lazy initialiser runs exactly once) — re-opening a zone
+  // with an existing polygon fits the map to its bounding box, while a
+  // brand-new shape (no vertices yet) keeps the fixed default view for the
+  // whole drawing session, even as vertices are added. See
+  // `computeBoundaryMapView` (GH#1031, bead tc-7se1w.7).
+  const [mapView] = useState(() => computeBoundaryMapView(vertices, centre));
+  const mapViewProps =
+    mapView.kind === 'fixed'
+      ? {
+          center: [mapView.center.latitude, mapView.center.longitude] as [number, number],
+          zoom: mapView.zoom,
+        }
+      : {
+          bounds: [
+            [mapView.southWest.latitude, mapView.southWest.longitude],
+            [mapView.northEast.latitude, mapView.northEast.longitude],
+          ] as LatLngBoundsExpression,
+        };
 
   return (
     <div>
@@ -97,8 +122,7 @@ export function BoundaryMap({
       </div>
       <div className={styles.container}>
         <MapContainer
-          center={centrePosition}
-          zoom={15}
+          {...mapViewProps}
           style={{ height: '100%', width: '100%' }}
           zoomControl={false}
           attributionControl={true}

--- a/web/src/components/BoundaryMap/__tests__/BoundaryMap.test.tsx
+++ b/web/src/components/BoundaryMap/__tests__/BoundaryMap.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi } from 'vitest';
 import { BoundaryMap } from '../BoundaryMap';
+import { computeBoundaryMapView } from '../boundaryMapView';
 
 interface LatLngPayload {
   latlng: { lat: number; lng: number };
@@ -26,13 +27,27 @@ interface PathLayerProps {
   positions: [number, number][];
 }
 
+interface MockMapContainerProps {
+  children: ReactNode;
+  center?: [number, number];
+  zoom?: number;
+  bounds?: [[number, number], [number, number]];
+}
+
 const { capturedMapEvents } = vi.hoisted(() => ({
   capturedMapEvents: { click: undefined as ((event: LatLngPayload) => void) | undefined },
 }));
 
 vi.mock('react-leaflet', () => ({
-  MapContainer: ({ children }: { children: ReactNode }) => (
-    <div data-testid="map-container">{children}</div>
+  MapContainer: ({ children, center, zoom, bounds }: MockMapContainerProps) => (
+    <div
+      data-testid="map-container"
+      data-center={center ? JSON.stringify(center) : undefined}
+      data-zoom={zoom}
+      data-bounds={bounds ? JSON.stringify(bounds) : undefined}
+    >
+      {children}
+    </div>
   ),
   TileLayer: () => <div data-testid="tile-layer" />,
   Marker: ({ position, eventHandlers }: MockMarkerProps) => (
@@ -82,6 +97,101 @@ describe('BoundaryMap', () => {
 
     expect(screen.getByTestId('map-container')).toBeInTheDocument();
     expect(screen.getByTestId('tile-layer')).toBeInTheDocument();
+  });
+
+  it('uses a fixed centre and zoom when there are no vertices at mount', () => {
+    render(
+      <BoundaryMap
+        centre={centre}
+        vertices={[]}
+        isClosed={false}
+        onAddVertex={() => {}}
+        onMoveVertex={() => {}}
+        onCloseRing={() => {}}
+        onUndo={() => {}}
+        onReset={() => {}}
+      />,
+    );
+
+    const mapContainer = screen.getByTestId('map-container');
+    expect(mapContainer).toHaveAttribute('data-center', JSON.stringify([centre.latitude, centre.longitude]));
+    expect(mapContainer).toHaveAttribute('data-zoom', '15');
+    expect(mapContainer).not.toHaveAttribute('data-bounds');
+  });
+
+  it('fits the map view to the vertices bounding box when vertices already exist at mount', () => {
+    const vertices = [
+      { latitude: 51.5, longitude: -0.1 },
+      { latitude: 51.51, longitude: -0.1 },
+      { latitude: 51.51, longitude: -0.09 },
+      { latitude: 51.5, longitude: -0.09 },
+    ];
+
+    render(
+      <BoundaryMap
+        centre={centre}
+        vertices={vertices}
+        isClosed={true}
+        onAddVertex={() => {}}
+        onMoveVertex={() => {}}
+        onCloseRing={() => {}}
+        onUndo={() => {}}
+        onReset={() => {}}
+      />,
+    );
+
+    const expected = computeBoundaryMapView(vertices, centre);
+    if (expected.kind !== 'fit-bounds') {
+      throw new Error('expected a fit-bounds view');
+    }
+
+    const mapContainer = screen.getByTestId('map-container');
+    expect(mapContainer).not.toHaveAttribute('data-center');
+    expect(mapContainer).toHaveAttribute(
+      'data-bounds',
+      JSON.stringify([
+        [expected.southWest.latitude, expected.southWest.longitude],
+        [expected.northEast.latitude, expected.northEast.longitude],
+      ]),
+    );
+  });
+
+  it('does not re-fit the view when vertices are added after mount', () => {
+    const initialVertices = [
+      { latitude: 51.5, longitude: -0.1 },
+      { latitude: 51.51, longitude: -0.1 },
+    ];
+
+    const { rerender } = render(
+      <BoundaryMap
+        centre={centre}
+        vertices={initialVertices}
+        isClosed={false}
+        onAddVertex={() => {}}
+        onMoveVertex={() => {}}
+        onCloseRing={() => {}}
+        onUndo={() => {}}
+        onReset={() => {}}
+      />,
+    );
+
+    const boundsBeforeAdd = screen.getByTestId('map-container').getAttribute('data-bounds');
+
+    rerender(
+      <BoundaryMap
+        centre={centre}
+        vertices={[...initialVertices, { latitude: 51.52, longitude: -0.08 }]}
+        isClosed={false}
+        onAddVertex={() => {}}
+        onMoveVertex={() => {}}
+        onCloseRing={() => {}}
+        onUndo={() => {}}
+        onReset={() => {}}
+      />,
+    );
+
+    const boundsAfterAdd = screen.getByTestId('map-container').getAttribute('data-bounds');
+    expect(boundsAfterAdd).toBe(boundsBeforeAdd);
   });
 
   it('renders one marker per vertex', () => {

--- a/web/src/components/BoundaryMap/__tests__/boundaryMapView.test.ts
+++ b/web/src/components/BoundaryMap/__tests__/boundaryMapView.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeBoundaryMapView,
+  FRESH_DRAW_ZOOM,
+  BOUNDS_MARGIN_FRACTION,
+  MINIMUM_SPAN_DEGREES,
+} from '../boundaryMapView';
+
+describe('computeBoundaryMapView', () => {
+  const initialCentre = { latitude: 52.2053, longitude: 0.1218 };
+
+  it('returns a fixed view centred on the initial centre when there are no vertices yet', () => {
+    const view = computeBoundaryMapView([], initialCentre);
+
+    expect(view).toEqual({ kind: 'fixed', center: initialCentre, zoom: FRESH_DRAW_ZOOM });
+  });
+
+  it('fits the bounding box of the vertices, with every vertex strictly inside the bounds', () => {
+    // A ~1.1km x 1.1km box — big enough that a fixed close-in zoom would clip it.
+    const vertices = [
+      { latitude: 51.5, longitude: -0.1 },
+      { latitude: 51.51, longitude: -0.1 },
+      { latitude: 51.51, longitude: -0.09 },
+      { latitude: 51.5, longitude: -0.09 },
+    ];
+
+    const view = computeBoundaryMapView(vertices, { latitude: 51.505, longitude: -0.095 });
+
+    if (view.kind !== 'fit-bounds') {
+      throw new Error('expected a fit-bounds view');
+    }
+    for (const vertex of vertices) {
+      expect(vertex.latitude).toBeGreaterThan(view.southWest.latitude);
+      expect(vertex.latitude).toBeLessThan(view.northEast.latitude);
+      expect(vertex.longitude).toBeGreaterThan(view.southWest.longitude);
+      expect(vertex.longitude).toBeLessThan(view.northEast.longitude);
+    }
+  });
+
+  it('centres the bounds on the vertices bounding box, not the initial centre', () => {
+    const vertices = [
+      { latitude: 51.5, longitude: -0.1 },
+      { latitude: 51.51, longitude: -0.1 },
+      { latitude: 51.51, longitude: -0.09 },
+      { latitude: 51.5, longitude: -0.09 },
+    ];
+
+    const view = computeBoundaryMapView(vertices, { latitude: 51.6, longitude: -0.2 });
+
+    if (view.kind !== 'fit-bounds') {
+      throw new Error('expected a fit-bounds view');
+    }
+    const centreLatitude = (view.southWest.latitude + view.northEast.latitude) / 2;
+    const centreLongitude = (view.southWest.longitude + view.northEast.longitude) / 2;
+    expect(centreLatitude).toBeCloseTo(51.505, 5);
+    expect(centreLongitude).toBeCloseTo(-0.095, 5);
+  });
+
+  it('applies the expected margin fraction to the raw bounding box span, not merely exceeding it', () => {
+    const vertices = [
+      { latitude: 51.5, longitude: -0.1 },
+      { latitude: 51.51, longitude: -0.1 },
+      { latitude: 51.51, longitude: -0.09 },
+      { latitude: 51.5, longitude: -0.09 },
+    ];
+
+    const view = computeBoundaryMapView(vertices, { latitude: 51.505, longitude: -0.095 });
+
+    if (view.kind !== 'fit-bounds') {
+      throw new Error('expected a fit-bounds view');
+    }
+    const latitudeSpan = view.northEast.latitude - view.southWest.latitude;
+    const longitudeSpan = view.northEast.longitude - view.southWest.longitude;
+    const expectedSpan = 0.01 * (1 + BOUNDS_MARGIN_FRACTION);
+    expect(latitudeSpan).toBeCloseTo(expectedSpan, 5);
+    expect(longitudeSpan).toBeCloseTo(expectedSpan, 5);
+  });
+
+  it('applies a minimum span for a single vertex rather than zooming in absurdly close', () => {
+    const vertex = { latitude: 51.5, longitude: -0.1 };
+
+    const view = computeBoundaryMapView([vertex], { latitude: 51.6, longitude: -0.2 });
+
+    if (view.kind !== 'fit-bounds') {
+      throw new Error('expected a fit-bounds view');
+    }
+    expect(view.northEast.latitude - view.southWest.latitude).toBeCloseTo(
+      MINIMUM_SPAN_DEGREES,
+      6,
+    );
+    expect(view.northEast.longitude - view.southWest.longitude).toBeCloseTo(
+      MINIMUM_SPAN_DEGREES,
+      6,
+    );
+  });
+
+  it('applies a minimum span for a tight cluster of vertices smaller than the minimum', () => {
+    const vertices = [
+      { latitude: 51.5, longitude: -0.1 },
+      { latitude: 51.50002, longitude: -0.10002 },
+    ];
+
+    const view = computeBoundaryMapView(vertices, { latitude: 51.6, longitude: -0.2 });
+
+    if (view.kind !== 'fit-bounds') {
+      throw new Error('expected a fit-bounds view');
+    }
+    expect(view.northEast.latitude - view.southWest.latitude).toBeCloseTo(
+      MINIMUM_SPAN_DEGREES,
+      6,
+    );
+  });
+});

--- a/web/src/components/BoundaryMap/boundaryMapView.ts
+++ b/web/src/components/BoundaryMap/boundaryMapView.ts
@@ -1,0 +1,84 @@
+import type { Coordinates } from '../../domain/types';
+
+/**
+ * Computes the map view `BoundaryMap` shows on first mount (GH#1031, bead
+ * tc-7se1w.7): a fixed close-in view centred on the postcode-geocoded centre
+ * when there are no vertices yet (a brand-new custom shape — today's
+ * behaviour, unchanged), or a view that fits the bounding box of the
+ * existing vertices with margin when re-opening a zone that already has a
+ * drawn polygon. Without this, the fixed zoom clips a large polygon's
+ * vertices/edges outside the visible map on reopen.
+ *
+ * Conceptual sibling of iOS's `BoundaryDrawingRegion.fitting` (tc-7se1w.2):
+ * same shape of fix (pure, unit-testable bounds computation; 30% margin;
+ * a minimum-span floor), expressed idiomatically for react-leaflet's
+ * `bounds` prop instead of MapKit's `MKCoordinateRegion`.
+ */
+
+/** The fixed zoom used when there are no vertices yet — matches the zoom
+ * `BoundaryMap` always used before tc-7se1w.7. */
+export const FRESH_DRAW_ZOOM = 15;
+
+/** Extra room around the tightest bounding box of the vertices, as a
+ * fraction of the box's own span — keeps drawn edges/vertices from sitting
+ * flush against the map's edge rather than comfortably inside it. */
+export const BOUNDS_MARGIN_FRACTION = 0.3;
+
+/** Smallest span (degrees of latitude/longitude) the fitted bounds are
+ * allowed to shrink to — stops a single vertex or a tightly clustered few
+ * vertices from producing an absurdly close-in zoom. */
+export const MINIMUM_SPAN_DEGREES = 0.006;
+
+export interface BoundaryMapFixedView {
+  readonly kind: 'fixed';
+  readonly center: Coordinates;
+  readonly zoom: number;
+}
+
+export interface BoundaryMapFitBoundsView {
+  readonly kind: 'fit-bounds';
+  readonly southWest: Coordinates;
+  readonly northEast: Coordinates;
+}
+
+export type BoundaryMapView = BoundaryMapFixedView | BoundaryMapFitBoundsView;
+
+export function computeBoundaryMapView(
+  vertices: readonly Coordinates[],
+  initialCentre: Coordinates,
+): BoundaryMapView {
+  if (vertices.length === 0) {
+    return { kind: 'fixed', center: initialCentre, zoom: FRESH_DRAW_ZOOM };
+  }
+
+  const latitudes = vertices.map((vertex) => vertex.latitude);
+  const longitudes = vertices.map((vertex) => vertex.longitude);
+  const minLatitude = Math.min(...latitudes);
+  const maxLatitude = Math.max(...latitudes);
+  const minLongitude = Math.min(...longitudes);
+  const maxLongitude = Math.max(...longitudes);
+
+  const centreLatitude = (minLatitude + maxLatitude) / 2;
+  const centreLongitude = (minLongitude + maxLongitude) / 2;
+
+  const latitudeSpan = Math.max(
+    (maxLatitude - minLatitude) * (1 + BOUNDS_MARGIN_FRACTION),
+    MINIMUM_SPAN_DEGREES,
+  );
+  const longitudeSpan = Math.max(
+    (maxLongitude - minLongitude) * (1 + BOUNDS_MARGIN_FRACTION),
+    MINIMUM_SPAN_DEGREES,
+  );
+
+  return {
+    kind: 'fit-bounds',
+    southWest: {
+      latitude: centreLatitude - latitudeSpan / 2,
+      longitude: centreLongitude - longitudeSpan / 2,
+    },
+    northEast: {
+      latitude: centreLatitude + latitudeSpan / 2,
+      longitude: centreLongitude + longitudeSpan / 2,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Fixes `BoundaryMap` always mounting its Leaflet `MapContainer` with a fixed `center`/`zoom={15}` regardless of the existing polygon's extent, which clipped large custom-shape watch zones outside the visible map on reopen.
- Adds `computeBoundaryMapView(vertices, initialCentre)`, a pure, unit-testable function: empty vertices keep today's fixed centre/zoom (fresh-draw case); non-empty vertices get a view fit to the vertices' bounding box with a 30% margin and a minimum-span floor so a single vertex or tight cluster doesn't zoom in absurdly close.
- `BoundaryMap` now computes this view once via a lazy `useState` initializer (guaranteed to run exactly once at mount) and spreads either `{center, zoom}` or `{bounds}` onto `MapContainer`, so a brand-new shape's fixed view never re-fits as vertices are added while drawing.

Bead: tc-7se1w.7 (child of epic tc-7se1w, GH#1031). Conceptual web sibling of the iOS fix for the same problem (tc-7se1w.2, commit ca28617, PR #1059) — same shape of fix (pure bounds computation, 30% margin, minimum-span floor), expressed idiomatically for react-leaflet's `bounds` prop instead of MapKit's `MKCoordinateRegion`. Scope is intentionally narrow to `web/src/components/BoundaryMap/` — sibling beads cover the map-page overlay gap (tc-7se1w.8) and marketing copy (tc-7se1w.10); neither is touched here.

## Test plan
- [x] New `boundaryMapView.test.ts` — 6 cases: fresh-draw fixed view, bounding-box fit with every vertex strictly inside, correct centering on the bounding box (not the initial centre), the exact 30% margin math, single-vertex minimum span, tight-cluster minimum span.
- [x] Extended `BoundaryMap.test.tsx` — 3 new integration cases: fixed centre/zoom when no vertices at mount, fit-bounds view when vertices exist at mount, no re-fit when vertices are appended after mount. All prior cases still pass.
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/components/BoundaryMap` — clean
- [x] `npx vitest run` — full suite, 144 files / 1407 tests, all passing
- [ ] Manual/browser verification of the actual reopen-a-large-polygon UX is outstanding — not done in this run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqbNXCjjTjG2UMGwErPCS8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map positioning when creating or viewing boundaries.
  * Existing boundary points now fit within the map view with appropriate margins.
  * Empty maps open at a consistent centre and zoom level.
  * Prevented excessive zoom when points are close together or only one point exists.
  * Preserved the initial map view when points are added after the map loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->