### PR TITLE
web: draw zone boundary overlay on main map (tc-7se1w.8)

### DIFF
--- a/web/src/features/Map/MapPage.tsx
+++ b/web/src/features/Map/MapPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect } from 'react';
 import { useNavigate } from 'react-router';
-import { MapContainer, TileLayer, Marker, useMap, useMapEvents } from 'react-leaflet';
+import { MapContainer, TileLayer, Marker, Circle, Polygon, useMap, useMapEvents } from 'react-leaflet';
 import type { MapPort, MapBounds } from '../../domain/ports/map-port';
 import type { ApplicationStatus, ClusterMember, MapCluster, WatchZoneSummary } from '../../domain/types';
 import { clusterMemberStatus } from '../../domain/types';
@@ -14,6 +14,43 @@ import './leaflet-overrides.css';
 const UK_CENTER: [number, number] = [54.5, -2.5];
 const ZONE_ZOOM = 13;
 const MAX_ZOOM = 18;
+
+// Leaflet SVG layers accept raw colour values, not CSS custom properties —
+// this hex MUST be kept in sync BY HAND with --tc-amber in tokens.css (dark
+// theme value, #E9A620 / rgb(233, 166, 32)) whenever the palette changes.
+// Mirrors ConfirmMap's/BoundaryMap's read-only boundary convention.
+const ZONE_BOUNDARY_OPTIONS = {
+  color: 'rgba(233, 166, 32, 0.8)',
+  fillColor: 'rgb(233, 166, 32)',
+  fillOpacity: 0.08,
+  weight: 2,
+  dashArray: '6 4',
+};
+
+interface ZoneBoundaryLayerProps {
+  readonly zone: WatchZoneSummary;
+}
+
+/**
+ * Read-only boundary overlay for the currently selected zone — a `<Circle>`
+ * for a plain zone, a `<Polygon>` (outer ring only) for a custom shape.
+ * GeoJSON vertex tuples are `[longitude, latitude]`; Leaflet positions are
+ * `[latitude, longitude]` — this is the one place that conversion happens.
+ */
+function ZoneBoundaryLayer({ zone }: ZoneBoundaryLayerProps) {
+  if (zone.boundary) {
+    const outerRing = zone.boundary.coordinates[0] ?? [];
+    const positions: [number, number][] = outerRing.map(([lng, lat]) => [lat, lng]);
+    return <Polygon positions={positions} pathOptions={ZONE_BOUNDARY_OPTIONS} />;
+  }
+  return (
+    <Circle
+      center={[zone.latitude, zone.longitude]}
+      radius={zone.radiusMetres}
+      pathOptions={ZONE_BOUNDARY_OPTIONS}
+    />
+  );
+}
 
 interface StatusChip {
   readonly label: string;
@@ -216,6 +253,7 @@ export function MapPage({ port }: Props) {
           style={{ height: '100%', width: '100%' }}
         >
           <TileLayer url={OSM_TILE_URL} attribution={OSM_ATTRIBUTION} />
+          {selectedZone && <ZoneBoundaryLayer zone={selectedZone} />}
           <ClusterLayer
             clusters={clusters}
             onRegionChange={onRegionChange}

--- a/web/src/features/Map/__tests__/MapPage.test.tsx
+++ b/web/src/features/Map/__tests__/MapPage.test.tsx
@@ -9,6 +9,7 @@ import {
   aBubbleCluster,
   aSinglePinCluster,
   anApplication,
+  aPolygonBoundary,
 } from './fixtures/map.fixtures';
 import { asApplicationUid } from '../../../domain/types';
 
@@ -29,6 +30,15 @@ const h = vi.hoisted(() => {
   };
 });
 
+interface CirclePathProps {
+  center: [number, number];
+  radius: number;
+}
+
+interface PolygonPathProps {
+  positions: [number, number][];
+}
+
 vi.mock('react-leaflet', () => ({
   MapContainer: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="map-container">{children}</div>
@@ -46,6 +56,21 @@ vi.mock('react-leaflet', () => ({
       data-icon-class={icon?.className}
       data-icon-html={icon?.html}
       onClick={() => eventHandlers?.click?.()}
+    />
+  ),
+  Circle: ({ center, radius }: CirclePathProps) => (
+    <div
+      data-testid="zone-circle"
+      data-lat={center[0]}
+      data-lng={center[1]}
+      data-radius={radius}
+    />
+  ),
+  Polygon: ({ positions }: PolygonPathProps) => (
+    <div
+      data-testid="zone-polygon"
+      data-count={positions.length}
+      data-positions={JSON.stringify(positions)}
     />
   ),
   useMap: () => h.mapInstance,
@@ -242,5 +267,49 @@ describe('MapPage', () => {
       expect(screen.getByTestId('map-container')).toBeInTheDocument();
     });
     expect(screen.queryByRole('combobox', { name: /watch zone/i })).not.toBeInTheDocument();
+  });
+
+  it('draws a circle overlay for a plain circle zone', async () => {
+    spy.fetchMyZonesResult = [aZone({ latitude: 52.2053, longitude: 0.1218, radiusMetres: 1000 })];
+
+    renderMap(spy);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('zone-circle')).toBeInTheDocument();
+    });
+    const circle = screen.getByTestId('zone-circle');
+    expect(circle.getAttribute('data-lat')).toBe('52.2053');
+    expect(circle.getAttribute('data-lng')).toBe('0.1218');
+    expect(circle.getAttribute('data-radius')).toBe('1000');
+    expect(screen.queryByTestId('zone-polygon')).not.toBeInTheDocument();
+  });
+
+  it('draws a polygon overlay for a custom-shape zone, converting lng/lat to lat/lng', async () => {
+    const boundary = aPolygonBoundary();
+    spy.fetchMyZonesResult = [aZone({ boundary })];
+
+    renderMap(spy);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('zone-polygon')).toBeInTheDocument();
+    });
+    const polygon = screen.getByTestId('zone-polygon');
+    const outerRing = boundary.coordinates[0]!;
+    expect(polygon.getAttribute('data-count')).toBe(String(outerRing.length));
+    const positions = JSON.parse(polygon.getAttribute('data-positions')!) as [number, number][];
+    expect(positions).toEqual(outerRing.map(([lng, lat]) => [lat, lng]));
+    expect(screen.queryByTestId('zone-circle')).not.toBeInTheDocument();
+  });
+
+  it('renders no boundary overlay when no zone is selected', async () => {
+    spy.fetchMyZonesResult = [];
+
+    renderMap(spy);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('map-container')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('zone-circle')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('zone-polygon')).not.toBeInTheDocument();
   });
 });

