### PR TITLE
web: wire CustomShapeUpsell CTA to App Store link at all 3 call sites

### DIFF
--- a/web/src/components/CustomShapeUpsell/CustomShapeUpsell.module.css
+++ b/web/src/components/CustomShapeUpsell/CustomShapeUpsell.module.css
@@ -50,6 +50,10 @@
 }
 
 .cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
   padding: var(--tc-space-sm) var(--tc-space-lg);
   background: var(--tc-amber);
   color: var(--tc-text-on-accent);
@@ -57,10 +61,13 @@
   border-radius: var(--tc-radius-md);
   font-weight: var(--tc-weight-semibold);
   font-size: var(--tc-text-body);
+  text-decoration: none;
   cursor: pointer;
   transition: background var(--tc-duration-fast);
 }
 
 .cta:hover {
   background: var(--tc-amber-hover);
+  color: var(--tc-text-on-accent);
+  text-decoration: none;
 }

--- a/web/src/components/CustomShapeUpsell/CustomShapeUpsell.tsx
+++ b/web/src/components/CustomShapeUpsell/CustomShapeUpsell.tsx
@@ -1,10 +1,16 @@
 import styles from './CustomShapeUpsell.module.css';
 
 interface Props {
-  onUpgradeClick?: () => void;
+  /**
+   * App Store link (campaign-tagged, see `appStoreUrl` in `config/links.ts`)
+   * for the upgrade CTA. Web has no in-app checkout — subscriptions are an
+   * iOS in-app purchase — so this points out to the store listing, mirroring
+   * `Pricing.tsx`. No CTA renders when omitted.
+   */
+  upgradeHref?: string;
 }
 
