### PR TITLE
feat(android): WatchZoneBoundary domain type + allowsCustomBoundary (tc-v6fo0.1)

### DIFF
--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/watchzones/Coordinate.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/watchzones/Coordinate.kt
@@ -1,5 +1,10 @@
 package uk.towncrierapp.domain.watchzones
 
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.sqrt
+
 /**
  * A geographic coordinate (latitude/longitude pair). Out-of-range values are
  * a programmer-error invariant here — coordinates only ever arrive already
@@ -16,4 +21,35 @@ public data class Coordinate(
         require(latitude in -90.0..90.0) { "latitude must be in -90..90, was $latitude" }
         require(longitude in -180.0..180.0) { "longitude must be in -180..180, was $longitude" }
     }
+}
+
+private const val EARTH_RADIUS_METRES = 6_371_000.0
+
+/**
+ * Great-circle distance between two raw lat/lon pairs, in metres. Takes raw
+ * values rather than two [Coordinate]s so a derived, not-yet-validated point
+ * — e.g. [WatchZoneBoundary.enclosingRadiusMetres]'s centroid — doesn't need
+ * to round-trip it through [Coordinate]'s `init` just to measure a distance.
+ * Port of iOS `Coordinate.haversineMetres`.
+ */
+internal fun haversineMetres(
+    latitude1: Double,
+    longitude1: Double,
+    latitude2: Double,
+    longitude2: Double,
+): Double {
+    val degToRad = Math.PI / 180
+    val phi1 = latitude1 * degToRad
+    val phi2 = latitude2 * degToRad
+    val deltaPhi = (latitude2 - latitude1) * degToRad
+    val deltaLambda = (longitude2 - longitude1) * degToRad
+    val haversine =
+        sin(deltaPhi / 2) * sin(deltaPhi / 2) +
+            cos(phi1) * cos(phi2) * sin(deltaLambda / 2) * sin(deltaLambda / 2)
+    // Clamp before the sqrts: floating-point round-off can push `haversine`
+    // fractionally above 1 for near-antipodal coordinates, which would make
+    // `1 - haversine` negative and `sqrt` return NaN.
+    val clampedHaversine = minOf(1.0, haversine)
+    val angularDistance = 2 * atan2(sqrt(clampedHaversine), sqrt(1 - clampedHaversine))
+    return EARTH_RADIUS_METRES * angularDistance
 }

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/watchzones/WatchZone.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/watchzones/WatchZone.kt
@@ -1,10 +1,16 @@
 package uk.towncrierapp.domain.watchzones
 
 /**
- * A circular geographic area a user monitors for planning applications. Port
- * of iOS `WatchZone` (epic #770). [authorityId] of `0` means "not yet
- * resolved" — the server reverse-geocodes it from [centre] when a zone is
- * created without one.
+ * A geographic area a user monitors for planning applications. Port of iOS
+ * `WatchZone` (epic #770). [authorityId] of `0` means "not yet resolved" —
+ * the server reverse-geocodes it from [centre] when a zone is created
+ * without one.
+ *
+ * [boundary] is `null` for the original circle-only zones and non-null for a
+ * custom-shape zone (GH#1072 Phase 1). A polygon zone still populates
+ * [centre]/[radiusMetres] server-side, derived from the boundary's centroid
+ * and enclosing radius, so no read path needs special-casing beyond checking
+ * whether [boundary] is present.
  */
 public data class WatchZone(
     public val id: WatchZoneId,
@@ -14,6 +20,7 @@ public data class WatchZone(
     public val authorityId: Int = 0,
     public val pushEnabled: Boolean = true,
     public val emailInstantEnabled: Boolean = true,
+    public val boundary: WatchZoneBoundary? = null,
 ) {
     init {
         require(name.isNotBlank()) { "watch zone name must not be blank" }

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/watchzones/WatchZoneBoundary.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/watchzones/WatchZoneBoundary.kt
@@ -1,0 +1,263 @@
+package uk.towncrierapp.domain.watchzones
+
+/**
+ * A closed polygon ring for a custom-shape watch zone, mirroring the
+ * server's `watchzones.Boundary` (`api-go/internal/watchzones/zone.go`).
+ *
+ * `WatchZone.boundary == null` means the zone is a circle; a non-null,
+ * validated [WatchZoneBoundary] means the zone is a custom shape. [of] is
+ * the only way to obtain one — the private constructor guarantees every
+ * instance in hand is already a valid, closed ring, so nothing downstream
+ * re-validates it (the smart-constructor idiom, android-coding-standards
+ * skill: architecture-and-modules.md). A hand-drawn shape failing validation
+ * is expected user input, not a programmer error — unlike [Coordinate]'s
+ * `require`-based invariants — so [of] returns a [WatchZoneBoundaryResult]
+ * the caller must handle exhaustively rather than throwing (kotlin-idiom.md).
+ * Port of iOS `WatchZoneBoundary`.
+ */
+public class WatchZoneBoundary private constructor(
+    public val vertices: List<Coordinate>,
+) {
+    /**
+     * The polygon centroid (area-weighted, shoelace formula) — not the
+     * arithmetic mean of the vertices, which differs from the true centroid
+     * for any non-uniform shape (e.g. an L-shape). Longitude and latitude
+     * are treated as planar x/y, an acceptable approximation at the
+     * sub-tens-of-km scale a hand-drawn watch zone can reach. Mirrors the
+     * server's `Boundary.Centroid()`.
+     */
+    public val centroid: Coordinate by lazy { computeCentroid() }
+
+    /**
+     * The great-circle distance in metres from [centroid] to the furthest
+     * vertex — the radius of the smallest centroid-centred circle that
+     * fully encloses the shape. Mirrors the server's
+     * `Boundary.EnclosingRadiusMetres()`, and what a custom-shape
+     * `WatchZone` derives into its `radiusMetres` field so every read path
+     * built for circles keeps working unchanged.
+     */
+    public val enclosingRadiusMetres: Double by lazy { computeEnclosingRadiusMetres() }
+
+    private fun computeCentroid(): Coordinate {
+        val edgeCount = vertices.size - 1
+        var area = 0.0
+        var centreX = 0.0
+        var centreY = 0.0
+        for (index in 0 until edgeCount) {
+            val vertex = vertices[index]
+            val next = vertices[index + 1]
+            val cross = vertex.longitude * next.latitude - next.longitude * vertex.latitude
+            area += cross
+            centreX += (vertex.longitude + next.longitude) * cross
+            centreY += (vertex.latitude + next.latitude) * cross
+        }
+        area /= 2
+        centreX /= 6 * area
+        centreY /= 6 * area
+        return Coordinate(latitude = centreY, longitude = centreX)
+    }
+
+    private fun computeEnclosingRadiusMetres(): Double {
+        val centre = centroid
+        var maxDistance = 0.0
+        for (vertex in vertices.dropLast(1)) {
+            val distance = haversineMetres(centre.latitude, centre.longitude, vertex.latitude, vertex.longitude)
+            maxDistance = maxOf(maxDistance, distance)
+        }
+        return maxDistance
+    }
+
+    override fun equals(other: Any?): Boolean = other is WatchZoneBoundary && vertices == other.vertices
+
+    override fun hashCode(): Int = vertices.hashCode()
+
+    public companion object {
+        // 3 is the geometric minimum for a polygon, 50 is generous for a
+        // hand-drawn shape while bounding payload size and matching-query
+        // cost. Both exclude the closing repeat.
+        private const val MIN_VERTICES = 3
+        private const val MAX_VERTICES = 50
+
+        // A generous bounding box around Great Britain and Northern Ireland,
+        // used only to reject vertices that are obviously not the UK — not a
+        // precise coastline check. Mirrors the server's uk* bounds constants.
+        private const val UK_MIN_LATITUDE = 49.5
+        private const val UK_MAX_LATITUDE = 61.0
+        private const val UK_MIN_LONGITUDE = -8.5
+        private const val UK_MAX_LONGITUDE = 2.0
+
+        /**
+         * Validates and normalises raw vertices into a closed polygon ring:
+         * 3-50 distinct vertices (after auto-closing, not counting the
+         * closing repeat), an open ring is auto-closed by appending a copy
+         * of the first vertex (a ring that already closes is left as-is),
+         * all vertices within UK bounds, and the ring must be simple (no two
+         * non-adjacent edges cross). Mirrors the server's `NewBoundary`.
+         */
+        public fun of(vertices: List<Coordinate>): WatchZoneBoundaryResult {
+            if (vertices.isEmpty()) return WatchZoneBoundaryResult.InvalidVertexCount
+
+            val ring = if (vertices.first() != vertices.last()) vertices + vertices.first() else vertices
+            val distinct = ring.dropLast(1)
+            if (distinct.size < MIN_VERTICES || distinct.size > MAX_VERTICES) {
+                return WatchZoneBoundaryResult.InvalidVertexCount
+            }
+            if (distinct.toSet().size != distinct.size) {
+                return WatchZoneBoundaryResult.DuplicateVertex
+            }
+            val allWithinUkBounds =
+                distinct.all { vertex ->
+                    vertex.latitude in UK_MIN_LATITUDE..UK_MAX_LATITUDE &&
+                        vertex.longitude in UK_MIN_LONGITUDE..UK_MAX_LONGITUDE
+                }
+            if (!allWithinUkBounds) return WatchZoneBoundaryResult.OutOfBounds
+
+            // A collinear ring has no interior, so no point can ever fall
+            // inside it; treat it as a degenerate (self-touching) shape.
+            if (signedArea(ring) == 0.0) return WatchZoneBoundaryResult.SelfIntersecting
+            if (selfIntersects(ring)) return WatchZoneBoundaryResult.SelfIntersecting
+
+            return WatchZoneBoundaryResult.Valid(WatchZoneBoundary(ring))
+        }
+
+        /**
+         * Twice the signed shoelace area of the closed ring. Zero only for a
+         * degenerate (zero-area, e.g. collinear) ring.
+         */
+        private fun signedArea(ring: List<Coordinate>): Double {
+            val edgeCount = ring.size - 1
+            if (edgeCount < 1) return 0.0
+            var sum = 0.0
+            for (index in 0 until edgeCount) {
+                sum +=
+                    ring[index].longitude * ring[index + 1].latitude -
+                    ring[index + 1].longitude * ring[index].latitude
+            }
+            return sum
+        }
+
+        /**
+         * Whether any two non-adjacent edges of the closed ring cross. O(n²)
+         * over the edges; n is capped at 50 vertices by [of], so this is
+         * cheap and a sweep-line algorithm is not warranted.
+         */
+        private fun selfIntersects(ring: List<Coordinate>): Boolean {
+            val edgeCount = ring.size - 1
+            if (edgeCount < 3) return false
+            for (first in 0 until edgeCount) {
+                val firstStart = ring[first]
+                val firstEnd = ring[first + 1]
+                if (first + 2 > edgeCount) continue
+                for (second in (first + 2) until edgeCount) {
+                    // The last edge and the first edge share vertex
+                    // ring[0]==ring[edgeCount]: adjacent via the ring's
+                    // wraparound, not a crossing.
+                    if (first == 0 && second == edgeCount - 1) continue
+                    val secondStart = ring[second]
+                    val secondEnd = ring[second + 1]
+                    if (segmentsIntersect(firstStart, firstEnd, secondStart, secondEnd)) return true
+                }
+            }
+            return false
+        }
+
+        /**
+         * Whether segments pt1-pt2 and pt3-pt4 intersect, including one
+         * touching the other at an endpoint or lying collinearly on it.
+         * Standard orientation-based test (see e.g. CLRS §33.1), split
+         * across [straddles] and [touchesCollinearly] to keep this
+         * function's own branching (and detekt's cyclomatic-complexity
+         * count) low.
+         */
+        private fun segmentsIntersect(
+            pt1: Coordinate,
+            pt2: Coordinate,
+            pt3: Coordinate,
+            pt4: Coordinate,
+        ): Boolean {
+            val ori1 = orientation(pt3, pt4, pt1)
+            val ori2 = orientation(pt3, pt4, pt2)
+            val ori3 = orientation(pt1, pt2, pt3)
+            val ori4 = orientation(pt1, pt2, pt4)
+
+            if (straddles(ori1, ori2) && straddles(ori3, ori4)) return true
+            return touchesCollinearly(pt1, pt2, pt3, pt4)
+        }
+
+        /** Whether points with orientations [oriA] and [oriB] (relative to the same edge) fall on opposite sides of it. */
+        private fun straddles(
+            oriA: Double,
+            oriB: Double,
+        ): Boolean = (oriA > 0 && oriB < 0) || (oriA < 0 && oriB > 0)
+
+        /**
+         * Whether either endpoint of one segment is collinear with, and
+         * lies on, the other segment — the "touching" case [straddles]
+         * alone doesn't catch. Recomputes each orientation locally (cheap;
+         * the ring is capped at 50 vertices) to keep this function's
+         * parameter list small rather than threading the four orientations
+         * through from [segmentsIntersect].
+         */
+        private fun touchesCollinearly(
+            pt1: Coordinate,
+            pt2: Coordinate,
+            pt3: Coordinate,
+            pt4: Coordinate,
+        ): Boolean {
+            if (orientation(pt3, pt4, pt1) == 0.0 && onSegment(pt3, pt4, pt1)) return true
+            if (orientation(pt3, pt4, pt2) == 0.0 && onSegment(pt3, pt4, pt2)) return true
+            if (orientation(pt1, pt2, pt3) == 0.0 && onSegment(pt1, pt2, pt3)) return true
+            if (orientation(pt1, pt2, pt4) == 0.0 && onSegment(pt1, pt2, pt4)) return true
+            return false
+        }
+
+        /**
+         * Twice the signed area of triangle origin,next,point: positive for
+         * counter-clockwise, negative for clockwise, zero when the three
+         * points are collinear.
+         */
+        private fun orientation(
+            origin: Coordinate,
+            next: Coordinate,
+            point: Coordinate,
+        ): Double =
+            (next.longitude - origin.longitude) * (point.latitude - origin.latitude) -
+                (next.latitude - origin.latitude) * (point.longitude - origin.longitude)
+
+        /**
+         * Whether [point], already known to be collinear with segment
+         * [segmentStart]-[segmentEnd], lies within its bounding box — i.e.
+         * actually on the segment rather than on the line through it
+         * extended beyond either endpoint.
+         */
+        private fun onSegment(
+            segmentStart: Coordinate,
+            segmentEnd: Coordinate,
+            point: Coordinate,
+        ): Boolean =
+            point.longitude >= minOf(segmentStart.longitude, segmentEnd.longitude) &&
+                point.longitude <= maxOf(segmentStart.longitude, segmentEnd.longitude) &&
+                point.latitude >= minOf(segmentStart.latitude, segmentEnd.latitude) &&
+                point.latitude <= maxOf(segmentStart.latitude, segmentEnd.latitude)
+    }
+}
+
+/** The outcome of [WatchZoneBoundary.of] — an expected, exhaustively-handled user-input validation result. */
+public sealed interface WatchZoneBoundaryResult {
+    /** [vertices] formed a valid, simple polygon ring within UK bounds. */
+    public data class Valid(
+        public val boundary: WatchZoneBoundary,
+    ) : WatchZoneBoundaryResult
+
+    /** Fewer than 3 or more than 50 distinct vertices (excluding the closing repeat). */
+    public data object InvalidVertexCount : WatchZoneBoundaryResult
+
+    /** Two non-adjacent (non-closing) vertices were identical. */
+    public data object DuplicateVertex : WatchZoneBoundaryResult
+
+    /** At least one vertex fell outside the generous UK bounding box. */
+    public data object OutOfBounds : WatchZoneBoundaryResult
+
+    /** The ring is degenerate (zero-area/collinear) or two non-adjacent edges cross. */
+    public data object SelfIntersecting : WatchZoneBoundaryResult
+}

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/watchzones/WatchZoneLimits.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/watchzones/WatchZoneLimits.kt
@@ -24,6 +24,14 @@ public data class WatchZoneLimits(
             SubscriptionTier.PRO -> 10_000.0
         }
 
+    /**
+     * Whether this tier can draw a custom-shape (polygon) zone rather than
+     * only a circle (GH#1072 Phase 1). Mirrors the server's
+     * `SubscriptionTier.AllowsCustomBoundary()` (`t.IsPaid()`) and iOS
+     * `WatchZoneLimits.allowsCustomBoundary`.
+     */
+    public val allowsCustomBoundary: Boolean = tier != SubscriptionTier.FREE
+
     /** Whether the user can add another zone given their current count. */
     public fun canAddZone(currentCount: Int): Boolean = currentCount < maxZones
 

--- a/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/watchzones/CoordinateTest.kt
+++ b/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/watchzones/CoordinateTest.kt
@@ -1,8 +1,11 @@
 package uk.towncrierapp.domain.watchzones
 
 import org.junit.jupiter.api.Test
+import kotlin.math.PI
+import kotlin.math.abs
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 /** Port of iOS `CoordinateTests` — latitude/longitude range validation (tc-z95t). */
 class CoordinateTest {
@@ -43,5 +46,36 @@ class CoordinateTest {
     @Test
     fun `coordinates with the same values are equal`() {
         assertEquals(Coordinate(52.2053, 0.1218), Coordinate(52.2053, 0.1218))
+    }
+
+    // MARK: - haversineMetres
+
+    @Test
+    fun `haversine distance between the same point is zero`() {
+        assertEquals(0.0, haversineMetres(52.2053, 0.1218, 52.2053, 0.1218))
+    }
+
+    // Antipodal points on the equator: haversine's `h` term computes to
+    // exactly 1.0, the boundary this test exists to cover. Regression for a
+    // CodeRabbit-flagged bug (ported from iOS) where `1 - h` could go
+    // negative and `sqrt` return NaN.
+    @Test
+    fun `haversine distance between antipodal points on the equator is half the earth's circumference`() {
+        val distance = haversineMetres(0.0, 0.0, 0.0, 180.0)
+
+        assertTrue(distance.isFinite())
+        assertTrue(abs(distance - PI * 6_371_000) < 1.0)
+    }
+
+    // A near-antipodal pair found (on iOS) by brute-force search over random
+    // near-antipodal inputs to push the raw (pre-clamp) haversine `h` term
+    // fractionally above 1.0 in double precision. Without the clamp, `1 - h`
+    // goes negative and `sqrt` returns NaN, poisoning `atan2`.
+    @Test
+    fun `haversine distance between a near-antipodal pair is finite not NaN`() {
+        val distance = haversineMetres(-58.97018354817475, -97.36776415155397, 58.970183085348935, 82.6322355333763)
+
+        assertTrue(distance.isFinite())
+        assertTrue(abs(distance - PI * 6_371_000) < 10.0)
     }
 }

--- a/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/watchzones/WatchZoneBoundaryTest.kt
+++ b/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/watchzones/WatchZoneBoundaryTest.kt
@@ -1,0 +1,215 @@
+package uk.towncrierapp.domain.watchzones
+
+import org.junit.jupiter.api.Test
+import kotlin.math.PI
+import kotlin.math.abs
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * Mirrors `api-go/internal/watchzones/zone.go`'s `NewBoundary`/`Boundary`
+ * validation and geometry, and iOS `WatchZoneBoundaryTests` (GH#1072 Phase 1,
+ * tc-v6fo0.1).
+ */
+class WatchZoneBoundaryTest {
+    // MARK: - Closure
+
+    @Test
+    fun `an open ring is auto-closed by appending a copy of the first vertex`() {
+        val triangle =
+            listOf(
+                Coordinate(latitude = 51.50, longitude = -0.10),
+                Coordinate(latitude = 51.51, longitude = -0.09),
+                Coordinate(latitude = 51.50, longitude = -0.09),
+            )
+
+        val result = assertIs<WatchZoneBoundaryResult.Valid>(WatchZoneBoundary.of(triangle))
+
+        assertEquals(triangle.size + 1, result.boundary.vertices.size)
+        assertEquals(result.boundary.vertices.first(), result.boundary.vertices.last())
+    }
+
+    @Test
+    fun `an already-closed ring is not doubled`() {
+        val closed =
+            listOf(
+                Coordinate(latitude = 51.50, longitude = -0.10),
+                Coordinate(latitude = 51.51, longitude = -0.09),
+                Coordinate(latitude = 51.50, longitude = -0.09),
+                Coordinate(latitude = 51.50, longitude = -0.10),
+            )
+
+        val result = assertIs<WatchZoneBoundaryResult.Valid>(WatchZoneBoundary.of(closed))
+
+        assertEquals(closed.size, result.boundary.vertices.size)
+    }
+
+    // MARK: - Vertex count
+
+    @Test
+    fun `fewer than 3 distinct vertices is rejected`() {
+        val vertices =
+            listOf(
+                Coordinate(latitude = 51.50, longitude = -0.10),
+                Coordinate(latitude = 51.51, longitude = -0.11),
+            )
+
+        assertEquals(WatchZoneBoundaryResult.InvalidVertexCount, WatchZoneBoundary.of(vertices))
+    }
+
+    @Test
+    fun `more than 50 distinct vertices is rejected`() {
+        val vertices =
+            (0 until 51).map { index ->
+                Coordinate(latitude = 51.5, longitude = -0.5 + index * 0.001)
+            }
+
+        assertEquals(WatchZoneBoundaryResult.InvalidVertexCount, WatchZoneBoundary.of(vertices))
+    }
+
+    @Test
+    fun `exactly 50 distinct vertices is accepted`() {
+        val centreLat = 51.5074
+        val centreLon = -0.1278
+        val radiusDeg = 0.05
+        val count = 50
+        val vertices =
+            (0 until count).map { index ->
+                val angle = 2 * PI * index / count
+                Coordinate(
+                    latitude = centreLat + radiusDeg * sin(angle),
+                    longitude = centreLon + radiusDeg * cos(angle),
+                )
+            }
+
+        val result = assertIs<WatchZoneBoundaryResult.Valid>(WatchZoneBoundary.of(vertices))
+
+        assertEquals(count + 1, result.boundary.vertices.size)
+    }
+
+    @Test
+    fun `a duplicate interior vertex is rejected`() {
+        val vertices =
+            listOf(
+                Coordinate(latitude = 51.50, longitude = -0.10),
+                Coordinate(latitude = 51.51, longitude = -0.09),
+                Coordinate(latitude = 51.51, longitude = -0.09),
+                Coordinate(latitude = 51.50, longitude = -0.08),
+            )
+
+        assertEquals(WatchZoneBoundaryResult.DuplicateVertex, WatchZoneBoundary.of(vertices))
+    }
+
+    // MARK: - Self-intersection
+
+    @Test
+    fun `a self-intersecting bowtie ring is rejected`() {
+        val bowtie =
+            listOf(
+                Coordinate(latitude = 51.50, longitude = -0.10),
+                Coordinate(latitude = 51.51, longitude = -0.09),
+                Coordinate(latitude = 51.50, longitude = -0.09),
+                Coordinate(latitude = 51.51, longitude = -0.10),
+            )
+
+        assertEquals(WatchZoneBoundaryResult.SelfIntersecting, WatchZoneBoundary.of(bowtie))
+    }
+
+    @Test
+    fun `a zero-area collinear ring is rejected`() {
+        val collinear =
+            listOf(
+                Coordinate(latitude = 51.50, longitude = -0.10),
+                Coordinate(latitude = 51.50, longitude = -0.09),
+                Coordinate(latitude = 51.50, longitude = -0.08),
+            )
+
+        assertEquals(WatchZoneBoundaryResult.SelfIntersecting, WatchZoneBoundary.of(collinear))
+    }
+
+    // MARK: - Out of bounds
+
+    @Test
+    fun `a vertex outside the UK bounding box is rejected`() {
+        val vertices =
+            listOf(
+                Coordinate(latitude = 51.5, longitude = -0.1),
+                Coordinate(latitude = 51.51, longitude = -0.11),
+                Coordinate(latitude = 51.5, longitude = 40.0),
+            )
+
+        assertEquals(WatchZoneBoundaryResult.OutOfBounds, WatchZoneBoundary.of(vertices))
+    }
+
+    // MARK: - Centroid
+
+    @Test
+    fun `centroid of a known rectangle is its geometric centre`() {
+        val rectangle =
+            listOf(
+                Coordinate(latitude = 51.0, longitude = -1.0),
+                Coordinate(latitude = 52.0, longitude = -1.0),
+                Coordinate(latitude = 52.0, longitude = 0.0),
+                Coordinate(latitude = 51.0, longitude = 0.0),
+            )
+        val result = assertIs<WatchZoneBoundaryResult.Valid>(WatchZoneBoundary.of(rectangle))
+
+        val centroid = result.boundary.centroid
+
+        assertTrue(abs(centroid.latitude - 51.5) < 1e-9)
+        assertTrue(abs(centroid.longitude - (-0.5)) < 1e-9)
+    }
+
+    @Test
+    fun `centroid is the area-weighted centre not the vertex average`() {
+        // A staircase/L-shape: (lat,lon) (0,0),(0,6),(2,6),(2,2),(4,2),(4,0).
+        // True polygon centroid is (1.5, 2.5); the naive vertex average is
+        // (2.0, 2.667) — different enough to fail a naive-average
+        // implementation. Shifted into UK bounds by a +51 latitude, -7
+        // longitude offset (the shape spans 6 degrees of longitude, so the
+        // offset must keep both ends within the UK longitude bounds, not
+        // just the starting vertex).
+        val baseLat = 51.0
+        val baseLon = -7.0
+        val shape =
+            listOf(
+                Coordinate(latitude = baseLat, longitude = baseLon),
+                Coordinate(latitude = baseLat, longitude = baseLon + 6),
+                Coordinate(latitude = baseLat + 2, longitude = baseLon + 6),
+                Coordinate(latitude = baseLat + 2, longitude = baseLon + 2),
+                Coordinate(latitude = baseLat + 4, longitude = baseLon + 2),
+                Coordinate(latitude = baseLat + 4, longitude = baseLon),
+            )
+        val result = assertIs<WatchZoneBoundaryResult.Valid>(WatchZoneBoundary.of(shape))
+
+        val centroid = result.boundary.centroid
+
+        assertTrue(abs(centroid.latitude - (baseLat + 1.5)) < 1e-9)
+        assertTrue(abs(centroid.longitude - (baseLon + 2.5)) < 1e-9)
+    }
+
+    // MARK: - Enclosing radius
+
+    @Test
+    fun `enclosing radius of a known square matches the precomputed distance`() {
+        val centreLat = 51.5074
+        val centreLon = -0.1278
+        val deltaLat = 0.0089831
+        val deltaLon = 0.0144328
+        val square =
+            listOf(
+                Coordinate(latitude = centreLat + deltaLat, longitude = centreLon + deltaLon),
+                Coordinate(latitude = centreLat + deltaLat, longitude = centreLon - deltaLon),
+                Coordinate(latitude = centreLat - deltaLat, longitude = centreLon - deltaLon),
+                Coordinate(latitude = centreLat - deltaLat, longitude = centreLon + deltaLon),
+            )
+        val result = assertIs<WatchZoneBoundaryResult.Valid>(WatchZoneBoundary.of(square))
+
+        val radius = result.boundary.enclosingRadiusMetres
+
+        assertTrue(abs(radius - 1_412.694_247_415_168) < 0.5)
+    }
+}

--- a/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/watchzones/WatchZoneLimitsTest.kt
+++ b/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/watchzones/WatchZoneLimitsTest.kt
@@ -62,4 +62,19 @@ class WatchZoneLimitsTest {
     fun `clampRadius exceeding the limit returns the max`() {
         assertEquals(5_000.0, WatchZoneLimits(SubscriptionTier.PERSONAL).clampRadius(8_000.0))
     }
+
+    @Test
+    fun `free tier does not allow a custom boundary`() {
+        assertFalse(WatchZoneLimits(SubscriptionTier.FREE).allowsCustomBoundary)
+    }
+
+    @Test
+    fun `personal tier allows a custom boundary`() {
+        assertTrue(WatchZoneLimits(SubscriptionTier.PERSONAL).allowsCustomBoundary)
+    }
+
+    @Test
+    fun `pro tier allows a custom boundary`() {
+        assertTrue(WatchZoneLimits(SubscriptionTier.PRO).allowsCustomBoundary)
+    }
 }

--- a/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/watchzones/WatchZoneTest.kt
+++ b/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/watchzones/WatchZoneTest.kt
@@ -44,4 +44,39 @@ class WatchZoneTest {
         assertEquals(true, zone.emailInstantEnabled)
         assertEquals(0, zone.authorityId)
     }
+
+    @Test
+    fun `boundary defaults to null meaning a circle zone`() {
+        val zone =
+            WatchZone(
+                id = WatchZoneId("wz-1"),
+                name = "Home",
+                centre = Coordinate(51.5074, -0.1278),
+                radiusMetres = 500.0,
+            )
+
+        assertEquals(null, zone.boundary)
+    }
+
+    @Test
+    fun `a custom-shape zone carries its boundary`() {
+        val triangle =
+            listOf(
+                Coordinate(latitude = 51.50, longitude = -0.10),
+                Coordinate(latitude = 51.51, longitude = -0.09),
+                Coordinate(latitude = 51.50, longitude = -0.09),
+            )
+        val boundary = (WatchZoneBoundary.of(triangle) as WatchZoneBoundaryResult.Valid).boundary
+
+        val zone =
+            WatchZone(
+                id = WatchZoneId("wz-1"),
+                name = "Home",
+                centre = Coordinate(51.5074, -0.1278),
+                radiusMetres = 500.0,
+                boundary = boundary,
+            )
+
+        assertEquals(boundary, zone.boundary)
+    }
 }


### PR DESCRIPTION
## Summary

Phase 1 of #1072 (Android parity: custom-shape polygon watch zones) — the pure-domain slice only. Adds:

- `WatchZoneBoundary` (`domain/watchzones/WatchZoneBoundary.kt`): a closed-polygon-ring value type, ported verbatim from iOS `WatchZoneBoundary` (`mobile/ios/packages/town-crier-domain/Sources/ValueObjects/WatchZoneBoundary.swift`) and mirroring the server's `watchzones.Boundary`/`NewBoundary` (`api-go/internal/watchzones/zone.go`). Validates 3–50 distinct vertices (auto-closing an open ring), rejects duplicate vertices, out-of-UK-bounds vertices, and self-intersecting/degenerate rings; exposes an area-weighted `centroid` and haversine `enclosingRadiusMetres`.
- `WatchZone.boundary: WatchZoneBoundary?` — `null` means a circle zone (unchanged behaviour), non-null means a custom shape.
- `WatchZoneLimits.allowsCustomBoundary: Boolean` — `true` for Personal/Pro, `false` for Free, mirroring iOS `WatchZoneLimits.allowsCustomBoundary`.
- `haversineMetres(...)` helper on `Coordinate.kt` (with the pre-sqrt clamp fix for near-antipodal points, ported from an existing iOS regression fix).

Because a hand-drawn shape failing validation is expected user input rather than a programmer error (unlike `Coordinate`'s `require()`-based invariants), `WatchZoneBoundary.of(vertices)` returns a `WatchZoneBoundaryResult` sealed interface (`Valid` / `InvalidVertexCount` / `DuplicateVertex` / `OutOfBounds` / `SelfIntersecting`) rather than throwing — the idiom documented in the `android-coding-standards` skill for recoverable domain validation.

**Scope:** `mobile/android/domain/` only. No server-side changes (already shipped), no `data`/`presentation`/`app` module changes — those are later phases of #1072, tracked as separate not-yet-ready beads (tc-v6fo0.2–.6).

## Test plan

- [x] `./gradlew :domain:test` — 39 tests in the `watchzones` package pass (12 new `WatchZoneBoundaryTest` cases mirroring the iOS suite, plus new/updated coverage on `Coordinate`, `WatchZone`, `WatchZoneLimits`)
- [x] `./gradlew :domain:ktlintCheck` — clean
- [x] `./gradlew :domain:detekt` — clean
- [ ] No Android SDK / emulator verification — not applicable, this module is pure Kotlin/JVM (no `android.*` dependency) and this PR touches no UI

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FZfMPwKKF6CxcWAgBdQRSW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom-shaped watch zone boundaries.
  * Watch zones can now calculate their centre and coverage radius from polygon shapes.
  * Custom boundaries are available on paid subscription tiers, while free-tier zones remain circle-based.
  * Invalid boundaries are clearly rejected for issues such as out-of-range points, duplicate vertices, self-intersections, or insufficient area.

* **Bug Fixes**
  * Improved distance calculations for locations that are extremely far apart, preventing invalid results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->