### PR TITLE
iOS: main map page draws polygon overlay for custom-shape zones (tc-7se1w.3)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/ClusteredMapView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/ClusteredMapView.swift
@@ -99,6 +99,10 @@
       /// The zone the camera is currently framed on, so we only reframe on a real
       /// zone change rather than on every cluster/filter update.
       private var framedZoneId: WatchZoneId?
+      /// The geometry the camera was last framed to, so a same-ID zone whose
+      /// boundary, centre, or radius changes (e.g. a mid-session edit) still
+      /// triggers a reframe.
+      private var framedZoneFraming: ClusteredZoneFraming?
       /// The currently-rendered radius circle (circle-shaped zones) and the
       /// centre/radius it was drawn for, so we redraw it only when the zone's
       /// geometry changes.
@@ -237,12 +241,13 @@
       ) {
         mapView.setRegion(Self.cameraRegion(framing: framing), animated: animated)
         framedZoneId = zoneId
+        framedZoneFraming = framing
       }
 
       func frameCameraIfZoneChanged(
         on mapView: MKMapView, framing: ClusteredZoneFraming, zoneId: WatchZoneId?
       ) {
-        guard zoneId != framedZoneId else { return }
+        guard zoneId != framedZoneId || framing != framedZoneFraming else { return }
         frameCamera(on: mapView, framing: framing, zoneId: zoneId, animated: true)
       }
 

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/ClusteredMapView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/ClusteredMapView.swift
@@ -37,38 +37,48 @@
         forAnnotationViewWithReuseIdentifier: Self.markerReuseIdentifier)
 
       let coordinator = context.coordinator
+      let framing = zoneFraming
       coordinator.frameCamera(
-        on: mapView,
-        centre: CLLocationCoordinate2D(
-          latitude: viewModel.centreLat, longitude: viewModel.centreLon),
-        radius: viewModel.radiusMetres,
-        zoneId: viewModel.selectedZone?.id,
-        animated: false)
+        on: mapView, framing: framing, zoneId: viewModel.selectedZone?.id, animated: false)
       coordinator.syncAnnotations(on: mapView, desired: viewModel.clusters)
-      coordinator.applyRadiusOverlay(
-        to: mapView,
-        centreLat: viewModel.centreLat,
-        centreLon: viewModel.centreLon,
-        radius: viewModel.radiusMetres)
+      coordinator.applyZoneOverlay(to: mapView, framing: framing)
       return mapView
     }
 
     func updateUIView(_ mapView: MKMapView, context: Context) {
       let coordinator = context.coordinator
+      let framing = zoneFraming
       coordinator.syncAnnotations(on: mapView, desired: viewModel.clusters)
-      coordinator.applyRadiusOverlay(
-        to: mapView,
-        centreLat: viewModel.centreLat,
-        centreLon: viewModel.centreLon,
-        radius: viewModel.radiusMetres)
+      coordinator.applyZoneOverlay(to: mapView, framing: framing)
       // Reframe only when the selected zone actually changes, so a refetch or a
       // status-chip change never yanks the user's current pan/zoom back.
       coordinator.frameCameraIfZoneChanged(
-        on: mapView,
+        on: mapView, framing: framing, zoneId: viewModel.selectedZone?.id)
+    }
+
+    private var zoneFraming: ClusteredZoneFraming {
+      ClusteredZoneFraming(
         centreLat: viewModel.centreLat,
         centreLon: viewModel.centreLon,
         radius: viewModel.radiusMetres,
-        zoneId: viewModel.selectedZone?.id)
+        boundaryVertices: viewModel.boundaryVertices)
+    }
+  }
+
+  /// The zone geometry ``ClusteredMapView``'s overlay and camera-framing logic
+  /// need, bundled into one value so passing it to ``ClusteredMapView/Coordinator``
+  /// stays within SwiftLint's function-parameter-count limit. `boundaryVertices`
+  /// non-nil/non-empty means a custom-shape zone (GH#1031, tc-7se1w.3); `nil`
+  /// means a circle, framed/overlaid from `centreLat`/`centreLon`/`radius` as
+  /// before.
+  struct ClusteredZoneFraming: Equatable {
+    let centreLat: Double
+    let centreLon: Double
+    let radius: Double
+    let boundaryVertices: [Coordinate]?
+
+    var centre: CLLocationCoordinate2D {
+      CLLocationCoordinate2D(latitude: centreLat, longitude: centreLon)
     }
   }
 
@@ -78,9 +88,10 @@
     /// ``MapViewModel/selectCluster(_:)``, opens the disambiguation list for an
     /// unsplittable (stacked) multi-member cell via
     /// ``MapViewModel/selectStack(_:)`` while zooming into a splittable one,
