### PR TITLE
iOS: fix onboarding custom-shape watch zone visibility and copy (tc-7se1w.4)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/CustomShapeAvailableCard.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/CustomShapeAvailableCard.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+/// In-context callout shown on the onboarding radius step once the user's
+/// tier already allows drawing a custom-shape (polygon) zone (GH#1031,
+/// tc-7se1w.4). Replaces a plain "Draw a custom shape instead" text link
+/// that carried no explanation of what the capability actually does — a
+/// paying user deserves the same clear introduction to the feature that
+/// ``CustomShapeUpsellCard`` gives a Free-tier user pre-purchase, just
+/// without the paywall framing. Shares that card's layout (the same
+/// ``CustomShapeUpsellGraphic``, title, and caption) so the two read as one
+/// consistent component with different copy for different entitlement
+/// states, not two unrelated pieces of UI.
+public struct CustomShapeAvailableCard: View {
+  /// User-facing copy, kept in one place so it can be unit-tested and reused.
+  enum Copy {
+    static let title = "Draw a custom shape"
+    static let benefits = "Trace the exact area you want to watch, instead of a circle."
+    static let accessibilityLabel = "Draw a custom shape. \(benefits)"
+    static let accessibilityHint = "Opens the shape drawing tool"
+  }
+
+  private let action: () -> Void
+
+  public init(action: @escaping () -> Void) {
+    self.action = action
+  }
+
+  public var body: some View {
+    Button(action: action) {
+      VStack(spacing: TCSpacing.small) {
+        CustomShapeUpsellGraphic()
+
+        Text(Copy.title)
+          .font(TCTypography.bodyEmphasis)
+          .foregroundStyle(Color.tcTextPrimary)
+
+        Text(Copy.benefits)
+          .font(TCTypography.caption)
+          .foregroundStyle(Color.tcTextSecondary)
+          .multilineTextAlignment(.center)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+      .padding(TCSpacing.medium)
+      .frame(maxWidth: .infinity)
+      .background(Color.tcAmberMuted)
+      .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.medium))
+    }
+    .buttonStyle(.plain)
+    .accessibilityLabel(Copy.accessibilityLabel)
+    .accessibilityHint(Copy.accessibilityHint)
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/OnboardingView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/OnboardingView.swift
@@ -17,8 +17,13 @@ public struct OnboardingView: View {
         stepIndicator
           .padding(.top, TCSpacing.medium)
 
-        Spacer()
-
+        // A single `.frame(maxHeight: .infinity)` — rather than sandwiching
+        // the step between two `Spacer()`s — centres short steps exactly as
+        // before, but gives a scrolling step (``RadiusPickerStepView``,
+        // tc-7se1w.4) the whole remaining height to scroll within. Two
+        // flanking `Spacer()`s would instead tie with the step's own
+        // `ScrollView` for "infinite" flexibility and split the space
+        // between them, shrinking the very viewport that needed to grow.
         Group {
           switch viewModel.currentStep {
           case .welcome:
@@ -33,6 +38,7 @@ public struct OnboardingView: View {
             NotificationPermissionStepView(viewModel: viewModel)
           }
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .transition(
           .asymmetric(
             insertion: .move(edge: .trailing).combined(with: .opacity),
@@ -40,8 +46,6 @@ public struct OnboardingView: View {
           )
         )
         .animation(.spring(response: 0.4), value: viewModel.currentStep)
-
-        Spacer()
       }
     }
     // In-wizard radius upsell (tc-w3cb.3): presented as a sheet *over* the

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/Steps/RadiusPickerStepView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/Steps/RadiusPickerStepView.swift
@@ -5,62 +5,76 @@ import SwiftUI
 /// Uses the same `Slider` paradigm as `WatchZoneEditorView`, bounded at the
 /// tier's maximum radius so a free user cannot exceed their 2 km cap by
 /// construction (tc-w3cb.2).
+///
+/// Wrapped in a `ScrollView` (tc-7se1w.4): this step can stack the radius
+/// control, the larger-radius upsell chip, the custom-shape card, and the
+/// large-radius warning all at once, and `OnboardingView` gives the step
+/// the full height below the step indicator rather than centring it — so on
+/// a compact screen or with larger Dynamic Type, content that doesn't fit
+/// scrolls instead of being silently clipped past the bottom of the
+/// viewport. A tester who never scrolled would see the visible portion but
+/// could miss anything pushed below the fold; before this fix there was no
+/// way to reach it at all.
 struct RadiusPickerStepView: View {
   @ObservedObject var viewModel: OnboardingViewModel
 
   var body: some View {
-    VStack(spacing: TCSpacing.large) {
-      Text("How far?")
-        .font(TCTypography.displaySmall)
-        .foregroundStyle(Color.tcTextPrimary)
+    ScrollView {
+      VStack(spacing: TCSpacing.large) {
+        Text("How far?")
+          .font(TCTypography.displaySmall)
+          .foregroundStyle(Color.tcTextPrimary)
 
-      Text("Choose a radius around your postcode to monitor for planning applications.")
+        Text("Choose a radius around your postcode to monitor for planning applications.")
+          .font(TCTypography.body)
+          .foregroundStyle(Color.tcTextSecondary)
+          .multilineTextAlignment(.center)
+
+        radiusControl
+
+        // Custom-shape mention (GH#1031, tc-6he3x.10; placement tc-7se1w.4):
+        // shown directly below the radius control, ahead of the larger-radius
+        // chip, so the newer polygon capability isn't the last thing a user
+        // scrolls past. Free tier sees the upsell card; a tier that already
+        // has the entitlement sees an equally clear card rather than a bare
+        // text link (previously the only mention it got).
+        if !viewModel.canDrawCustomShape {
+          CustomShapeUpsellCard {
+            viewModel.requestCustomShapeUpgrade()
+          }
+        } else {
+          // Re-entry point for a user whose tier already allows custom shapes
+          // (tc-6he3x.10) — without this, backing out of the drawing step once
+          // would strand an already-paying user on a circle for the rest of
+          // onboarding, since the upsell card above only shows pre-purchase.
+          CustomShapeAvailableCard {
+            viewModel.selectCustomShape()
+          }
+        }
+
+        if viewModel.canUnlockLargerRadius {
+          UnlockLargerZonesChip {
+            viewModel.requestLargerRadiusUpgrade()
+          }
+        }
+
+        if viewModel.showsLargeRadiusWarning {
+          LargeRadiusWarningView()
+        }
+
+        PrimaryButton("Continue") {
+          viewModel.confirmRadius()
+        }
+
+        Button("Back") {
+          viewModel.goBack()
+        }
         .font(TCTypography.body)
         .foregroundStyle(Color.tcTextSecondary)
-        .multilineTextAlignment(.center)
-
-      radiusControl
-
-      if viewModel.canUnlockLargerRadius {
-        UnlockLargerZonesChip {
-          viewModel.requestLargerRadiusUpgrade()
-        }
       }
-
-      if !viewModel.canDrawCustomShape {
-        // Custom-shape upsell (GH#1031, tc-6he3x.10): distinct from the
-        // larger-radius chip above — Free tier can see both together, since
-        // they sell different entitlements.
-        CustomShapeUpsellCard {
-          viewModel.requestCustomShapeUpgrade()
-        }
-      } else {
-        // Re-entry point for a user whose tier already allows custom shapes
-        // (tc-6he3x.10) — without this, backing out of the drawing step once
-        // would strand an already-paying user on a circle for the rest of
-        // onboarding, since the upsell card above only shows pre-purchase.
-        Button("Draw a custom shape instead") {
-          viewModel.selectCustomShape()
-        }
-        .font(TCTypography.body)
-        .foregroundStyle(Color.tcAmber)
-      }
-
-      if viewModel.showsLargeRadiusWarning {
-        LargeRadiusWarningView()
-      }
-
-      PrimaryButton("Continue") {
-        viewModel.confirmRadius()
-      }
-
-      Button("Back") {
-        viewModel.goBack()
-      }
-      .font(TCTypography.body)
-      .foregroundStyle(Color.tcTextSecondary)
+      .padding(TCSpacing.extraLarge)
+      .frame(maxWidth: .infinity)
     }
-    .padding(TCSpacing.extraLarge)
   }
 
   private var radiusControl: some View {

--- a/mobile/ios/town-crier-tests/Sources/Features/CustomShapeAvailableCardTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/CustomShapeAvailableCardTests.swift
@@ -1,0 +1,45 @@
+import Testing
+
+@testable import TownCrierPresentation
+
+@MainActor
+@Suite("CustomShapeAvailableCard")
+struct CustomShapeAvailableCardTests {
+
+  // Shown on the onboarding radius step in place of the old plain-text
+  // "Draw a custom shape instead" button once the user's tier already allows
+  // a custom-shape zone (tc-7se1w.4) — gives the capability the same
+  // introduction weight ``CustomShapeUpsellCard`` gives a Free-tier user
+  // pre-purchase, rather than a footnote link with no explanation.
+
+  // MARK: - Copy
+
+  @Test func title_isActionLed() {
+    #expect(CustomShapeAvailableCard.Copy.title == "Draw a custom shape")
+  }
+
+  @Test func benefits_explainsTheAlternativeToACircle() {
+    #expect(
+      CustomShapeAvailableCard.Copy.benefits
+        == "Trace the exact area you want to watch, instead of a circle."
+    )
+  }
+
+  @Test func accessibilityLabel_combinesTitleAndBenefits() {
+    #expect(
+      CustomShapeAvailableCard.Copy.accessibilityLabel
+        == "Draw a custom shape. Trace the exact area you want to watch, instead of a circle."
+    )
+  }
+
+  @Test func accessibilityHint_opensTheDrawingTool() {
+    #expect(CustomShapeAvailableCard.Copy.accessibilityHint == "Opens the shape drawing tool")
+  }
+
+  // MARK: - View
+
+  @Test func body_renders() {
+    let sut = CustomShapeAvailableCard {}
+    _ = sut.body
+  }
+}


### PR DESCRIPTION
## Summary

Investigated tester feedback that fresh onboarding never mentioned the new custom-shape (polygon) watch zone capability. Found no gating bug: `OnboardingViewModel.canDrawCustomShape` (backed by `WatchZoneLimits.allowsCustomBoundary`) is correctly wired for free/personal/pro and already fully covered by tests.

The real bug is layout, not gating. `RadiusPickerStepView` stacks the radius slider, its min/max labels, the "unlock larger zones" chip, the custom-shape upsell, an optional large-radius warning, and the Continue/Back buttons inside a plain `VStack` with no `ScrollView` - and `OnboardingView` sandwiched that step between two `Spacer()`s, which tied for "infinite" flexibility with nothing to scroll and shrank the visible area rather than growing it. On a free-tier fresh-onboarding account (the common case), that's enough stacked content that the custom-shape mention could be genuinely unreachable on a compact screen or with larger Dynamic Type, not just easy to miss - which matches the tester report of no mention at all.

Separately, the acceptance criteria also flagged a real copy gap: once a tier already has the entitlement, the step showed only a bare, unstyled text button ("Draw a custom shape instead") with no explanation of what it does.

## Changes

- `RadiusPickerStepView` now wraps its content in a `ScrollView`, so nothing can be clipped past the bottom of the viewport regardless of device size or Dynamic Type.
- `OnboardingView`'s step container switched from two flanking `Spacer()`s to a single `.frame(maxHeight: .infinity)` on the step, so a scrolling step gets the full remaining height instead of splitting it with Spacers that were never going to shrink.
- The custom-shape section now appears directly after the radius slider, ahead of the pre-existing "unlock larger zones" chip, so the newer capability isn't the last thing a user scrolls past.
- New `CustomShapeAvailableCard` component replaces the bare text button for tiers that already have the entitlement, matching the visual weight and copy pattern of `CustomShapeUpsellCard` ("Draw a custom shape" / "Trace the exact area you want to watch, instead of a circle.") instead of a footnote link.

Kept the fix at the existing radius-picker step (placement, copy, scroll behaviour) rather than adding a dedicated onboarding step, per the bead's scope - a new step adds routing/back-button surface area and friction for every user regardless of relevance. Did not touch the entitled-tier upsell surfaces covered by the separate tc-7se1w.5.

Release-Note: The onboarding radius step now scrolls, so nothing gets cut off, and it introduces custom-shape watch zones more clearly.

## Test plan

- [x] `swift build` - clean
- [x] `swift test` - 1967/1967 pass (no regressions)
- [x] `swiftlint lint --strict` - clean on changed files (84 pre-existing unrelated violations in test fixtures found and filed separately as tc-odyqh, not touched here)
- [x] New `CustomShapeAvailableCardTests` (copy + body render), red-then-green
- [x] Existing `RadiusPickerStepViewTests` / `OnboardingViewTests` / `OnboardingViewModelBoundaryDrawingTests` all still pass as regression coverage for the view/container restructuring (this codebase has no ViewInspector/snapshot tooling for deeper SwiftUI body assertions, matching the existing shallow-render-testing convention)
- [ ] Live simulator check not performed in this session (no Agent/mobile-mcp tool available to this worker) - recommend a UI-verification pass on the free-tier and personal/pro-tier onboarding flows before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)