### PR TITLE
fix: map watch-zone name conflict to 409 instead of 500 (tc-h4y98)

### DIFF
--- a/api-go/internal/watchzones/handler.go
+++ b/api-go/internal/watchzones/handler.go
@@ -50,6 +50,13 @@ const (
 	// the caller's tier cap (profiles.SubscriptionTier.MaxZoneRadiusMetres).
 	boundaryTooLargeCode    = "boundary_too_large"
 	boundaryTooLargeMessage = "The boundary is too large for your subscription tier."
+	// zoneNameTakenCode/-Message: 409, Store.Save returned ErrDuplicateName --
+	// the caller already owns a watch zone with this name (watch_zones' UNIQUE
+	// (user_id, name) constraint). A resource conflict, not a validation
+	// failure, so it sits apart from the 400 boundary_* codes above but uses
+	// the same stable-code convention (GH#1083, tc-h4y98).
+	zoneNameTakenCode    = "zone_name_taken"
+	zoneNameTakenMessage = "You already have a watch zone with this name."
 )
 
 // errProfileReaderNotWired signals a wiring bug: setting a watch-zone boundary
@@ -450,6 +457,10 @@ func (h *handler) patch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.store.Save(r.Context(), updated); err != nil {
+		if errors.Is(err, ErrDuplicateName) {
+			h.writeErrorCode(w, r, http.StatusConflict, zoneNameTakenCode, zoneNameTakenMessage)
+			return
+		}
 		h.serverError(w, r, "save watch zone", err)
 		return
 	}

--- a/api-go/internal/watchzones/handler_test.go
+++ b/api-go/internal/watchzones/handler_test.go
@@ -323,6 +323,29 @@ func TestHandler_Patch_BlankNameIsServerError(t *testing.T) {
 	}
 }
 
+// TestHandler_Patch_DuplicateNameIs409 proves that a Store.Save failure
+// carrying ErrDuplicateName (a unique-violation on watch_zones' UNIQUE
+// (user_id, name) constraint against a different, already-existing row) maps
+// to 409 zone_name_taken rather than falling through to the generic 500
+// (GH#1083, tc-h4y98).
+func TestHandler_Patch_DuplicateNameIs409(t *testing.T) {
+	t.Parallel()
+	z := testZone(t)
+	store := &fakeZoneStore{zones: []WatchZone{z}, saveErr: ErrDuplicateName}
+	rec := doReq(t, testMux(t, store), http.MethodPatch, "/v1/me/watch-zones/"+z.ID, `{"name":"Taken Name"}`)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status: got %d, want 409 (body %s)", rec.Code, rec.Body)
+	}
+	var env apiErrorResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode error envelope: %v", err)
+	}
+	if env.Error != zoneNameTakenCode {
+		t.Errorf("error code: got %q, want %q", env.Error, zoneNameTakenCode)
+	}
+}
+
 // --- PATCH boundary tri-state tests (tc-6he3x.4) ----------------------------
 
 // TestHandler_Patch_Boundary_AbsentLeavesShapeUnchanged proves an absent

--- a/api-go/internal/watchzones/nearby.go
+++ b/api-go/internal/watchzones/nearby.go
@@ -319,6 +319,10 @@ func (h *handler) create(w http.ResponseWriter, r *http.Request) {
 	// centroid/radius above were already computed from the same b.
 	zone.Boundary = boundary
 	if err := h.store.Save(r.Context(), zone); err != nil {
+		if errors.Is(err, ErrDuplicateName) {
+			h.writeErrorCode(w, r, http.StatusConflict, zoneNameTakenCode, zoneNameTakenMessage)
+			return
+		}
 		h.serverError(w, r, "save watch zone", err)
 		return
 	}

--- a/api-go/internal/watchzones/nearby_test.go
+++ b/api-go/internal/watchzones/nearby_test.go
@@ -421,6 +421,37 @@ func TestCreate_QuotaExceededIs403(t *testing.T) {
 	}
 }
 