-    /// debounces the region-change refetch, and renders the zone radius circle.
-    /// All callbacks run on the main thread (MapKit guarantees it), matching the
-    /// `@MainActor` isolation.
+    /// debounces the region-change refetch, and renders the zone overlay (a
+    /// circle, or an `MKPolygon` outline for a custom-shape zone). All callbacks
+    /// run on the main thread (MapKit guarantees it), matching the `@MainActor`
+    /// isolation.
     @MainActor
     final class Coordinator: NSObject, MKMapViewDelegate {
       private let viewModel: MapViewModel
@@ -88,16 +99,34 @@
       /// The zone the camera is currently framed on, so we only reframe on a real
       /// zone change rather than on every cluster/filter update.
       private var framedZoneId: WatchZoneId?
-      /// The currently-rendered radius circle and the centre/radius it was drawn
-      /// for, so we redraw it only when the zone's geometry changes.
+      /// The currently-rendered radius circle (circle-shaped zones) and the
+      /// centre/radius it was drawn for, so we redraw it only when the zone's
+      /// geometry changes.
       private var radiusOverlay: MKCircle?
       private var renderedCentreLat: Double?
       private var renderedCentreLon: Double?
       private var renderedRadius: Double?
+      /// The currently-rendered polygon (custom-shape zones, GH#1031) and the
+      /// vertices it was drawn for, so we redraw it only when the boundary
+      /// actually changes. ``applyZoneOverlay(to:framing:)`` shows at most one
+      /// of `radiusOverlay`/`polygonOverlay` at a time — the other is torn down
+      /// when the selected zone's shape mode differs from what's currently on
+      /// screen (tc-7se1w.3: the overlay must match whichever shape drives
+      /// application filtering for this zone).
+      private var polygonOverlay: MKPolygon?
+      private var renderedVertices: [Coordinate]?
 
       /// The pending debounced refetch, cancelled and rescheduled on each region
       /// change so a pan/zoom flurry issues a single fetch when it settles.
       private var refetchTask: Task<Void, Never>?
+
+      /// Extra room around the polygon's bounding box when framing the camera
+      /// for a custom-shape zone — mirrors `BoundaryDrawingRegion.marginFraction`,
+      /// which tc-7se1w.2 uses for the same "zoom to fit" need in the
+      /// boundary-drawing editor.
+      private static let polygonMarginFraction = 0.3
+      /// Mirrors `BoundaryDrawingRegion.minimumSpanDegrees`.
+      private static let polygonMinimumSpanDegrees = 0.006
 
       init(viewModel: MapViewModel) {
         self.viewModel = viewModel
@@ -127,9 +156,30 @@
         }
       }
 
-      // MARK: - Radius overlay
+      // MARK: - Zone overlay (circle or custom-shape polygon)
 
-      func applyRadiusOverlay(
+      /// Shows exactly one overlay for the selected zone: an `MKPolygon`
+      /// outline for a custom shape (GH#1031), or the existing `MKCircle`
+      /// radius overlay otherwise. Tears down the other kind first, so
+      /// switching between a circle zone and a custom-shape zone never leaves
+      /// a stale overlay of the wrong kind on screen (tc-7se1w.3 — the overlay
+      /// must match whichever shape actually drives application filtering for
+      /// this zone).
+      func applyZoneOverlay(to mapView: MKMapView, framing: ClusteredZoneFraming) {
+        guard let boundaryVertices = framing.boundaryVertices, !boundaryVertices.isEmpty else {
+          clearPolygonOverlay(from: mapView)
+          applyRadiusOverlay(
+            to: mapView,
+            centreLat: framing.centreLat,
+            centreLon: framing.centreLon,
+            radius: framing.radius)
+          return
+        }
+        clearRadiusOverlay(from: mapView)
+        applyPolygonOverlay(to: mapView, vertices: boundaryVertices)
+      }
+
+      private func applyRadiusOverlay(
         to mapView: MKMapView, centreLat: Double, centreLon: Double, radius: Double
       ) {
         if renderedRadius == radius, renderedCentreLat == centreLat, renderedCentreLon == centreLon {
@@ -148,38 +198,74 @@
         renderedRadius = radius
       }
 
+      private func applyPolygonOverlay(to mapView: MKMapView, vertices: [Coordinate]) {
+        if renderedVertices == vertices {
+          return
+        }
+        if let polygonOverlay {
+          mapView.removeOverlay(polygonOverlay)
+        }
+        let coordinates = vertices.map { vertex in
+          CLLocationCoordinate2D(latitude: vertex.latitude, longitude: vertex.longitude)
+        }
+        let polygon = MKPolygon(coordinates: coordinates, count: coordinates.count)
+        mapView.addOverlay(polygon, level: .aboveRoads)
+        polygonOverlay = polygon
+        renderedVertices = vertices
+      }
+
+      private func clearRadiusOverlay(from mapView: MKMapView) {
+        guard let radiusOverlay else { return }
+        mapView.removeOverlay(radiusOverlay)
+        self.radiusOverlay = nil
+        renderedCentreLat = nil
+        renderedCentreLon = nil
+        renderedRadius = nil
+      }
+
+      private func clearPolygonOverlay(from mapView: MKMapView) {
+        guard let polygonOverlay else { return }
+        mapView.removeOverlay(polygonOverlay)
+        self.polygonOverlay = nil
+        renderedVertices = nil
+      }
+
       // MARK: - Camera framing
 
       func frameCamera(
-        on mapView: MKMapView,
-        centre: CLLocationCoordinate2D,
-        radius: Double,
-        zoneId: WatchZoneId?,
-        animated: Bool
+        on mapView: MKMapView, framing: ClusteredZoneFraming, zoneId: WatchZoneId?, animated: Bool
       ) {
-        // Span 2.5x the zone radius so the whole circle plus a margin is visible.
-        let region = MKCoordinateRegion(
-          center: centre,
-          latitudinalMeters: radius * 2.5,
-          longitudinalMeters: radius * 2.5)
-        mapView.setRegion(region, animated: animated)
+        mapView.setRegion(Self.cameraRegion(framing: framing), animated: animated)
         framedZoneId = zoneId
       }
 
       func frameCameraIfZoneChanged(
-        on mapView: MKMapView,
-        centreLat: Double,
-        centreLon: Double,
-        radius: Double,
-        zoneId: WatchZoneId?
+        on mapView: MKMapView, framing: ClusteredZoneFraming, zoneId: WatchZoneId?
       ) {
         guard zoneId != framedZoneId else { return }
-        frameCamera(
-          on: mapView,
-          centre: CLLocationCoordinate2D(latitude: centreLat, longitude: centreLon),
-          radius: radius,
-          zoneId: zoneId,
-          animated: true)
+        frameCamera(on: mapView, framing: framing, zoneId: zoneId, animated: true)
+      }
+
+      /// The region to frame for a zone: fitted to the polygon's bounding box
+      /// for a custom shape (tc-7se1w.3), or the existing 2.5x-radius span for
+      /// a circle.
+      private static func cameraRegion(framing: ClusteredZoneFraming) -> MKCoordinateRegion {
+        guard let boundaryVertices = framing.boundaryVertices, !boundaryVertices.isEmpty else {
+          return circleRegion(framing: framing)
+        }
+        return PolygonBoundingRegion.fitting(
+          vertices: boundaryVertices,
+          marginFraction: polygonMarginFraction,
+          minimumSpanDegrees: polygonMinimumSpanDegrees
+        ) ?? circleRegion(framing: framing)
+      }
+
+      private static func circleRegion(framing: ClusteredZoneFraming) -> MKCoordinateRegion {
+        // Span 2.5x the zone radius so the whole circle plus a margin is visible.
+        MKCoordinateRegion(
+          center: framing.centre,
+          latitudinalMeters: framing.radius * 2.5,
+          longitudinalMeters: framing.radius * 2.5)
       }
 
       // MARK: - MKMapViewDelegate
@@ -232,8 +318,8 @@
             // Members are coincident (or closer than the finest grid cell), so no
             // zoom level can ever split them. Open the disambiguation list of the
             // stacked applications instead of zooming forever (GH#722).
-            let viewModel = self.viewModel
-            Task { await viewModel.selectStack(cluster) }
+            let capturedViewModel = self.viewModel
+            Task { await capturedViewModel.selectStack(cluster) }
           } else {
             // Splittable cell: zoom into it so its members spread into finer cells
             // on the next (debounced) refetch.
@@ -245,8 +331,8 @@
             mapView.setRegion(region, animated: true)
           }
         } else {
-          let viewModel = self.viewModel
-          Task { await viewModel.selectCluster(cluster) }
+          let capturedViewModel = self.viewModel
+          Task { await capturedViewModel.selectCluster(cluster) }
         }
       }
 
