### PR TITLE
iOS: watch zone list thumbnail shows drawn polygon for custom-shape zones (tc-7se1w.1)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/ZoneMapPreview.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/ZoneMapPreview.swift
@@ -2,34 +2,63 @@ import MapKit
 import SwiftUI
 import TownCrierDomain
 
-/// A non-interactive map preview showing a zone circle around a centre coordinate.
+/// A non-interactive map preview showing a zone's shape around a centre
+/// coordinate: a circle by default, or a custom-drawn polygon outline when
+/// `boundaryVertices` describes one (tc-7se1w.1).
 ///
 /// Size is controlled externally via SwiftUI `.frame()` modifiers.
-/// The `strokeWidth` parameter allows callers to adjust circle border
+/// The `strokeWidth` parameter allows callers to adjust border
 /// thickness for different display contexts (compact vs. large).
 struct ZoneMapPreview: View {
   let centre: Coordinate
   let radiusMetres: Double
   let strokeWidth: CGFloat
+  /// The zone's custom-shape polygon ring, or `nil` for a circle. Mirrors
+  /// ``WatchZone/isCustomShape`` — callers pass a non-nil
+  /// `WatchZoneBoundary.vertices` for a custom-shape zone.
+  let boundaryVertices: [Coordinate]?
 
-  init(centre: Coordinate, radiusMetres: Double, strokeWidth: CGFloat = 1) {
+  init(
+    centre: Coordinate,
+    radiusMetres: Double,
+    strokeWidth: CGFloat = 1,
+    boundaryVertices: [Coordinate]? = nil
+  ) {
     self.centre = centre
     self.radiusMetres = radiusMetres
     self.strokeWidth = strokeWidth
+    self.boundaryVertices = boundaryVertices
+  }
+
+  /// Whether `boundaryVertices` describes a polygon (3 or more vertices) —
+  /// the minimum needed to enclose an area, matching the domain's
+  /// `WatchZoneBoundary` validation.
+  var isCustomShape: Bool {
+    (boundaryVertices?.count ?? 0) >= 3
   }
 
   var body: some View {
     Map(initialPosition: .region(region)) {
-      MapCircle(center: clLocation, radius: radiusMetres)
-        .foregroundStyle(Color.tcAmber.opacity(0.2))
-        .stroke(Color.tcAmber, style: StrokeStyle(lineWidth: strokeWidth, dash: [6, 4]))
+      if isCustomShape, let boundaryVertices {
+        MapPolygon(coordinates: boundaryVertices.map(Self.clLocation))
+          .foregroundStyle(Color.tcAmber.opacity(0.2))
+          .stroke(Color.tcAmber, style: StrokeStyle(lineWidth: strokeWidth, dash: [6, 4]))
+      } else {
+        MapCircle(center: clLocation, radius: radiusMetres)
+          .foregroundStyle(Color.tcAmber.opacity(0.2))
+          .stroke(Color.tcAmber, style: StrokeStyle(lineWidth: strokeWidth, dash: [6, 4]))
+      }
     }
     .mapStyle(.standard(elevation: .flat))
     .allowsHitTesting(false)
   }
 
   private var clLocation: CLLocationCoordinate2D {
-    CLLocationCoordinate2D(latitude: centre.latitude, longitude: centre.longitude)
+    Self.clLocation(centre)
+  }
+
+  private static func clLocation(_ coordinate: Coordinate) -> CLLocationCoordinate2D {
+    CLLocationCoordinate2D(latitude: coordinate.latitude, longitude: coordinate.longitude)
   }
 
   private var region: MKCoordinateRegion {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListView.swift
@@ -194,9 +194,13 @@ private struct WatchZoneRow: View {
 
   var body: some View {
     HStack(spacing: TCSpacing.medium) {
-      ZoneMapPreview(centre: zone.centre, radiusMetres: zone.radiusMetres)
-        .frame(width: 56, height: 56)
-        .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.small))
+      ZoneMapPreview(
+        centre: zone.centre,
+        radiusMetres: zone.radiusMetres,
+        boundaryVertices: zone.boundary?.vertices
+      )
+      .frame(width: 56, height: 56)
+      .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.small))
 
       VStack(alignment: .leading, spacing: TCSpacing.extraSmall) {
         // Mono header strip: radius reads as the zone's metadata line,

--- a/mobile/ios/town-crier-tests/Sources/Features/ZoneMapPreviewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ZoneMapPreviewTests.swift
@@ -28,4 +28,61 @@ struct ZoneMapPreviewTests {
     let sut = ZoneMapPreview(centre: centre, radiusMetres: 2000, strokeWidth: 2)
     #expect(sut.strokeWidth == 2)
   }
+
+  // MARK: - Custom-shape boundary (tc-7se1w.1)
+
+  @Test func init_withoutBoundaryVertices_defaultsToNil() throws {
+    let centre = try Coordinate(latitude: 52.2053, longitude: 0.1218)
+    let sut = ZoneMapPreview(centre: centre, radiusMetres: 1000)
+    #expect(sut.boundaryVertices == nil)
+  }
+
+  @Test func init_withBoundaryVertices_storesVertices() throws {
+    let centre = try Coordinate(latitude: 52.2053, longitude: 0.1218)
+    let vertices = try [
+      Coordinate(latitude: 52.20, longitude: 0.12),
+      Coordinate(latitude: 52.21, longitude: 0.13),
+      Coordinate(latitude: 52.20, longitude: 0.13),
+    ]
+    let sut = ZoneMapPreview(centre: centre, radiusMetres: 1000, boundaryVertices: vertices)
+    #expect(sut.boundaryVertices == vertices)
+  }
+
+  @Test func body_withBoundaryVertices_createsView() throws {
+    let centre = try Coordinate(latitude: 52.2053, longitude: 0.1218)
+    let vertices = try [
+      Coordinate(latitude: 52.20, longitude: 0.12),
+      Coordinate(latitude: 52.21, longitude: 0.13),
+      Coordinate(latitude: 52.20, longitude: 0.13),
+    ]
+    let sut = ZoneMapPreview(centre: centre, radiusMetres: 1000, boundaryVertices: vertices)
+    _ = sut.body
+  }
+
+  @Test func isCustomShape_withThreeOrMoreVertices_isTrue() throws {
+    let centre = try Coordinate(latitude: 52.2053, longitude: 0.1218)
+    let vertices = try [
+      Coordinate(latitude: 52.20, longitude: 0.12),
+      Coordinate(latitude: 52.21, longitude: 0.13),
+      Coordinate(latitude: 52.20, longitude: 0.13),
+    ]
+    let sut = ZoneMapPreview(centre: centre, radiusMetres: 1000, boundaryVertices: vertices)
+    #expect(sut.isCustomShape)
+  }
+
+  @Test func isCustomShape_withNilVertices_isFalse() throws {
+    let centre = try Coordinate(latitude: 52.2053, longitude: 0.1218)
+    let sut = ZoneMapPreview(centre: centre, radiusMetres: 1000)
+    #expect(!sut.isCustomShape)
+  }
+
+  @Test func isCustomShape_withFewerThanThreeVertices_isFalse() throws {
+    let centre = try Coordinate(latitude: 52.2053, longitude: 0.1218)
+    let vertices = try [
+      Coordinate(latitude: 52.20, longitude: 0.12),
+      Coordinate(latitude: 52.21, longitude: 0.13),
+    ]
+    let sut = ZoneMapPreview(centre: centre, radiusMetres: 1000, boundaryVertices: vertices)
+    #expect(!sut.isCustomShape)
+  }
 }


### PR DESCRIPTION
## Summary
- `ZoneMapPreview` gains an optional `boundaryVertices: [Coordinate]?` init param and an `isCustomShape` computed property (true at ≥3 vertices).
- `body` now draws a `MapPolygon` (same amber fill/stroke styling as the circle) when `isCustomShape` is true, falling back to the original `MapCircle` otherwise.
- `WatchZoneRow` (Watch Zones list) now passes `boundaryVertices: zone.boundary?.vertices`, so a custom-drawn zone's actual polygon outline shows in its list thumbnail instead of always falling back to a circle.
- Checked every other `ZoneMapPreview` call site (`WatchZoneEditorView` ×2, `DeviceLocalZoneConversionView`, `AnonymousPostcodeEntryView`, `DeviceLocalZoneEditorView`, `DeviceLocalZoneListView`) — none pass `boundaryVertices`, so the default `nil` keeps them all circle-only and unaffected. `DeviceLocalZone` has no boundary field at all, so device-local/anonymous zones are correctly out of scope.

Fixes tc-7se1w.1.

## Test plan
- [x] Red: 6 new `@Test` functions (already drafted by a prior worker session) confirmed to fail compilation before the fix (commit `efbc0498`)
- [x] Green: implementation added, full suite passes (commit `2d278fc5`)
- [x] `swift build` — clean
- [x] `swift test` — 1968 tests, 243 suites, all passing
- [x] `swiftlint lint --strict` — 0 violations against the CI-pinned 0.63.2 binary (local 0.65.0 has known pre-existing ruleset drift, unrelated to this change — see tc-sketk)
- [ ] Manual polygon-vs-circle thumbnail check on a real device/simulator — left to reviewer/CI since this worker doesn't drive the simulator

Release-Note: Watch zones with a custom-drawn shape now show that shape, not a circle, in the zone list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)