### PR TITLE
fix(ios): stop watch-zone error banner overlapping the shape picker

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorView.swift
@@ -12,28 +12,28 @@ public struct WatchZoneEditorView: View {
 
   public var body: some View {
     NavigationStack {
-      Form {
-        nameSection
-        if viewModel.isPostcodeFieldVisible {
-          postcodeSection
-        }
-        if viewModel.geocodedCoordinate != nil {
-          shapeModeSection
-          if viewModel.shapeMode == .circle {
-            radiusSection
-            mapPreviewSection
-          } else if viewModel.canDrawCustomShape {
-            boundaryDrawingSection
-          } else {
-            lockedCustomShapeSection
+      VStack(spacing: 0) {
+        errorBanner
+        Form {
+          nameSection
+          if viewModel.isPostcodeFieldVisible {
+            postcodeSection
+          }
+          if viewModel.geocodedCoordinate != nil {
+            shapeModeSection
+            if viewModel.shapeMode == .circle {
+              radiusSection
+              mapPreviewSection
+            } else if viewModel.canDrawCustomShape {
+              boundaryDrawingSection
+            } else {
+              lockedCustomShapeSection
+            }
+          }
+          if viewModel.areNotificationTogglesVisible {
+            notificationsSection
           }
         }
-        if viewModel.areNotificationTogglesVisible {
-          notificationsSection
-        }
-      }
-      .safeAreaInset(edge: .top, spacing: 0) {
-        errorBanner
       }
       .navigationTitle(viewModel.isEditing ? "Edit Watch Zone" : "New Watch Zone")
       #if os(iOS)
@@ -357,15 +357,20 @@ public struct WatchZoneEditorView: View {
     }
   }
 
-  /// Pinned above the `Form`'s scrollable content via `.safeAreaInset(edge:
-  /// .top)` rather than a trailing `Form` `Section` (tc-9oyhw, GH#1085) --
-  /// a save failure while scrolled into the custom-shape drawing section
-  /// with the keyboard open used to render entirely off-screen. Always
-  /// attached so the inset participates in layout consistently; the
-  /// `if let` inside collapses to zero size when there's no error, mirroring
-  /// `MapView`'s `headerSection` precedent for an always-on, conditionally
-  /// empty inset. Tracks `viewModel.error` exactly as the removed section
-  /// conditional did -- no new appearance/disappearance timing.
+  /// Pinned above the `Form` as a plain `VStack` sibling rather than a
+  /// trailing `Form` `Section` (tc-9oyhw, GH#1085) -- a save failure while
+  /// scrolled into the custom-shape drawing section with the keyboard open
+  /// used to render entirely off-screen. Deliberately NOT a `.safeAreaInset`
+  /// on the `Form` (tried first, reverted in tc-p8oks): `Form`/`List` is
+  /// UIKit-backed, and its content-inset doesn't reliably track the inset
+  /// view's height when that height changes dynamically (e.g. `userMessage`
+  /// wrapping to two lines) -- the first `Form` row rendered underneath the
+  /// banner's translucent background instead of below it. `MapView`'s
+  /// `headerSection` precedent (also a `.safeAreaInset`) doesn't hit this:
+  /// it sits over a `ZStack`/`Map`, not a `Form`. A `VStack` sibling lays
+  /// out deterministically instead. Always attached so the `if let` inside
+  /// collapses to zero size when there's no error -- no new appearance/
+  /// disappearance timing versus the removed section conditional.
   @ViewBuilder
   private var errorBanner: some View {
     if let error = viewModel.error {


### PR DESCRIPTION
## Summary
- The New/Edit Watch Zone save-error banner (shipped in #1087, tc-9oyhw) was pinned via `.safeAreaInset(edge: .top)` on the `Form`. `Form`/`List` is UIKit-backed and doesn't reliably resize its content inset when the inset view's height changes dynamically — when the `boundary_too_large` message wrapped to two lines, the Circle/Custom shape picker row rendered underneath the banner's translucent red background instead of below it (reported by user via screenshot).
- Fix: move the banner out of `.safeAreaInset` on `Form` into a plain `VStack` sibling above it (`VStack { errorBanner; Form { ... } }`), so it reserves real layout space deterministically regardless of text wrap.

## Test plan
- [x] `swift build` clean
- [x] `swiftlint --strict` clean on the changed file
- [x] Full `swift test` — 1979/1979 (one pre-existing flake in `MapViewModelStackTests`, confirmed unrelated and passes in isolation)
- [x] Live simulator verification (Pro tier, iPhone 17 Pro / iOS 26.2): reproduced the real `400 boundary_too_large` response via a large custom-shape boundary on the create path, confirmed the banner's bounding box ends exactly where the Form's first row begins (zero overlap), confirmed the banner stays pinned while scrolling the Form

bd: tc-p8oks (discovered-from tc-9oyhw)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXYgYtaYRSKsieijf9Fb4j

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the placement and visibility of error messages in the Watch Zone editor.
  * Error banners now appear clearly above the form without affecting the form’s layout or section visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->