### PR TITLE
feat(api): watch-zone filter_key store persistence + HTTP create/patch gating (tc-w825j.3)

### DIFF
--- a/api-go/internal/watchzones/handler.go
+++ b/api-go/internal/watchzones/handler.go
@@ -76,12 +76,13 @@ const (
 	filterKeyInvalidMessage = "Unrecognised filter."
 )
 
-// errProfileReaderNotWired signals a wiring bug: setting a watch-zone boundary
-// requires the profile reader to check the caller's tier entitlement, and the
-// handler refuses to run an unverified tier check without it. Unreachable in
-// production, where Routes/NearbyRoutes are always wired WithProfileReader
-// whenever a profile store is configured (cmd/api/wiring.go).
-var errProfileReaderNotWired = errors.New("profile reader not wired for boundary tier gate")
+// errProfileReaderNotWired signals a wiring bug: setting a watch-zone
+// boundary or filter key requires the profile reader to check the caller's
+// tier entitlement, and the handler refuses to run an unverified tier check
+// without it. Unreachable in production, where Routes/NearbyRoutes are
+// always wired WithProfileReader whenever a profile store is configured
+// (cmd/api/wiring.go).
+var errProfileReaderNotWired = errors.New("profile reader not wired for watch-zone tier gate")
 
 // isBoundaryValidationError reports whether err is one of the shape-validation
 // sentinels NewBoundary returns (see zone.go), which WithUpdates propagates
@@ -340,6 +341,11 @@ type patchRequest struct {
 	PushEnabled         *bool           `json:"pushEnabled"`
 	EmailInstantEnabled *bool           `json:"emailInstantEnabled"`
 	Boundary            json.RawMessage `json:"boundary"`
+	// FilterKey is tri-state (GH#1090, epic tc-w825j), mirroring Boundary
+	// exactly and for the same reason: a plain *string cannot distinguish an
+	// absent key from an explicit "filterKey": null. See
+	// decodeFilterKeyUpdate.
+	FilterKey json.RawMessage `json:"filterKey"`
 }
 
 // rangeValid reports whether the present coordinate/radius fields are in
@@ -362,8 +368,10 @@ func (req patchRequest) rangeValid() bool {
 }
 
 // toUpdate builds the domain ZoneUpdate, threading the already-decoded
