### PR TITLE
feat(api): watch-zone filter domain FilterKey + Pro entitlement gate (tc-w825j.2)

### DIFF
--- a/api-go/internal/profiles/profile.go
+++ b/api-go/internal/profiles/profile.go
@@ -96,6 +96,13 @@ func (t SubscriptionTier) WatchZoneLimit() int {
 // never Free. Part of the custom-shape watch zones entitlement (epic GH#1031).
 func (t SubscriptionTier) AllowsCustomBoundary() bool { return t.IsPaid() }
 
+// AllowsWatchZoneFilter reports whether the tier may set a pre-canned
+// keyword filter on a watch zone: Pro only, never Free or Personal. Narrower
+// than AllowsCustomBoundary (which any paid tier grants via IsPaid) —
+// pre-canned filters are a deliberate Pro-tier-exclusive upsell (GH#1090,
+// epic tc-w825j), not a Personal-tier capability.
+func (t SubscriptionTier) AllowsWatchZoneFilter() bool { return t.IsPaidPro() }
+
 // MaxZoneRadiusMetres returns the maximum enclosing-circle radius, in metres,
 // permitted for a custom-shape polygon boundary: Free=2000, Personal=5000,
 // Pro=10000, mirroring mobile/ios/packages/town-crier-domain/Sources/

--- a/api-go/internal/profiles/profile_test.go
+++ b/api-go/internal/profiles/profile_test.go
@@ -184,6 +184,20 @@ func TestSubscriptionTier_AllowsCustomBoundary(t *testing.T) {
 	}
 }
 
+func TestSubscriptionTier_AllowsWatchZoneFilter(t *testing.T) {
+	t.Parallel()
+
+	if TierFree.AllowsWatchZoneFilter() {
+		t.Error("Free should not allow a watch-zone filter")
+	}
+	if TierPersonal.AllowsWatchZoneFilter() {
+		t.Error("Personal should not allow a watch-zone filter (Pro-only, narrower than AllowsCustomBoundary)")
+	}
+	if !TierPro.AllowsWatchZoneFilter() {
+		t.Error("Pro should allow a watch-zone filter")
+	}
+}
+
 func TestSubscriptionTier_MaxZoneRadiusMetres(t *testing.T) {
 	t.Parallel()
 

--- a/api-go/internal/watchzones/zone.go
+++ b/api-go/internal/watchzones/zone.go
@@ -12,6 +12,7 @@ package watchzones
 
 import (
 	"errors"
+	"fmt"
 	"math"
 	"strings"
 	"time"
@@ -43,6 +44,11 @@ var (
 	ErrBoundaryOutOfBounds = errors.New("boundary vertices must be within the UK")
 )
 
+// ErrUnknownFilterKey signals a ZoneUpdate.FilterKey value that is not a
+// member of the filter catalog (see IsValidFilterKey). Consumers should use
+// errors.Is rather than string matching.
+var ErrUnknownFilterKey = errors.New("unknown watch-zone filter key")
+
 // WatchZone is a user's geofenced monitoring area scoped to one planning
 // authority: either a circle (centre + radius) or, when Boundary is non-nil,
 // a custom-shape polygon. A custom-shape zone still carries Latitude,
@@ -63,6 +69,13 @@ type WatchZone struct {
 	PushEnabled         bool
 	EmailInstantEnabled bool
 	Boundary            Boundary
+	// FilterKey is the zone's pre-canned keyword filter (GH#1090, epic
+	// tc-w825j): the zero value ("") means unfiltered, the same
+	// zero-value-means-unset pattern as most other domain fields — unlike
+	// Boundary, no derived field needs recomputing when it changes. Setting
+	// it to a non-empty value is a Pro-tier-only entitlement, enforced by
+	// the HTTP layer, not here.
+	FilterKey FilterKey
 }
 
 // NewWatchZone validates and constructs a circle watch zone (Boundary nil).
@@ -400,6 +413,14 @@ func (b Boundary) EnclosingRadiusMetres() float64 {
 // This is the domain-level representation of the tri-state; decoding the
 // HTTP PATCH body's `"boundary": null` vs absent vs a value into this shape
 // is a separate, JSON-layer concern (json.RawMessage) handled by the handler.
+//
+// FilterKey is tri-state too, mirroring Boundary's shape exactly (a plain
+// *string cannot distinguish an absent PATCH key from an explicit
+// `"filterKey": null`, since both decode to a nil pointer):
+//   - nil                  — absent: leave the zone's filter alone.
+//   - non-nil, pointing to "" — explicit clear: revert to unfiltered.
+//   - non-nil, pointing to a value — set this filter, validated against
+//     IsValidFilterKey; an unrecognised value returns ErrUnknownFilterKey.
 type ZoneUpdate struct {
 	Name                *string
 	Latitude            *float64
@@ -408,6 +429,7 @@ type ZoneUpdate struct {
 	PushEnabled         *bool
 	EmailInstantEnabled *bool
 	Boundary            *Boundary
+	FilterKey           *string
 }
 
 // WithUpdates returns a copy of the zone with the non-nil fields of u applied,
@@ -455,6 +477,18 @@ func (z WatchZone) WithUpdates(u ZoneUpdate) (WatchZone, error) {
 		}
 	}
 
+	if u.FilterKey != nil {
+		if *u.FilterKey == "" {
+			// Explicit clear: revert to unfiltered. No validation needed —
+			// "" is always a valid target, unlike a set.
+			updated.FilterKey = ""
+		} else if !IsValidFilterKey(*u.FilterKey) {
+			return WatchZone{}, fmt.Errorf("%w: %q", ErrUnknownFilterKey, *u.FilterKey)
+		} else {
+			updated.FilterKey = FilterKey(*u.FilterKey)
+		}
+	}
+
 	result, err := NewWatchZone(
 		updated.ID,
 		updated.UserID,
@@ -470,5 +504,6 @@ func (z WatchZone) WithUpdates(u ZoneUpdate) (WatchZone, error) {
 		return WatchZone{}, err
 	}
 	result.Boundary = updated.Boundary
+	result.FilterKey = updated.FilterKey
 	return result, nil
 }

--- a/api-go/internal/watchzones/zone_test.go
+++ b/api-go/internal/watchzones/zone_test.go
@@ -572,3 +572,55 @@ func TestWatchZone_WithUpdates_BoundaryTriState(t *testing.T) {
 		}
 	})
 }