-export function CustomShapeUpsell({ onUpgradeClick }: Props) {
+export function CustomShapeUpsell({ upgradeHref }: Props) {
   return (
     <div className={styles.container}>
       <svg
@@ -31,10 +37,15 @@ export function CustomShapeUpsell({ onUpgradeClick }: Props) {
         We&apos;ll watch it and notify you the moment something changes.
       </p>
 
-      {onUpgradeClick && (
-        <button type="button" className={styles.cta} onClick={onUpgradeClick}>
+      {upgradeHref && (
+        <a
+          className={styles.cta}
+          href={upgradeHref}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           Upgrade to draw custom shapes
-        </button>
+        </a>
       )}
     </div>
   );

--- a/web/src/components/CustomShapeUpsell/__tests__/CustomShapeUpsell.test.tsx
+++ b/web/src/components/CustomShapeUpsell/__tests__/CustomShapeUpsell.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { describe, it, expect } from 'vitest';
 import { CustomShapeUpsell } from '../CustomShapeUpsell';
 
@@ -21,21 +20,21 @@ describe('CustomShapeUpsell', () => {
     expect(svg).toHaveAttribute('aria-hidden', 'true');
   });
 
-  it('does not render a call-to-action button when no handler is given', () => {
+  it('does not render a call-to-action link when no upgradeHref is given', () => {
     render(<CustomShapeUpsell />);
 
-    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 
-  it('renders a call-to-action button that invokes onUpgradeClick when clicked', async () => {
-    const user = userEvent.setup();
-    let clicked = 0;
+  it('renders a call-to-action link pointing at upgradeHref, opening in a new tab', () => {
+    render(<CustomShapeUpsell upgradeHref="https://apps.apple.com/gb/app/town-crier-planning-alerts/id6764095657?ct=test" />);
 
-    render(<CustomShapeUpsell onUpgradeClick={() => (clicked += 1)} />);
-
-    const button = screen.getByRole('button', { name: /upgrade/i });
-    await user.click(button);
-
-    expect(clicked).toBe(1);
+    const link = screen.getByRole('link', { name: /upgrade/i });
+    expect(link).toHaveAttribute(
+      'href',
+      'https://apps.apple.com/gb/app/town-crier-planning-alerts/id6764095657?ct=test',
+    );
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
   });
 });

--- a/web/src/features/WatchZones/WatchZoneCreatePage.tsx
+++ b/web/src/features/WatchZones/WatchZoneCreatePage.tsx
@@ -11,6 +11,7 @@ import { ConfirmMap } from '../../components/ConfirmMap/ConfirmMap';
 import { ShapeModeToggle } from './ShapeModeToggle';
 import { BoundaryMap } from '../../components/BoundaryMap/BoundaryMap';
 import { CustomShapeUpsell } from '../../components/CustomShapeUpsell/CustomShapeUpsell';
+import { appStoreUrl } from '../../config/links';
 import styles from './WatchZoneCreatePage.module.css';
 
 interface Props {
@@ -104,7 +105,11 @@ export function WatchZoneCreatePage({ repository, geocodingPort, navigate, tier 
             </>
           )}
 
-          {!canDrawCustomShape && <CustomShapeUpsell />}
+          {!canDrawCustomShape && (
+            <CustomShapeUpsell
+              upgradeHref={appStoreUrl('web-watch-zone-create-custom-shape')}
+            />
+          )}
 
           {error && (
             <p className={styles.error} role="alert">

--- a/web/src/features/WatchZones/WatchZoneEditPage.tsx
+++ b/web/src/features/WatchZones/WatchZoneEditPage.tsx
@@ -10,6 +10,7 @@ import { Toggle } from '../../components/Toggle/Toggle';
 import { ShapeModeToggle } from './ShapeModeToggle';
 import { BoundaryMap } from '../../components/BoundaryMap/BoundaryMap';
 import { CustomShapeUpsell } from '../../components/CustomShapeUpsell/CustomShapeUpsell';
+import { appStoreUrl } from '../../config/links';
 import styles from './WatchZoneEditPage.module.css';
 
 interface Props {
@@ -126,7 +127,11 @@ export function WatchZoneEditPage({ repository, zone, tier = 'Free' }: Props) {
           </>
         )}
 
-        {!canDrawCustomShape && !shapeLockedByTier && <CustomShapeUpsell />}
+        {!canDrawCustomShape && !shapeLockedByTier && (
+          <CustomShapeUpsell
+            upgradeHref={appStoreUrl('web-watch-zone-edit-custom-shape')}
+          />
+        )}
 
         {zoneEdit.boundaryError && (
           <p className={styles.fieldError}>{zoneEdit.boundaryError}</p>

--- a/web/src/features/WatchZones/__tests__/WatchZoneCreatePage.test.tsx
+++ b/web/src/features/WatchZones/__tests__/WatchZoneCreatePage.test.tsx
@@ -7,6 +7,7 @@ import { WatchZoneCreatePage } from '../WatchZoneCreatePage';
 import { SpyWatchZoneRepository } from './spies/spy-watch-zone-repository';
 import { aWatchZone } from './fixtures/watch-zone.fixtures';
 import type { GeocodingPort } from '../../../domain/ports/geocoding-port';
+import { appStoreUrl } from '../../../config/links';
 
 interface LatLngPayload {
   latlng: { lat: number; lng: number };
@@ -284,6 +285,14 @@ describe('WatchZoneCreatePage', () => {
       expect(
         screen.getByRole('heading', { name: /draw any shape/i }),
       ).toBeInTheDocument();
+
+      const cta = screen.getByRole('link', { name: /upgrade/i });
+      expect(cta).toHaveAttribute(
+        'href',
+        appStoreUrl('web-watch-zone-create-custom-shape'),
+      );
+      expect(cta).toHaveAttribute('target', '_blank');
+      expect(cta).toHaveAttribute('rel', 'noopener noreferrer');
     });
 
     it('shows the shape toggle for Personal/Pro tier', async () => {

--- a/web/src/features/WatchZones/__tests__/WatchZoneEditPage.test.tsx
+++ b/web/src/features/WatchZones/__tests__/WatchZoneEditPage.test.tsx
@@ -6,6 +6,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { WatchZoneEditPage } from '../WatchZoneEditPage';
 import { SpyWatchZoneRepository } from './spies/spy-watch-zone-repository';
 import { aWatchZone, aWatchZoneBoundary, zonePreferences } from './fixtures/watch-zone.fixtures';
+import { appStoreUrl } from '../../../config/links';
 
 interface LatLngPayload {
   latlng: { lat: number; lng: number };
@@ -446,6 +447,14 @@ describe('WatchZoneEditPage', () => {
       expect(screen.getByRole('radiogroup', { name: /radius/i })).toBeInTheDocument();
       expect(screen.queryByRole('radiogroup', { name: /shape/i })).not.toBeInTheDocument();
       expect(screen.getByRole('heading', { name: /draw any shape/i })).toBeInTheDocument();
+
+      const cta = screen.getByRole('link', { name: /upgrade/i });
+      expect(cta).toHaveAttribute(
+        'href',
+        appStoreUrl('web-watch-zone-edit-custom-shape'),
+      );
+      expect(cta).toHaveAttribute('target', '_blank');
+      expect(cta).toHaveAttribute('rel', 'noopener noreferrer');
     });
 
     it('surfaces a locked notice, not the radius picker, for a Free-tier user holding a pre-existing custom-shape zone', () => {

--- a/web/src/features/onboarding/OnboardingPage.tsx
+++ b/web/src/features/onboarding/OnboardingPage.tsx
@@ -7,6 +7,7 @@ import { RadiusPicker } from '../../components/RadiusPicker/RadiusPicker';
 import { BoundaryMap } from '../../components/BoundaryMap/BoundaryMap';
 import { CustomShapeUpsell } from '../../components/CustomShapeUpsell/CustomShapeUpsell';
 import { useBoundaryDrawing } from '../../hooks/useBoundaryDrawing';
+import { appStoreUrl } from '../../config/links';
 import { useOnboarding } from './useOnboarding';
 import styles from './OnboardingPage.module.css';
 
@@ -75,7 +76,11 @@ export function OnboardingPage({ onboardingPort, geocodingPort }: Props) {
               selectedMetres={radiusMetres}
               onSelect={selectRadius}
             />
-            {tier === 'Free' && <CustomShapeUpsell />}
+            {tier === 'Free' && (
+              <CustomShapeUpsell
+                upgradeHref={appStoreUrl('web-onboarding-custom-shape')}
+              />
+            )}
             <button
               type="button"
               className={styles.primaryButton}

--- a/web/src/features/onboarding/__tests__/OnboardingPage.test.tsx
+++ b/web/src/features/onboarding/__tests__/OnboardingPage.test.tsx
@@ -5,6 +5,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { OnboardingPage } from '../OnboardingPage';
 import { SpyOnboardingPort } from './spies/spy-onboarding-port';
 import { SpyGeocodingPort } from './spies/spy-geocoding-port';
+import { appStoreUrl } from '../../../config/links';
 
 vi.mock('react-leaflet', () => ({
   MapContainer: ({ children }: { children: React.ReactNode }) => (
@@ -176,9 +177,13 @@ describe('OnboardingPage', () => {
     expect(
       screen.getByRole('heading', { name: /draw any shape/i }),
     ).toBeInTheDocument();
-    // No purchase/checkout route exists on web yet (GH#1031 section 8) —
-    // the upsell must not render an "Upgrade" CTA button.
-    expect(screen.queryByRole('button', { name: /upgrade/i })).not.toBeInTheDocument();
+    // No web checkout exists (GH#1031) — the upsell CTA links out to the App
+    // Store instead of a web purchase flow, tagged so installs attribute
+    // back to this surface.
+    const cta = screen.getByRole('link', { name: /upgrade/i });
+    expect(cta).toHaveAttribute('href', appStoreUrl('web-onboarding-custom-shape'));
+    expect(cta).toHaveAttribute('target', '_blank');
+    expect(cta).toHaveAttribute('rel', 'noopener noreferrer');
   });
 
   it('shows error when API call fails', async () => {


### PR DESCRIPTION
## Summary

- `CustomShapeUpsell` took an optional `onUpgradeClick` handler that none of its 3 call sites (`OnboardingPage`, `WatchZoneCreatePage`, `WatchZoneEditPage`) ever passed, so the "Upgrade to draw custom shapes" CTA never rendered anywhere — free-tier users saw the upsell copy with no way to act on it.
- Web has no checkout of its own (subscriptions are purchased as an iOS in-app purchase — confirmed there is no `/pricing` route, no billing section in Settings, nothing beyond the public landing page's `Pricing` component, whose own CTA already links out to the App Store). So the fix changes the component's prop from a click callback to `upgradeHref?: string`, rendering the CTA as an `<a target="_blank" rel="noopener noreferrer">` App Store link — exactly mirroring the existing pattern in `Pricing.tsx` — instead of building new web checkout infrastructure (out of scope).
- Each call site passes a distinct, campaign-tagged `appStoreUrl(...)` so App Store Connect can attribute installs back to the surface that sent them, following the existing `web-home`/`web-pricing` naming convention.

## Test plan

- [x] `npx vitest run` — 143 files, 1398 tests passed
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — succeeds
- [x] Live-rendered `CustomShapeUpsell` in isolation (with/without `upgradeHref`) via a dispatched browser-verification subagent — CTA renders as an amber pill link with correct `href`/`target`/`rel`; screenshot reviewed
- [ ] Full authenticated-route verification (`/onboarding`, `/watch-zones/new`, `/watch-zones/:id`) — **not done**; this environment has no Auth0 test credentials to get past the app's `AuthGuard`. Component-level and page-level tests cover the wiring at all 3 call sites instead.

Bead: tc-7se1w.9 (child of epic tc-7se1w). GH#1031.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdH9Rmi73PnaZJmVZjkNf5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Free-tier custom-shape upgrade prompts now provide a direct link to the App Store.
  * Upgrade links open securely in a new browser tab.
* **Style**
  * Improved CTA alignment, sizing, text color, and hover presentation.
* **Tests**
  * Added coverage for upgrade URLs, new-tab behavior, and link security attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->