@@ -260,12 +346,12 @@
       private func scheduleClusterRefetch(for mapView: MKMapView) {
         let viewport = Self.viewport(from: mapView)
         let zoom = Self.zoom(from: mapView)
-        let viewModel = self.viewModel
+        let capturedViewModel = self.viewModel
         refetchTask?.cancel()
         refetchTask = Task { @MainActor in
           try? await Task.sleep(nanoseconds: 250_000_000)
           guard !Task.isCancelled else { return }
-          await viewModel.loadClusters(viewport: viewport, zoom: zoom)
+          await capturedViewModel.loadClusters(viewport: viewport, zoom: zoom)
         }
       }
 
@@ -283,31 +369,22 @@
       }
 
       func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
-        guard let circle = overlay as? MKCircle else {
-          return MKOverlayRenderer(overlay: overlay)
+        if let circle = overlay as? MKCircle {
+          let renderer = MKCircleRenderer(circle: circle)
+          renderer.strokeColor = UIColor(Color.tcAmber.opacity(0.3))
+          renderer.fillColor = UIColor(Color.tcAmber.opacity(0.08))
+          renderer.lineWidth = 1.5
+          return renderer
         }
-        let renderer = MKCircleRenderer(circle: circle)
-        renderer.strokeColor = UIColor(Color.tcAmber.opacity(0.3))
-        renderer.fillColor = UIColor(Color.tcAmber.opacity(0.08))
-        renderer.lineWidth = 1.5
-        return renderer
+        if let polygon = overlay as? MKPolygon {
+          let renderer = MKPolygonRenderer(polygon: polygon)
+          renderer.strokeColor = UIColor(Color.tcAmber.opacity(0.3))
+          renderer.fillColor = UIColor(Color.tcAmber.opacity(0.08))
+          renderer.lineWidth = 1.5
+          return renderer
+        }
+        return MKOverlayRenderer(overlay: overlay)
       }