-// tri-state boundary (see decodeBoundaryUpdate) into ZoneUpdate.Boundary.
-func (req patchRequest) toUpdate(boundary *Boundary) ZoneUpdate {
+// tri-state boundary (see decodeBoundaryUpdate) into ZoneUpdate.Boundary and
+// the already-decoded tri-state filter key (see decodeFilterKeyUpdate) into
+// ZoneUpdate.FilterKey.
+func (req patchRequest) toUpdate(boundary *Boundary, filterKey *string) ZoneUpdate {
 	return ZoneUpdate{
 		Name:                req.Name,
 		Latitude:            req.Latitude,
@@ -372,6 +380,7 @@ func (req patchRequest) toUpdate(boundary *Boundary) ZoneUpdate {
 		PushEnabled:         req.PushEnabled,
 		EmailInstantEnabled: req.EmailInstantEnabled,
 		Boundary:            boundary,
+		FilterKey:           filterKey,
 	}
 }
 
@@ -407,13 +416,46 @@ func decodeBoundaryUpdate(raw json.RawMessage) (*Boundary, error) {
 	return &b, nil
 }
 
+// decodeFilterKeyUpdate resolves the PATCH body's tri-state "filterKey" field
+// (raw, exactly as captured by patchRequest.FilterKey's json.RawMessage) into
+// ZoneUpdate.FilterKey's pointer-to-string shape (see that field's doc
+// comment on ZoneUpdate), mirroring decodeBoundaryUpdate exactly:
+//
+//   - raw is nil (the JSON key was absent): (nil, nil) -- leave the zone's
+//     filter alone.
+//   - raw is the 4-byte JSON literal null (the key was present, explicitly
+//     null): a pointer to "" -- clear the filter, reverting to unfiltered.
+//   - raw is a JSON string value: a pointer to its value, UNVALIDATED against
+//     the catalog -- WithUpdates validates it (via IsValidFilterKey) when it
+//     applies the merge; this function does not re-implement that check,
+//     mirroring how decodeBoundaryUpdate defers shape validation.
+//
+// A value that is valid JSON but not a string (e.g. a number or object)
+// returns an error; the caller maps it to the filter_key_invalid response.
+func decodeFilterKeyUpdate(raw json.RawMessage) (*string, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	if bytes.Equal(raw, []byte("null")) {
+		empty := ""
+		return &empty, nil
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return nil, fmt.Errorf("decode filter key update: %w", err)
+	}
+	return &s, nil
+}
+
 // patch implements PATCH /v1/me/watch-zones/{zoneId}: range-validate the body
-// (400), decode the tri-state boundary field (400 boundary_invalid on
-// malformed GeoJSON), gate a boundary-setting update on the caller's tier
-// (403 boundary_requires_paid_tier), load the zone (404 if absent), apply the
-// merge (400 boundary_invalid on an invalid shape, 500 on any other domain
-// invariant violation e.g. a blank name), gate the resulting radius (400
-// boundary_too_large), persist, and return the updated summary.
+// (400), decode the tri-state boundary and filterKey fields (400
+// boundary_invalid / filter_key_invalid on a malformed value), gate a
+// boundary-setting or filter-setting update on the caller's tier (403
+// boundary_requires_paid_tier / filter_requires_pro_tier), load the zone (404
+// if absent), apply the merge (400 boundary_invalid / filter_key_invalid on
+// an invalid shape/key, 500 on any other domain invariant violation e.g. a
+// blank name), gate the resulting radius (400 boundary_too_large), persist,
+// and return the updated summary.
 func (h *handler) patch(w http.ResponseWriter, r *http.Request) {
 	userID := auth.Subject(r.Context())
 	zoneID := r.PathValue("zoneId")
@@ -439,10 +481,20 @@ func (h *handler) patch(w http.ResponseWriter, r *http.Request) {
 	// radius ceiling apply to (tc-6he3x.4 acceptance criteria 4 and 6).
 	settingBoundary := boundaryUpdate != nil && len(*boundaryUpdate) > 0
 
+	filterKeyUpdate, err := decodeFilterKeyUpdate(req.FilterKey)
+	if err != nil {
+		h.writeErrorCode(w, r, http.StatusBadRequest, filterKeyInvalidCode, filterKeyInvalidMessage)
+		return
+	}
+	// "Setting" a filter (as opposed to leaving it alone, or explicitly
+	// nulling it back to unfiltered) is the only case the Pro-tier gate
+	// applies to (GH#1090, epic tc-w825j) -- mirrors settingBoundary exactly.
+	settingFilter := filterKeyUpdate != nil && *filterKeyUpdate != ""
+
 	var tier profiles.SubscriptionTier
-	if settingBoundary {
+	if settingBoundary || settingFilter {
 		if h.profiles == nil {
-			h.serverError(w, r, "boundary tier gate", errProfileReaderNotWired)
+			h.serverError(w, r, "watch-zone tier gate", errProfileReaderNotWired)
 			return
 		}
 		profile, perr := h.profiles.Get(r.Context(), userID)
@@ -450,12 +502,16 @@ func (h *handler) patch(w http.ResponseWriter, r *http.Request) {
 			// A missing profile for an authenticated caller is a server-side
 			// inconsistency (the iOS app always registers on first launch) --
 			// mirroring nearby.go's create-path quota check.
-			h.serverError(w, r, "load profile for boundary tier gate", perr)
+			h.serverError(w, r, "load profile for watch-zone tier gate", perr)
 			return
 		}
 		tier = profile.EffectiveTier(h.now())
-		if !tier.AllowsCustomBoundary() {
+		if settingBoundary && !tier.AllowsCustomBoundary() {
 			h.writeErrorCode(w, r, http.StatusForbidden, boundaryRequiresPaidTierCode, boundaryRequiresPaidTierMessage)
+			return
+		}
+		if settingFilter && !tier.AllowsWatchZoneFilter() {
+			h.writeErrorCode(w, r, http.StatusForbidden, filterRequiresProTierCode, filterRequiresProTierMessage)
 			return
 		}
 	}
@@ -470,10 +526,14 @@ func (h *handler) patch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	updated, err := zone.WithUpdates(req.toUpdate(boundaryUpdate))
+	updated, err := zone.WithUpdates(req.toUpdate(boundaryUpdate, filterKeyUpdate))
 	if err != nil {
 		if isBoundaryValidationError(err) {
 			h.writeErrorCode(w, r, http.StatusBadRequest, boundaryInvalidCode, boundaryInvalidMessage)
+			return
+		}
+		if errors.Is(err, ErrUnknownFilterKey) {
+			h.writeErrorCode(w, r, http.StatusBadRequest, filterKeyInvalidCode, filterKeyInvalidMessage)
 			return
 		}
 		h.serverError(w, r, "apply watch-zone update", err)

--- a/api-go/internal/watchzones/handler.go
+++ b/api-go/internal/watchzones/handler.go
@@ -59,6 +59,23 @@ const (
 	zoneNameTakenMessage = "You already have a watch zone with this name."
 )
 
+// Pre-canned watch-zone filter error codes and messages (GH#1090, epic
+// tc-w825j), sitting alongside the boundary_* codes above and sharing their
+// (code, message) convention. Shared by both the create path (nearby.go) and
+// the patch path (this file) rather than duplicated per file.
+const (
+	// filterRequiresProTierCode/-Message: 403, a Free- or Personal-tier caller
+	// supplied a non-empty filterKey on create, or on a PATCH that sets one.
+	// Pro-only -- deliberately narrower than AllowsCustomBoundary's IsPaid()
+	// gate (see profiles.SubscriptionTier.AllowsWatchZoneFilter).
+	filterRequiresProTierCode    = "filter_requires_pro_tier"
+	filterRequiresProTierMessage = "Pre-canned watch-zone filters require a Pro subscription."
+	// filterKeyInvalidCode/-Message: 400, the supplied filterKey is not a
+	// member of the catalog (see IsValidFilterKey / ErrUnknownFilterKey).
+	filterKeyInvalidCode    = "filter_key_invalid"
+	filterKeyInvalidMessage = "Unrecognised filter."
+)
+
 // errProfileReaderNotWired signals a wiring bug: setting a watch-zone boundary
 // requires the profile reader to check the caller's tier entitlement, and the
 // handler refuses to run an unverified tier check without it. Unreachable in
@@ -191,6 +208,10 @@ type watchZoneSummary struct {
 	// the polygon's derived centroid/enclosing radius either way, so every
 	// pre-existing circle-shaped consumer keeps working unchanged.
 	Boundary *boundaryGeoJSON `json:"boundary"`
+	// FilterKey is null for an unfiltered zone and the catalog key string
+	// otherwise (GH#1090, epic tc-w825j), mirroring Boundary's presence
+	// convention.
+	FilterKey *string `json:"filterKey"`
 }
 
 func summaryOf(z WatchZone, paused bool) watchZoneSummary {
@@ -209,7 +230,19 @@ func summaryOf(z WatchZone, paused bool) watchZoneSummary {
 		EmailInstantEnabled: z.EmailInstantEnabled,
 		Paused:              paused,
 		Boundary:            boundaryToGeoJSON(z.Boundary),
+		FilterKey:           filterKeyToWire(z.FilterKey),
 	}
+}
+
+// filterKeyToWire renders a domain FilterKey as its nullable wire form: nil
+// for the unfiltered zero value, a pointer to the string form otherwise --
+// the same presence convention boundaryToGeoJSON uses for Boundary.
+func filterKeyToWire(k FilterKey) *string {
+	if k == "" {
+		return nil
+	}
+	s := string(k)
+	return &s
 }
 
 // listResult is the GET /v1/me/watch-zones response: { zones: [...] }.

--- a/api-go/internal/watchzones/handler_test.go
+++ b/api-go/internal/watchzones/handler_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/AmyDe/town-crier/api-go/internal/auth"
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
 )
 
 const testUser = "auth0|user"
@@ -565,6 +566,193 @@ func TestHandler_Patch_Boundary_NoProfileReaderWiredIs500(t *testing.T) {
 		t.Error("must not save when the tier gate cannot be verified")
 	}
 }
+
+// --- PATCH filterKey tri-state tests (GH#1090, epic tc-w825j) --------------
+
+// TestHandler_Patch_FilterKey_FreeOrPersonalTierIs403 proves a non-Pro
+// caller's PATCH that SETS a non-empty filterKey is rejected with 403
+// filter_requires_pro_tier and never persisted.
+func TestHandler_Patch_FilterKey_FreeOrPersonalTierIs403(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		profile func(*testing.T) *profiles.UserProfile
+	}{
+		{"Free tier", freeProfile},
+		{"Personal tier", personalProfile},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			z := testZone(t)
+			store := &fakeZoneStore{zones: []WatchZone{z}}
+			mux := http.NewServeMux()
+			Routes(mux, store, slog.New(slog.DiscardHandler), WithProfileReader(&fakeProfileReader{profile: tc.profile(t)}))
+
+			body := mustJSON(t, struct {
+				FilterKey *string `json:"filterKey"`
+			}{FilterKey: strPtr(string(FilterKeyHouseBuilder))})
+			rec := doReq(t, mux, http.MethodPatch, "/v1/me/watch-zones/"+z.ID, body)
+
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("status: got %d, want 403 (body %s)", rec.Code, rec.Body)
+			}
+			var env apiErrorResponse
+			if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+				t.Fatalf("decode error envelope: %v", err)
+			}
+			if env.Error != filterRequiresProTierCode {
+				t.Errorf("error code: got %q, want %q", env.Error, filterRequiresProTierCode)
+			}
+			if store.saved != nil {
+				t.Error("must not save when the filter tier gate rejects the request")
+			}
+		})
+	}
+}
+
+// TestHandler_Patch_FilterKey_ProTierSetsAndRoundTrips proves a Pro-tier
+// caller's PATCH that sets a valid filterKey succeeds (200), persists it, and
+// round-trips it in the response.
+func TestHandler_Patch_FilterKey_ProTierSetsAndRoundTrips(t *testing.T) {
+	t.Parallel()
+	z := testZone(t)
+	store := &fakeZoneStore{zones: []WatchZone{z}}
+	mux := http.NewServeMux()
+	Routes(mux, store, slog.New(slog.DiscardHandler), WithProfileReader(&fakeProfileReader{profile: proProfile(t)}))
+
+	body := mustJSON(t, struct {
+		FilterKey *string `json:"filterKey"`
+	}{FilterKey: strPtr(string(FilterKeyHMOHouseShares))})
+	rec := doReq(t, mux, http.MethodPatch, "/v1/me/watch-zones/"+z.ID, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (body %s)", rec.Code, rec.Body)
+	}
+	if store.saved == nil || store.saved.FilterKey != FilterKeyHMOHouseShares {
+		t.Fatalf("saved zone filter key: got %+v", store.saved)
+	}
+	var got struct {
+		Zone watchZoneSummary `json:"zone"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Zone.FilterKey == nil || *got.Zone.FilterKey != string(FilterKeyHMOHouseShares) {
+		t.Errorf("response filterKey: got %v, want %q", got.Zone.FilterKey, FilterKeyHMOHouseShares)
+	}
+}
+
+// TestHandler_Patch_FilterKey_ExplicitNullClearsRegardlessOfTier proves a
+// literal `"filterKey": null` always clears an existing filter back to
+// unfiltered, with no tier check at all -- the test wires no profile reader,
+// and the request still succeeds, mirroring the boundary revert's no-gate
+// behaviour.
+func TestHandler_Patch_FilterKey_ExplicitNullClearsRegardlessOfTier(t *testing.T) {
+	t.Parallel()
+	z := testZone(t)
+	z.FilterKey = FilterKeyHouseBuilder
+	store := &fakeZoneStore{zones: []WatchZone{z}}
+	rec := doReq(t, testMux(t, store), http.MethodPatch, "/v1/me/watch-zones/"+z.ID, `{"filterKey":null}`)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (body %s)", rec.Code, rec.Body)
+	}
+	if store.saved == nil || store.saved.FilterKey != "" {
+		t.Fatalf("filter key must be cleared: got %+v", store.saved)
+	}
+	var got struct {
+		Zone watchZoneSummary `json:"zone"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Zone.FilterKey != nil {
+		t.Error("response filterKey must be null after clearing")
+	}
+}
+
+// TestHandler_Patch_FilterKey_AbsentLeavesExistingFilterUntouched proves
+// omitting the "filterKey" key entirely leaves an existing filter alone, and
+// requires no profile reader (mirrors the boundary absent-key test).
+func TestHandler_Patch_FilterKey_AbsentLeavesExistingFilterUntouched(t *testing.T) {
+	t.Parallel()
+	z := testZone(t)
+	z.FilterKey = FilterKeyNewHomes
+	store := &fakeZoneStore{zones: []WatchZone{z}}
+	rec := doReq(t, testMux(t, store), http.MethodPatch, "/v1/me/watch-zones/"+z.ID, `{"name":"Renamed"}`)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (body %s)", rec.Code, rec.Body)
+	}
+	if store.saved == nil || store.saved.FilterKey != FilterKeyNewHomes {
+		t.Fatalf("filter key must be untouched by an absent field: got %+v", store.saved)
+	}
+	var got struct {
+		Zone watchZoneSummary `json:"zone"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Zone.FilterKey == nil || *got.Zone.FilterKey != string(FilterKeyNewHomes) {
+		t.Errorf("response filterKey: got %v, want %q", got.Zone.FilterKey, FilterKeyNewHomes)
+	}
+}
+
+// TestHandler_Patch_FilterKey_UnrecognisedIs400 proves an unrecognised
+// filterKey string maps to 400 filter_key_invalid (via WithUpdates'
+// ErrUnknownFilterKey), even for a Pro-tier caller who has passed the
+// entitlement gate.
+func TestHandler_Patch_FilterKey_UnrecognisedIs400(t *testing.T) {
+	t.Parallel()
+	z := testZone(t)
+	store := &fakeZoneStore{zones: []WatchZone{z}}
+	mux := http.NewServeMux()
+	Routes(mux, store, slog.New(slog.DiscardHandler), WithProfileReader(&fakeProfileReader{profile: proProfile(t)}))
+
+	body := mustJSON(t, struct {
+		FilterKey *string `json:"filterKey"`
+	}{FilterKey: strPtr("not_a_real_filter")})
+	rec := doReq(t, mux, http.MethodPatch, "/v1/me/watch-zones/"+z.ID, body)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400 (body %s)", rec.Code, rec.Body)
+	}
+	var env apiErrorResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode error envelope: %v", err)
+	}
+	if env.Error != filterKeyInvalidCode {
+		t.Errorf("error code: got %q, want %q", env.Error, filterKeyInvalidCode)
+	}
+	if store.saved != nil {
+		t.Error("must not save a zone with an unrecognised filter key")
+	}
+}
+
+// TestHandler_Patch_FilterKey_NoProfileReaderWiredIs500 proves that attempting
+// to SET a filterKey without a profile reader wired is a 500 (a wiring bug),
+// mirroring the boundary tier gate's equivalent test.
+func TestHandler_Patch_FilterKey_NoProfileReaderWiredIs500(t *testing.T) {
+	t.Parallel()
+	z := testZone(t)
+	store := &fakeZoneStore{zones: []WatchZone{z}}
+	body := mustJSON(t, struct {
+		FilterKey *string `json:"filterKey"`
+	}{FilterKey: strPtr(string(FilterKeyHouseBuilder))})
+	rec := doReq(t, testMux(t, store), http.MethodPatch, "/v1/me/watch-zones/"+z.ID, body)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status: got %d, want 500", rec.Code)
+	}
+	if store.saved != nil {
+		t.Error("must not save when the filter tier gate cannot be verified")
+	}
+}
+
+// strPtr is a tiny test helper for building an inline *string, mirroring
+// mustJSON/mustBoundary's role for filterKey request bodies.
+func strPtr(s string) *string { return &s }
 
 func TestHandler_Delete(t *testing.T) {
 	t.Parallel()

--- a/api-go/internal/watchzones/handler_test.go
+++ b/api-go/internal/watchzones/handler_test.go
@@ -634,8 +634,8 @@ func TestHandler_List_MarksPausedZonesOverEffectiveTierLimit(t *testing.T) {
 	}
 
 	// Golden-check first: every pre-existing field must round-trip unchanged,
-	// and "paused" plus "boundary" (tc-6he3x.4) are the only additions (10
-	// keys total per zone).
+	// and "paused", "boundary" (tc-6he3x.4) and "filterKey" (GH#1090, epic
+	// tc-w825j) are the only additions (11 keys total per zone).
 	var raw struct {
 		Zones []map[string]any `json:"zones"`
 	}
@@ -645,7 +645,7 @@ func TestHandler_List_MarksPausedZonesOverEffectiveTierLimit(t *testing.T) {
 	if len(raw.Zones) != 3 {
 		t.Fatalf("zones: got %d, want 3", len(raw.Zones))
 	}
-	wantKeys := []string{"id", "name", "latitude", "longitude", "radiusMetres", "authorityId", "pushEnabled", "emailInstantEnabled", "paused", "boundary"}
+	wantKeys := []string{"id", "name", "latitude", "longitude", "radiusMetres", "authorityId", "pushEnabled", "emailInstantEnabled", "paused", "boundary", "filterKey"}
 	for i, obj := range raw.Zones {
 		if len(obj) != len(wantKeys) {
 			t.Errorf("zone %d: got %d keys %v, want %d keys %v", i, len(obj), keysOf(obj), len(wantKeys), wantKeys)

--- a/api-go/internal/watchzones/nearby.go
+++ b/api-go/internal/watchzones/nearby.go
@@ -124,6 +124,12 @@ type createRequest struct {
 	PushEnabled         *bool            `json:"pushEnabled"`
 	EmailInstantEnabled *bool            `json:"emailInstantEnabled"`
 	Boundary            *boundaryGeoJSON `json:"boundary"`
+	// FilterKey is the pre-canned watch-zone filter to apply (GH#1090, epic
+	// tc-w825j). A plain pointer suffices on create -- unlike PATCH, there is
+	// no existing value to distinguish "leave alone" from, so nil and "" both
+	// mean "no filter". Non-empty requires Pro (see create's gating block) and
+	// must be a member of the catalog (IsValidFilterKey).
+	FilterKey *string `json:"filterKey"`
 }
 
 // maxRadiusMetres is the server-side ceiling for a watch-zone radius. It matches
@@ -227,6 +233,9 @@ type createResult struct {
 	RadiusMetres       float64                     `json:"radiusMetres"`
 	Boundary           *boundaryGeoJSON            `json:"boundary"`
 	NearbyApplications []applications.NearbyResult `json:"nearbyApplications"`
+	// FilterKey round-trips the persisted filter (GH#1090, epic tc-w825j): nil
+	// for an unfiltered zone, the catalog key string otherwise.
+	FilterKey *string `json:"filterKey"`
 }
 
 // create implements POST /v1/me/watch-zones: validate (400), gate a
@@ -284,6 +293,23 @@ func (h *handler) create(w http.ResponseWriter, r *http.Request) {
 		req.RadiusMetres = radius
 	}
 
+	// A non-empty filterKey is a Pro-only entitlement (GH#1090, epic
+	// tc-w825j) -- gated right after the boundary block (mirroring its
+	// cheapest-check-first order) and before the quota check below, so a
+	// disallowed or unrecognised filter never consumes a quota slot.
+	var filterKey FilterKey
+	if req.FilterKey != nil && *req.FilterKey != "" {
+		if !tier.AllowsWatchZoneFilter() {
+			h.writeErrorCode(w, r, http.StatusForbidden, filterRequiresProTierCode, filterRequiresProTierMessage)
+			return
+		}
+		if !IsValidFilterKey(*req.FilterKey) {
+			h.writeErrorCode(w, r, http.StatusBadRequest, filterKeyInvalidCode, filterKeyInvalidMessage)
+			return
+		}
+		filterKey = FilterKey(*req.FilterKey)
+	}
+
 	// Atomic quota gate: the CAS-backed profile counter is the ONLY create path,
 	// so there is no non-atomic footgun. A nil profileCAS at request time is a
 	// wiring bug (never reachable in production, where NearbyRoutes is always
@@ -318,6 +344,7 @@ func (h *handler) create(w http.ResponseWriter, r *http.Request) {
 	// read-path pattern) rather than re-deriving it through WithBoundary: the
 	// centroid/radius above were already computed from the same b.
 	zone.Boundary = boundary
+	zone.FilterKey = filterKey
 	if err := h.store.Save(r.Context(), zone); err != nil {
 		if errors.Is(err, ErrDuplicateName) {
 			h.writeErrorCode(w, r, http.StatusConflict, zoneNameTakenCode, zoneNameTakenMessage)
@@ -349,6 +376,7 @@ func (h *handler) create(w http.ResponseWriter, r *http.Request) {
 		RadiusMetres:       zone.RadiusMetres,
 		Boundary:           boundaryToGeoJSON(zone.Boundary),
 		NearbyApplications: results,
+		FilterKey:          filterKeyToWire(zone.FilterKey),
 	})
 }
 

--- a/api-go/internal/watchzones/nearby_test.go
+++ b/api-go/internal/watchzones/nearby_test.go
@@ -1099,6 +1099,161 @@ func TestCreate_Boundary_InvalidShapeIs400(t *testing.T) {
 	}
 }
 
+// --- filterKey create tests (GH#1090, epic tc-w825j) ------------------------
+
+// TestCreate_FilterKey_FreeOrPersonalTierIs403 proves a non-Pro caller
+// supplying a non-empty filterKey on create is rejected with 403
+// filter_requires_pro_tier and never persisted -- Pro-only, deliberately
+// narrower than the boundary gate's IsPaid() (acceptance criteria).
+func TestCreate_FilterKey_FreeOrPersonalTierIs403(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		profile func(*testing.T) *profiles.UserProfile
+	}{
+		{"Free tier", freeProfile},
+		{"Personal tier", personalProfile},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			d := nearbyDeps{
+				store:    &fakeZoneStore{},
+				profiles: &fakeProfileReader{profile: tc.profile(t)},
+				apps:     &fakeAppFinder{},
+				unread:   &fakeUnread{},
+			}
+			mux := newNearbyMux(t, d)
+
+			key := string(FilterKeyHouseBuilder)
+			body := mustJSON(t, createRequest{
+				Name: "My Zone", Latitude: 51.5, Longitude: -0.12, RadiusMetres: 1000,
+				FilterKey: &key,
+			})
+			rec := doReq(t, mux, http.MethodPost, "/v1/me/watch-zones", body)
+
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("status: got %d, want 403 (body %s)", rec.Code, rec.Body)
+			}
+			var env apiErrorResponse
+			if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+				t.Fatalf("decode error envelope: %v", err)
+			}
+			if env.Error != filterRequiresProTierCode {
+				t.Errorf("error code: got %q, want %q", env.Error, filterRequiresProTierCode)
+			}
+			if d.store.saved != nil {
+				t.Error("must not save a zone when the filter tier gate rejects the request")
+			}
+		})
+	}
+}
+
+// TestCreate_FilterKey_ProTierPersistsAndRoundTrips proves a Pro-tier caller's
+// create with a valid filterKey succeeds (201), persists FilterKey on the
+// saved zone, and the response body's filterKey round-trips the sent value.
+func TestCreate_FilterKey_ProTierPersistsAndRoundTrips(t *testing.T) {
+	t.Parallel()
+	d := nearbyDeps{
+		store:    &fakeZoneStore{},
+		profiles: &fakeProfileReader{profile: proProfile(t)},
+		apps:     &fakeAppFinder{},
+		unread:   &fakeUnread{},
+	}
+	mux := newNearbyMux(t, d)
+
+	key := string(FilterKeyLoftExtension)
+	body := mustJSON(t, createRequest{
+		Name: "My Zone", Latitude: 51.5, Longitude: -0.12, RadiusMetres: 1000,
+		FilterKey: &key,
+	})
+	rec := doReq(t, mux, http.MethodPost, "/v1/me/watch-zones", body)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status: got %d, want 201 (body %s)", rec.Code, rec.Body)
+	}
+	if d.store.saved == nil || d.store.saved.FilterKey != FilterKeyLoftExtension {
+		t.Fatalf("saved zone filter key: got %+v", d.store.saved)
+	}
+	var got struct {
+		FilterKey *string `json:"filterKey"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.FilterKey == nil || *got.FilterKey != string(FilterKeyLoftExtension) {
+		t.Errorf("response filterKey: got %v, want %q", got.FilterKey, FilterKeyLoftExtension)
+	}
+}
+
+// TestCreate_FilterKey_UnrecognisedIs400 proves an unrecognised filterKey
+// string on create is rejected with 400 filter_key_invalid, even for a
+// Pro-tier caller who has passed the entitlement gate.
+func TestCreate_FilterKey_UnrecognisedIs400(t *testing.T) {
+	t.Parallel()
+	d := nearbyDeps{
+		store:    &fakeZoneStore{},
+		profiles: &fakeProfileReader{profile: proProfile(t)},
+		apps:     &fakeAppFinder{},
+		unread:   &fakeUnread{},
+	}
+	mux := newNearbyMux(t, d)
+
+	key := "not_a_real_filter"
+	body := mustJSON(t, createRequest{
+		Name: "My Zone", Latitude: 51.5, Longitude: -0.12, RadiusMetres: 1000,
+		FilterKey: &key,
+	})
+	rec := doReq(t, mux, http.MethodPost, "/v1/me/watch-zones", body)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400 (body %s)", rec.Code, rec.Body)
+	}
+	var env apiErrorResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode error envelope: %v", err)
+	}
+	if env.Error != filterKeyInvalidCode {
+		t.Errorf("error code: got %q, want %q", env.Error, filterKeyInvalidCode)
+	}
+	if d.store.saved != nil {
+		t.Error("must not save a zone with an unrecognised filter key")
+	}
+}
+
+// TestCreate_FilterKey_AbsentIsUnfilteredAndNullOnWire proves the default,
+// no-filterKey create path is unaffected: the saved zone's FilterKey stays
+// the zero value and the response's filterKey field is null.
+func TestCreate_FilterKey_AbsentIsUnfilteredAndNullOnWire(t *testing.T) {
+	t.Parallel()
+	d := nearbyDeps{
+		store:    &fakeZoneStore{},
+		profiles: &fakeProfileReader{profile: freeProfile(t)},
+		apps:     &fakeAppFinder{},
+		unread:   &fakeUnread{},
+	}
+	mux := newNearbyMux(t, d)
+
+	body := `{"name":"My Zone","latitude":51.5,"longitude":-0.12,"radiusMetres":1000}`
+	rec := doReq(t, mux, http.MethodPost, "/v1/me/watch-zones", body)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status: got %d, want 201 (body %s)", rec.Code, rec.Body)
+	}
+	if d.store.saved == nil || d.store.saved.FilterKey != "" {
+		t.Fatalf("saved zone must be unfiltered: %+v", d.store.saved)
+	}
+	var got struct {
+		FilterKey *string `json:"filterKey"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.FilterKey != nil {
+		t.Errorf("response filterKey: got %v, want null", got.FilterKey)
+	}
+}
+
 // NOTE (tc-grlnc, discovered-from tc-acbsh): two tests used to live here --
 // TestApplications_CustomShapeZone_UsesEnclosingRadiusInterimFallback and
 // TestClusters_CustomShapeZone_UsesEnclosingRadiusInterimFallback -- pinning

--- a/api-go/internal/watchzones/store_postgres.go
+++ b/api-go/internal/watchzones/store_postgres.go
@@ -72,17 +72,21 @@ func NewPostgresStore(db querier) *PostgresStore {
 // pgZoneColumns is the read projection. id is rendered as text; ST_Y is the
 // latitude and ST_X the longitude of the (NOT NULL) geography point;
 // ST_AsGeoJSON(boundary) is NULL for a circle zone and a GeoJSON Polygon for a
-// custom-shape one. The order MUST match scanZone.
+// custom-shape one; filter_key (GH#1090, epic tc-w825j) is NULL for an
+// unfiltered zone. The order MUST match scanZone.
 const pgZoneColumns = "id::text, user_id, name, ST_Y(location::geometry), " +
 	"ST_X(location::geometry), radius_metres, created_at, " +
-	"push_enabled, email_instant_enabled, ST_AsGeoJSON(boundary)"
+	"push_enabled, email_instant_enabled, ST_AsGeoJSON(boundary), filter_key"
 
 // scanZone hydrates one zone through NewWatchZone, so the same invariants the
 // domain enforces (positive radius, non-blank id/user/name) gate a row read
 // from the database. A non-NULL boundary column is decoded from GeoJSON and
 // re-validated through NewBoundary (via decodeBoundaryGeoJSON), applying the
 // same domain invariants to a boundary read back from the database as to one
-// supplied by a client.
+// supplied by a client. A non-NULL filter_key column is coalesced straight
+// onto FilterKey -- unlike boundary it needs no re-validation (the catalog is
+// pure Go data, not a store-side invariant), and a NULL column leaves
+// FilterKey at its unfiltered zero value.
 func scanZone(row pgx.Row) (WatchZone, error) {
 	var (
 		id, userID, name       string
@@ -91,9 +95,10 @@ func scanZone(row pgx.Row) (WatchZone, error) {
 		createdAt              time.Time
 		pushEnabled, emailFlag bool
 		boundaryGeoJSON        *string
+		filterKey              *string
 	)
 	if err := row.Scan(&id, &userID, &name, &latitude, &longitude, &radiusMetres,
-		&createdAt, &pushEnabled, &emailFlag, &boundaryGeoJSON); err != nil {
+		&createdAt, &pushEnabled, &emailFlag, &boundaryGeoJSON, &filterKey); err != nil {
 		return WatchZone{}, err
 	}
 	zone, err := NewWatchZone(id, userID, name, latitude, longitude, radiusMetres,
@@ -107,6 +112,9 @@ func scanZone(row pgx.Row) (WatchZone, error) {
 			return WatchZone{}, fmt.Errorf("hydrate watch zone %q boundary: %w", id, err)
 		}
 		zone.Boundary = boundary
+	}
+	if filterKey != nil {
+		zone.FilterKey = FilterKey(*filterKey)
 	}
 	return zone, nil
 }
@@ -226,10 +234,10 @@ func (s *PostgresStore) Get(ctx context.Context, userID, zoneID string) (WatchZo
 const pgSaveZoneQuery = `
 INSERT INTO watch_zones (
 	id, user_id, name, location, radius_metres,
-	push_enabled, email_instant_enabled, created_at, boundary
+	push_enabled, email_instant_enabled, created_at, boundary, filter_key
 ) VALUES (
 	$1::uuid, $2, $3, ST_SetSRID(ST_MakePoint($4, $5), 4326)::geography,
-	$6, $7, $8, $9, ST_GeomFromGeoJSON($10)::geography
+	$6, $7, $8, $9, ST_GeomFromGeoJSON($10)::geography, $11
 )
 ON CONFLICT (id) DO UPDATE SET
 	user_id = EXCLUDED.user_id,
@@ -239,13 +247,29 @@ ON CONFLICT (id) DO UPDATE SET
 	push_enabled = EXCLUDED.push_enabled,
 	email_instant_enabled = EXCLUDED.email_instant_enabled,
 	created_at = EXCLUDED.created_at,
-	boundary = EXCLUDED.boundary`
+	boundary = EXCLUDED.boundary,
+	filter_key = EXCLUDED.filter_key`
+
+// encodeFilterKey renders z's filter key as the nullable string bind value
+// Save passes for the filter_key column: nil for the unfiltered zero value
+// (writing SQL NULL, mirroring encodeBoundaryGeoJSON's nil-for-absent
+// convention), a pointer to the string form otherwise. No validation happens
+// here -- by the time a zone reaches Save its FilterKey has already been
+// validated (WithUpdates / IsValidFilterKey at the HTTP layer).
+func encodeFilterKey(k FilterKey) *string {
+	if k == "" {
+		return nil
+	}
+	s := string(k)
+	return &s
+}
 
 // Save upserts the zone keyed on its uuid id, creating it or overwriting every
-// column -- including boundary -- on an existing row. A nil/empty z.Boundary
-// (a circle zone) writes SQL NULL, so saving a zone that previously had a
-// custom shape with Boundary cleared correctly reverts the persisted row to a
-// circle rather than leaving a stale polygon behind.
+// column -- including boundary and filter_key -- on an existing row. A
+// nil/empty z.Boundary (a circle zone) writes SQL NULL, so saving a zone that
+// previously had a custom shape with Boundary cleared correctly reverts the
+// persisted row to a circle rather than leaving a stale polygon behind; the
+// same holds for FilterKey's zero value ("") and the filter_key column.
 //
 // ON CONFLICT (id) only dedupes an upsert of the SAME id -- it does not catch
 // a name collision against a different, already-existing row for the same
@@ -261,6 +285,7 @@ func (s *PostgresStore) Save(ctx context.Context, z WatchZone) error {
 	_, err = s.db.Exec(ctx, pgSaveZoneQuery,
 		z.ID, z.UserID, z.Name, z.Longitude, z.Latitude, z.RadiusMetres,
 		z.PushEnabled, z.EmailInstantEnabled, z.CreatedAt, boundaryGeoJSON,
+		encodeFilterKey(z.FilterKey),
 	)
 	if err != nil {
 		if isUniqueViolation(err) {

--- a/api-go/internal/watchzones/store_postgres_filter_test.go
+++ b/api-go/internal/watchzones/store_postgres_filter_test.go
@@ -1,0 +1,161 @@
+package watchzones
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// fakeZoneRow is a hand-written pgx.Row test double scanning the 11-column
+// pgZoneColumns projection scanZone expects: id, user_id, name, latitude,
+// longitude, radius_metres, created_at, push_enabled, email_instant_enabled,
+// boundary geojson, filter_key (GH#1090, epic tc-w825j). It exists purely to
+// prove filter_key's round trip through scanZone at the fake level -- the
+// store's broader read/write behaviour (list/get/delete/find, boundary
+// geometry) is already covered by the real-DB integration suite in
+// store_postgres_test.go.
+type fakeZoneRow struct {
+	id, userID, name                  string
+	latitude, longitude, radiusMetres float64
+	createdAt                         time.Time
+	pushEnabled, emailFlag            bool
+	boundaryGeoJSON                   *string
+	filterKey                         *string
+}
+
+func (r *fakeZoneRow) Scan(dest ...any) error {
+	if len(dest) != 11 {
+		return errFakeZoneRowArity
+	}
+	*dest[0].(*string) = r.id
+	*dest[1].(*string) = r.userID
+	*dest[2].(*string) = r.name
+	*dest[3].(*float64) = r.latitude
+	*dest[4].(*float64) = r.longitude
+	*dest[5].(*float64) = r.radiusMetres
+	*dest[6].(*time.Time) = r.createdAt
+	*dest[7].(*bool) = r.pushEnabled
+	*dest[8].(*bool) = r.emailFlag
+	*dest[9].(**string) = r.boundaryGeoJSON
+	*dest[10].(**string) = r.filterKey
+	return nil
+}
+
+var errFakeZoneRowArity = errors.New("fakeZoneRow: unexpected scan destination count")
+
+// fakeZoneQuerier is a hand-written test double for the store's consumer-side
+// querier interface. It exists only to drive the filter_key round-trip tests
+// below: QueryRow always returns the configured row, and Exec records the
+// bound args (and returns the configured error) so Save's filter_key
+// parameter can be asserted without a live database.
+type fakeZoneQuerier struct {
+	row     pgx.Row
+	execErr error
+	gotArgs []any
+}
+
+func (f *fakeZoneQuerier) Exec(_ context.Context, _ string, args ...any) (pgconn.CommandTag, error) {
+	f.gotArgs = args
+	return pgconn.CommandTag{}, f.execErr
+}
+
+func (f *fakeZoneQuerier) Query(_ context.Context, _ string, _ ...any) (pgx.Rows, error) {
+	return nil, errors.New("fakeZoneQuerier: Query not implemented")
+}
+
+func (f *fakeZoneQuerier) QueryRow(_ context.Context, _ string, _ ...any) pgx.Row {
+	return f.row
+}
+
+// TestPostgresStore_Get_FilterKeyPresent proves a non-NULL filter_key column
+// hydrates onto WatchZone.FilterKey.
+func TestPostgresStore_Get_FilterKeyPresent(t *testing.T) {
+	t.Parallel()
+	key := "house_builder"
+	q := &fakeZoneQuerier{row: &fakeZoneRow{
+		id: "zone-1", userID: "user-1", name: "Home",
+		latitude: 51.5, longitude: -0.1, radiusMetres: 1000,
+		createdAt: time.Now(), pushEnabled: true, emailFlag: true,
+		filterKey: &key,
+	}}
+	store := NewPostgresStore(q)
+
+	got, err := store.Get(context.Background(), "user-1", "zone-1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.FilterKey != FilterKeyHouseBuilder {
+		t.Errorf("FilterKey: got %q, want %q", got.FilterKey, FilterKeyHouseBuilder)
+	}
+}
+
+// TestPostgresStore_Get_FilterKeyNullCoalescesToEmpty proves a NULL
+// filter_key column (every zone before this migration, or one never
+// filtered) hydrates as the zero value "" (unfiltered), not a nil-pointer
+// panic.
+func TestPostgresStore_Get_FilterKeyNullCoalescesToEmpty(t *testing.T) {
+	t.Parallel()
+	q := &fakeZoneQuerier{row: &fakeZoneRow{
+		id: "zone-1", userID: "user-1", name: "Home",
+		latitude: 51.5, longitude: -0.1, radiusMetres: 1000,
+		createdAt: time.Now(), pushEnabled: true, emailFlag: true,
+		filterKey: nil,
+	}}
+	store := NewPostgresStore(q)
+
+	got, err := store.Get(context.Background(), "user-1", "zone-1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.FilterKey != "" {
+		t.Errorf("FilterKey: got %q, want empty (unfiltered)", got.FilterKey)
+	}
+}
+
+// TestPostgresStore_Save_PassesFilterKeyArg proves Save binds a non-empty
+// FilterKey as a pointer-to-string argument -- the last positional arg of
+// pgSaveZoneQuery.
+func TestPostgresStore_Save_PassesFilterKeyArg(t *testing.T) {
+	t.Parallel()
+	q := &fakeZoneQuerier{}
+	store := NewPostgresStore(q)
+	z := testZone(t)
+	z.FilterKey = FilterKeyLoftExtension
+
+	if err := store.Save(context.Background(), z); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if len(q.gotArgs) == 0 {
+		t.Fatal("Save must bind args")
+	}
+	last := q.gotArgs[len(q.gotArgs)-1]
+	s, ok := last.(*string)
+	if !ok || s == nil || *s != string(FilterKeyLoftExtension) {
+		t.Errorf("filter_key arg: got %#v, want pointer to %q", last, FilterKeyLoftExtension)
+	}
+}
+
+// TestPostgresStore_Save_EmptyFilterKeyPassesNil proves an unfiltered zone
+// (the FilterKey zero value) binds a nil argument -- SQL NULL -- for
+// filter_key, mirroring how an unset Boundary binds nil.
+func TestPostgresStore_Save_EmptyFilterKeyPassesNil(t *testing.T) {
+	t.Parallel()
+	q := &fakeZoneQuerier{}
+	store := NewPostgresStore(q)
+	z := testZone(t) // FilterKey left at its zero value ("")
+
+	if err := store.Save(context.Background(), z); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if len(q.gotArgs) == 0 {
+		t.Fatal("Save must bind args")
+	}
+	last := q.gotArgs[len(q.gotArgs)-1]
+	if s, ok := last.(*string); !ok || s != nil {
+		t.Errorf("filter_key arg for unfiltered zone: got %#v, want nil *string", last)
+	}
+}


### PR DESCRIPTION
## Summary

Third of five child beads under epic tc-w825j / GH#1090 ("pre-canned keyword filters on watch zones, Pro-tier"). Implements sections 4, 6, and 7 of that issue: store persistence for `watch_zones.filter_key` and Pro-tier-gated HTTP create/patch handling.

- `store_postgres.go` — `filter_key` added to the read projection (`pgZoneColumns`), `scanZone` (NULL coalesces to the unfiltered zero value), and the upsert query/`Save` (new `encodeFilterKey` helper writing SQL NULL for an unfiltered zone).
- `nearby.go` (POST create) — `createRequest.FilterKey` / `createResult.FilterKey`; a non-empty value is gated on `tier.AllowsWatchZoneFilter()` (403 `filter_requires_pro_tier`) then `IsValidFilterKey` (400 `filter_key_invalid`), before the quota check.
- `handler.go` (PATCH) — shared `filterRequiresProTierCode`/`filterKeyInvalidCode` constants; tri-state `patchRequest.FilterKey` (`json.RawMessage`, mirroring `Boundary`) decoded via new `decodeFilterKeyUpdate`; the Pro-tier gate only fires when *setting* a filter, not when leaving it alone or explicitly clearing it (`null`); `ErrUnknownFilterKey` from `WithUpdates` maps to 400; `watchZoneSummary`/`summaryOf` now round-trip `filterKey`.

Builds on already-merged sibling beads: tc-w825j.1 (#1091, catalog + migration), tc-w825j.2 (#1092, domain `FilterKey`/tri-state `WithUpdates` + `AllowsWatchZoneFilter` entitlement), tc-w825j.4 (#1093, description matcher — separate, unrelated to this PR).

Out of scope here (separate beads): the Enqueuer filter-matching wiring (tc-w825j.5) and everything iOS/web (explicitly deferred in GH#1090).

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` — clean
- [x] `go test ./...` — all packages pass, including new fake-level round-trip tests for `filter_key` in `store_postgres_filter_test.go` and new gating/round-trip tests in `nearby_test.go` / `handler_test.go`
- [ ] `make test-integration` (real Postgres) — **not run**: this cloud session's Docker daemon cannot start (`ulimit: error setting limit (Operation not permitted)` — a sandbox privilege restriction, not a code issue). This change adds a plain nullable text column with no new SQL behaviour beyond an existing pattern already covered by `boundary`'s integration coverage, so the risk is low, but the PR gate should be treated as authoritative here since it runs the real-Postgres suite.
- [ ] `golangci-lint` — not run: this sandbox's installed binary is built with go1.25 while `go.mod` targets go1.26 (`can't load config: the Go language version (go1.25)...`), a pre-existing environment mismatch confirmed to fail identically with zero local changes (`git stash` reproduces it on main). Not caused by this change.

Bead: tc-w825j.3 (child of epic tc-w825j / GH#1090 §4, §6, §7).


---
_Generated by [Claude Code](https://claude.ai/code/session_0171ZcicbmrV1QVhRaPGqV2L)_