### PR TITLE
chore(api): re-point devseed.Seeder at geometry-scoped prod query (tc-9nbs4.1)

### DIFF
--- a/api-go/cmd/api/export_adapters_test.go
+++ b/api-go/cmd/api/export_adapters_test.go
@@ -37,6 +37,8 @@ func (f *fakeWatchZoneStore) FindZonesContaining(_ context.Context, _, _ float64
 	return nil, nil
 }
 
+func (f *fakeWatchZoneStore) All(_ context.Context) ([]watchzones.WatchZone, error) { return nil, nil }
+
 // TestWatchZoneExportReader_ReadsThroughStoreInterface proves the export adapter
 // is backed by the consumer-side watchzones.Store interface, so GET /v1/me/data
 // exports a user's watch zones (bead tc-s8g1). The fake is a plain

--- a/api-go/cmd/worker/fakes_test.go
+++ b/api-go/cmd/worker/fakes_test.go
@@ -50,3 +50,5 @@ func (s *spyZoneStore) Delete(_ context.Context, _, _ string) error { return nil
 func (s *spyZoneStore) DeleteAllByUserID(_ context.Context, _ string) error { return nil }
 
 func (s *spyZoneStore) DistinctAuthorityIDs(_ context.Context) ([]int, error) { return nil, nil }
+
+func (s *spyZoneStore) All(_ context.Context) ([]watchzones.WatchZone, error) { return nil, nil }

--- a/api-go/internal/applications/recentnearzones.go
+++ b/api-go/internal/applications/recentnearzones.go
@@ -1,0 +1,109 @@
+package applications
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// ZoneGeometry is a watch zone's geometry, decoupled from the watchzones
+// package: applications cannot import watchzones, which already imports
+// applications (see Coordinate's doc in boundarypage.go) -- so a caller
+// (devseed.Seeder) translates each watchzones.WatchZone into this shape
+// before calling RecentNearZones. A zero-length Boundary means a circle zone
+// (Latitude, Longitude and RadiusMetres apply); a non-empty Boundary means a
+// custom-shape zone (Boundary applies, the circle fields are ignored) --
+// mirroring watchzones.WatchZone.IsCustomShape.
+type ZoneGeometry struct {
+	Latitude     float64
+	Longitude    float64
+	RadiusMetres float64
+	Boundary     []Coordinate
+}
+
+// isCustomShape reports whether g is a custom-shape (polygon) zone rather
+// than a circle, mirroring watchzones.WatchZone.IsCustomShape's zero-length
+// Boundary discriminator.
+func (g ZoneGeometry) isCustomShape() bool {
+	return len(g.Boundary) > 0
+}
+
+// pgRecentNearZonesQuery is RecentInAuthorities' geometry-scoped replacement
+// (bd tc-9nbs4.1, GH#1076 Phase 1): rather than an authority_id membership
+// test, an application matches if it falls within ANY of the given zones,
+// circle or polygon -- the same OR-of-circle-or-polygon shape
+// watchzones.pgFindZonesContainingQuery uses for one point against every
+// zone, applied the other way around: N zones against every application.
+//
+// The `circles` and `polygons` CTEs unnest their respective parallel-array
+// parameters into per-zone rows -- the same shape pgRecentNearestTownQuery's
+// `towns` CTE uses for sibling towns -- so the query text never changes shape
+// however many zones of either kind are passed; a kind with zero zones
+// contributes zero rows to its CTE, so its EXISTS branch is simply never
+// true (never a SQL error). EXISTS, not a JOIN, is deliberate: it
+// de-duplicates for free when an application falls within more than one
+// zone, where a JOIN would multiply rows.
+const pgRecentNearZonesQuery = `
+WITH circles AS (
+	SELECT ST_SetSRID(ST_MakePoint(lng, lat), 4326)::geography AS pt, radius
+	FROM unnest($1::double precision[], $2::double precision[], $3::double precision[])
+	     AS c(lng, lat, radius)
+),
+polygons AS (
+	SELECT ST_GeomFromGeoJSON(g)::geography AS geom
+	FROM unnest($4::text[]) AS p(g)
+)
+SELECT ` + appColumns + `
+FROM applications a
+WHERE EXISTS (SELECT 1 FROM circles c WHERE ST_DWithin(a.location, c.pt, c.radius))
+   OR EXISTS (SELECT 1 FROM polygons p WHERE ST_Covers(p.geom, a.location))
+ORDER BY last_different DESC
+LIMIT $5`
+
+// RecentNearZones returns up to limit most-recently-changed applications
+// (last_different DESC, mirroring RecentInAuthorities' ordering) whose
+// location falls within any of zones: a circle zone via ST_DWithin against
+// its centre and radius, a custom-shape zone via ST_Covers against its
+// polygon -- deduplicated, so an application inside more than one zone is
+// returned once. It backs the dev-seed job's prod read (bd tc-9nbs4.1,
+// GH#1076 Phase 1): dev's watch zones no longer need a "home" authority to
+// scope the read, since notification matching is purely geographic (ADR
+// 0041/0044).
+//
+// A nil or empty zones is a normal no-op -- mirroring RecentInAuthorities'
+// nil/empty authorityIDs handling -- and returns an empty slice with no query
+// executed and no error.
+func (s *PostgresStore) RecentNearZones(ctx context.Context, zones []ZoneGeometry, limit int) ([]PlanningApplication, error) {
+	if len(zones) == 0 {
+		return []PlanningApplication{}, nil
+	}
+
+	lngs := make([]float64, 0, len(zones))
+	lats := make([]float64, 0, len(zones))
+	radii := make([]float64, 0, len(zones))
+	polygonsGeoJSON := make([]string, 0, len(zones))
+	for _, z := range zones {
+		if !z.isCustomShape() {
+			lngs = append(lngs, z.Longitude)
+			lats = append(lats, z.Latitude)
+			radii = append(radii, z.RadiusMetres)
+			continue
+		}
+		g, err := encodeBoundaryGeoJSON(z.Boundary)
+		if err != nil {
+			return nil, fmt.Errorf("encode zone boundary geojson: %w", err)
+		}
+		polygonsGeoJSON = append(polygonsGeoJSON, g)
+	}
+
+	rows, err := s.db.Query(ctx, pgRecentNearZonesQuery, lngs, lats, radii, polygonsGeoJSON, limit)
+	if err != nil {
+		return nil, fmt.Errorf("recent applications near %d zones: %w", len(zones), err)
+	}
+	apps, err := pgx.CollectRows(rows, scanAppRow)
+	if err != nil {
+		return nil, fmt.Errorf("recent applications near %d zones: %w", len(zones), err)
+	}
+	return apps, nil
+}

--- a/api-go/internal/applications/store_postgres_test.go
+++ b/api-go/internal/applications/store_postgres_test.go
@@ -664,6 +664,155 @@ func TestPostgresStore_RecentInAuthorities(t *testing.T) {
 	}
 }
 