-    }
-  }
-
-  /// A reference-type `MKAnnotation` wrapping a value-type ``MapCluster`` so
-  /// MapKit can hold it. Carries the cluster the coordinator needs to style the
-  /// marker and route a tap.
-  final class MapClusterAnnotation: NSObject, MKAnnotation {
-    let cluster: MapCluster
-    let clusterId: String
-    let coordinate: CLLocationCoordinate2D
-
-    init(cluster: MapCluster) {
-      self.cluster = cluster
-      self.clusterId = cluster.id
-      self.coordinate = CLLocationCoordinate2D(
-        latitude: cluster.coordinate.latitude, longitude: cluster.coordinate.longitude)
     }
   }
 #endif

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapClusterAnnotation.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapClusterAnnotation.swift
@@ -1,0 +1,20 @@
+#if canImport(UIKit)
+  import MapKit
+  import TownCrierDomain
+
+  /// A reference-type `MKAnnotation` wrapping a value-type ``MapCluster`` so
+  /// MapKit can hold it. Carries the cluster ``ClusteredMapView/Coordinator``
+  /// needs to style the marker and route a tap.
+  final class MapClusterAnnotation: NSObject, MKAnnotation {
+    let cluster: MapCluster
+    let clusterId: String
+    let coordinate: CLLocationCoordinate2D
+
+    init(cluster: MapCluster) {
+      self.cluster = cluster
+      self.clusterId = cluster.id
+      self.coordinate = CLLocationCoordinate2D(
+        latitude: cluster.coordinate.latitude, longitude: cluster.coordinate.longitude)
+    }
+  }
+#endif

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapViewModel.swift
@@ -42,6 +42,17 @@ public final class MapViewModel: ObservableObject, ErrorHandlingViewModel {
   @Published private(set) var centreLon: Double = -0.1278
   @Published private(set) var radiusMetres: Double = 2000
 
+  /// The selected zone's custom-shape polygon vertices (GH#1031), or `nil`
+  /// for a circle zone. Derived from ``selectedZone`` rather than stored
+  /// separately, so it always tracks the current selection with no extra
+  /// state to keep in sync. `ClusteredMapView` uses this to draw an
+  /// `MKPolygon` overlay instead of the default `MKCircle` for a
+  /// custom-shape zone (tc-7se1w.3 — the polygon already drives application
+  /// filtering; this makes the overlay match it).
+  var boundaryVertices: [Coordinate]? {
+    selectedZone?.boundary?.vertices
+  }
+
   private let repository: PlanningApplicationRepository
   private let watchZoneRepository: WatchZoneRepository
   private let savedApplicationRepository: SavedApplicationRepository?

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/PolygonBoundingRegion.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/PolygonBoundingRegion.swift
@@ -1,0 +1,49 @@
+import MapKit
+import TownCrierDomain
+
+/// Fits a map region to a polygon's bounding box: the shared "zoom to fit
+/// these vertices" math behind ``BoundaryDrawingRegion`` (the boundary-
+/// drawing editor, GH#1031 bead tc-7se1w.2) and ``ClusteredMapView``'s
+/// camera framing for a custom-shape zone on the main Map page (bead
+/// tc-7se1w.3 — the polygon already drives application filtering; this
+/// makes the camera framing match it instead of always fitting a circle).
+///
+/// A free-standing, non-generic type outside any `#if canImport(UIKit)`
+/// guard — it only needs `MapKit`/`CoreLocation`, both available on macOS,
+/// so `swift test`'s bare-macOS build (no UIKit) can still see it and the
+/// zoom-to-fit math is directly unit-testable without a concrete
+/// `UIViewRepresentable`/`MKMapView`.
+enum PolygonBoundingRegion {
+  /// Fits a region to `vertices`' bounding box, widened by `marginFraction`
+  /// of the box's own span and floored at `minimumSpanDegrees` so a single
+  /// vertex or a tightly-clustered few vertices doesn't produce an absurdly
+  /// close-in zoom. Returns `nil` for empty `vertices` — callers decide
+  /// their own no-vertices fallback (e.g. a fixed region centred elsewhere).
+  static func fitting(
+    vertices: [Coordinate],
+    marginFraction: Double,
+    minimumSpanDegrees: Double
+  ) -> MKCoordinateRegion? {
+    guard !vertices.isEmpty else { return nil }
+
+    let latitudes = vertices.map(\.latitude)
+    let longitudes = vertices.map(\.longitude)
+    // Force-unwrap-free: `vertices` is non-empty here, so `min()`/`max()`
+    // always succeed; the `??` fallback only guards the type-checker.
+    let minLatitude = latitudes.min() ?? 0
+    let maxLatitude = latitudes.max() ?? 0
+    let minLongitude = longitudes.min() ?? 0
+    let maxLongitude = longitudes.max() ?? 0
+
+    let centre = CLLocationCoordinate2D(
+      latitude: (minLatitude + maxLatitude) / 2,
+      longitude: (minLongitude + maxLongitude) / 2
+    )
+    let span = MKCoordinateSpan(
+      latitudeDelta: max((maxLatitude - minLatitude) * (1 + marginFraction), minimumSpanDegrees),
+      longitudeDelta: max(
+        (maxLongitude - minLongitude) * (1 + marginFraction), minimumSpanDegrees)
+    )
+    return MKCoordinateRegion(center: centre, span: span)
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/BoundaryDrawingMapView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/BoundaryDrawingMapView.swift
@@ -31,8 +31,16 @@ enum BoundaryDrawingRegion {
   /// few vertices from producing an absurdly close-in zoom.
   static let minimumSpanDegrees = 0.006
 
+  /// Delegates the non-empty-vertices case to ``PolygonBoundingRegion``
+  /// (extracted in tc-7se1w.3, which needs the identical bounding-box-with-
+  /// margin math to frame the main Map page's camera on a custom-shape
+  /// zone) — only the "no vertices yet" fixed-region fallback is specific
+  /// to this editor.
   static func fitting(vertices: [Coordinate], initialCentre: Coordinate) -> MKCoordinateRegion {
-    guard !vertices.isEmpty else {
+    guard
+      let fitted = PolygonBoundingRegion.fitting(
+        vertices: vertices, marginFraction: marginFraction, minimumSpanDegrees: minimumSpanDegrees)
+    else {
       return MKCoordinateRegion(
         center: CLLocationCoordinate2D(
           latitude: initialCentre.latitude, longitude: initialCentre.longitude),
@@ -40,26 +48,7 @@ enum BoundaryDrawingRegion {
         longitudinalMeters: freshDrawRegionMetres
       )
     }
-
-    let latitudes = vertices.map(\.latitude)
-    let longitudes = vertices.map(\.longitude)
-    // Force-unwrap-free: `vertices` is non-empty here, so `min()`/`max()`
-    // always succeed; the `??` fallback only guards the type-checker.
-    let minLatitude = latitudes.min() ?? initialCentre.latitude
-    let maxLatitude = latitudes.max() ?? initialCentre.latitude
-    let minLongitude = longitudes.min() ?? initialCentre.longitude
-    let maxLongitude = longitudes.max() ?? initialCentre.longitude
-
-    let centre = CLLocationCoordinate2D(
-      latitude: (minLatitude + maxLatitude) / 2,
-      longitude: (minLongitude + maxLongitude) / 2
-    )
-    let span = MKCoordinateSpan(
-      latitudeDelta: max((maxLatitude - minLatitude) * (1 + marginFraction), minimumSpanDegrees),
-      longitudeDelta: max(
-        (maxLongitude - minLongitude) * (1 + marginFraction), minimumSpanDegrees)
-    )
-    return MKCoordinateRegion(center: centre, span: span)
+    return fitted
   }
 }
 

--- a/mobile/ios/town-crier-tests/Sources/Features/ClusteredMapViewCoordinatorFramingTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ClusteredMapViewCoordinatorFramingTests.swift
@@ -1,0 +1,70 @@
+#if canImport(UIKit)
+  import MapKit
+  import Testing
+  import TownCrierDomain
+
+  @testable import TownCrierPresentation
+
+  /// `ClusteredMapView.Coordinator.frameCameraIfZoneChanged(on:framing:zoneId:)`
+  /// — regression coverage for a bug flagged by CodeRabbit on PR #1069: the
+  /// guard compared only `zoneId`, so reloading the same zone with an edited
+  /// boundary, centre, or radius left the camera framed on the stale
+  /// geometry. Gated behind `#if canImport(UIKit)` like `ClusteredMapView`
+  /// itself (see `reference_ios_uikit_gated_files_invisible_to_swift_test`).
+  @Suite("ClusteredMapView.Coordinator camera framing")
+  @MainActor
+  struct ClusteredMapViewCoordinatorFramingTests {
+    private static let zoneId = WatchZoneId("zone-1")
+
+    private func makeSUT() -> (ClusteredMapView.Coordinator, MKMapView) {
+      let spy = SpyPlanningApplicationRepository()
+      spy.fetchClustersResult = .success([])
+      let watchZoneSpy = SpyWatchZoneRepository()
+      watchZoneSpy.loadAllResult = .success([])
+      let viewModel = MapViewModel(repository: spy, watchZoneRepository: watchZoneSpy)
+      let coordinator = ClusteredMapView.Coordinator(viewModel: viewModel)
+      // A zero-size MKMapView clamps/ignores setRegion, so give it a real frame.
+      let mapView = MKMapView(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+      return (coordinator, mapView)
+    }
+
+    private func framing(centreLat: Double, radius: Double = 500) -> ClusteredZoneFraming {
+      ClusteredZoneFraming(
+        centreLat: centreLat, centreLon: 0.1218, radius: radius, boundaryVertices: nil)
+    }
+
+    @Test func sameZoneIdChangedGeometry_reframesCamera() {
+      let (sut, mapView) = makeSUT()
+      let original = framing(centreLat: 52.2053)
+      let edited = framing(centreLat: 52.9000)
+
+      sut.frameCameraIfZoneChanged(on: mapView, framing: original, zoneId: Self.zoneId)
+      let framedLatitude = mapView.region.center.latitude
+
+      sut.frameCameraIfZoneChanged(on: mapView, framing: edited, zoneId: Self.zoneId)
+
+      #expect(mapView.region.center.latitude != framedLatitude)
+      #expect(abs(mapView.region.center.latitude - edited.centreLat) < 0.01)
+    }
+
+    @Test func sameZoneIdSameGeometry_doesNotReframe() {
+      let (sut, mapView) = makeSUT()
+      let unchanged = framing(centreLat: 52.2053)
+
+      sut.frameCameraIfZoneChanged(on: mapView, framing: unchanged, zoneId: Self.zoneId)
+
+      // Nudge the map away from the framed region so a no-op reframe call is
+      // distinguishable from a real one: a real reframe would snap it back.
+      let sentinelRegion = MKCoordinateRegion(
+        center: CLLocationCoordinate2D(latitude: 10, longitude: 10),
+        latitudinalMeters: 1000,
+        longitudinalMeters: 1000
+      )
+      mapView.setRegion(sentinelRegion, animated: false)
+
+      sut.frameCameraIfZoneChanged(on: mapView, framing: unchanged, zoneId: Self.zoneId)
+
+      #expect(abs(mapView.region.center.latitude - 10) < 0.01)
+    }
+  }
+#endif

--- a/mobile/ios/town-crier-tests/Sources/Features/ClusteredMapViewCoordinatorOverlayTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ClusteredMapViewCoordinatorOverlayTests.swift
@@ -1,0 +1,85 @@
+#if canImport(UIKit)
+  import MapKit
+  import Testing
+  import TownCrierDomain
+
+  @testable import TownCrierPresentation
+
+  /// `ClusteredMapView.Coordinator.applyZoneOverlay(to:framing:)` — regression
+  /// coverage for a bug found in live simulator verification of tc-7se1w.3:
+  /// selecting a custom-shape zone (drawing an `MKPolygon`) and then selecting
+  /// a plain radius/circle zone left a stale (or wrongly-shaped) overlay
+  /// instead of showing an `MKCircle`. Gated behind `#if canImport(UIKit)`
+  /// like `ClusteredMapView` itself — `UIViewRepresentable` and `MKMapView`'s
+  /// overlay APIs the Coordinator drives are UIKit-only, so this only compiles
+  /// (and only catches this class of bug) when the test target builds for
+  /// iOS, not the bare-macOS `swift test` run (see
+  /// `reference_ios_uikit_gated_files_invisible_to_swift_test`).
+  @Suite("ClusteredMapView.Coordinator zone overlay")
+  @MainActor
+  struct ClusteredMapViewCoordinatorOverlayTests {
+    private func makeSUT() -> (ClusteredMapView.Coordinator, MKMapView) {
+      let spy = SpyPlanningApplicationRepository()
+      spy.fetchClustersResult = .success([])
+      let watchZoneSpy = SpyWatchZoneRepository()
+      watchZoneSpy.loadAllResult = .success([])
+      let viewModel = MapViewModel(repository: spy, watchZoneRepository: watchZoneSpy)
+      let coordinator = ClusteredMapView.Coordinator(viewModel: viewModel)
+      let mapView = MKMapView()
+      return (coordinator, mapView)
+    }
+
+    private func polygonFraming() throws -> ClusteredZoneFraming {
+      let vertices = try [
+        Coordinate(latitude: 52.2043, longitude: 0.1218),
+        Coordinate(latitude: 52.2063, longitude: 0.1238),
+        Coordinate(latitude: 52.2043, longitude: 0.1258),
+      ]
+      return ClusteredZoneFraming(
+        centreLat: 52.2053, centreLon: 0.1218, radius: 500, boundaryVertices: vertices)
+    }
+
+    private func circleFraming() -> ClusteredZoneFraming {
+      // KT2 6EJ-shaped fixture: a plain radius zone, nowhere near the polygon
+      // fixture's coordinates, so a leftover polygon at the wrong location
+      // would be as detectable as a leftover polygon shape at the right one.
+      ClusteredZoneFraming(
+        centreLat: 51.4095, centreLon: -0.2864, radius: 2000, boundaryVertices: nil)
+    }
+
+    @Test func customShapeThenCircle_showsOnlyACircleOverlay() throws {
+      let (sut, mapView) = makeSUT()
+
+      sut.applyZoneOverlay(to: mapView, framing: try polygonFraming())
+      #expect(mapView.overlays.contains { $0 is MKPolygon })
+
+      sut.applyZoneOverlay(to: mapView, framing: circleFraming())
+
+      #expect(mapView.overlays.count == 1)
+      #expect(mapView.overlays.first is MKCircle)
+      #expect(!mapView.overlays.contains { $0 is MKPolygon })
+    }
+
+    @Test func circleThenCustomShape_showsOnlyAPolygonOverlay() throws {
+      let (sut, mapView) = makeSUT()
+
+      sut.applyZoneOverlay(to: mapView, framing: circleFraming())
+      #expect(mapView.overlays.contains { $0 is MKCircle })
+
+      sut.applyZoneOverlay(to: mapView, framing: try polygonFraming())
+
+      #expect(mapView.overlays.count == 1)
+      #expect(mapView.overlays.first is MKPolygon)
+      #expect(!mapView.overlays.contains { $0 is MKCircle })
+    }
+
+    @Test func circleOnly_showsACircleOverlay() {
+      let (sut, mapView) = makeSUT()
+
+      sut.applyZoneOverlay(to: mapView, framing: circleFraming())
+
+      #expect(mapView.overlays.count == 1)
+      #expect(mapView.overlays.first is MKCircle)
+    }
+  }
+#endif

--- a/mobile/ios/town-crier-tests/Sources/Features/MapViewModelBoundaryVerticesTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/MapViewModelBoundaryVerticesTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+/// `MapViewModel.boundaryVertices` — threads the selected zone's custom-shape
+/// polygon (GH#1031) through to `ClusteredMapView` so it can draw an
+/// `MKPolygon` overlay instead of always drawing an `MKCircle` (tc-7se1w.3).
+/// `nil` means "this zone is a circle" — the map view's existing circle path
+/// stays untouched for that case.
+@Suite("MapViewModel boundary vertices")
+@MainActor
+struct MapViewModelBoundaryVerticesTests {
+  private func makeSUT(
+    watchZones: [WatchZone]
+  ) -> (MapViewModel, SpyWatchZoneRepository) {
+    let spy = SpyPlanningApplicationRepository()
+    spy.fetchClustersResult = .success([])
+    let watchZoneSpy = SpyWatchZoneRepository()
+    watchZoneSpy.loadAllResult = .success(watchZones)
+    let vm = MapViewModel(repository: spy, watchZoneRepository: watchZoneSpy)
+    return (vm, watchZoneSpy)
+  }
+
+  @Test func boundaryVertices_nilForCircleZone() async {
+    let (sut, _) = makeSUT(watchZones: [.cambridge])
+
+    await sut.loadApplications()
+
+    #expect(sut.boundaryVertices == nil)
+  }
+
+  @Test func boundaryVertices_returnsVerticesForCustomShapeZone() async throws {
+    let boundary = try WatchZoneBoundary(vertices: [
+      Coordinate(latitude: 51.50, longitude: -0.10),
+      Coordinate(latitude: 51.51, longitude: -0.09),
+      Coordinate(latitude: 51.50, longitude: -0.09),
+    ])
+    let zone = try WatchZone(
+      name: "Custom Area",
+      centre: Coordinate(latitude: 51.505, longitude: -0.095),
+      radiusMetres: 1000,
+      boundary: boundary
+    )
+    let (sut, _) = makeSUT(watchZones: [zone])
+
+    await sut.loadApplications()
+
+    #expect(sut.boundaryVertices == boundary.vertices)
+  }
+
+  @Test func boundaryVertices_updatesOnSelectZone() async throws {
+    let boundary = try WatchZoneBoundary(vertices: [
+      Coordinate(latitude: 51.50, longitude: -0.10),
+      Coordinate(latitude: 51.51, longitude: -0.09),
+      Coordinate(latitude: 51.50, longitude: -0.09),
+    ])
+    let customZone = try WatchZone(
+      id: WatchZoneId("zone-custom"),
+      name: "Custom Area",
+      centre: Coordinate(latitude: 51.505, longitude: -0.095),
+      radiusMetres: 1000,
+      boundary: boundary
+    )
+    let (sut, _) = makeSUT(watchZones: [.cambridge, customZone])
+    await sut.loadApplications()
+    #expect(sut.boundaryVertices == nil)
+
+    await sut.selectZone(customZone)
+
+    #expect(sut.boundaryVertices == boundary.vertices)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/MapViewModelBoundaryVerticesTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/MapViewModelBoundaryVerticesTests.swift
@@ -12,19 +12,28 @@ import TownCrierDomain
 @Suite("MapViewModel boundary vertices")
 @MainActor
 struct MapViewModelBoundaryVerticesTests {
+  /// Isolated `UserDefaults` suite (not `.standard`) — a shared instance
+  /// across parallel `swift test` runs would let one test's persisted
+  /// zone-selection key (`selectZone(_:)` writes it) leak into another's
+  /// `resolveInitialZone` and pick the wrong starting zone.
   private func makeSUT(
     watchZones: [WatchZone]
-  ) -> (MapViewModel, SpyWatchZoneRepository) {
+  ) throws -> (MapViewModel, SpyWatchZoneRepository) {
     let spy = SpyPlanningApplicationRepository()
     spy.fetchClustersResult = .success([])
     let watchZoneSpy = SpyWatchZoneRepository()
     watchZoneSpy.loadAllResult = .success(watchZones)
-    let vm = MapViewModel(repository: spy, watchZoneRepository: watchZoneSpy)
+    let defaults = try #require(UserDefaults(suiteName: UUID().uuidString))
+    let vm = MapViewModel(
+      repository: spy,
+      watchZoneRepository: watchZoneSpy,
+      userDefaults: defaults,
+      zoneSelectionKey: "test.zone")
     return (vm, watchZoneSpy)
   }
 
-  @Test func boundaryVertices_nilForCircleZone() async {
-    let (sut, _) = makeSUT(watchZones: [.cambridge])
+  @Test func boundaryVertices_nilForCircleZone() async throws {
+    let (sut, _) = try makeSUT(watchZones: [.cambridge])
 
     await sut.loadApplications()
 
@@ -43,7 +52,7 @@ struct MapViewModelBoundaryVerticesTests {
       radiusMetres: 1000,
       boundary: boundary
     )
-    let (sut, _) = makeSUT(watchZones: [zone])
+    let (sut, _) = try makeSUT(watchZones: [zone])
 
     await sut.loadApplications()
 
@@ -63,7 +72,7 @@ struct MapViewModelBoundaryVerticesTests {
       radiusMetres: 1000,
       boundary: boundary
     )
-    let (sut, _) = makeSUT(watchZones: [.cambridge, customZone])
+    let (sut, _) = try makeSUT(watchZones: [.cambridge, customZone])
     await sut.loadApplications()
     #expect(sut.boundaryVertices == nil)
 

--- a/mobile/ios/town-crier-tests/Sources/Features/MapViewModelBoundaryVerticesTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/MapViewModelBoundaryVerticesTests.swift
@@ -80,4 +80,32 @@ struct MapViewModelBoundaryVerticesTests {
 
     #expect(sut.boundaryVertices == boundary.vertices)
   }
+
+  /// The reverse of `boundaryVertices_updatesOnSelectZone`: starting on a
+  /// custom-shape zone and switching to a plain radius/circle zone must
+  /// resolve `boundaryVertices` back to `nil` — regression coverage for a
+  /// bug found in live simulator verification of tc-7se1w.3, where
+  /// switching from a custom-shape zone to a circle zone on the Map tab
+  /// drew a polygon instead of the expected circle.
+  @Test func boundaryVertices_updatesOnSelectZone_fromCustomShapeToCircle() async throws {
+    let boundary = try WatchZoneBoundary(vertices: [
+      Coordinate(latitude: 51.50, longitude: -0.10),
+      Coordinate(latitude: 51.51, longitude: -0.09),
+      Coordinate(latitude: 51.50, longitude: -0.09),
+    ])
+    let customZone = try WatchZone(
+      id: WatchZoneId("zone-custom"),
+      name: "Custom Area",
+      centre: Coordinate(latitude: 51.505, longitude: -0.095),
+      radiusMetres: 1000,
+      boundary: boundary
+    )
+    let (sut, _) = try makeSUT(watchZones: [customZone, .cambridge])
+    await sut.loadApplications()
+    #expect(sut.boundaryVertices == boundary.vertices)
+
+    await sut.selectZone(.cambridge)
+
+    #expect(sut.boundaryVertices == nil)
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/PolygonBoundingRegionTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/PolygonBoundingRegionTests.swift
@@ -1,0 +1,90 @@
+import MapKit
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+/// `PolygonBoundingRegion.fitting(vertices:marginFraction:minimumSpanDegrees:)`
+/// — the shared "fit a map region to a polygon's bounding box" math behind
+/// both `BoundaryDrawingRegion` (the boundary-drawing editor, tc-7se1w.2) and
+/// `ClusteredMapView`'s camera framing for custom-shape zones on the main Map
+/// page (tc-7se1w.3). A free-standing, non-UIKit type so the zoom-to-fit math
+/// is directly unit-testable without a `UIViewRepresentable`/`MKMapView`.
+@Suite("PolygonBoundingRegion")
+struct PolygonBoundingRegionTests {
+  private let marginFraction = 0.3
+  private let minimumSpanDegrees = 0.006
+
+  private func coordinate(_ latitude: Double, _ longitude: Double) throws -> Coordinate {
+    try Coordinate(latitude: latitude, longitude: longitude)
+  }
+
+  @Test func emptyVertices_returnsNil() {
+    let region = PolygonBoundingRegion.fitting(
+      vertices: [], marginFraction: marginFraction, minimumSpanDegrees: minimumSpanDegrees)
+
+    #expect(region == nil)
+  }
+
+  @Test func largePolygon_fitsBoundingBoxWithMargin() throws {
+    // A ~1.1km x 1.1km box around Cambridge.
+    let vertices = try [
+      coordinate(51.50, -0.10),
+      coordinate(51.51, -0.10),
+      coordinate(51.51, -0.09),
+      coordinate(51.50, -0.09),
+    ]
+
+    let region = try #require(
+      PolygonBoundingRegion.fitting(
+        vertices: vertices, marginFraction: marginFraction, minimumSpanDegrees: minimumSpanDegrees)
+    )
+
+    // Centred on the bounding box.
+    #expect(abs(region.center.latitude - 51.505) < 0.0001)
+    #expect(abs(region.center.longitude - (-0.095)) < 0.0001)
+
+    // Every vertex must lie strictly inside the region (with margin, not
+    // flush against the edge).
+    for vertex in vertices {
+      let latHalfSpan = region.span.latitudeDelta / 2
+      let lonHalfSpan = region.span.longitudeDelta / 2
+      #expect(abs(vertex.latitude - region.center.latitude) < latHalfSpan)
+      #expect(abs(vertex.longitude - region.center.longitude) < lonHalfSpan)
+    }
+
+    // Margin actually applies the expected 30% widening (0.01deg raw box *
+    // 1.3 = 0.013deg) rather than merely exceeding the raw bounding box.
+    #expect(abs(region.span.latitudeDelta - 0.013) < 0.0001)
+    #expect(abs(region.span.longitudeDelta - 0.013) < 0.0001)
+  }
+
+  @Test func singleVertex_appliesMinimumSpanRatherThanZoomingToNothing() throws {
+    let vertex = try coordinate(51.50, -0.10)
+
+    let region = try #require(
+      PolygonBoundingRegion.fitting(
+        vertices: [vertex], marginFraction: marginFraction, minimumSpanDegrees: minimumSpanDegrees)
+    )
+
+    #expect(region.center.latitude == vertex.latitude)
+    #expect(region.center.longitude == vertex.longitude)
+    #expect(region.span.latitudeDelta == minimumSpanDegrees)
+    #expect(region.span.longitudeDelta == minimumSpanDegrees)
+  }
+
+  @Test func tightCluster_appliesMinimumSpanWhenBoundingBoxIsSmallerThanMinimum() throws {
+    let vertices = try [
+      coordinate(51.50000, -0.10000),
+      coordinate(51.50002, -0.10002),
+    ]
+
+    let region = try #require(
+      PolygonBoundingRegion.fitting(
+        vertices: vertices, marginFraction: marginFraction, minimumSpanDegrees: minimumSpanDegrees)
+    )
+
+    #expect(region.span.latitudeDelta == minimumSpanDegrees)
+    #expect(region.span.longitudeDelta == minimumSpanDegrees)
+  }
+}


### PR DESCRIPTION
## Summary

- Fixes the main Map page always drawing an `MKCircle` around a zone's centre, even for a polygon-shaped watch zone where application filtering already used the drawn boundary — the overlay just never matched what was actually filtering.
- `ClusteredMapView.Coordinator` now draws an `MKPolygon` outline (matching `MKPolygonRenderer`, same `tcAmber` stroke/fill as the circle) for a custom-shape zone, and fits the camera to the polygon's bounding box instead of `radius * 2.5`. Circle zones are unaffected — same `MKCircle`/`radius * 2.5` path as before.
- `MapViewModel.boundaryVertices` (derived from `selectedZone`, `nil` for a circle) threads the zone's shape mode into `ClusteredMapView`.
- Extracted `PolygonBoundingRegion.fitting(vertices:marginFraction:minimumSpanDegrees:)`, a pure, unit-testable bounding-box-with-margin helper shared with tc-7se1w.2's `BoundaryDrawingRegion` (the boundary-drawing editor's "zoom to fit" need) — `BoundaryDrawingRegion` now delegates to it with zero behaviour change; its existing tests still pass.
- Extracted `MapClusterAnnotation` to its own file to keep `ClusteredMapView.swift` under SwiftLint's 400-line file-length limit after the new overlay/framing code.

Bead: tc-7se1w.3 (child of epic tc-7se1w, GH#1031). Scope is intentionally narrow to the main Map page's overlay rendering — sibling beads cover the editor's zoom-to-fit (tc-7se1w.2, already shipped in #1059) and the equivalent web bug (tc-7se1w.7); neither is touched here. Anonymous browse mode's map (`AnonymousClusteredMapView`/`AnonymousMapViewModel`) has no custom-shape zone support at all today, so it's untouched too — not a regression, out of scope.

## Test plan

- [x] `PolygonBoundingRegionTests` — empty vertices, large-polygon bounding-box-with-margin fit, single-vertex and tight-cluster minimum-span floor (TDD red→green).
- [x] `MapViewModelBoundaryVerticesTests` — `nil` for a circle zone, the zone's vertices for a custom shape, and updates correctly across `selectZone(_:)` (TDD red→green).
- [x] `BoundaryDrawingRegionTests` (pre-existing, tc-7se1w.2) still green after `BoundaryDrawingRegion` was refactored to delegate to `PolygonBoundingRegion`.
- [x] `swift build` — clean.
- [x] `swift test` — 1969 tests, 245 suites, all passing (ran twice to rule out flakiness).
- [x] `swiftlint lint --strict` — 0 violations against both the CI-pinned SwiftLint 0.63.2 (downloaded locally to match `pr-gate.yml`) and the locally-installed 0.65.0 restricted to the files this bead touches. (Full-project `swiftlint lint --strict` under the local 0.65.0 install has ~80 pre-existing, unrelated violations — ruleset drift the project already documents via tc-6kdu; not touched here.)
- [ ] `ClusteredMapView.Coordinator`'s overlay/camera-framing logic is UIKit-gated (`#if canImport(UIKit)`) and invisible to `swift test`'s bare-macOS build, matching this file's pre-existing untested `Coordinator` — no direct unit test exists for it before or after this change. The two pure layers it composes (bounding-box math, shape-mode threading) are covered per above. **Manual/simulator verification of the actual polygon-vs-circle overlay on the Map page is outstanding** — not done in this run.

Release-Note: Custom-shape watch zones now draw their actual outline on the map instead of a circle.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Map views now support watch zones defined by custom polygon boundaries as well as radius circles.
  * The camera automatically frames polygon boundaries with appropriate margins.
  * Switching between zone types now displays only the active boundary overlay.

* **Bug Fixes**
  * Improved map positioning for small or tightly grouped polygon boundaries.
  * Prevented outdated overlays from remaining visible after changing zones.

* **Tests**
  * Added coverage for polygon framing, overlay switching, and boundary updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->