### PR TITLE
feat(api): description matcher for watch-zone filter catalog (tc-w825j.4)

### DIFF
--- a/api-go/internal/applications/store_postgres.go
+++ b/api-go/internal/applications/store_postgres.go
@@ -253,6 +253,22 @@ func (s *PostgresStore) GetByUID(ctx context.Context, uid, authorityCode string)
 	return a, true, nil
 }
 
+const matchesExpressionQuery = "SELECT to_tsvector('english', $1::text) @@ to_tsquery('english', $2)"
+
+// MatchesExpression reports whether description matches the given
+// to_tsquery('english', ...) boolean expression under Postgres full-text
+// search — the watch-zone pre-canned filter matcher (GH#1090, epic tc-w825j;
+// see watchzones.FilterDefinition.Expression for the catalog this is built
+// to evaluate). It touches no table: both operands are literals, so there is
+// no index or row cost to this call beyond the tsvector/tsquery parse.
+func (s *PostgresStore) MatchesExpression(ctx context.Context, description, expression string) (bool, error) {
+	var matches bool
+	if err := s.db.QueryRow(ctx, matchesExpressionQuery, description, expression).Scan(&matches); err != nil {
+		return false, fmt.Errorf("match description against expression %q: %w", expression, err)
+	}
+	return matches, nil
+}
+
 // recentRealDateOrder is the shared "sort by the stable real-world lifecycle
 // date, not PlanIt's last_different re-index marker" ORDER BY clause (#819
 // decision 1). last_different is bumped to "now" whenever PlanIt re-indexes an