+// TestPostgresStore_RecentNearZones_CircleZone proves the circle branch: an app
+// inside the zone's radius matches, one outside does not (bd tc-9nbs4.1,
+// GH#1076 Phase 1 -- RecentInAuthorities' geometry-scoped replacement).
+func TestPostgresStore_RecentNearZones_CircleZone(t *testing.T) {
+	ctx := context.Background()
+	store := newAppPGStore(t)
+
+	zone := ZoneGeometry{Latitude: pgCentreLat, Longitude: pgCentreLon, RadiusMetres: 1000}
+
+	inside := at(pgApp("INSIDE", 100), 500)
+	outside := at(pgApp("OUTSIDE", 100), 5000)
+	for _, a := range []PlanningApplication{inside, outside} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	got, err := store.RecentNearZones(ctx, []ZoneGeometry{zone}, 10)
+	if err != nil {
+		t.Fatalf("RecentNearZones: %v", err)
+	}
+	assertNames(t, appNames(got), []string{"INSIDE"})
+}
+
+// TestPostgresStore_RecentNearZones_PolygonZone proves the polygon branch: an
+// app inside the zone's boundary matches (via ST_Covers, mirroring
+// FindInBoundaryPage), one outside does not.
+func TestPostgresStore_RecentNearZones_PolygonZone(t *testing.T) {
+	ctx := context.Background()
+	store := newAppPGStore(t)
+
+	zone := ZoneGeometry{Boundary: squareBoundary(0.005)}
+
+	inside := pgApp("INSIDE", 100)
+	inside.Longitude = pgPtr(pgCentreLon + 0.001)
+	inside.Latitude = pgPtr(pgCentreLat + 0.001)
+
+	outside := pgApp("OUTSIDE", 100)
+	outside.Longitude = pgPtr(pgCentreLon + 0.02)
+	outside.Latitude = pgPtr(pgCentreLat + 0.02)
+
+	for _, a := range []PlanningApplication{inside, outside} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	got, err := store.RecentNearZones(ctx, []ZoneGeometry{zone}, 10)
+	if err != nil {
+		t.Fatalf("RecentNearZones: %v", err)
+	}
+	assertNames(t, appNames(got), []string{"INSIDE"})
+}
+
+// TestPostgresStore_RecentNearZones_OrdersByLastDifferentDescAndRespectsLimit
+// mirrors TestPostgresStore_RecentInAuthorities' ordering/limit proof, scoped
+// by geometry instead of authority id.
+func TestPostgresStore_RecentNearZones_OrdersByLastDifferentDescAndRespectsLimit(t *testing.T) {
+	ctx := context.Background()
+	store := newAppPGStore(t)
+
+	zone := ZoneGeometry{Latitude: pgCentreLat, Longitude: pgCentreLon, RadiusMetres: 5000}
+
+	older := at(pgApp("OLD", 100), 100)
+	older.LastDifferent = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	mid := at(pgApp("MID", 100), 200)
+	mid.LastDifferent = time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	newer := at(pgApp("NEW", 100), 300)
+	newer.LastDifferent = time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	outside := at(pgApp("OUTSIDE", 100), 50000) // outside the 5000m zone; must never appear
+	outside.LastDifferent = time.Date(2026, 12, 1, 0, 0, 0, 0, time.UTC)
+
+	for _, a := range []PlanningApplication{older, mid, newer, outside} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	got, err := store.RecentNearZones(ctx, []ZoneGeometry{zone}, 10)
+	if err != nil {
+		t.Fatalf("RecentNearZones: %v", err)
+	}
+	assertNames(t, appNames(got), []string{"NEW", "MID", "OLD"})
+
+	capped, err := store.RecentNearZones(ctx, []ZoneGeometry{zone}, 2)
+	if err != nil {
+		t.Fatalf("RecentNearZones capped: %v", err)
+	}
+	assertNames(t, appNames(capped), []string{"NEW", "MID"})
+}
+
+// TestPostgresStore_RecentNearZones_DedupsAcrossOverlappingZones proves an
+// application matched by more than one zone (here a circle and a polygon that
+// both cover it) is returned exactly once -- the EXISTS/OR shape, not a JOIN
+// that would multiply rows.
+func TestPostgresStore_RecentNearZones_DedupsAcrossOverlappingZones(t *testing.T) {
+	ctx := context.Background()
+	store := newAppPGStore(t)
+
+	circle := ZoneGeometry{Latitude: pgCentreLat, Longitude: pgCentreLon, RadiusMetres: 1000}
+	// A ~5.5km half-side square comfortably covers the whole circle too, with a
+	// large safety margin against geodesic-vs-planar rounding.
+	hugePolygon := ZoneGeometry{Boundary: squareBoundary(0.05)}
+
+	inBoth := at(pgApp("IN-BOTH", 100), 500)
+	farOutside := at(pgApp("FAR-OUTSIDE", 100), 20000)
+	for _, a := range []PlanningApplication{inBoth, farOutside} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	got, err := store.RecentNearZones(ctx, []ZoneGeometry{circle, hugePolygon}, 10)
+	if err != nil {
+		t.Fatalf("RecentNearZones: %v", err)
+	}
+	assertNames(t, appNames(got), []string{"IN-BOTH"})
+}
+
+// TestPostgresStore_RecentNearZones_EmptyZones_NoOp mirrors
+// TestPostgresStore_RecentInAuthorities' empty/nil handling: an empty or nil
+// zones list is a normal no-op (a fresh/empty dev environment), not an error,
+// even with a matching application present.
+func TestPostgresStore_RecentNearZones_EmptyZones_NoOp(t *testing.T) {
+	ctx := context.Background()
+	store := newAppPGStore(t)
+
+	if err := store.Upsert(ctx, at(pgApp("ANY", 100), 0)); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	empty, err := store.RecentNearZones(ctx, []ZoneGeometry{}, 10)
+	if err != nil {
+		t.Fatalf("RecentNearZones empty zones: %v", err)
+	}
+	if len(empty) != 0 {
+		t.Errorf("RecentNearZones empty zones: got %d rows, want 0", len(empty))
+	}
+
+	var nilZones []ZoneGeometry
+	nilResult, err := store.RecentNearZones(ctx, nilZones, 10)
+	if err != nil {
+		t.Fatalf("RecentNearZones nil zones: %v", err)
+	}
+	if len(nilResult) != 0 {
+		t.Errorf("RecentNearZones nil zones: got %d rows, want 0", len(nilResult))
+	}
+}
+
 // TestPostgresStore_BreakdownByAuthority returns exact per-app_state counts
 // including the NULL-app_state bucket, sorted by sortStateCounts, scoped to the
 // authority and summing to the true total.

