### PR TITLE
fix(api): restore authorityId in watch-zone response for back-compat (tc-9nbs4.6)

### DIFF
--- a/api-go/internal/watchzones/handler.go
+++ b/api-go/internal/watchzones/handler.go
@@ -166,13 +166,16 @@ func Routes(mux *http.ServeMux, store zoneStore, logger *slog.Logger, opts ...Op
 
 // watchZoneSummary is the per-zone wire shape returned by list and update.
 // createdAt is deliberately absent from the summary. Paused is additive
-// (GH#889): a derived, never-stored flag — see pausedIDs.
+// (GH#889): a derived, never-stored flag — see pausedIDs. AuthorityID is a
+// wire-format-only back-compat shim (tc-9nbs4.6): the domain no longer has
+// an authority id, but the field must stay present for older clients.
 type watchZoneSummary struct {
 	ID                  string  `json:"id"`
 	Name                string  `json:"name"`
 	Latitude            float64 `json:"latitude"`
 	Longitude           float64 `json:"longitude"`
 	RadiusMetres        float64 `json:"radiusMetres"`
+	AuthorityID         int     `json:"authorityId"`
 	PushEnabled         bool    `json:"pushEnabled"`
 	EmailInstantEnabled bool    `json:"emailInstantEnabled"`
 	Paused              bool    `json:"paused"`
@@ -185,11 +188,16 @@ type watchZoneSummary struct {
 
 func summaryOf(z WatchZone, paused bool) watchZoneSummary {
 	return watchZoneSummary{
-		ID:                  z.ID,
-		Name:                z.Name,
-		Latitude:            z.Latitude,
-		Longitude:           z.Longitude,
-		RadiusMetres:        z.RadiusMetres,
+		ID:           z.ID,
+		Name:         z.Name,
+		Latitude:     z.Latitude,
+		Longitude:    z.Longitude,
+		RadiusMetres: z.RadiusMetres,
+		// AuthorityID is hardcoded to 0, not resolved from z: it's a
+		// wire-format-only back-compat shim for the pre-tc-9nbs4.4 shipped
+		// iOS client's strict decode. No client reads the value — see
+		// bead tc-9nbs4.6 / GH#1076.
+		AuthorityID:         0,
 		PushEnabled:         z.PushEnabled,
 		EmailInstantEnabled: z.EmailInstantEnabled,
 		Paused:              paused,

--- a/api-go/internal/watchzones/handler_test.go
+++ b/api-go/internal/watchzones/handler_test.go
@@ -185,9 +185,18 @@ func TestHandler_Patch_UpdatesAndReturnsZone(t *testing.T) {
 	if got.Zone.Latitude != z.Latitude {
 		t.Errorf("unset fields changed: %+v", got.Zone)
 	}
-	// Back-compat shim (tc-9nbs4.6): authorityId is always present and 0.
-	if got.Zone.AuthorityID != 0 {
-		t.Errorf("authorityId: got %d, want 0", got.Zone.AuthorityID)
+	// Back-compat shim (tc-9nbs4.6): authorityId must be present on the wire,
+	// not just zero-valued after decode (absence also decodes as 0).
+	var raw struct {
+		Zone map[string]json.RawMessage `json:"zone"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode raw: %v", err)
+	}
+	authorityRaw, ok := raw.Zone["authorityId"]
+	var authorityID int
+	if !ok || json.Unmarshal(authorityRaw, &authorityID) != nil || authorityID != 0 {
+		t.Errorf("authorityId: got %s, want 0", authorityRaw)
 	}
 }
 
@@ -228,6 +237,19 @@ func TestHandler_Patch_UpdatesEveryMappedField(t *testing.T) {
 	}
 	if got.Zone != want {
 		t.Errorf("response zone: got %+v, want %+v", got.Zone, want)
+	}
+	// Back-compat shim (tc-9nbs4.6): authorityId must be present on the wire,
+	// not just zero-valued after decode (absence also decodes as 0).
+	var raw struct {
+		Zone map[string]json.RawMessage `json:"zone"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode raw: %v", err)
+	}
+	authorityRaw, ok := raw.Zone["authorityId"]
+	var authorityID int
+	if !ok || json.Unmarshal(authorityRaw, &authorityID) != nil || authorityID != 0 {
+		t.Errorf("authorityId: got %s, want 0", authorityRaw)
 	}
 	if store.saved == nil {
 		t.Fatal("zone not persisted")
@@ -611,7 +633,7 @@ func TestHandler_List_MarksPausedZonesOverEffectiveTierLimit(t *testing.T) {
 			}
 		}
 		// authorityId is a back-compat shim (tc-9nbs4.6): always present, always 0.
-		if authorityID, _ := obj["authorityId"].(float64); authorityID != 0 {
+		if authorityID, ok := obj["authorityId"].(float64); !ok || authorityID != 0 {
 			t.Errorf("zone %d: authorityId = %v, want 0", i, obj["authorityId"])
 		}
 	}

--- a/api-go/internal/watchzones/handler_test.go
+++ b/api-go/internal/watchzones/handler_test.go
@@ -143,7 +143,7 @@ func TestHandler_List(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if len(got.Zones) != 1 || got.Zones[0].ID != z.ID {
+	if len(got.Zones) != 1 || got.Zones[0].ID != z.ID || got.Zones[0].AuthorityID != 0 {
 		t.Errorf("zones: got %+v", got.Zones)
 	}
 }
@@ -185,6 +185,10 @@ func TestHandler_Patch_UpdatesAndReturnsZone(t *testing.T) {
 	if got.Zone.Latitude != z.Latitude {
 		t.Errorf("unset fields changed: %+v", got.Zone)
 	}
+	// Back-compat shim (tc-9nbs4.6): authorityId is always present and 0.
+	if got.Zone.AuthorityID != 0 {
+		t.Errorf("authorityId: got %d, want 0", got.Zone.AuthorityID)
+	}
 }
 
 func TestHandler_Patch_UpdatesEveryMappedField(t *testing.T) {
@@ -211,11 +215,13 @@ func TestHandler_Patch_UpdatesEveryMappedField(t *testing.T) {
 		t.Fatalf("decode: %v", err)
 	}
 	want := watchZoneSummary{
-		ID:                  z.ID,
-		Name:                "Renamed Office",
-		Latitude:            52.4862,
-		Longitude:           -1.8904,
-		RadiusMetres:        3000,
+		ID:           z.ID,
+		Name:         "Renamed Office",
+		Latitude:     52.4862,
+		Longitude:    -1.8904,
+		RadiusMetres: 3000,
+		// Back-compat shim (tc-9nbs4.6): always 0, never resolved.
+		AuthorityID:         0,
 		PushEnabled:         false,
 		EmailInstantEnabled: false,
 		Paused:              got.Zone.Paused,
@@ -594,7 +600,7 @@ func TestHandler_List_MarksPausedZonesOverEffectiveTierLimit(t *testing.T) {
 	if len(raw.Zones) != 3 {
 		t.Fatalf("zones: got %d, want 3", len(raw.Zones))
 	}
-	wantKeys := []string{"id", "name", "latitude", "longitude", "radiusMetres", "pushEnabled", "emailInstantEnabled", "paused", "boundary"}
+	wantKeys := []string{"id", "name", "latitude", "longitude", "radiusMetres", "authorityId", "pushEnabled", "emailInstantEnabled", "paused", "boundary"}
 	for i, obj := range raw.Zones {
 		if len(obj) != len(wantKeys) {
 			t.Errorf("zone %d: got %d keys %v, want %d keys %v", i, len(obj), keysOf(obj), len(wantKeys), wantKeys)
@@ -603,6 +609,10 @@ func TestHandler_List_MarksPausedZonesOverEffectiveTierLimit(t *testing.T) {
 			if _, ok := obj[k]; !ok {
 				t.Errorf("zone %d: missing pre-existing/expected key %q", i, k)
 			}
+		}
+		// authorityId is a back-compat shim (tc-9nbs4.6): always present, always 0.
+		if authorityID, _ := obj["authorityId"].(float64); authorityID != 0 {
+			t.Errorf("zone %d: authorityId = %v, want 0", i, obj["authorityId"])
 		}
 	}
 


### PR DESCRIPTION
## Summary

PR #1080 (tc-9nbs4.2) dropped `authorityId` from the `watchZoneSummary` wire shape returned by `GET /v1/me/watch-zones` (list) and `PATCH /v1/me/watch-zones/{zoneId}` (update).

The currently-shipped iOS app (`MARKETING_VERSION` 1.2.10, commit `8c55b4e15` — live on the App Store today) does a **strict, non-optional** decode of that field (`WatchZoneSummaryDTO.init(from:)`, `container.decode(Int.self, forKey: .authorityId)`). With the field absent, `Decodable` throws, the whole zone-list fetch fails, and both the Map and Applications pages go blank for every user on that build. Confirmed via TestFlight-vs-dev testing (see GH#1076 comment, 2026-08-12).

- Re-adds `AuthorityID int` (`json:"authorityId"`) to `watchZoneSummary` in `api-go/internal/watchzones/handler.go`, populated with a hardcoded `0` in `summaryOf` — a wire-format-only back-compat shim, not a resurrection of the domain concept. The `WatchZone` domain struct, Postgres store, and `authority_id` column stay removed exactly as PR #1080 left them.
- Confirmed via git history + the shipped iOS source that `createResult` (the `POST` create response) never carried `authorityId` in its response body even before PR #1080 — only the create *request* had it as an optional input — so no change was needed there.
- Confirmed via `git grep` across the shipped app's presentation/domain layers that `authorityId` is never read anywhere beyond being stored on the domain value object, so the hardcoded `0` is functionally safe for every client.
- Updated the existing handler tests (which PR #1080 had flipped to assert *absence*) to assert the field is present and `0`, rather than deleting coverage.

Permanent removal is tracked separately in GH#1081, gated on bumping the app's `minimumVersion` force-update gate past a release containing tc-9nbs4.4's client-side fix.

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `gofmt -l .` — clean (no output)
- [x] `go test -count=1 ./...` — all packages pass

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01SU1CHr7m4FBAgEDYT3ikeA

---
_Generated by [Claude Code](https://claude.ai/code/session_01SU1CHr7m4FBAgEDYT3ikeA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Watch-zone responses now consistently include the `authorityId` field for compatibility with existing clients.
  * The field is returned with a value of `0` across watch-zone list and update responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->