### PR TITLE
chore: pin local SwiftLint to 0.63.2 via Mintfile to match CI (tc-sq7wp)

### DIFF
--- a/mobile/ios/.swiftlint.yml
+++ b/mobile/ios/.swiftlint.yml
@@ -7,7 +7,7 @@
 #
 #   brew install mint          # once
 #   cd mobile/ios && mint bootstrap
-#   mint run realm/swiftlint@0.63.2 lint --strict
+#   mint run realm/SwiftLint@0.63.2 lint --strict
 #
 # If you already have a Homebrew swiftlint that's drifted from 0.63.2, prefer the Mint
 # invocation above over reinstalling a pinned Homebrew formula — versioned Homebrew

--- a/mobile/ios/.swiftlint.yml
+++ b/mobile/ios/.swiftlint.yml
@@ -1,3 +1,18 @@
+# SwiftLint version is pinned to 0.63.2 to match CI (pr-gate.yml / cd-ios-testflight.yml,
+# which download the portable release zip from GitHub directly). A newer local Homebrew
+# build (e.g. 0.65.0) can flag rules CI's 0.63.2 doesn't recognize (or vice versa),
+# causing local-only false positives/negatives and `--strict` failures on rule-name
+# mismatches. Install/run the pinned version via Mint (see ./Mintfile) rather than a
+# bare `brew install swiftlint`:
+#
+#   brew install mint          # once
+#   cd mobile/ios && mint bootstrap
+#   mint run realm/swiftlint@0.63.2 lint --strict
+#
+# If you already have a Homebrew swiftlint that's drifted from 0.63.2, prefer the Mint
+# invocation above over reinstalling a pinned Homebrew formula — versioned Homebrew
+# formulae get pulled from homebrew-core over time, while Mint resolves the exact
+# tagged GitHub release CI uses.
 opt_in_rules:
   - all
 

--- a/mobile/ios/Mintfile
+++ b/mobile/ios/Mintfile
@@ -1,0 +1,1 @@
+realm/SwiftLint@0.63.2


### PR DESCRIPTION
## Summary
- Local Homebrew SwiftLint drifts to whatever's latest (0.65.0 at time of writing), while CI (`pr-gate.yml`, `cd-ios-testflight.yml`) downloads the portable 0.63.2 release zip directly from GitHub. The version skew caused local-only false positives (`discouraged_default_parameter`, a rule 0.63.2 doesn't recognize) that blocked a commit via the `.claude/settings.json` git-commit hook, and a `swiftlint:disable` workaround added to silence it then failed CI's `--strict` pass as `superfluous_disable_command`. Discovered 2026-08-07 while resolving a merge conflict on PR #1070.
- Added `mobile/ios/Mintfile` pinning `realm/SwiftLint@0.63.2` — Mint resolves the exact tagged GitHub release CI consumes, unlike a versioned Homebrew formula which can be pulled from homebrew-core over time.
- Added a doc comment block at the top of `mobile/ios/.swiftlint.yml` stating the pinned version, why it must match CI, and the install/run command.
- Deliberately left `.claude/settings.json`'s two SwiftLint hook invocations pointed at bare `swiftlint` on PATH — no Swift/Mint toolchain was available in this session to verify a rewritten invocation works inside the existing jq/grep pipelines; documented the correct manual command instead. A local session could pick this up as a small follow-up if desired.

## Test plan
- [x] Config/doc-only change — no Swift source touched.
- [ ] No Swift/Xcode toolchain was available in this session to run `swift build`/`swift test`/`swiftlint lint --strict`; verification that `mint bootstrap && mint run realm/swiftlint@0.63.2 lint --strict` resolves and runs cleanly is outstanding and should be done on a machine with Mint/Xcode installed.

Bead: tc-sq7wp

---
_Generated by [Claude Code](https://claude.ai/code/session_01PmSQ5qRDbcaYicDSCx4uC4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for installing and running SwiftLint through Mint.
  * Documented the pinned SwiftLint version required for CI compatibility.

* **Chores**
  * Added SwiftLint version 0.63.2 to the iOS development tooling configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->