--- a/api-go/internal/devseed/seeder.go
+++ b/api-go/internal/devseed/seeder.go
@@ -12,19 +12,23 @@ import (
 
 	"github.com/AmyDe/town-crier/api-go/internal/applications"
 	"github.com/AmyDe/town-crier/api-go/internal/polling"
+	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
 )
 
-// authorityLister lists the distinct authority ids dev currently has watch
-// zones in. *watchzones.PostgresStore (dev-bound) satisfies it.
-type authorityLister interface {
-	DistinctAuthorityIDs(ctx context.Context) ([]int, error)
+// zoneLister lists every watch zone dev currently has, across every user.
+// *watchzones.PostgresStore (dev-bound) satisfies it. It replaces the
+// authority-scoped authorityLister (bd tc-9nbs4.1, GH#1076 Phase 1): dev's
+// watch zones no longer need a "home" authority to scope the prod read, since
+// notification matching is purely geographic (ADR 0041/0044).
+type zoneLister interface {
+	All(ctx context.Context) ([]watchzones.WatchZone, error)
 }
 
-// prodReader reads the most-recently-changed prod applications scoped to a
-// set of authority ids. *applications.PostgresStore, bound to a read-only
-// prod pool, satisfies it.
+// prodReader reads the most-recently-changed prod applications that fall
+// within a set of watch-zone geometries. *applications.PostgresStore, bound
+// to a read-only prod pool, satisfies it.
 type prodReader interface {
-	RecentInAuthorities(ctx context.Context, authorityIDs []int, limit int) ([]applications.PlanningApplication, error)
+	RecentNearZones(ctx context.Context, zones []applications.ZoneGeometry, limit int) ([]applications.PlanningApplication, error)
 }
 
 // pushFlusher drives the poll-cycle push coalescer's lifecycle, the same
@@ -36,11 +40,11 @@ type pushFlusher interface {
 	Flush(ctx context.Context) error
 }
 
-// Seeder runs one dev-seed cycle: read dev's watched authorities, pull the
-// most-recently-changed prod applications within them, and feed each through
-// the real ingest pipeline.
+// Seeder runs one dev-seed cycle: read dev's watch zones, pull the
+// most-recently-changed prod applications that fall within any of them, and
+// feed each through the real ingest pipeline.
 type Seeder struct {
-	zones    authorityLister
+	zones    zoneLister
 	prodApps prodReader
 	ingester *polling.Ingester
 	push     pushFlusher
@@ -49,7 +53,7 @@ type Seeder struct {
 }
 
 // NewSeeder wires a Seeder.
-func NewSeeder(zones authorityLister, prodApps prodReader, ingester *polling.Ingester, push pushFlusher, limit int, logger *slog.Logger) *Seeder {
+func NewSeeder(zones zoneLister, prodApps prodReader, ingester *polling.Ingester, push pushFlusher, limit int, logger *slog.Logger) *Seeder {
 	return &Seeder{
 		zones:    zones,
 		prodApps: prodApps,
@@ -65,16 +69,21 @@ func NewSeeder(zones authorityLister, prodApps prodReader, ingester *polling.Ing
 // not an error: it is logged at info level and returns (0, nil) without
 // touching the prod reader or the push coalescer.
 func (s *Seeder) Run(ctx context.Context) (int, error) {
-	authorityIDs, err := s.zones.DistinctAuthorityIDs(ctx)
+	watchZones, err := s.zones.All(ctx)
 	if err != nil {
 		return 0, err
 	}
-	if len(authorityIDs) == 0 {
-		s.logger.InfoContext(ctx, "dev-seed: no watched authorities, skipping cycle")
+	if len(watchZones) == 0 {
+		s.logger.InfoContext(ctx, "dev-seed: no watch zones, skipping cycle")
 		return 0, nil
 	}
 
-	apps, err := s.prodApps.RecentInAuthorities(ctx, authorityIDs, s.limit)
+	geometries := make([]applications.ZoneGeometry, len(watchZones))
+	for i, z := range watchZones {
+		geometries[i] = zoneGeometryOf(z)
+	}
+
+	apps, err := s.prodApps.RecentNearZones(ctx, geometries, s.limit)
 	if err != nil {
 		return 0, err
 	}
@@ -98,4 +107,25 @@ func (s *Seeder) Run(ctx context.Context) (int, error) {
 	}
 
 	return count, nil
+}
+
+// zoneGeometryOf maps a watch zone's shape into applications.ZoneGeometry.
+// applications cannot import watchzones (which already imports applications,
+// see applications.Coordinate's doc), so this mapping lives on the devseed
+// side, which imports both. A custom-shape zone (non-empty Boundary) carries
+// its own polygon ring; a circle zone carries its centre and radius with an
+// empty Boundary — mirroring watchzones.WatchZone.IsCustomShape.
+func zoneGeometryOf(z watchzones.WatchZone) applications.ZoneGeometry {
+	g := applications.ZoneGeometry{
+		Latitude:     z.Latitude,
+		Longitude:    z.Longitude,
+		RadiusMetres: z.RadiusMetres,
+	}
+	if z.IsCustomShape() {
+		g.Boundary = make([]applications.Coordinate, len(z.Boundary))
+		for i, v := range z.Boundary {
+			g.Boundary[i] = applications.Coordinate{Longitude: v.Longitude, Latitude: v.Latitude}
+		}
+	}
+	return g
 }

--- a/api-go/internal/devseed/seeder_test.go
+++ b/api-go/internal/devseed/seeder_test.go
@@ -58,6 +58,48 @@ func testZone(t *testing.T, id string, lat, lon, radius float64) watchzones.Watc
 	return z
 }
 
+// TestZoneGeometryOf_CustomShape exercises zoneGeometryOf's polygon branch
+// directly, using a real WithBoundary zone rather than a circle -- PR #1077
+// review feedback: the only prior coverage of a custom-shape ZoneGeometry was
+// at the applications.RecentNearZones store level, via a directly-constructed
+// ZoneGeometry that bypasses this exact translation, so a regression here
+// (e.g. a swapped Longitude/Latitude field, or a boundary-shaped zone losing
+// its ring) would have slipped through both suites.
+func TestZoneGeometryOf_CustomShape(t *testing.T) {
+	t.Parallel()
+
+	base := testZone(t, "z1", 51.5, -0.12, 500)
+	polygon, err := base.WithBoundary([]watchzones.Coordinate{
+		{Longitude: -0.130, Latitude: 51.510},
+		{Longitude: -0.110, Latitude: 51.510},
+		{Longitude: -0.110, Latitude: 51.490},
+	})
+	if err != nil {
+		t.Fatalf("WithBoundary: %v", err)
+	}
+	if !polygon.IsCustomShape() {
+		t.Fatal("test setup: WithBoundary must produce a custom-shape zone")
+	}
+
+	got := zoneGeometryOf(polygon)
+
+	if len(got.Boundary) != len(polygon.Boundary) {
+		t.Fatalf("zoneGeometryOf Boundary length = %d, want %d (source ring, closed by NewBoundary)",
+			len(got.Boundary), len(polygon.Boundary))
+	}
+	for i, v := range polygon.Boundary {
+		want := applications.Coordinate{Longitude: v.Longitude, Latitude: v.Latitude}
+		if got.Boundary[i] != want {
+			t.Fatalf("zoneGeometryOf Boundary[%d] = %+v, want %+v (Longitude/Latitude must not be swapped)",
+				i, got.Boundary[i], want)
+		}
+	}
+	if got.Latitude != polygon.Latitude || got.Longitude != polygon.Longitude || got.RadiusMetres != polygon.RadiusMetres {
+		t.Fatalf("zoneGeometryOf circle-fallback fields = {%v,%v,%v}, want {%v,%v,%v} (still populated from the derived centroid/enclosing radius, even for a custom-shape zone)",
+			got.Latitude, got.Longitude, got.RadiusMetres, polygon.Latitude, polygon.Longitude, polygon.RadiusMetres)
+	}
+}
+
 // fakePushFlusher is a hand-written fake for pushFlusher.
 type fakePushFlusher struct {
 	resetCalls int

--- a/api-go/internal/devseed/seeder_test.go
+++ b/api-go/internal/devseed/seeder_test.go
@@ -10,19 +10,21 @@ import (
 	"reflect"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/AmyDe/town-crier/api-go/internal/applications"
 	"github.com/AmyDe/town-crier/api-go/internal/polling"
+	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
 )
 
-// fakeAuthorityLister is a hand-written fake for authorityLister.
-type fakeAuthorityLister struct {
-	ids []int
-	err error
+// fakeZoneLister is a hand-written fake for zoneLister.
+type fakeZoneLister struct {
+	zones []watchzones.WatchZone
+	err   error
 }
 
-func (f *fakeAuthorityLister) DistinctAuthorityIDs(ctx context.Context) ([]int, error) {
-	return f.ids, f.err
+func (f *fakeZoneLister) All(ctx context.Context) ([]watchzones.WatchZone, error) {
+	return f.zones, f.err
 }
 
 // fakeProdReader is a hand-written fake for prodReader.
@@ -30,16 +32,30 @@ type fakeProdReader struct {
 	apps []applications.PlanningApplication
 	err  error
 
-	calls           int
-	gotAuthorityIDs []int
-	gotLimit        int
+	calls    int
+	gotZones []applications.ZoneGeometry
+	gotLimit int
 }
 
-func (f *fakeProdReader) RecentInAuthorities(ctx context.Context, authorityIDs []int, limit int) ([]applications.PlanningApplication, error) {
+func (f *fakeProdReader) RecentNearZones(ctx context.Context, zones []applications.ZoneGeometry, limit int) ([]applications.PlanningApplication, error) {
 	f.calls++
-	f.gotAuthorityIDs = authorityIDs
+	f.gotZones = zones
 	f.gotLimit = limit
 	return f.apps, f.err
+}
+
+// testZone builds a validated watch zone at the given coordinates. authorityID
+// is arbitrary and fixed at 1 -- devseed no longer reads it, but
+// watchzones.NewWatchZone still requires it positive (that invariant is out
+// of this bead's scope; see tc-9nbs4.2).
+func testZone(t *testing.T, id string, lat, lon, radius float64) watchzones.WatchZone {
+	t.Helper()
+	z, err := watchzones.NewWatchZone(id, "user-1", "zone-"+id, lat, lon, radius, 1,
+		time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC), true, false)
+	if err != nil {
+		t.Fatalf("NewWatchZone(%s): %v", id, err)
+	}
+	return z
 }
 
 // fakePushFlusher is a hand-written fake for pushFlusher.
@@ -134,7 +150,7 @@ func testApp(uid string, areaID int, description string) applications.PlanningAp
 func TestSeeder_Run_NoWatchZones_NoOp(t *testing.T) {
 	t.Parallel()
 
-	zones := &fakeAuthorityLister{ids: nil}
+	zones := &fakeZoneLister{zones: nil}
 	prod := &fakeProdReader{}
 	push := &fakePushFlusher{}
 	ingester := polling.NewIngester(&fakeAppStore{}, &fakeDecisionDispatcher{}, &fakeEnqueuer{})
@@ -150,7 +166,7 @@ func TestSeeder_Run_NoWatchZones_NoOp(t *testing.T) {
 		t.Fatalf("Run() count = %d, want 0", count)
 	}
 	if prod.calls != 0 {
-		t.Fatalf("RecentInAuthorities called %d times, want 0 (no-op before reaching prod)", prod.calls)
+		t.Fatalf("RecentNearZones called %d times, want 0 (no-op before reaching prod)", prod.calls)
 	}
 	if push.resetCalls != 0 || push.flushCalls != 0 {
 		t.Fatalf("push Reset/Flush = %d/%d, want 0/0 (no-op returns before touching push)", push.resetCalls, push.flushCalls)
@@ -161,7 +177,7 @@ func TestSeeder_Run_ZonesListerError(t *testing.T) {
 	t.Parallel()
 
 	wantErr := errors.New("zones down")
-	zones := &fakeAuthorityLister{err: wantErr}
+	zones := &fakeZoneLister{err: wantErr}
 	prod := &fakeProdReader{}
 	push := &fakePushFlusher{}
 	ingester := polling.NewIngester(&fakeAppStore{}, &fakeDecisionDispatcher{}, &fakeEnqueuer{})
@@ -177,7 +193,7 @@ func TestSeeder_Run_ZonesListerError(t *testing.T) {
 		t.Fatalf("Run() count = %d, want 0", count)
 	}
 	if prod.calls != 0 {
-		t.Fatalf("RecentInAuthorities called %d times, want 0", prod.calls)
+		t.Fatalf("RecentNearZones called %d times, want 0", prod.calls)
 	}
 	if push.resetCalls != 0 || push.flushCalls != 0 {
 		t.Fatalf("push Reset/Flush = %d/%d, want 0/0", push.resetCalls, push.flushCalls)
@@ -188,7 +204,7 @@ func TestSeeder_Run_ProdReaderError(t *testing.T) {
 	t.Parallel()
 
 	wantErr := errors.New("prod down")
-	zones := &fakeAuthorityLister{ids: []int{100}}
+	zones := &fakeZoneLister{zones: []watchzones.WatchZone{testZone(t, "z1", 51.5, -0.12, 500)}}
 	prod := &fakeProdReader{err: wantErr}
 	push := &fakePushFlusher{}
 	ingester := polling.NewIngester(&fakeAppStore{}, &fakeDecisionDispatcher{}, &fakeEnqueuer{})
@@ -211,7 +227,7 @@ func TestSeeder_Run_ProdReaderError(t *testing.T) {
 func TestSeeder_Run_ZeroAppsReturned_StillFlushesOnce(t *testing.T) {
 	t.Parallel()
 
-	zones := &fakeAuthorityLister{ids: []int{100}}
+	zones := &fakeZoneLister{zones: []watchzones.WatchZone{testZone(t, "z1", 51.5, -0.12, 500)}}
 	prod := &fakeProdReader{apps: nil}
 	push := &fakePushFlusher{}
 	ingester := polling.NewIngester(&fakeAppStore{}, &fakeDecisionDispatcher{}, &fakeEnqueuer{})
@@ -227,7 +243,7 @@ func TestSeeder_Run_ZeroAppsReturned_StillFlushesOnce(t *testing.T) {
 		t.Fatalf("Run() count = %d, want 0", count)
 	}
 	if push.resetCalls != 1 || push.flushCalls != 1 {
-		t.Fatalf("push Reset/Flush = %d/%d, want 1/1 (non-zero authorities still flush, even with zero candidates)", push.resetCalls, push.flushCalls)
+		t.Fatalf("push Reset/Flush = %d/%d, want 1/1 (non-zero zones still flush, even with zero candidates)", push.resetCalls, push.flushCalls)
 	}
 }
 
@@ -249,7 +265,9 @@ func TestSeeder_Run_HappyPath_MixOfNewUnchangedChanged(t *testing.T) {
 	decision := &fakeDecisionDispatcher{}
 	ingester := polling.NewIngester(appStore, decision, enqueuer)
 
-	zones := &fakeAuthorityLister{ids: []int{100, 200}}
+	zone1 := testZone(t, "z1", 51.5, -0.12, 500)
+	zone2 := testZone(t, "z2", 52.2, -1.3, 750)
+	zones := &fakeZoneLister{zones: []watchzones.WatchZone{zone1, zone2}}
 	prod := &fakeProdReader{apps: []applications.PlanningApplication{unchanged, newApp, changedNew}}
 	push := &fakePushFlusher{}
 
@@ -263,11 +281,12 @@ func TestSeeder_Run_HappyPath_MixOfNewUnchangedChanged(t *testing.T) {
 	if count != 3 {
 		t.Fatalf("Run() count = %d, want 3 (all three processed without error)", count)
 	}
-	if got, want := prod.gotAuthorityIDs, []int{100, 200}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("RecentInAuthorities authorityIDs = %v, want %v", got, want)
+	wantGeometries := []applications.ZoneGeometry{zoneGeometryOf(zone1), zoneGeometryOf(zone2)}
+	if got := prod.gotZones; !reflect.DeepEqual(got, wantGeometries) {
+		t.Fatalf("RecentNearZones zones = %+v, want %+v", got, wantGeometries)
 	}
 	if prod.gotLimit != 5 {
-		t.Fatalf("RecentInAuthorities limit = %d, want 5", prod.gotLimit)
+		t.Fatalf("RecentNearZones limit = %d, want 5", prod.gotLimit)
 	}
 	if push.resetCalls != 1 || push.flushCalls != 1 {
 		t.Fatalf("push Reset/Flush = %d/%d, want 1/1", push.resetCalls, push.flushCalls)
@@ -298,7 +317,7 @@ func TestSeeder_Run_IngestErrorDoesNotAbortBatch(t *testing.T) {
 	enqueuer := &fakeEnqueuer{}
 	ingester := polling.NewIngester(appStore, &fakeDecisionDispatcher{}, enqueuer)
 
-	zones := &fakeAuthorityLister{ids: []int{100}}
+	zones := &fakeZoneLister{zones: []watchzones.WatchZone{testZone(t, "z1", 51.5, -0.12, 500)}}
 	prod := &fakeProdReader{apps: []applications.PlanningApplication{ok1, failing, ok2}}
 	push := &fakePushFlusher{}
 
@@ -323,7 +342,7 @@ func TestSeeder_Run_IngestErrorDoesNotAbortBatch(t *testing.T) {
 func TestSeeder_Run_FlushErrorIsSwallowed(t *testing.T) {
 	t.Parallel()
 
-	zones := &fakeAuthorityLister{ids: []int{100}}
+	zones := &fakeZoneLister{zones: []watchzones.WatchZone{testZone(t, "z1", 51.5, -0.12, 500)}}
 	prod := &fakeProdReader{apps: []applications.PlanningApplication{testApp("a1", 100, "d")}}
 	push := &fakePushFlusher{flushErr: errors.New("push down")}
 	ingester := polling.NewIngester(&fakeAppStore{}, &fakeDecisionDispatcher{}, &fakeEnqueuer{})

--- a/api-go/internal/watchzones/store_postgres.go
+++ b/api-go/internal/watchzones/store_postgres.go
@@ -32,6 +32,7 @@ type Store interface {
 	DeleteAllByUserID(ctx context.Context, userID string) error
 	DistinctAuthorityIDs(ctx context.Context) ([]int, error)
 	FindZonesContaining(ctx context.Context, latitude, longitude float64) ([]WatchZone, error)
+	All(ctx context.Context) ([]WatchZone, error)
 }
 
 // Compile-time check: the store satisfies the consumer-side Store interface.
@@ -289,6 +290,27 @@ func (s *PostgresStore) DistinctAuthorityIDs(ctx context.Context) ([]int, error)
 		return nil, fmt.Errorf("query distinct authority ids: %w", err)
 	}
 	return ids, nil
+}
+
+const pgAllZonesQuery = "SELECT " + pgZoneColumns + " FROM watch_zones ORDER BY id"
+
+// All returns every watch zone across every user, ordered by id for
+// determinism. It backs the dev-seed job's zone-geometry read (bd tc-9nbs4.1,
+// GH#1076 Phase 1): the same "every zone dev currently has" input
+// DistinctAuthorityIDs previously served as a set of authority ids, now served
+// as full zone geometries, so devseed can query prod by geography instead of
+// authority id -- notification matching is purely geographic (ADR 0041/0044),
+// so a watch zone no longer needs a "home" authority to scope the read.
+func (s *PostgresStore) All(ctx context.Context) ([]WatchZone, error) {
+	rows, err := s.db.Query(ctx, pgAllZonesQuery)
+	if err != nil {
+		return nil, fmt.Errorf("query all watch zones: %w", err)
+	}
+	zones, err := pgx.CollectRows(rows, scanZoneRow)
+	if err != nil {
+		return nil, fmt.Errorf("query all watch zones: %w", err)
+	}
+	return zones, nil
 }
 
 const pgFindZonesContainingQuery = "SELECT " + pgZoneColumns +

--- a/api-go/internal/watchzones/store_postgres_test.go
+++ b/api-go/internal/watchzones/store_postgres_test.go
@@ -208,6 +208,45 @@ func TestWatchZonePostgresStore_GetByUserID_OrderedAndScoped(t *testing.T) {
 	assertStrings(t, zoneNames(list), []string{"first", "second", "third"})
 }
 
+// TestWatchZonePostgresStore_All returns every zone across every user, ordered
+// by id — the dev-seed job's "every zone dev currently has" read (bd
+// tc-9nbs4.1, GH#1076), replacing the authority-scoped DistinctAuthorityIDs.
+func TestWatchZonePostgresStore_All(t *testing.T) {
+	ctx := context.Background()
+	store := newZonePGStore(t)
+
+	for _, z := range []WatchZone{
+		pgZone(t, uuidN(2), "user-1", "second", 51.5, -0.12, 500, 10),
+		pgZone(t, uuidN(1), "user-1", "first", 51.5, -0.12, 500, 10),
+		pgZone(t, uuidN(3), "user-2", "third", 51.6, -0.13, 750, 20),
+	} {
+		if err := store.Save(ctx, z); err != nil {
+			t.Fatalf("Save %s: %v", z.Name, err)
+		}
+	}
+
+	all, err := store.All(ctx)
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	assertStrings(t, zoneNames(all), []string{"first", "second", "third"})
+}
+
+// TestWatchZonePostgresStore_All_Empty returns an empty slice, not an error,
+// when no watch zones exist -- the fresh/empty dev environment case.
+func TestWatchZonePostgresStore_All_Empty(t *testing.T) {
+	ctx := context.Background()
+	store := newZonePGStore(t)
+
+	all, err := store.All(ctx)
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	if len(all) != 0 {
+		t.Fatalf("All on empty table: got %d zones, want 0", len(all))
+	}
+}
+
 // TestWatchZonePostgresStore_Delete removes a zone; a miss returns ErrNotFound.
 func TestWatchZonePostgresStore_Delete(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Phase 1, one slice, of GH#1076 (drop `watch_zones.authority_id`): re-points `devseed.Seeder` — the dev-only job that pulls recent prod applications into dev for realistic local testing — at a geometry-scoped prod query instead of an authority-id-scoped one. This is the one real remaining consumer of `authority_id` identified in #1076's research, and unblocks a later bead (tc-9nbs4.2) removing `authority_id` from the watch-zone core entirely.

- `watchzones.PostgresStore.All` — new store method returning every watch zone across every user (replaces `DistinctAuthorityIDs` as devseed's "what does dev currently watch" input). `DistinctAuthorityIDs` itself is left untouched — its removal is tc-9nbs4.2's job, not this PR's.
- `applications.PostgresStore.RecentNearZones` — new method, geometry-scoped replacement for `RecentInAuthorities`: returns the most-recently-changed applications whose location falls within any of a set of zone geometries (circle via `ST_DWithin`, polygon via `ST_Covers`), deduplicated across overlapping zones. Reuses the OR-of-circle-or-polygon shape `watchzones.FindZonesContaining` already uses, applied the other way around (N zones against every application, via `unnest()`-built CTEs + `EXISTS`, mirroring the existing `pgRecentNearestTownQuery` idiom in the same file).
- `devseed.Seeder` — now reads `zoneLister.All()` and maps each `watchzones.WatchZone` to the new `applications.ZoneGeometry` type before calling `prodReader.RecentNearZones`. (`applications` can't import `watchzones`, which already imports `applications` — so the mapping lives on the devseed side, which imports both.)

## Scope

Deliberately narrow — only the devseed data source changes. Untouched: `nearby.go`, `handler.go`, `zone.go`'s `AuthorityID` field, `document.go`, `geocoding/authority.go`, `applicationauthorities.go`, web/iOS, the `watch_zones.authority_id` column/migration. Those are separate sibling beads in the same epic (tc-9nbs4.2 – .5).

## Test plan

- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./...` and `go test -race ./...` green
- [x] `go build -tags=integration ./...` / `go vet -tags=integration ./...` clean
- [ ] Real-DB integration suite (`make test-integration`) for the new `watchzones.All` / `applications.RecentNearZones` tests — Docker wasn't available in this session (no daemon), so these compiled and confirmed to skip cleanly locally but weren't run against real Postgres+PostGIS. The PR gate runs this suite in CI.
- `golangci-lint` didn't run locally due to a pre-existing go1.25/go1.26 toolchain mismatch in this environment, unrelated to this change; CI's lint step is authoritative.

Refs: bd tc-9nbs4.1, [GH#1076](https://github.com/AmyDe/town-crier/issues/1076)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VMmYP35krjysTyrE2fSCdi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for finding recent planning applications near watch zones.
  - Supports circular and custom polygon boundaries.
  - Results exclude duplicates, prioritize recent changes, and respect result limits.
  - Added the ability to retrieve all configured watch zones.

- **Enhancements**
  - Development data seeding now uses watch-zone geography to find nearby applications.
  - Handles empty zone lists without unnecessary processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->