+
+func TestWatchZone_WithUpdates_FilterKeyTriState(t *testing.T) {
+	t.Parallel()
+	filteredZone := testZone(t)
+	filteredZone.FilterKey = FilterKeyHouseBuilder
+
+	t.Run("absent leaves the filter untouched", func(t *testing.T) {
+		t.Parallel()
+		updated, err := filteredZone.WithUpdates(ZoneUpdate{})
+		if err != nil {
+			t.Fatalf("WithUpdates: %v", err)
+		}
+		if updated.FilterKey != filteredZone.FilterKey {
+			t.Errorf("FilterKey changed by an absent update: got %q, want %q", updated.FilterKey, filteredZone.FilterKey)
+		}
+	})
+
+	t.Run("explicit empty string clears the filter", func(t *testing.T) {
+		t.Parallel()
+		cleared := ""
+		updated, err := filteredZone.WithUpdates(ZoneUpdate{FilterKey: &cleared})
+		if err != nil {
+			t.Fatalf("WithUpdates: %v", err)
+		}
+		if updated.FilterKey != "" {
+			t.Errorf("FilterKey not cleared: got %q", updated.FilterKey)
+		}
+	})
+
+	t.Run("a valid catalog key sets the filter", func(t *testing.T) {
+		t.Parallel()
+		zone := testZone(t)
+		key := string(FilterKeyLoftExtension)
+		updated, err := zone.WithUpdates(ZoneUpdate{FilterKey: &key})
+		if err != nil {
+			t.Fatalf("WithUpdates: %v", err)
+		}
+		if updated.FilterKey != FilterKeyLoftExtension {
+			t.Errorf("FilterKey: got %q, want %q", updated.FilterKey, FilterKeyLoftExtension)
+		}
+	})
+
+	t.Run("an unrecognised key is rejected", func(t *testing.T) {
+		t.Parallel()
+		zone := testZone(t)
+		bogus := "not_a_real_filter"
+		_, err := zone.WithUpdates(ZoneUpdate{FilterKey: &bogus})
+		if !errors.Is(err, ErrUnknownFilterKey) {
+			t.Fatalf("WithUpdates: got %v, want ErrUnknownFilterKey", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Adds `WatchZone.FilterKey` (zero value `""` = unfiltered) and a tri-state `ZoneUpdate.FilterKey *string` mirroring the existing `Boundary` tri-state pattern exactly (nil = absent/leave alone, pointer-to-`""` = explicit clear, pointer-to-value = set + validate).
- `WithUpdates` validates a set against the filter catalog (`IsValidFilterKey`, merged in tc-w825j.1) and returns a new sentinel `ErrUnknownFilterKey` on an unrecognised value.
- Adds `SubscriptionTier.AllowsWatchZoneFilter()`, gated on `IsPaidPro()` — deliberately narrower than `AllowsCustomBoundary()`'s `IsPaid()`, since pre-canned filters are a Pro-tier-only upsell per GH#1090.

## Context
Part of epic tc-w825j / GH#1090 (pre-canned keyword filters on watch zones, Pro-tier). This bead covers issue sections 3 (domain) and 5 (entitlement) only — HTTP wiring, store persistence, the full-text matcher, and Enqueuer wiring are separate sibling beads (tc-w825j.3/.4/.5) that build on this.

## Test plan
- [x] `TestWatchZone_WithUpdates_FilterKeyTriState` — absent/clear/set/invalid subtests
- [x] `TestSubscriptionTier_AllowsWatchZoneFilter` — Free/Personal/Pro
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `go test ./...` — full suite green, no regressions
- [ ] `golangci-lint` — could not run in this session; the pinned binary was built with go1.25 but `go.mod` targets go 1.26, a pre-existing environment mismatch unrelated to this change. PR Gate CI runs its own compatible toolchain.

Closes tc-w825j.2 (bead left `in_progress` pending merge, per this repo's Claude-routine triage policy — PR Gate green means ready for review, not merged).

---
_Generated by [Claude Code](https://claude.ai/code/session_012jRgpXMvTdxG922ZFfroEb)_