### PR TITLE
chore(api): drop watch_zones.authority_id column (tc-9nbs4.5)

### DIFF
--- a/api-go/internal/platform/postgres/migrations/0025_drop_watch_zone_authority_id.sql
+++ b/api-go/internal/platform/postgres/migrations/0025_drop_watch_zone_authority_id.sql
@@ -15,7 +15,7 @@
 -- No backfill needed: the column is nullable with no default
 -- (0001_init_postgis.sql:49), so this is a straight drop.
 ALTER TABLE watch_zones
-    DROP COLUMN authority_id;
+    DROP COLUMN IF EXISTS authority_id;
 
 -- +goose Down
 
@@ -23,4 +23,4 @@ ALTER TABLE watch_zones
 -- that existed before the Up ran are gone and cannot be recovered by this
 -- Down -- nothing in the running system re-resolves or backfills them.
 ALTER TABLE watch_zones
-    ADD COLUMN authority_id integer;
+    ADD COLUMN IF NOT EXISTS authority_id integer;

--- a/api-go/internal/platform/postgres/migrations/0025_drop_watch_zone_authority_id.sql
+++ b/api-go/internal/platform/postgres/migrations/0025_drop_watch_zone_authority_id.sql
@@ -1,0 +1,26 @@
+-- +goose Up
+
+-- Phase 2 of the watch_zones.authority_id removal (epic tc-9nbs4, GH#1076).
+-- Phase 1 (tc-9nbs4.2, PR #1080) removed every Go code path that reads or
+-- writes this column -- resolution, storage, and the wire format (the
+-- surviving `authorityId` in the API response is a hardcoded-0 back-compat
+-- shim for old clients, tc-9nbs4.6, backed by no column). Notification
+-- matching is purely geographic (ADR 0041/0044, notifydispatch/decision.go)
+-- and has never read this column, so dropping it has no effect on delivery.
+--
+-- Sequenced as its own PR/migration, opened only after Phase 1 has been
+-- live in prod and soaked, specifically so a column-reading old replica can
+-- never run against a schema that's already dropped it mid-rollout.
+--
+-- No backfill needed: the column is nullable with no default
+-- (0001_init_postgis.sql:49), so this is a straight drop.
+ALTER TABLE watch_zones
+    DROP COLUMN authority_id;
+
+-- +goose Down
+
+-- Restores the column shape only, not its data: any authority_id values
+-- that existed before the Up ran are gone and cannot be recovered by this
+-- Down -- nothing in the running system re-resolves or backfills them.
+ALTER TABLE watch_zones
+    ADD COLUMN authority_id integer;


### PR DESCRIPTION
## Summary

Phase 2 of the `watch_zones.authority_id` removal (epic tc-9nbs4, GH#1076): drops the now-unused `authority_id` column from `watch_zones` via a new goose migration (`0025_drop_watch_zone_authority_id.sql`).

- Phase 1 (tc-9nbs4.2, PR #1080) already removed every Go code path that reads or writes this column — resolution, storage, and matching. Notification matching is purely geographic (ADR 0041/0044) and never read this column.
- The surviving `authorityId` in the API response is a hardcoded-0 back-compat shim for old app clients (tc-9nbs4.6, PR #1082) backed by no column, so it is unaffected by this drop.
- **Precondition satisfied**: per GH#1076's design ("Phase 2 migration is a separate PR from Phase 1, only opened/merged after Phase 1 is confirmed live in prod" — to avoid a column-reading old replica running against an already-dropped schema mid-rollout), Phase 1 (commit 19384f5) and the back-compat shim (commit 09d9db1) are both live in prod as of tags v0.21.22 and v0.21.23, cd-prod green, over a day of soak elapsed.
- Column is nullable with no default, so no backfill is needed — a straight `DROP COLUMN`.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `gofmt -l .` — empty
- [x] `go test ./...` — all packages pass
- [x] Repo-wide search confirms no remaining code references `watch_zones.authority_id` (all other `authority_id` hits are on unrelated tables: `poll_state`, `saved_applications`, `notifications`)
- [ ] Real-Postgres integration suite (`make test-integration`) — not runnable in this cloud session (no Docker); the PR gate runs it against real Postgres/PostGIS and will catch any schema-level issue

Bead: tc-9nbs4.5 (left `in_progress`, PR link + gate state to be recorded on it once gate result is known — not merged by this routine per repo policy).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01Er7QxuJ9GfGXGkucq4JmuF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Er7QxuJ9GfGXGkucq4JmuF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the deprecated authority identifier field from watch zone data.
  * Existing authority identifier values will not be restored if the database change is rolled back.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->