### PR TITLE
Web: mention custom-shape watch zones in marketing copy (tc-7se1w.10)

### DIFF
--- a/web/src/components/HowItWorks/HowItWorks.tsx
+++ b/web/src/components/HowItWorks/HowItWorks.tsx
@@ -17,7 +17,7 @@ const STEPS: Step[] = [
     icon: '🔭',
     title: 'Create a watch zone',
     description:
-      'Draw a circle around the area you care about: your street, neighbourhood, or an entire ward. You choose the radius.',
+      "Draw a circle around the area you care about: your street, neighbourhood, or an entire ward. You choose the radius, or trace a custom shape instead if a circle doesn't fit.",
   },
   {
     icon: '🔔',

--- a/web/src/components/HowItWorks/__tests__/HowItWorks.test.tsx
+++ b/web/src/components/HowItWorks/__tests__/HowItWorks.test.tsx
@@ -51,6 +51,14 @@ describe('HowItWorks', () => {
     }
   });
 
+  it('mentions custom shapes as an alternative to a circle in the watch zone step', () => {
+    render(<HowItWorks />);
+
+    const items = screen.getAllByRole('listitem');
+
+    expect(within(items[1]!).getByText(/custom shape/i)).toBeInTheDocument();
+  });
+
   it('marks step icons as aria-hidden', () => {
     render(<HowItWorks />);
 

--- a/web/src/components/Pricing/Pricing.tsx
+++ b/web/src/components/Pricing/Pricing.tsx
@@ -11,6 +11,7 @@ interface Feature {
 const FEATURES: Feature[] = [
   { label: 'Watch Zones', free: '1', personal: '3', pro: 'Unlimited' },
   { label: 'Radius', free: '500m', personal: '2km', pro: '5km' },
+  { label: 'Custom Shapes', free: 'Circle only', personal: 'Yes', pro: 'Yes' },
   { label: 'Notifications', free: 'Weekly digest', personal: 'Instant', pro: 'Instant' },
   { label: 'Search', free: 'Basic', personal: 'Advanced', pro: 'Advanced + Filters' },
   { label: 'Historical Data', free: 'None', personal: '6 months', pro: '5 years' },

--- a/web/src/components/Pricing/__tests__/Pricing.test.tsx
+++ b/web/src/components/Pricing/__tests__/Pricing.test.tsx
@@ -92,6 +92,30 @@ describe('Pricing', () => {
     expect(screen.getAllByText('Notifications').length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText('Search').length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText('Historical Data').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('Custom Shapes').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows custom shapes as circle only on Free and available on Personal and Pro', () => {
+    render(<Pricing />);
+
+    const cards = screen.getAllByRole('article');
+    const freeCard = cards.find((card) => within(card).queryByText('Free'));
+    const personalCard = cards.find((card) => within(card).queryByText('Personal'));
+    const proCard = cards.find((card) => within(card).queryByText('Pro'));
+    expect(freeCard).toBeDefined();
+    expect(personalCard).toBeDefined();
+    expect(proCard).toBeDefined();
+
+    const freeRow = within(freeCard!).getByText('Custom Shapes').closest('li');
+    const personalRow = within(personalCard!).getByText('Custom Shapes').closest('li');
+    const proRow = within(proCard!).getByText('Custom Shapes').closest('li');
+    expect(freeRow).toBeDefined();
+    expect(personalRow).toBeDefined();
+    expect(proRow).toBeDefined();
+
+    expect(within(freeRow!).getByText('Circle only')).toBeInTheDocument();
+    expect(within(personalRow!).getByText('Yes')).toBeInTheDocument();
+    expect(within(proRow!).getByText('Yes')).toBeInTheDocument();
   });
 
   it('renders a section heading', () => {


### PR DESCRIPTION
## Summary
- The public marketing page never mentioned custom-shape (polygon) watch zones — a shipped Personal/Pro entitlement (GH#1031) — so a prospective customer reading the pricing page before signing up had no way to learn the feature exists.
- `HowItWorks` step 2 copy now mentions tracing a custom shape as an alternative to a circle.
- The `Pricing` features table gains a "Custom Shapes" row: Free = "Circle only", Personal/Pro = "Yes".

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — full suite, 143 files / 1400 tests passed
- [x] `npx eslint src/components/HowItWorks src/components/Pricing` — clean
- [x] Added/updated tests in `HowItWorks.test.tsx` and `Pricing.test.tsx` asserting the new copy

Closes bead tc-7se1w.10 (child of epic tc-7se1w).

---
_Generated by [Claude Code](https://claude.ai/code/session_01YLUwfQWfsew4VhVwVdxRUP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added custom-shape tracing as an option when creating watch zones.
  * Updated pricing comparisons to show custom-shape availability by plan: circle-only on Free, and included on Personal and Pro.
* **Documentation**
  * Clarified the watch zone setup instructions to mention custom shapes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->