### PR TITLE
fix(api): classify poll-cycle lane errors by origin so exit code only pages on genuine failures (tc-uitxr)

### DIFF
--- a/api-go/cmd/worker/main.go
+++ b/api-go/cmd/worker/main.go
@@ -619,6 +619,7 @@ func (a *pollOrchestratorAdapter) RunOnce(ctx context.Context) (worker.PollRunRe
 		out.ApplicationCount = res.PollResult.ApplicationCount
 		out.AuthoritiesPolled = res.PollResult.AuthoritiesPolled
 		out.AuthorityErrors = res.PollResult.AuthorityErrors
+		out.AuthorityErrorIsPlanIt = res.PollResult.AuthorityErrorIsPlanIt
 		out.Termination = res.PollResult.TerminationReason.TelemetryValue()
 		out.OldestHWMAgeSeconds = res.PollResult.OldestHWMAgeSeconds
 		out.OldestHWMNeverPolled = res.PollResult.OldestHWMNeverPolled

--- a/api-go/internal/polling/backfill.go
+++ b/api-go/internal/polling/backfill.go
@@ -154,8 +154,13 @@ type backfillOutcome struct {
 	rateLimited     bool
 	retryAfter      *time.Duration
 	err             error
-	planitTotal     *int
-	complete        bool
+	// planitOrigin mirrors laneOutcome.planitOrigin (nationallane.go): true
+	// only when err came from the FetchBackfillPage call, false (default) for
+	// a state-read (h.state.Get), ingest, or state-save error -- all genuine
+	// state-store problems unrelated to PlanIt (tc-uitxr).
+	planitOrigin bool
+	planitTotal  *int
+	complete     bool
 }
 
 // Run fetches up to MaxPagesPerCycle pages of the current backward-sliding
@@ -216,6 +221,7 @@ pageLoop:
 				out.retryAfter = rl.RetryAfter
 			} else {
 				out.err = ferr
+				out.planitOrigin = true
 			}
 			break pageLoop
 		}

--- a/api-go/internal/polling/backfill_test.go
+++ b/api-go/internal/polling/backfill_test.go
@@ -474,6 +474,85 @@ func TestBackfillHandler_Run_FetchErrorDoesNotAdvanceCursor(t *testing.T) {
 	if len(apps.upserts) != 2 {
 		t.Errorf("upserts: got %d, want 2 (page 0's records were still ingested)", len(apps.upserts))
 	}
+	if !out.planitOrigin {
+		t.Error("planitOrigin: got false, want true (the error came straight from FetchBackfillPage, tc-uitxr)")
+	}
+}
+
+// TestBackfillHandler_Run_StateGetErrorLeavesPlanitOriginFalse proves the
+// origin classification (tc-uitxr): a failure reading the persisted backfill
+// state -- a genuine state-store problem, unrelated to PlanIt -- must never
+// be misclassified as planitOrigin.
+func TestBackfillHandler_Run_StateGetErrorLeavesPlanitOriginFalse(t *testing.T) {
+	t.Parallel()
+	fetcher := newFakeBackfillFetcher()
+	apps := newFakeApps()
+	state := newFakeBackfillStateStore()
+	state.getErr = errors.New("postgres: connection refused")
+
+	h := newBackfillHandler(t, fetcher, apps, state, defaultBackfillOpts())
+	out := h.Run(context.Background())
+
+	if out.err == nil {
+		t.Fatal("expected the state-read error to surface on the outcome")
+	}
+	if out.planitOrigin {
+		t.Error("planitOrigin: got true, want false (a state-store read failure is never PlanIt-origin)")
+	}
+	if fetcher.calls != 0 {
+		t.Errorf("expected no PlanIt fetch when the state read fails first, got %d calls", fetcher.calls)
+	}
+}
+
+// TestBackfillHandler_Run_IngestErrorLeavesPlanitOriginFalse proves an
+// Ingester.Ingest failure (Postgres upsert) is likewise never PlanIt-origin,
+// even though it happens mid-page, after a successful fetch.
+func TestBackfillHandler_Run_IngestErrorLeavesPlanitOriginFalse(t *testing.T) {
+	t.Parallel()
+	windowEnd := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	ld := time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC)
+	fetcher := newFakeBackfillFetcher(fakeBackfillResponse{
+		result: planit.FetchPageResult{Applications: []applications.PlanningApplication{testApp("a", 300, ld)}, HasMorePages: false},
+	})
+	apps := newFakeApps()
+	apps.upsertErr = errors.New("postgres: connection refused")
+	state := newFakeBackfillStateStore()
+	state.state = BackfillState{WindowEnd: windowEnd}
+
+	h := newBackfillHandler(t, fetcher, apps, state, defaultBackfillOpts())
+	out := h.Run(context.Background())
+
+	if out.err == nil {
+		t.Fatal("expected the ingest (upsert) error to surface on the outcome")
+	}
+	if out.planitOrigin {
+		t.Error("planitOrigin: got true, want false (the fetch itself succeeded; the failure is a Postgres upsert)")
+	}
+}
+
+// TestBackfillHandler_Run_SaveErrorLeavesPlanitOriginFalse proves a state
+// persistence failure (Postgres save) is likewise never PlanIt-origin.
+func TestBackfillHandler_Run_SaveErrorLeavesPlanitOriginFalse(t *testing.T) {
+	t.Parallel()
+	windowEnd := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	ld := time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC)
+	fetcher := newFakeBackfillFetcher(fakeBackfillResponse{
+		result: planit.FetchPageResult{Applications: []applications.PlanningApplication{testApp("a", 300, ld)}, HasMorePages: true},
+	})
+	apps := newFakeApps()
+	state := newFakeBackfillStateStore()
+	state.state = BackfillState{WindowEnd: windowEnd}
+	state.saveErr = errors.New("postgres: connection refused")
+
+	h := newBackfillHandler(t, fetcher, apps, state, defaultBackfillOpts())
+	out := h.Run(context.Background())
+
+	if out.err == nil {
+		t.Fatal("expected the state-save error to surface on the outcome")
+	}
+	if out.planitOrigin {
+		t.Error("planitOrigin: got true, want false (the fetch itself succeeded; the failure is a Postgres save)")
+	}
 }
 
 // TestBackfillHandler_Run_RateLimitedDoesNotAdvanceCursor mirrors the fetch-