+// TestCreate_DuplicateNameIs409 proves that a Store.Save failure carrying
+// ErrDuplicateName (a unique-violation on watch_zones' UNIQUE (user_id, name)
+// constraint against a different, already-existing row -- create always
+// mints a fresh id, so ON CONFLICT (id) can never catch this) maps to 409
+// zone_name_taken rather than falling through to the generic 500 (GH#1083,
+// tc-h4y98).
+func TestCreate_DuplicateNameIs409(t *testing.T) {
+	t.Parallel()
+	d := nearbyDeps{
+		store:    &fakeZoneStore{saveErr: ErrDuplicateName},
+		profiles: &fakeProfileReader{profile: proProfile(t)},
+		apps:     &fakeAppFinder{},
+		unread:   &fakeUnread{},
+	}
+	mux := newNearbyMux(t, d)
+
+	body := `{"name":"My Zone","latitude":51.5,"longitude":-0.12,"radiusMetres":1000}`
+	rec := doReq(t, mux, http.MethodPost, "/v1/me/watch-zones", body)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status: got %d, want 409 (body %s)", rec.Code, rec.Body)
+	}
+	var env apiErrorResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode error envelope: %v", err)
+	}
+	if env.Error != zoneNameTakenCode {
+		t.Errorf("error code: got %q, want %q", env.Error, zoneNameTakenCode)
+	}
+}
+
 func TestCreate_ProTierBypassesQuota(t *testing.T) {
 	t.Parallel()
 	manyZones := make([]WatchZone, 10)

--- a/api-go/internal/watchzones/store_postgres.go
+++ b/api-go/internal/watchzones/store_postgres.go
@@ -11,6 +11,22 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 )
 
+// pgUniqueViolationCode is the Postgres SQLSTATE for a unique-constraint
+// violation. Save uses it to detect a name collision against the
+// watch_zones_user_id_name_key constraint (GH#1083, tc-h4y98), mirroring
+// internal/offercodes/store_postgres.go's identical helper.
+const pgUniqueViolationCode = "23505"
+
+// isUniqueViolation reports whether err is a Postgres unique-constraint
+// violation (SQLSTATE 23505).
+func isUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code == pgUniqueViolationCode
+	}
+	return false
+}
+
 // querier is the consumer-side slice of *pgxpool.Pool the store uses. Defining it
 // here keeps the store decoupled from the concrete pool; both *pgxpool.Pool and
 // pgx.Tx satisfy it structurally.
@@ -230,6 +246,13 @@ ON CONFLICT (id) DO UPDATE SET
 // (a circle zone) writes SQL NULL, so saving a zone that previously had a
 // custom shape with Boundary cleared correctly reverts the persisted row to a
 // circle rather than leaving a stale polygon behind.