--- a/web/src/features/Map/__tests__/fixtures/map.fixtures.ts
+++ b/web/src/features/Map/__tests__/fixtures/map.fixtures.ts
@@ -3,6 +3,7 @@ import type {
   PlanningApplication,
   MapCluster,
   ClusterMember,
+  WatchZoneBoundary,
 } from '../../../../domain/types';
 import { asWatchZoneId, asAuthorityId, asApplicationUid } from '../../../../domain/types';
 
@@ -16,6 +17,8 @@ export function aZone(overrides?: Partial<WatchZoneSummary>): WatchZoneSummary {
     authorityId: asAuthorityId(1),
     pushEnabled: true,
     emailInstantEnabled: false,
+    paused: false,
+    boundary: null,
     ...overrides,
   };
 }
@@ -30,6 +33,28 @@ export function aSecondZone(overrides?: Partial<WatchZoneSummary>): WatchZoneSum
     authorityId: asAuthorityId(2),
     pushEnabled: true,
     emailInstantEnabled: false,
+    paused: false,
+    boundary: null,
+    ...overrides,
+  };
+}
+
+/** A GeoJSON boundary for a custom-shape zone — vertex tuples are
+ * `[longitude, latitude]` (GeoJSON/RFC 7946 order), the reverse of this
+ * codebase's `Coordinates`/Leaflet convention. */
+export function aPolygonBoundary(
+  overrides?: Partial<WatchZoneBoundary>,
+): WatchZoneBoundary {
+  return {
+    type: 'Polygon',
+    coordinates: [
+      [
+        [0.1218, 52.2053],
+        [0.13, 52.21],
+        [0.125, 52.2],
+        [0.1218, 52.2053],
+      ],
+    ],
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary
- The web map page (`/map`) rendered only a centre marker and clustered application pins for the selected watch zone — no boundary overlay at all, for either shape type. Verified via browser inspection against dev.towncrierapp.uk (zero `.leaflet-overlay-pane path` elements for both a circle zone and a polygon zone).
- Adds a `ZoneBoundaryLayer` to `MapPage.tsx` that renders a read-only `<Circle>` for a plain zone or a `<Polygon>` (outer ring, GeoJSON `[lng,lat]` → Leaflet `[lat,lng]` converted) for a custom-shape zone's boundary, whenever a zone is selected. Styling mirrors the existing amber, raw-hex `pathOptions` convention used by `ConfirmMap.tsx` and `BoundaryMap.tsx`.
- No change to clustering, filtering, or marker rendering.

## Test plan
- [x] `npx vitest run src/features/Map` — 4 files, 32/32 passed (3 new tests: circle overlay, polygon overlay with lng/lat conversion assertion, no overlay when unselected)
- [x] `npx vitest run` (full suite) — 143 files, 1401/1401 passed
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — succeeds

Closes bead tc-7se1w.8 (child of epic tc-7se1w, polygon watch zones TestFlight follow-up).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgFV1LcZ6R5meMBLaa24XE)_