### PR TITLE
web: render CustomShapeUpsell for Free-tier users with a locked custom-shape zone (tc-utvrv)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/ZoneMapPreview.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/ZoneMapPreview.swift
@@ -21,9 +21,7 @@ struct ZoneMapPreview: View {
   init(
     centre: Coordinate,
     radiusMetres: Double,
-    // swiftlint:disable:next discouraged_default_parameter
     strokeWidth: CGFloat = 1,
-    // swiftlint:disable:next discouraged_default_parameter
     boundaryVertices: [Coordinate]? = nil
   ) {
     self.centre = centre

--- a/web/src/features/WatchZones/WatchZoneEditPage.tsx
+++ b/web/src/features/WatchZones/WatchZoneEditPage.tsx
@@ -126,7 +126,7 @@ export function WatchZoneEditPage({ repository, zone, tier = 'Free' }: Props) {
           </>
         )}
 
-        {!canDrawCustomShape && !shapeLockedByTier && <CustomShapeUpsell />}
+        {!canDrawCustomShape && <CustomShapeUpsell />}
 
         {zoneEdit.boundaryError && (
           <p className={styles.fieldError}>{zoneEdit.boundaryError}</p>

--- a/web/src/features/WatchZones/__tests__/WatchZoneEditPage.test.tsx
+++ b/web/src/features/WatchZones/__tests__/WatchZoneEditPage.test.tsx
@@ -448,7 +448,7 @@ describe('WatchZoneEditPage', () => {
       expect(screen.getByRole('heading', { name: /draw any shape/i })).toBeInTheDocument();
     });
 
-    it('surfaces a locked notice, not the radius picker, for a Free-tier user holding a pre-existing custom-shape zone', () => {
+    it('surfaces a locked notice and the custom-shape upsell, not the radius picker, for a Free-tier user holding a pre-existing custom-shape zone', () => {
       spy.getPreferencesResult = zonePreferences();
       const boundary = aWatchZoneBoundary();
 
@@ -458,9 +458,7 @@ describe('WatchZoneEditPage', () => {
 
       expect(screen.getByText(/this zone uses a custom shape/i)).toBeInTheDocument();
       expect(screen.queryByRole('radiogroup', { name: /radius/i })).not.toBeInTheDocument();
-      expect(
-        screen.queryByRole('heading', { name: /draw any shape/i }),
-      ).not.toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: /draw any shape/i })).toBeInTheDocument();
       expect(screen.queryByTestId('boundary-polygon')).not.toBeInTheDocument();
     });
 


### PR DESCRIPTION
## Summary
- `WatchZoneEditPage.tsx` suppressed `CustomShapeUpsell` whenever `shapeLockedByTier` was true (a Free-tier user viewing an existing custom-shaped zone their tier no longer allows editing). That left only a text-only locked-shape notice, with no promotional/upgrade surface at all.
- Drops the `!shapeLockedByTier` clause from the render condition so `CustomShapeUpsell` now renders in that state too, alongside the existing locked-shape notice (not instead of it).

## Context
Flagged by CodeRabbit on PR #1064 (tc-7se1w.9) and filed separately as tc-utvrv since it predates that PR and is out of scope for its literal ask. Note: wiring the `onUpgradeClick` prop into `CustomShapeUpsell` (so the CTA button itself becomes clickable) is tc-7se1w.9's scope, currently in progress elsewhere — this PR deliberately does not touch that to avoid duplicating/conflicting with that work.

## Test plan
- [x] Extended the existing test `surfaces a locked notice and the custom-shape upsell, not the radius picker, for a Free-tier user holding a pre-existing custom-shape zone` in `WatchZoneEditPage.test.tsx` to assert the upsell heading is now present (previously asserted its absence, which directly encoded the bug).
- [x] `npx vitest run` — 143 files / 1398 tests passed.
- [x] `npx tsc --noEmit` — clean.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Atg1ccMiBEKLFXygibvfDB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Custom-shape upsell messaging now appears for all users who cannot draw custom shapes, including downgraded users with existing locked custom-shape zones.
  * Updated the locked-zone experience to clearly show the “Draw any shape” upgrade option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->