+//
+// ON CONFLICT (id) only dedupes an upsert of the SAME id -- it does not catch
+// a name collision against a different, already-existing row for the same
+// user (watch_zones also has UNIQUE (user_id, name)). create always mints a
+// fresh id, so that case reaches Postgres as a raw unique-violation on
+// watch_zones_user_id_name_key; isUniqueViolation translates it into the
+// domain sentinel ErrDuplicateName instead (GH#1083, tc-h4y98).
 func (s *PostgresStore) Save(ctx context.Context, z WatchZone) error {
 	boundaryGeoJSON, err := encodeBoundaryGeoJSON(z.Boundary)
 	if err != nil {
@@ -240,6 +263,9 @@ func (s *PostgresStore) Save(ctx context.Context, z WatchZone) error {
 		z.PushEnabled, z.EmailInstantEnabled, z.CreatedAt, boundaryGeoJSON,
 	)
 	if err != nil {
+		if isUniqueViolation(err) {
+			return ErrDuplicateName
+		}
 		return fmt.Errorf("upsert watch zone %q: %w", z.ID, err)
 	}
 	return nil

--- a/api-go/internal/watchzones/store_postgres_test.go
+++ b/api-go/internal/watchzones/store_postgres_test.go
@@ -183,6 +183,42 @@ func TestWatchZonePostgresStore_Save_UpsertOnID(t *testing.T) {
 	}
 }
 
+// TestWatchZonePostgresStore_Save_DuplicateNameSameUserIsErrDuplicateName proves
+// that Save's ON CONFLICT (id) upsert does NOT catch a name collision against a
+// different, already-existing row for the same user: watch_zones has a separate
+// UNIQUE (user_id, name) constraint (0001_init_postgis.sql), so inserting a
+// second zone with a fresh id but a name the user already owns must surface as
+// the domain sentinel ErrDuplicateName rather than the raw Postgres
+// unique-violation (GH#1083, tc-h4y98) -- the bug that was propagating as an
+// unhandled 500 through both the create and patch handlers.
+func TestWatchZonePostgresStore_Save_DuplicateNameSameUserIsErrDuplicateName(t *testing.T) {
+	ctx := context.Background()
+	store := newZonePGStore(t)
+
+	first := pgZone(t, uuidN(1), "user-1", "My Zone", 51.5, -0.12, 500)
+	if err := store.Save(ctx, first); err != nil {
+		t.Fatalf("Save first: %v", err)
+	}
+
+	second := pgZone(t, uuidN(2), "user-1", "My Zone", 52.0, -1.0, 750)
+	err := store.Save(ctx, second)
+	if !errors.Is(err, ErrDuplicateName) {
+		t.Fatalf("Save duplicate name: got %v, want ErrDuplicateName", err)
+	}
+
+	// The first zone's row must be untouched by the failed second insert.
+	got, err := store.Get(ctx, "user-1", uuidN(1))
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	assertZoneEqual(t, got, first)
+
+	// The second zone must never have been persisted.
+	if _, err := store.Get(ctx, "user-1", uuidN(2)); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Get second zone: got %v, want ErrNotFound", err)
+	}
+}
+
 // TestWatchZonePostgresStore_GetByUserID_OrderedAndScoped lists a user's zones in
 // id order and excludes other users' zones.
 func TestWatchZonePostgresStore_GetByUserID_OrderedAndScoped(t *testing.T) {

--- a/api-go/internal/watchzones/zone.go
+++ b/api-go/internal/watchzones/zone.go
@@ -20,6 +20,12 @@ import (
 // ErrNotFound signals that no watch zone exists for the given (user, zone) pair.
 var ErrNotFound = errors.New("watch zone not found")
 
+// ErrDuplicateName signals that the user already owns a watch zone with this
+// name: watch_zones has UNIQUE (user_id, name) (0001_init_postgis.sql), a
+// constraint the store's Save upsert (ON CONFLICT (id)) cannot itself dedupe
+// against, since create always mints a fresh id (GH#1083, tc-h4y98).
+var ErrDuplicateName = errors.New("a watch zone with this name already exists")
+
 // Boundary validation errors. All are returned by NewBoundary (and therefore
 // by WatchZone.WithBoundary and WithUpdates when a new boundary value is
 // supplied); consumers should use errors.Is rather than string matching.


### PR DESCRIPTION
## Changes

Fixes GH#1083 (polygon watch-zone creation failing in dev). Root cause posted at https://github.com/AmyDe/town-crier/issues/1083#issuecomment-5267186072 — dev container app logs showed `POST /v1/me/watch-zones` 500ing on an unhandled Postgres unique-constraint violation on `watch_zones(user_id, name)`, not a boundary/tier/quota issue and unrelated to the `authorityId` back-compat change (tc-9nbs4.6).

`PostgresStore.Save`'s `ON CONFLICT (id) DO UPDATE` only dedupes on the row's own id, so a `name` collision against a *different* pre-existing zone owned by the same user surfaced the raw SQLSTATE 23505 straight through both `create` and `patch` handlers, both of which routed every `Save` error to an unconditional 500.

- `internal/watchzones/zone.go` — new sentinel `ErrDuplicateName`, alongside the existing `ErrNotFound`.
- `internal/watchzones/store_postgres.go` — `isUniqueViolation` helper (SQLSTATE 23505), mirroring the existing pattern in `internal/offercodes/store_postgres.go`; `Save` now returns `ErrDuplicateName` instead of a generic wrapped error.
- `internal/watchzones/handler.go` — new `zoneNameTakenCode`/`zoneNameTakenMessage` constants alongside the existing `boundary_*` codes; `patch` maps `ErrDuplicateName` to `409 zone_name_taken`.
- `internal/watchzones/nearby.go` — same mapping added to `create`.
- Tests: real-DB integration test for the store-level translation, plus unit tests for both handler call sites using the existing `fakeZoneStore.saveErr` injection hook.

No client (iOS/web) changes — this was a server-side bug reachable from any client, for any zone shape (circle or polygon) whose name collides with one the caller already owns.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l .`, `golangci-lint run ./...` — clean.
- `go test -race ./...` — 2151 tests, all packages pass.
- `go test -tags=integration ./...` (real Postgres+PostGIS) — 2384 tests, all packages pass, including the new duplicate-name integration test.
- End-to-end UI verification: stood up the fixed branch against a local Postgres+PostGIS and local web dev server, logged in as the Pro-tier dev test account, drew a convex pentagon (single authority, centroid inside) through the app's real custom-shape drawing UI, and confirmed it created successfully — row present in Postgres with `ST_IsValid(boundary)=true` and the centroid contained.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicate watch-zone names now return a clear conflict response instead of a generic server error.
  * Existing watch zones remain unchanged when a duplicate-name save is rejected.
  * Consistent `zone_name_taken` error details are provided for both creating and updating watch zones.

* **Tests**
  * Added coverage for duplicate-name handling across create, update, and persistence flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->