--- a/api-go/internal/applications/store_postgres_integration_test.go
+++ b/api-go/internal/applications/store_postgres_integration_test.go
@@ -1,0 +1,104 @@
+//go:build integration
+
+// External test package (applications_test, not applications): watchzones
+// imports applications in production code (nearby.go), so a same-package
+// test file cannot import watchzones without an import cycle. MatchesExpression
+// touches no table, so this test needs no unexported helper from
+// store_postgres_test.go — pgtest.New and applications.NewPostgresStore are
+// both exported and sufficient.
+package applications_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/platform/postgres/pgtest"
+	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
+)
+
+// The two catalog expressions this suite exercises, copied verbatim from
+// watchzones.filterCatalog[watchzones.FilterKeyLoftExtension] and
+// watchzones.filterCatalog[watchzones.FilterKeyHMOHouseShares]
+// (api-go/internal/watchzones/filter.go). filterCatalog itself is
+// unexported and the watchzones package has no exported accessor to read a
+// single entry's Expression from outside the package, so these cannot be
+// pulled in programmatically without adding one to watchzones — out of
+// scope for this bead (tc-w825j.4 stays entirely within
+// internal/applications/). The IsValidFilterKey checks in the test below at
+// least tie this file to the real FilterKey constants, so a renamed or
+// removed key fails loudly instead of silently drifting. If watchzones ever
+// grows an exported per-key expression accessor, these two constants should
+// be deleted in favour of it.
+const (
+	// loftExtensionExpression mirrors filterCatalog[FilterKeyLoftExtension].Expression.
+	loftExtensionExpression = "loft | dormer | (hip <2> gable) | roofspace | (roof <-> space)"
+	// hmoHouseSharesExpression mirrors filterCatalog[FilterKeyHMOHouseShares].Expression.
+	hmoHouseSharesExpression = "hmo | (multiple <-> occupation) | (class <-> c4) | ((sui <-> generis) & (bedroom | occupation | lodging))"
+)
+
+// TestPostgresStore_MatchesExpression proves MatchesExpression evaluates real
+// Postgres full-text semantics correctly against a handful of the pre-canned
+// watch-zone filter catalog's own validated expressions (GH#1090, epic
+// tc-w825j) and real example descriptions.
+func TestPostgresStore_MatchesExpression(t *testing.T) {
+	if !watchzones.IsValidFilterKey(string(watchzones.FilterKeyLoftExtension)) {
+		t.Fatalf("watchzones.FilterKeyLoftExtension is no longer a valid catalog key")
+	}
+	if !watchzones.IsValidFilterKey(string(watchzones.FilterKeyHMOHouseShares)) {
+		t.Fatalf("watchzones.FilterKeyHMOHouseShares is no longer a valid catalog key")
+	}
+
+	pool := pgtest.New(t)
+	store := applications.NewPostgresStore(pool)
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		description string
+		expression  string
+		want        bool
+	}{
+		{
+			name:        "loft_extension: description with dormer but not the word loft still matches",
+			description: "Erection of a two storey rear extension with a dormer window to the roof",
+			expression:  loftExtensionExpression,
+			want:        true,
+		},
+		{
+			name:        "loft_extension: hip <2> gable matches the hyphenated Hip-to-gable spelling",
+			description: "Single storey side extension with hip-to-gable roof alteration",
+			expression:  loftExtensionExpression,
+			want:        true,
+		},
+		{
+			name:        "loft_extension: unrelated description does not match",
+			description: "Felling of one protected oak tree",
+			expression:  loftExtensionExpression,
+			want:        false,
+		},
+		{
+			name:        "hmo_house_shares: class <-> c4 excludes a Condition 4 description",
+			description: "Discharge of Condition 4 relating to construction hours",
+			expression:  hmoHouseSharesExpression,
+			want:        false,
+		},
+		{
+			name:        "hmo_house_shares: Class C4 phrase matches",
+			description: "Change of use from dwellinghouse to Class C4 HMO",
+			expression:  hmoHouseSharesExpression,
+			want:        true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := store.MatchesExpression(ctx, tc.description, tc.expression)
+			if err != nil {
+				t.Fatalf("MatchesExpression: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %v, want %v (description %q, expression %q)", got, tc.want, tc.description, tc.expression)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `applications.PostgresStore.MatchesExpression(ctx, description, expression) (bool, error)`, a thin wrapper around `SELECT to_tsvector('english', $1) @@ to_tsquery('english', $2)` — no table or index touched, both operands are literals.
- This is the "matcher" piece (section 8) of the pre-canned watch-zone filter feature (GH#1090, epic tc-w825j): the Postgres full-text query that will decide whether an application's description matches one of the seven catalog filter expressions (already shipped in `watchzones.filterCatalog`, tc-w825j.1).
- Wiring this into the notification-dispatch Enqueuer (a `descriptionMatcher` consumer interface, `NewEnqueuer` param, `matchesFilter`) is the still-blocked sibling bead tc-w825j.5 — deliberately not touched here.

## Why a real-DB integration test, not a fake

Per GH#1090's Test Strategy and ADR 0032, a hand-written fake would not honestly reproduce Postgres's actual English-config stemming and `<N>`-distance semantics that the catalog's expressions were validated against. `MatchesExpression` is covered only by `api-go/internal/applications/store_postgres_integration_test.go` (`//go:build integration`), exercising the real `loft_extension` and `hmo_house_shares` catalog expressions (copied verbatim, with a comment pointing at the source) against real example descriptions — dormer-without-"loft", hyphenated "hip-to-gable", and the "Condition 4" vs "Class C4" `c4` disambiguation.

**This integration test was not executed in this session** — no Docker daemon is available in this cloud/CCR environment (confirmed via `docker ps`). It compiles cleanly under `-tags=integration` and follows the existing `pgtest` harness conventions used by every other integration test in this package, but it needs a real run against Postgres (`make test-integration`) before merge to confirm the assertions actually hold.

## Test plan

- [x] `gofmt -l .` — clean
- [x] `go vet ./...` — clean
- [x] `go build ./...` and `go build -tags=integration ./...` — clean
- [x] `go test ./...` — all packages pass (untagged suite; `TestPostgresStore_MatchesExpression` correctly does not run here, it's integration-tagged)
- [ ] `make test-integration` — **not run in this session, no Docker available**; the PR gate's real-Postgres suite should exercise this, but please double-check it before merging

## Follow-up worth filing

`watchzones.filterCatalog` is unexported with no per-key expression accessor, so this test hardcodes copies of two catalog expressions (verified verbatim, with `IsValidFilterKey` assertions as an anti-drift guard) rather than importing them directly — importing `watchzones` from the same-package `applications` test file isn't possible (`watchzones` imports `applications` in production code). An exported `watchzones.FilterExpression(key) (string, bool)` accessor would remove the duplication; not added here since it's outside tc-w825j.4's scope and could be folded into tc-w825j.5.

Bead: tc-w825j.4, part of epic tc-w825j, GH#1090.

---
🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0123MNnW9ZaqorisyrJTrNhn)_