### PR TITLE
iOS: free-tier upsell copy mentions custom-shape watch zones (tc-7se1w.5)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/UnlockLargerZonesChip.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/UnlockLargerZonesChip.swift
@@ -10,20 +10,22 @@ import SwiftUI
 /// unlocks live. The richer "locked region on the track" gesture is an open
 /// question to be prototyped in TestFlight before release.
 ///
-/// The copy sells the whole upgrade, not just a bigger radius: bigger zones, more
-/// than one zone, and instant alerts by push and email (the free tier gets a
-/// weekly digest only). Uses the brand amber at 15% opacity so it reads as an
-/// invitation, not an error — mirrors ``LargeRadiusWarningView``.
+/// The copy sells the whole upgrade, not just a bigger radius: bigger zones, custom
+/// shapes instead of a circle, more than one zone, and instant alerts by push and
+/// email (the free tier gets a weekly digest only). Uses the brand amber at 15%
+/// opacity so it reads as an invitation, not an error — mirrors
+/// ``LargeRadiusWarningView``.
 public struct UnlockLargerZonesChip: View {
   /// User-facing copy, kept in one place so it can be unit-tested and reused.
   enum Copy {
     static let title = "Do more with a plan"
     static let benefits =
-      "Bigger watch zones up to 10 km, more than one zone, and instant alerts by "
-      + "push and email. Free gives you a weekly digest."
+      "Bigger watch zones up to 10 km, custom shapes instead of a circle, more than "
+      + "one zone, and instant alerts by push and email. Free gives you a weekly digest."
     static let accessibilityLabel =
-      "Do more with a plan. Bigger watch zones up to 10 kilometres, more than one "
-      + "watch zone, and instant alerts by push and email. Free gives you a weekly digest."
+      "Do more with a plan. Bigger watch zones up to 10 kilometres, custom shapes "
+      + "instead of a circle, more than one watch zone, and instant alerts by push and "
+      + "email. Free gives you a weekly digest."
     static let accessibilityHint = "Opens subscription plans"
   }
 

--- a/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/UnlockLargerZonesChip.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/UnlockLargerZonesChip.swift
@@ -21,7 +21,7 @@ public struct UnlockLargerZonesChip: View {
     static let title = "Do more with a plan"
     static let benefits =
       "Bigger watch zones up to 10 km, custom shapes instead of a circle, more than "
-      + "one zone, and instant alerts by push and email. Free gives you a weekly digest."
+      + "one watch zone, and instant alerts by push and email. Free gives you a weekly digest."
     static let accessibilityLabel =
       "Do more with a plan. Bigger watch zones up to 10 kilometres, custom shapes "
       + "instead of a circle, more than one watch zone, and instant alerts by push and "

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneInlineUpsellCard.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneInlineUpsellCard.swift
@@ -4,9 +4,10 @@ import SwiftUI
 /// filling the space they would otherwise see empty once they hit their one-zone
 /// limit (tc-t8hc).
 ///
-/// It sells the whole plan, not just one feature: bigger zones, more than one
-/// zone, and instant alerts by push and email (the free tier gets a weekly digest
-/// only). Tapping "View Plans" opens the subscription paywall via the host's
+/// It sells the whole plan, not just one feature: bigger zones, custom shapes
+/// instead of a circle, more than one zone, and instant alerts by push and email
+/// (the free tier gets a weekly digest only). Tapping "View Plans" opens the
+/// subscription paywall via the host's
 /// `onViewPlans` closure, which the list wires to
 /// ``WatchZoneListViewModel/viewPlans()``.
 ///
@@ -26,12 +27,14 @@ public struct WatchZoneInlineUpsellCard: View {
     static let eyebrow = "Upgrade"
     static let title = "Do more with a plan"
     static let biggerZones = "Bigger watch zones, up to 10 km"
+    static let customShapes = "Custom shapes instead of a circle"
     static let moreThanOneZone = "More than one watch zone"
     static let instantAlerts = "Instant alerts by push and email"
     static let freeClarifier = "Free gives you a weekly digest."
     static let viewPlans = "View Plans"
     static let accessibilityLabel =
       "Do more with a plan. Bigger watch zones, up to 10 kilometres. "
+      + "Custom shapes instead of a circle. "
       + "More than one watch zone. Instant alerts by push and email. "
       + "Free gives you a weekly digest."
     static let accessibilityHint = "Opens subscription plans"
@@ -61,6 +64,7 @@ public struct WatchZoneInlineUpsellCard: View {
 
         VStack(alignment: .leading, spacing: TCSpacing.small) {
           benefitRow(icon: "arrow.up.left.and.arrow.down.right", text: Copy.biggerZones)
+          benefitRow(icon: "scribble", text: Copy.customShapes)
           benefitRow(icon: "square.on.square", text: Copy.moreThanOneZone)
           benefitRow(icon: "bell.badge", text: Copy.instantAlerts)
         }

--- a/mobile/ios/town-crier-tests/Sources/Features/UnlockLargerZonesChipTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/UnlockLargerZonesChipTests.swift
@@ -23,7 +23,7 @@ struct UnlockLargerZonesChipTests {
   }
 
   @Test func benefits_coverMoreThanOneZone() {
-    #expect(UnlockLargerZonesChip.Copy.benefits.contains("more than one zone"))
+    #expect(UnlockLargerZonesChip.Copy.benefits.contains("more than one watch zone"))
   }
 
   @Test func benefits_coverCustomShapes() {
@@ -45,7 +45,7 @@ struct UnlockLargerZonesChipTests {
     #expect(
       UnlockLargerZonesChip.Copy.benefits
         == "Bigger watch zones up to 10 km, custom shapes instead of a circle, more than "
-        + "one zone, and instant alerts by push and email. Free gives you a weekly digest."
+        + "one watch zone, and instant alerts by push and email. Free gives you a weekly digest."
     )
   }
 

--- a/mobile/ios/town-crier-tests/Sources/Features/UnlockLargerZonesChipTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/UnlockLargerZonesChipTests.swift
@@ -26,6 +26,12 @@ struct UnlockLargerZonesChipTests {
     #expect(UnlockLargerZonesChip.Copy.benefits.contains("more than one zone"))
   }
 
+  @Test func benefits_coverCustomShapes() {
+    // Custom-shape (polygon) zones are a real Personal/Pro entitlement (GH#1031,
+    // tc-7se1w.5) and belong alongside radius and zone-count.
+    #expect(UnlockLargerZonesChip.Copy.benefits.contains("custom shapes instead of a circle"))
+  }
+
   @Test func benefits_phrasePushAndEmailAsOneAlert() {
     // Push + email are two channels for the SAME alert, never two features.
     #expect(UnlockLargerZonesChip.Copy.benefits.contains("instant alerts by push and email"))
@@ -38,8 +44,8 @@ struct UnlockLargerZonesChipTests {
   @Test func benefits_exactWording() {
     #expect(
       UnlockLargerZonesChip.Copy.benefits
-        == "Bigger watch zones up to 10 km, more than one zone, and instant alerts by "
-        + "push and email. Free gives you a weekly digest."
+        == "Bigger watch zones up to 10 km, custom shapes instead of a circle, more than "
+        + "one zone, and instant alerts by push and email. Free gives you a weekly digest."
     )
   }
 
@@ -48,8 +54,15 @@ struct UnlockLargerZonesChipTests {
   @Test func accessibilityLabel_describesTheWholeUpgrade() {
     #expect(
       UnlockLargerZonesChip.Copy.accessibilityLabel
-        == "Do more with a plan. Bigger watch zones up to 10 kilometres, more than one "
-        + "watch zone, and instant alerts by push and email. Free gives you a weekly digest."
+        == "Do more with a plan. Bigger watch zones up to 10 kilometres, custom shapes "
+        + "instead of a circle, more than one watch zone, and instant alerts by push and "
+        + "email. Free gives you a weekly digest."
+    )
+  }
+
+  @Test func accessibilityLabel_describesCustomShapes() {
+    #expect(
+      UnlockLargerZonesChip.Copy.accessibilityLabel.contains("custom shapes instead of a circle")
     )
   }
 

--- a/mobile/ios/town-crier-tests/Sources/Features/WatchZoneInlineUpsellCardTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WatchZoneInlineUpsellCardTests.swift
@@ -31,6 +31,12 @@ struct WatchZoneInlineUpsellCardTests {
     #expect(WatchZoneInlineUpsellCard.Copy.biggerZones == "Bigger watch zones, up to 10 km")
   }
 
+  @Test func benefit_customShapes() {
+    // Custom-shape (polygon) zones are a real Personal/Pro entitlement (GH#1031,
+    // tc-7se1w.5) and belong alongside radius and zone-count.
+    #expect(WatchZoneInlineUpsellCard.Copy.customShapes == "Custom shapes instead of a circle")
+  }
+
   @Test func benefit_moreThanOneZone() {
     #expect(WatchZoneInlineUpsellCard.Copy.moreThanOneZone == "More than one watch zone")
   }
@@ -60,6 +66,7 @@ struct WatchZoneInlineUpsellCardTests {
     let label = WatchZoneInlineUpsellCard.Copy.accessibilityLabel
     #expect(label.contains("Do more with a plan"))
     #expect(label.contains("Bigger watch zones, up to 10 kilometres"))
+    #expect(label.contains("Custom shapes instead of a circle"))
     #expect(label.contains("More than one watch zone"))
     #expect(label.contains("Instant alerts by push and email"))
     #expect(label.contains("Free gives you a weekly digest."))


### PR DESCRIPTION
## Summary
- Free-tier upsell surfaces (`UnlockLargerZonesChip`, `WatchZoneInlineUpsellCard`) never mentioned custom-shape (polygon) watch zones as a paid benefit, even though it's a real Personal/Pro entitlement (GH#1031). They only listed radius, zone count, and instant alerts.
- Both `Copy` structs now mention custom shapes, in their visible text and their `accessibilityLabel`, keeping the two surfaces' wording consistent with each other (tc-42gc "one voice" rule) and in the same spirit as the existing `CustomShapeUpsellCard` wording.
- `WatchZoneInlineUpsellCard` gained a new benefit row (`Copy.customShapes`, "Custom shapes instead of a circle") with a `scribble` icon, positioned between the radius and zone-count benefits.
- Copy checked against the `voice` skill: plain, concrete, no em dash.

## Test plan
- [x] TDD: red commit (failing/non-compiling tests) → green commit (Copy implementation)
- [x] `swift test` — full suite, 1965 tests pass
- [x] `swiftlint lint --strict` — clean on the touched files (pre-existing, unrelated lint debt on `main` filed separately as tc-yy1tb)
- [x] `swift build` — clean

Release-Note: Upgrade prompts now mention custom-shape watch zones, not just bigger radius and more zones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Watch-zone upgrade messaging now highlights support for custom zone shapes.
  * Added a dedicated custom-shapes benefit to the watch-zone upsell card.
  * Clarified that free plans include a weekly digest.

* **Accessibility**
  * Updated accessibility text to include custom-shape benefits and plan details.

* **Tests**
  * Added coverage validating the updated benefit descriptions and accessibility labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->