--- a/api-go/internal/polling/handler.go
+++ b/api-go/internal/polling/handler.go
@@ -115,14 +115,28 @@ type HandlerOptions struct {
 }
 
 // PollPlanItResult is the outcome of one ingestion cycle. Drives the worker's
-// exit code (exit 1 only when ApplicationCount==0 AND AuthorityErrors>0) and
-// the next-run cadence.
+// exit code and the next-run cadence: exit 1 only when ApplicationCount==0,
+// AuthorityErrors>0, AND that error did NOT originate from a PlanIt fetch
+// call (see AuthorityErrorIsPlanIt) -- an isolated PlanIt-origin error on an
+// otherwise-quiet cycle self-heals (the orchestrator still completes the
+// message and publishes the next trigger normally) and is already covered by
+// the ratio-based alert-planit-failure-rate-shared log alert, so it must not
+// also page alert-job-failed-poll-prod. Any other error type (a
+// watermark/state-store or Postgres failure) still exits 1 immediately
+// (tc-uitxr).
 type PollPlanItResult struct {
 	ApplicationCount  int
 	AuthoritiesPolled int
 	RateLimited       bool
 	TerminationReason TerminationReason
 	AuthorityErrors   int
+	// AuthorityErrorIsPlanIt is true when the lane error counted in
+	// AuthorityErrors originated from a PlanIt fetch call (any error, not
+	// just a timeout -- see laneOutcome.planitOrigin/backfillOutcome.planitOrigin),
+	// false when it came from a watermark/cursor read or persistence error,
+	// or an Ingester.Ingest failure -- genuine state-store problems unrelated
+	// to PlanIt. Meaningless when AuthorityErrors == 0.
+	AuthorityErrorIsPlanIt bool
 	// RetryAfter is the Retry-After hint bubbled up from a 429, consumed by the
 	// scheduler to time the next trigger. nil when not rate-limited or absent.
 	RetryAfter *time.Duration

--- a/api-go/internal/polling/handler_test.go
+++ b/api-go/internal/polling/handler_test.go
@@ -115,6 +115,11 @@ type fakeStateStore struct {
 	saves    []savedState
 	lruOrder []int
 	lruErr   error
+	// getErr, when set, is returned by every Get call (mirroring fakeApps.getErr
+	// / fakeBackfillStateStore.getErr) -- lets a test simulate a genuine
+	// watermark-read (state-store) failure, as distinct from a PlanIt fetch
+	// error (tc-uitxr).
+	getErr error
 }
 
 type savedState struct {
@@ -129,6 +134,9 @@ func newFakeStateStore() *fakeStateStore {
 }
 
 func (f *fakeStateStore) Get(_ context.Context, authorityID int) (PollState, bool, error) {
+	if f.getErr != nil {
+		return PollState{}, false, f.getErr
+	}
 	s, ok := f.states[authorityID]
 	return s, ok, nil
 }

--- a/api-go/internal/polling/handler_test.go
+++ b/api-go/internal/polling/handler_test.go
@@ -120,6 +120,11 @@ type fakeStateStore struct {
 	// watermark-read (state-store) failure, as distinct from a PlanIt fetch
 	// error (tc-uitxr).
 	getErr error
+	// saveErr, when set, is returned by every Save call -- lets a test
+	// simulate a genuine watermark-write (state-store) failure landing on
+	// top of an already-classified PlanIt fetch/hydration error (CodeRabbit
+	// follow-up on tc-uitxr).
+	saveErr error
 }
 
 type savedState struct {
@@ -149,6 +154,9 @@ func (f *fakeStateStore) Get(_ context.Context, authorityID int) (PollState, boo
 func (f *fakeStateStore) Save(ctx context.Context, authorityID int, lastPollTime, highWaterMark time.Time, cursor *PollCursor) error {
 	if err := ctx.Err(); err != nil {
 		return err
+	}
+	if f.saveErr != nil {
+		return f.saveErr
 	}
 	f.saves = append(f.saves, savedState{authorityID, lastPollTime, highWaterMark, cursor})
 	f.states[authorityID] = PollState{LastPollTime: lastPollTime, HighWaterMark: highWaterMark, Cursor: cursor}

--- a/api-go/internal/polling/lanec.go
+++ b/api-go/internal/polling/lanec.go
@@ -225,8 +225,14 @@ func (h *InverseMaskLaneHandler) RunOnePage(ctx context.Context) laneOutcome {
 		// fetched, so no progress exists to checkpoint) but with
 		// last_poll_time advanced to now, so a page-fetch 429/error still
 		// rotates this lane off the LRU front instead of freezing it there.
-		if serr := h.watermark.save(ctx, now, loadedEpochUpper, cursor); serr != nil && out.err == nil {
-			out.err = serr
+		if serr := h.watermark.save(ctx, now, loadedEpochUpper, cursor); serr != nil {
+			// A save failure is a state-store problem, never PlanIt's fault —
+			// join it onto any PlanIt fetch error above and clear
+			// planitOrigin, so a genuine persistence failure never gets
+			// hidden behind a self-healing PlanIt classification (CodeRabbit
+			// follow-up on tc-uitxr).
+			out.err = errors.Join(out.err, serr)
+			out.planitOrigin = false
 		}
 		out.watermarkAfter = epochUpper
 		h.recordOutcome(ctx, out)
@@ -312,8 +318,12 @@ func (h *InverseMaskLaneHandler) RunOnePage(ctx context.Context) laneOutcome {
 			nextIndex = cursor.NextIndex
 		}
 		newCursor := &PollCursor{DifferentStart: epochLower, NextIndex: nextIndex, KnownTotal: res.Total}
-		if serr := h.watermark.save(ctx, now, epochUpper, newCursor); serr != nil && out.err == nil {
-			out.err = serr
+		if serr := h.watermark.save(ctx, now, epochUpper, newCursor); serr != nil {
+			// See the page-fetch save above: a save failure is never
+			// PlanIt's fault, even when it lands on top of a PlanIt-origin
+			// hydration error (CodeRabbit follow-up on tc-uitxr).
+			out.err = errors.Join(out.err, serr)
+			out.planitOrigin = false
 		}
 		out.watermarkAfter = epochUpper
 		h.recordOutcome(ctx, out)

--- a/api-go/internal/polling/lanec.go
+++ b/api-go/internal/polling/lanec.go
@@ -219,6 +219,7 @@ func (h *InverseMaskLaneHandler) RunOnePage(ctx context.Context) laneOutcome {
 		} else {
 			out.err = ferr
 			out.timedOut = isTimeoutError(ferr)
+			out.planitOrigin = true
 		}
 		// GH#986: re-persist the epoch/cursor exactly as loaded (nothing was
 		// fetched, so no progress exists to checkpoint) but with
@@ -407,12 +408,14 @@ func (h *InverseMaskLaneHandler) hydrate(ctx context.Context, uid string, wantAr
 			out.retryAfter = rl.RetryAfter
 			return nil
 		}
-		// timedOut is set here, at the actual PlanIt fetch site, rather than
-		// re-derived from processStraggler's aggregate error at the
-		// RunOnePage call site -- so a Postgres GetByUID error (the sibling
-		// error source processStraggler wraps) never gets misclassified as a
-		// PlanIt timeout (tc-c5tmz, CodeRabbit follow-up on tc-pmh5y).
+		// timedOut/planitOrigin are set here, at the actual PlanIt fetch site,
+		// rather than re-derived from processStraggler's aggregate error at
+		// the RunOnePage call site -- so a Postgres GetByUID error (the
+		// sibling error source processStraggler wraps) never gets
+		// misclassified as PlanIt-origin (tc-c5tmz, CodeRabbit follow-up on
+		// tc-pmh5y; tc-uitxr).
 		out.timedOut = isTimeoutError(err)
+		out.planitOrigin = true
 		return fmt.Errorf("lane C: hydration fetch %q: %w", uid, err)
 	}
 	for _, app := range full.Applications {

--- a/api-go/internal/polling/lanec_test.go
+++ b/api-go/internal/polling/lanec_test.go
@@ -587,6 +587,9 @@ func TestInverseMaskLane_PageFetchTimeoutSetsTimedOut(t *testing.T) {
 	if !out.timedOut {
 		t.Error("timedOut: got false, want true (page-fetch client timeout)")
 	}
+	if !out.planitOrigin {
+		t.Error("planitOrigin: got false, want true (page-fetch error, tc-uitxr)")
+	}
 }
 
 // TestInverseMaskLane_HydrationTimeoutSetsTimedOut mirrors
@@ -620,6 +623,9 @@ func TestInverseMaskLane_HydrationTimeoutSetsTimedOut(t *testing.T) {
 	}
 	if !out.timedOut {
 		t.Error("timedOut: got false, want true (hydration client timeout)")
+	}
+	if !out.planitOrigin {
+		t.Error("planitOrigin: got false, want true (hydration fetch error, tc-uitxr)")
 	}
 }
 
@@ -661,6 +667,9 @@ func TestInverseMaskLane_GetByUIDTimeoutDoesNotSetTimedOut(t *testing.T) {
 	}
 	if out.timedOut {
 		t.Error("timedOut: got true, want false (GetByUID is Postgres, never PlanIt -- isTimeoutError must never be consulted on this path)")
+	}
+	if out.planitOrigin {
+		t.Error("planitOrigin: got true, want false (GetByUID is Postgres, never PlanIt, tc-uitxr)")
 	}
 	if len(fetcher.hydrateCalls) != 0 {
 		t.Errorf("expected hydrate() never called when GetByUID fails, got %v", fetcher.hydrateCalls)

--- a/api-go/internal/polling/lanec_test.go
+++ b/api-go/internal/polling/lanec_test.go
@@ -629,6 +629,84 @@ func TestInverseMaskLane_HydrationTimeoutSetsTimedOut(t *testing.T) {
 	}
 }
 
+// TestInverseMaskLane_PageFetchErrorPlusWatermarkSaveFailureClearsPlanitOrigin
+// covers the gap CodeRabbit flagged as a follow-up on tc-uitxr: the page-fetch
+// error path sets planitOrigin=true, then unconditionally re-saves the
+// watermark (GH#986, so LastPollTime still advances and the lane rotates off
+// the LRU). If THAT save also fails, the failure is a genuine Postgres/
+// state-store problem -- never PlanIt's fault -- so it must surface on
+// out.err rather than being silently dropped, and it must clear
+// planitOrigin so NationalPollHandler.Handle never misclassifies the cycle
+// as self-healing PlanIt noise and lets runPollSB exit 0 on a real
+// persistence failure.
+func TestInverseMaskLane_PageFetchErrorPlusWatermarkSaveFailureClearsPlanitOrigin(t *testing.T) {
+	t.Parallel()
+	epochLower := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	epochUpper := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+	fetchErr := errors.New("planit: page fetch failed")
+	saveErr := errors.New("postgres: save failed")
+
+	fetcher := newFakeInverseMaskFetcher()
+	fetcher.failNth[1] = fetchErr
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	state.states[sentinelLaneC] = PollState{HighWaterMark: epochUpper, Cursor: &PollCursor{DifferentStart: epochLower, NextIndex: 300}}
+	state.saveErr = saveErr
+
+	h := newLaneCHandler(t, fetcher, apps, state, defaultInverseMaskOpts())
+	out := h.RunOnePage(context.Background())
+
+	if out.planitOrigin {
+		t.Error("planitOrigin: got true, want false (watermark save also failed, so this is a genuine non-PlanIt failure)")
+	}
+	if out.err == nil || !errors.Is(out.err, fetchErr) {
+		t.Errorf("out.err: got %v, want it to wrap the original page-fetch error %v", out.err, fetchErr)
+	}
+	if out.err == nil || !errors.Is(out.err, saveErr) {
+		t.Errorf("out.err: got %v, want it to wrap the watermark save error %v", out.err, saveErr)
+	}
+}
+
+// TestInverseMaskLane_HydrationErrorPlusWatermarkSaveFailureClearsPlanitOrigin
+// mirrors the page-fetch case above for the OTHER watermark.save call
+// CodeRabbit flagged: the stoppedEarly checkpoint-and-return path, reached
+// when a hydration fetch fails mid-page. Same requirement -- a save failure
+// stacked on top must surface and clear planitOrigin.
+func TestInverseMaskLane_HydrationErrorPlusWatermarkSaveFailureClearsPlanitOrigin(t *testing.T) {
+	t.Parallel()
+	epochLower := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	epochUpper := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+	newLD := epochLower.Add(time.Hour)
+	hydrateErr := errors.New("planit: hydration fetch failed")
+	saveErr := errors.New("postgres: save failed")
+
+	fetcher := newFakeInverseMaskFetcher()
+	fetcher.pages[0] = planit.FetchPageResult{
+		From:         0,
+		Applications: []applications.PlanningApplication{lightApp("first/FUL", 99, "Permitted", newLD)},
+		HasMorePages: false,
+	}
+	fetcher.hydrateErr["first/FUL"] = hydrateErr
+
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	state.states[sentinelLaneC] = PollState{HighWaterMark: epochUpper, Cursor: &PollCursor{DifferentStart: epochLower, NextIndex: 0}}
+	state.saveErr = saveErr
+
+	h := newLaneCHandler(t, fetcher, apps, state, defaultInverseMaskOpts())
+	out := h.RunOnePage(context.Background())
+
+	if out.planitOrigin {
+		t.Error("planitOrigin: got true, want false (watermark save also failed, so this is a genuine non-PlanIt failure)")
+	}
+	if out.err == nil || !errors.Is(out.err, hydrateErr) {
+		t.Errorf("out.err: got %v, want it to wrap the original hydration fetch error %v", out.err, hydrateErr)
+	}
+	if out.err == nil || !errors.Is(out.err, saveErr) {
+		t.Errorf("out.err: got %v, want it to wrap the watermark save error %v", out.err, saveErr)
+	}
+}
+
 // TestInverseMaskLane_GetByUIDTimeoutDoesNotSetTimedOut proves
 // processStraggler's two error sources are classified by provenance
 // (tc-c5tmz, a CodeRabbit follow-up on tc-pmh5y): a Postgres GetByUID read

--- a/api-go/internal/polling/nationallane.go
+++ b/api-go/internal/polling/nationallane.go
@@ -231,7 +231,18 @@ type laneOutcome struct {
 	// watermark/cursor persistence error, which is unrelated to PlanIt. It
 	// lets Handle's loop distinguish "PlanIt needs space" (TerminationTimeout)
 	// from a genuine natural completion (tc-pmh5y).
-	timedOut        bool
+	timedOut bool
+	// planitOrigin is the broader sibling of timedOut (tc-uitxr): true when
+	// err came from a PlanIt fetch call (page fetch or hydration) — ANY such
+	// error, not just a timeout — and false (default) when err came from a
+	// watermark/cursor read or persistence error, or an Ingester.Ingest
+	// failure, all of which are genuine state-store (Postgres) problems
+	// unrelated to PlanIt. Handle threads it onto PollPlanItResult so the
+	// worker's exit-code rule can tell an isolated, self-healing PlanIt
+	// hiccup (already covered by the ratio-based
+	// alert-planit-failure-rate-shared log alert) apart from a genuine
+	// DB-layer failure that should keep paging.
+	planitOrigin    bool
 	planitTotal     *int
 	watermarkBefore time.Time
 	watermarkAfter  time.Time
@@ -346,6 +357,7 @@ func (h *NationalLaneHandler) RunOnePage(ctx context.Context) laneOutcome {
 		} else {
 			out.err = ferr
 			out.timedOut = isTimeoutError(ferr)
+			out.planitOrigin = true
 		}
 		out.watermarkAfter = watermarkBefore
 		h.recordRunMetrics(ctx, out, now)
@@ -486,6 +498,7 @@ func (h *NationalLaneHandler) seed(ctx context.Context, span trace.Span, now, ma
 		} else {
 			out.err = ferr
 			out.timedOut = isTimeoutError(ferr)
+			out.planitOrigin = true
 		}
 		// out.watermarkAfter is still the zero time here — the seeding fetch
 		// itself failed, so nothing was ever established this run. Recording
@@ -703,6 +716,12 @@ type commonLaneOutcome struct {
 	// no equivalent, so it always reads false from that branch — Lane D is
 	// out of scope for tc-pmh5y's timeout classification).
 	timedOut bool
+	// planitOrigin mirrors laneOutcome.planitOrigin (Lane A/B/C) and
+	// backfillOutcome.planitOrigin (Lane D, mapped in execOnePage's Lane D
+	// case) — unlike timedOut, Lane D DOES track this one: a fetch-origin
+	// error must stop an otherwise-quiet cycle without paging, whichever
+	// lane it came from (tc-uitxr).
+	planitOrigin bool
 }
 
 // Handle runs one ADR 0044 poll cycle: a planner/executor loop replacing the
@@ -738,12 +757,13 @@ func (h *NationalPollHandler) Handle(ctx context.Context) (PollPlanItResult, err
 	}
 
 	var (
-		totalIngested int
-		lastErr       error
-		rateLimited   bool
-		retryAfter    *time.Duration
-		reason        = TerminationNatural
-		pagesRun      = map[LaneName]int{}
+		totalIngested       int
+		lastErr             error
+		lastErrPlanitOrigin bool
+		rateLimited         bool
+		retryAfter          *time.Duration
+		reason              = TerminationNatural
+		pagesRun            = map[LaneName]int{}
 	)
 
 loop:
@@ -772,6 +792,7 @@ loop:
 
 		if out.err != nil {
 			lastErr = out.err
+			lastErrPlanitOrigin = out.planitOrigin
 			if out.timedOut {
 				reason = TerminationTimeout
 			}
@@ -792,20 +813,23 @@ loop:
 	}
 
 	laneErrors := 0
+	authorityErrorIsPlanIt := false
 	if lastErr != nil {
 		laneErrors = 1
+		authorityErrorIsPlanIt = lastErrPlanitOrigin
 	}
 
 	h.recorder().CycleCompleted(ctx, "National", reason.TelemetryValue())
 
 	return PollPlanItResult{
-		ApplicationCount:  totalIngested,
-		AuthoritiesPolled: 0, // no per-authority concept in the national lanes
-		RateLimited:       rateLimited,
-		TerminationReason: reason,
-		AuthorityErrors:   laneErrors,
-		RetryAfter:        retryAfter,
-		CycleType:         "National",
+		ApplicationCount:       totalIngested,
+		AuthoritiesPolled:      0, // no per-authority concept in the national lanes
+		RateLimited:            rateLimited,
+		TerminationReason:      reason,
+		AuthorityErrors:        laneErrors,
+		AuthorityErrorIsPlanIt: authorityErrorIsPlanIt,
+		RetryAfter:             retryAfter,
+		CycleType:              "National",
 	}, nil
 }
 
@@ -881,13 +905,13 @@ func (h *NationalPollHandler) execOnePage(ctx context.Context, lane LaneName) co
 		if out.err != nil {
 			h.logger.ErrorContext(ctx, "lane A poll error", "error", out.err)
 		}
-		return commonLaneOutcome{recordsIngested: out.recordsIngested, rateLimited: out.rateLimited, retryAfter: out.retryAfter, err: out.err, timedOut: out.timedOut}
+		return commonLaneOutcome{recordsIngested: out.recordsIngested, rateLimited: out.rateLimited, retryAfter: out.retryAfter, err: out.err, timedOut: out.timedOut, planitOrigin: out.planitOrigin}
 	case LaneB:
 		out := h.laneB.RunOnePage(ctx)
 		if out.err != nil {
 			h.logger.ErrorContext(ctx, "lane B poll error", "error", out.err)
 		}
-		return commonLaneOutcome{recordsIngested: out.recordsIngested, rateLimited: out.rateLimited, retryAfter: out.retryAfter, err: out.err, timedOut: out.timedOut}
+		return commonLaneOutcome{recordsIngested: out.recordsIngested, rateLimited: out.rateLimited, retryAfter: out.retryAfter, err: out.err, timedOut: out.timedOut, planitOrigin: out.planitOrigin}
 	case LaneC:
 		if h.laneC == nil {
 			return commonLaneOutcome{}
@@ -896,7 +920,7 @@ func (h *NationalPollHandler) execOnePage(ctx context.Context, lane LaneName) co
 		if out.err != nil {
 			h.logger.ErrorContext(ctx, "lane C poll error", "error", out.err)
 		}
-		return commonLaneOutcome{recordsIngested: out.recordsIngested, rateLimited: out.rateLimited, retryAfter: out.retryAfter, err: out.err, timedOut: out.timedOut}
+		return commonLaneOutcome{recordsIngested: out.recordsIngested, rateLimited: out.rateLimited, retryAfter: out.retryAfter, err: out.err, timedOut: out.timedOut, planitOrigin: out.planitOrigin}
 	case LaneD:
 		if h.laneD == nil {
 			return commonLaneOutcome{}
@@ -905,7 +929,7 @@ func (h *NationalPollHandler) execOnePage(ctx context.Context, lane LaneName) co
 		if out.err != nil {
 			h.logger.ErrorContext(ctx, "lane D backfill error", "error", out.err)
 		}
-		return commonLaneOutcome{rateLimited: out.rateLimited, retryAfter: out.retryAfter, err: out.err}
+		return commonLaneOutcome{rateLimited: out.rateLimited, retryAfter: out.retryAfter, err: out.err, planitOrigin: out.planitOrigin}
 	default:
 		return commonLaneOutcome{}
 	}

--- a/api-go/internal/polling/nationallane_test.go
+++ b/api-go/internal/polling/nationallane_test.go
@@ -336,6 +336,9 @@ func TestNationalLane_NeverAdvancesWatermarkPastAnErroredPage(t *testing.T) {
 	if got := state.states[sentinelLaneA].Cursor; got == nil || got.NextIndex != 1 {
 		t.Errorf("cursor after the failed page: got %+v, want the untouched page-1 checkpoint (NextIndex=1)", got)
 	}
+	if !secondOut.planitOrigin {
+		t.Error("planitOrigin: got false, want true (the error came straight from FetchNationalDeltaPage, tc-uitxr)")
+	}
 }
 
 // TestNationalLane_NeverAdvancesWatermarkOn429 mirrors the errored-page test
@@ -722,6 +725,9 @@ func TestNationalLane_SeedFetchErrorLeavesLaneUnseeded(t *testing.T) {
 	if len(state.saves) != 0 {
 		t.Errorf("expected NO Save call when the seed fetch fails, got %+v", state.saves)
 	}
+	if !out.planitOrigin {
+		t.Error("planitOrigin: got false, want true (seed()'s FetchNationalDeltaPage error branch must set it too, tc-uitxr)")
+	}
 }
 
 // TestNationalLane_SeedRateLimitedLeavesLaneUnseeded mirrors the error case
@@ -772,6 +778,63 @@ func TestNationalLane_SeedFetchTimeoutSetsTimedOut(t *testing.T) {
 	}
 	if len(state.saves) != 0 {
 		t.Errorf("expected NO Save call when the seed fetch times out, got %+v", state.saves)
+	}
+}
+
+// TestNationalLane_WatermarkReadErrorLeavesPlanitOriginFalse proves the
+// origin classification (tc-uitxr): a failure reading the persisted
+// watermark -- a genuine state-store problem, unrelated to PlanIt -- must
+// never be misclassified as planitOrigin, mirroring
+// TestInverseMaskLane_GetByUIDTimeoutDoesNotSetTimedOut's "provenance, not
+// symptom" rule for the sibling timedOut flag.
+func TestNationalLane_WatermarkReadErrorLeavesPlanitOriginFalse(t *testing.T) {
+	t.Parallel()
+	fetcher := newFakeNationalFetcher()
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	state.getErr = errors.New("postgres: connection refused")
+
+	h := newLaneHandler(t, fetcher, apps, state, laneAOpts())
+	out := h.RunOnePage(context.Background())
+
+	if out.err == nil {
+		t.Fatal("expected the watermark-read error to surface on the outcome")
+	}
+	if out.planitOrigin {
+		t.Error("planitOrigin: got true, want false (a watermark/state-store read failure is never PlanIt-origin)")
+	}
+	if fetcher.calls != 0 {
+		t.Errorf("expected no PlanIt fetch when the watermark read fails first, got %d calls", fetcher.calls)
+	}
+}
+
+// TestNationalLane_IngestErrorLeavesPlanitOriginFalse proves an
+// Ingester.Ingest failure (Postgres upsert) is likewise never PlanIt-origin,
+// even though it happens mid-page, after a successful fetch.
+func TestNationalLane_IngestErrorLeavesPlanitOriginFalse(t *testing.T) {
+	t.Parallel()
+	watermark := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	ld := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+
+	fetcher := newFakeNationalFetcher()
+	fetcher.pages[0] = planit.FetchPageResult{
+		From:         0,
+		Applications: []applications.PlanningApplication{testApp("a", 300, ld)},
+		HasMorePages: false,
+	}
+	apps := newFakeApps()
+	apps.upsertErr = errors.New("postgres: connection refused")
+	state := newFakeStateStore()
+	state.states[sentinelLaneA] = PollState{HighWaterMark: watermark, LastPollTime: watermark}
+
+	h := newLaneHandler(t, fetcher, apps, state, laneAOpts())
+	out := h.RunOnePage(context.Background())
+
+	if out.err == nil {
+		t.Fatal("expected the ingest (upsert) error to surface on the outcome")
+	}
+	if out.planitOrigin {
+		t.Error("planitOrigin: got true, want false (the fetch itself succeeded; the failure is a Postgres upsert)")
 	}
 }
 
@@ -1018,7 +1081,10 @@ func TestNationalPollHandler_Handle_RunsBothLanesToCompletion(t *testing.T) {
 // TestNationalPollHandler_Handle_StopsOnFirstLaneError proves a lane error
 // stops the WHOLE loop immediately (ADR 0044's single break, replacing the
 // old per-lane fold): the cycle still returns a nil error (self-healing —
-// the last checkpoint holds) but AuthorityErrors reports the stop.
+// the last checkpoint holds) but AuthorityErrors reports the stop. It also
+// proves the error's origin (tc-uitxr): a plain PlanIt fetch failure sets
+// AuthorityErrorIsPlanIt so runPollSB's exit-code rule treats it as
+// self-healing rather than paging.
 func TestNationalPollHandler_Handle_StopsOnFirstLaneError(t *testing.T) {
 	t.Parallel()
 	clockTime := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
@@ -1049,6 +1115,9 @@ func TestNationalPollHandler_Handle_StopsOnFirstLaneError(t *testing.T) {
 	if res.AuthorityErrors != 1 {
 		t.Errorf("AuthorityErrors: got %d, want 1", res.AuthorityErrors)
 	}
+	if !res.AuthorityErrorIsPlanIt {
+		t.Error("AuthorityErrorIsPlanIt: got false, want true (the error came straight from a PlanIt fetch call)")
+	}
 	// A plain, non-timeout transport error must NOT be misclassified as
 	// TerminationTimeout (tc-pmh5y regression guard: isTimeoutError must not
 	// over-match a generic error).
@@ -1060,6 +1129,49 @@ func TestNationalPollHandler_Handle_StopsOnFirstLaneError(t *testing.T) {
 	// covers whichever lane errors, without a per-lane fold to omit one.
 	if fetcherB.calls != 0 {
 		t.Errorf("lane B fetcher: got %d calls, want 0 (the loop stopped on lane A's error before lane B's turn)", fetcherB.calls)
+	}
+}
+
+// TestNationalPollHandler_Handle_NonPlanItOriginErrorLeavesAuthorityErrorIsPlanItFalse
+// mirrors TestNationalPollHandler_Handle_StopsOnFirstLaneError for a genuine
+// state-store failure (a Postgres upsert error, mid-page, AFTER a successful
+// PlanIt fetch): AuthorityErrors still reports the stop, but
+// AuthorityErrorIsPlanIt must stay false so runPollSB's exit-code rule keeps
+// paging on this class of failure (tc-uitxr).
+func TestNationalPollHandler_Handle_NonPlanItOriginErrorLeavesAuthorityErrorIsPlanItFalse(t *testing.T) {
+	t.Parallel()
+	clockTime := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	longAgo := clockTime.Add(-time.Hour)
+	ld := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+
+	fetcherA := newFakeNationalFetcher()
+	fetcherA.pages[0] = planit.FetchPageResult{From: 0, Applications: []applications.PlanningApplication{testApp("a", 300, ld)}}
+	fetcherB := newFakeNationalFetcher()
+	fetcherB.pages[0] = planit.FetchPageResult{From: 0, Applications: nil, HasMorePages: false}
+
+	apps := newFakeApps()
+	apps.upsertErr = errors.New("postgres: connection refused")
+	state := newFakeStateStore()
+	watermark := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	state.states[sentinelLaneA] = PollState{HighWaterMark: watermark, LastPollTime: longAgo}
+	state.states[sentinelLaneB] = PollState{HighWaterMark: watermark, LastPollTime: longAgo}
+	logger := slog.New(slog.NewTextHandler(discard{}, nil))
+	clock := func() time.Time { return clockTime }
+
+	laneAHandler := NewNationalLaneHandler(fetcherA, state, apps, laneAOpts(), clock, logger)
+	laneBHandler := NewNationalLaneHandler(fetcherB, state, apps, laneBOpts(20), clock, logger)
+	planner := NewPlanner(newTestPlannerOpts())
+	handler := NewNationalPollHandler(laneAHandler, laneBHandler, nil, planner, NationalPollOptions{HandlerBudget: 4 * time.Minute}, clock, logger)
+
+	res, err := handler.Handle(context.Background())
+	if err != nil {
+		t.Fatalf("Handle must not fail the cycle on a lane error: %v", err)
+	}
+	if res.AuthorityErrors != 1 {
+		t.Errorf("AuthorityErrors: got %d, want 1", res.AuthorityErrors)
+	}
+	if res.AuthorityErrorIsPlanIt {
+		t.Error("AuthorityErrorIsPlanIt: got true, want false (the fetch succeeded; the failure is a Postgres upsert)")
 	}
 }
 

--- a/api-go/internal/worker/dispatch.go
+++ b/api-go/internal/worker/dispatch.go
@@ -113,7 +113,14 @@ type PollRunResult struct {
 	ApplicationCount  int
 	AuthoritiesPolled int
 	AuthorityErrors   int
-	Termination       string
+	// AuthorityErrorIsPlanIt mirrors polling.PollPlanItResult.AuthorityErrorIsPlanIt:
+	// true when the lane error counted in AuthorityErrors originated from a
+	// PlanIt fetch call -- self-healing, already covered by the ratio-based
+	// alert-planit-failure-rate-shared log alert -- rather than a genuine
+	// state-store/Postgres failure. Meaningless when AuthorityErrors == 0
+	// (tc-uitxr).
+	AuthorityErrorIsPlanIt bool
+	Termination            string
 	// OldestHWMAgeSeconds mirrors polling.PollPlanItResult.OldestHWMAgeSeconds:
 	// the staleness (seconds) of the least-recently-polled candidate
 	// authority's high-water mark at cycle start, nil when the cycle had no
@@ -230,9 +237,17 @@ func Run(ctx context.Context, mode string, bootstrapper *Bootstrapper, digester 
 // keep working). It tags the span with the canonical keys
 // (polling.sb.message_received / published_next / authorities_polled /
 // applications_ingested / termination / authority_errors) and applies the
-// exit-code rule: exit 1 only when the run did NO useful work AND hit authority
-// errors. A nil orchestrator (job missing Service Bus / Cosmos config) is an
-// exit-1 condition; an orchestrator error is recorded on the span and also exits 1.
+// exit-code rule: exit 1 only when the run did NO useful work, hit an
+// authority error, AND that error did NOT originate from a PlanIt fetch call
+// (res.AuthorityErrorIsPlanIt) -- an isolated PlanIt-origin error on an
+// otherwise-quiet cycle self-heals (the orchestrator still completes the
+// message and publishes the next trigger normally) and is already covered by
+// the ratio-based alert-planit-failure-rate-shared log alert, so it exits 0
+// rather than paging alert-job-failed-poll-prod (tc-uitxr). Any other error
+// type -- a watermark/state-store or Postgres failure -- still exits 1
+// immediately, exactly as before. A nil orchestrator (job missing Service Bus
+// / Cosmos config) is an exit-1 condition; an orchestrator error is recorded
+// on the span and also exits 1.
 func runPollSB(ctx context.Context, poller PollOrchestrator, logger *slog.Logger) int {
 	tracer := otel.Tracer(tracerName)
 	ctx, span := tracer.Start(ctx, "Polling Cycle (SB)")
@@ -257,6 +272,7 @@ func runPollSB(ctx context.Context, poller PollOrchestrator, logger *slog.Logger
 		attribute.Int("polling.authorities_polled", res.AuthoritiesPolled),
 		attribute.Int("polling.applications_ingested", res.ApplicationCount),
 		attribute.Int("polling.authority_errors", res.AuthorityErrors),
+		attribute.Bool("polling.authority_error_is_planit", res.AuthorityErrorIsPlanIt),
 		attribute.String("polling.termination", res.Termination),
 		attribute.String("polling.cycle_type", res.CycleType),
 	)
@@ -273,12 +289,16 @@ func runPollSB(ctx context.Context, poller PollOrchestrator, logger *slog.Logger
 		"applicationsIngested", res.ApplicationCount,
 		"authoritiesPolled", res.AuthoritiesPolled,
 		"authorityErrors", res.AuthorityErrors,
+		"authorityErrorIsPlanIt", res.AuthorityErrorIsPlanIt,
 		"leaseUnavailable", res.LeaseUnavailable)
 
-	// Exit-code rule: only exit 1 when the run did no useful work AND hit
-	// authority errors. A quiet cycle (0 apps, 0 errors), a lease-unavailable
-	// exit, and any cycle that ingested apps all exit 0.
-	if res.ApplicationCount == 0 && res.AuthorityErrors > 0 {
+	// Exit-code rule (tc-uitxr): only exit 1 when the run did no useful work,
+	// hit an authority error, AND that error is NOT PlanIt-origin. A quiet
+	// cycle (0 apps, 0 errors), a lease-unavailable exit, any cycle that
+	// ingested apps, and an isolated PlanIt-origin error on an otherwise-quiet
+	// cycle (self-healing -- covered by alert-planit-failure-rate-shared
+	// instead) all exit 0. A genuine state-store/Postgres error still exits 1.
+	if res.ApplicationCount == 0 && res.AuthorityErrors > 0 && !res.AuthorityErrorIsPlanIt {
 		return 1
 	}
 	return 0

--- a/api-go/internal/worker/dispatch_test.go
+++ b/api-go/internal/worker/dispatch_test.go
@@ -301,8 +301,8 @@ func TestRun_PollSBExitsOneOnlyWhenNoAppsAndAuthorityErrors(t *testing.T) {
 		wantExit int
 	}{
 		{
-			name:     "no apps and authority errors -> exit 1",
-			result:   PollRunResult{MessageReceived: true, ApplicationCount: 0, AuthorityErrors: 2},
+			name:     "no apps and non-PlanIt-origin authority errors -> exit 1",
+			result:   PollRunResult{MessageReceived: true, ApplicationCount: 0, AuthorityErrors: 2, AuthorityErrorIsPlanIt: false},
 			wantExit: 1,
 		},
 		{
@@ -319,6 +319,23 @@ func TestRun_PollSBExitsOneOnlyWhenNoAppsAndAuthorityErrors(t *testing.T) {
 			name:     "lease unavailable -> exit 0 (peer is polling)",
 			result:   PollRunResult{LeaseUnavailable: true},
 			wantExit: 0,
+		},
+		{
+			// tc-uitxr: an isolated PlanIt-origin fetch error on an otherwise
+			// quiet cycle self-heals (the orchestrator still completes the
+			// message and publishes the next trigger normally) and is already
+			// covered by the ratio-based alert-planit-failure-rate-shared log
+			// alert, so it must not also page alert-job-failed-poll-prod.
+			name:     "no apps, authority error is PlanIt-origin -> exit 0 (self-healing)",
+			result:   PollRunResult{MessageReceived: true, ApplicationCount: 0, AuthorityErrors: 1, AuthorityErrorIsPlanIt: true},
+			wantExit: 0,
+		},
+		{
+			// tc-uitxr: a genuine state-store/Postgres error must keep paging
+			// immediately, exactly as before.
+			name:     "no apps, authority error is NOT PlanIt-origin -> exit 1 (genuine failure)",
+			result:   PollRunResult{MessageReceived: true, ApplicationCount: 0, AuthorityErrors: 1, AuthorityErrorIsPlanIt: false},
+			wantExit: 1,
 		},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary

`alert-job-failed-poll-prod` (Sev2) has been firing almost daily for the last 30 days, always auto-resolving — training the owner to ignore Sev2 pages entirely. Root cause: `poll-sb`'s exit code couldn't distinguish a self-healing PlanIt fetch hiccup from a genuine Postgres/state-store failure — both incremented the same `AuthorityErrors` counter, and the worker exited 1 for either.

This adds origin classification (`planitOrigin` / `AuthorityErrorIsPlanIt`) through the lane handlers (A/B/C/D), `PollPlanItResult`, and `PollRunResult`, so `runPollSB`'s exit rule becomes:

```go
if res.ApplicationCount == 0 && res.AuthorityErrors > 0 && !res.AuthorityErrorIsPlanIt {
    return 1
}
```

- An isolated PlanIt-origin fetch error on an otherwise-quiet cycle now exits 0 — the orchestrator already completes the message and publishes the next trigger normally either way, and sustained PlanIt trouble is already caught by the ratio-based `alert-planit-failure-rate-shared` log alert.
- Any other error (watermark/state-store, Postgres) still exits 1 immediately, unchanged.

Follow-up (tc-8dg4a, blocked on this shipping to prod via a release — **not part of this PR, and no release is being cut in this session**): narrow `alert-job-failed-poll-prod`'s threshold back down now that exit-1 is reserved for genuine failures.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test -race ./...` — all packages pass (2159 tests)
- [x] Scope check: only `api-go/` files touched, no `infra/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DvMGPudoDWfr2ZPLxgrCm7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for authority polling failures.
  * PlanIt-originated fetch errors are now distinguished from state-store and ingestion errors.
  * Isolated PlanIt errors no longer cause an otherwise empty polling cycle to exit with failure.
  * Other authority and database errors continue to trigger failure status as expected.
  * Improved timeout and error reporting accuracy in polling workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->