### PR TITLE
feat(api): enqueuer filter matching + worker wiring (tc-w825j.5)

### DIFF
--- a/api-go/cmd/worker/fakes_test.go
+++ b/api-go/cmd/worker/fakes_test.go
@@ -50,3 +50,25 @@ func (s *spyZoneStore) Delete(_ context.Context, _, _ string) error { return nil
 func (s *spyZoneStore) DeleteAllByUserID(_ context.Context, _ string) error { return nil }
 
 func (s *spyZoneStore) All(_ context.Context) ([]watchzones.WatchZone, error) { return nil, nil }
+
+// fakeDescriptionMatcher is a hand-written double for notifydispatch's
+// consumer-side descriptionMatcher interface (GH#1090, epic tc-w825j,
+// tc-w825j.5): it proves the worker wiring builds an Enqueuer whose matcher
+// dependency structurally satisfies that interface, the same role
+// *applications.PostgresStore plays in production. The notify wiring tests
+// here only exercise FindZonesContaining (see spyZoneStore), so
+// MatchesExpression is never expected to be called; matched/err let a future
+// test drive it if that changes.
+type fakeDescriptionMatcher struct {
+	mu      sync.Mutex
+	calls   int
+	matched bool
+	err     error
+}
+
+func (f *fakeDescriptionMatcher) MatchesExpression(_ context.Context, _, _ string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	return f.matched, f.err
+}

--- a/api-go/cmd/worker/main.go
+++ b/api-go/cmd/worker/main.go
@@ -513,6 +513,7 @@ func buildNotifyFanOut(cfg platform.Config, registry *metrics.Registry, zoneStor
 		deviceStore    *devicetokens.PostgresStore
 		statePushStore *notificationstate.PostgresStore
 		savedStore     *savedapplications.PostgresStore
+		appStore       *applications.PostgresStore
 	)
 	if st != nil {
 		notifStore = st.notification
@@ -520,12 +521,13 @@ func buildNotifyFanOut(cfg platform.Config, registry *metrics.Registry, zoneStor
 		deviceStore = st.device
 		statePushStore = st.notifState
 		savedStore = st.savedApp
+		appStore = st.app
 	}
 
 	pushDispatcher := buildPlatformDispatcher(cfg, registry, logger)
 	coalescer := notifydispatch.NewPushCoalescer(deviceStore, statePushStore, pushDispatcher, zoneStore, logger)
 	enqueuer := notifydispatch.NewEnqueuer(
-		notifStore, zoneStore, profileStore, coalescer,
+		notifStore, zoneStore, profileStore, coalescer, appStore,
 		uuid.NewString, time.Now, logger,
 	)
 	dispatcher := notifydispatch.NewDecisionDispatcher(

--- a/api-go/cmd/worker/wiring_test.go
+++ b/api-go/cmd/worker/wiring_test.go
@@ -100,8 +100,9 @@ func TestEnqueuer_FindZonesContainingFlowsThroughInterface(t *testing.T) {
 	t.Parallel()
 
 	spy := newSpyZoneStore()
+	matcher := &fakeDescriptionMatcher{}
 	enqueuer := notifydispatch.NewEnqueuer(
-		nil, spy, nil, nil,
+		nil, spy, nil, nil, matcher,
 		func() string { return "id" },
 		func() time.Time { return time.Unix(0, 0).UTC() },
 		discardLogger(),

--- a/api-go/internal/notifydispatch/digest_roundtrip_test.go
+++ b/api-go/internal/notifydispatch/digest_roundtrip_test.go
@@ -25,7 +25,7 @@ func TestEnqueuer_CreatedRecordIsDigestReadable(t *testing.T) {
 	zone := testZoneAt(t, "zone-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
 	zones := &fakeZones{zones: []watchzones.WatchZone{zone}}
 
-	enq := NewEnqueuer(notifs, zones, profs, &fakePushQueue{},
+	enq := NewEnqueuer(notifs, zones, profs, &fakePushQueue{}, nil,
 		func() string { return "n-roundtrip" },
 		func() time.Time { return time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC) },
 		testLogger(t))

--- a/api-go/internal/notifydispatch/enqueuer.go
+++ b/api-go/internal/notifydispatch/enqueuer.go
@@ -78,6 +78,15 @@ type notificationMetricsRecorder interface {
 	NotificationCreated(ctx context.Context, eventType, sources string)
 }
 
+// descriptionMatcher is the consumer-side slice of the applications store the
+// enqueuer needs to evaluate a watch zone's pre-canned keyword filter
+// (GH#1090, epic tc-w825j): a full-text match of an application's description
+// against a catalog filter's to_tsquery expression.
+// *applications.PostgresStore satisfies it.
+type descriptionMatcher interface {
+	MatchesExpression(ctx context.Context, description, expression string) (bool, error)
+}
+
 // Enqueuer handles new-application zone fan-out: for a new application that
 // matched a watch zone, it dedups, creates the notification record (which feeds
 // the digest pipeline), and — for paid tiers with push enabled — queues an
@@ -88,6 +97,7 @@ type Enqueuer struct {
 	zones         zoneRanker
 	profiles      profileReader
 	push          pushQueue
+	matcher       descriptionMatcher
 	newID         func() string
 	now           func() time.Time
 	logger        *slog.Logger
@@ -105,12 +115,14 @@ func (e *Enqueuer) WithMetrics(rec notificationMetricsRecorder) *Enqueuer {
 
 // NewEnqueuer wires the enqueuer. newID mints the notification id (a GUID in
 // production); now stamps the record's creation time. Both are injected so tests
-// can pin them.
+// can pin them. matcher evaluates a filtered zone's keyword expression
+// (GH#1090, epic tc-w825j) — see matchesFilter.
 func NewEnqueuer(
 	notifs notificationWriter,
 	zones zoneRanker,
 	profs profileReader,
 	push pushQueue,
+	matcher descriptionMatcher,
 	newID func() string,
 	now func() time.Time,
 	logger *slog.Logger,
@@ -120,6 +132,7 @@ func NewEnqueuer(
 		zones:         zones,
 		profiles:      profs,
 		push:          push,
+		matcher:       matcher,
 		newID:         newID,
 		now:           now,
 		logger:        logger,
@@ -161,6 +174,14 @@ func (e *Enqueuer) Enqueue(ctx context.Context, app applications.PlanningApplica
 		return err
 	}
 	if existing != nil {
+		return nil
+	}
+
+	matched, err := e.matchesFilter(ctx, zone, app)
+	if err != nil {
+		return err
+	}
+	if !matched {
 		return nil
 	}
 
@@ -225,6 +246,33 @@ func (e *Enqueuer) Enqueue(ctx context.Context, app applications.PlanningApplica
 		e.metrics.NotificationCreated(ctx, string(n.EventType), n.Sources)
 	}
 	return nil
+}
+
+// matchesFilter reports whether app passes zone's pre-canned keyword filter
+// (GH#1090, epic tc-w825j). An unfiltered zone (the FilterKey zero value)
+// always matches — no catalog lookup, no DB call. A FilterKey not found in
+// the catalog fails open (matches) rather than blocking a fan-out on a
+// read-time inconsistency that create/patch validation should already have
+// prevented, mirroring this file's fail-open conventions elsewhere (a
+// missing profile in Enqueue, a zoneID absent from its own zone set in
+// isPaused). The app_type gate is checked first and is a plain in-memory
+// membership test against the already-loaded application — no DB call — so
+// an excluded app_type is rejected before ever reaching the matcher.
+func (e *Enqueuer) matchesFilter(ctx context.Context, zone watchzones.WatchZone, app applications.PlanningApplication) (bool, error) {
+	if zone.FilterKey == "" {
+		return true, nil
+	}
+	def, ok := watchzones.FilterDefinitionFor(zone.FilterKey)
+	if !ok {
+		return true, nil
+	}
+	if app.AppType != nil && watchzones.IsExcludedAppType(*app.AppType) {
+		return false, nil
+	}
+	if def.Expression == "" {
+		return true, nil
+	}
+	return e.matcher.MatchesExpression(ctx, app.Description, def.Expression)
 }
 
 // isPaused reports whether the zone identified by zoneID is paused (GH#889):

--- a/api-go/internal/notifydispatch/enqueuer_test.go
+++ b/api-go/internal/notifydispatch/enqueuer_test.go
@@ -80,6 +80,30 @@ func (f *fakePushQueue) Add(userID string, n notifications.DigestNotification) {
 	f.queued = append(f.queued, queuedPush{userID: userID, notification: n})
 }
 
+// fakeDescriptionMatcher is a hand-written double for the enqueuer's
+// consumer-side descriptionMatcher interface (GH#1090, epic tc-w825j): it
+// records every MatchesExpression call so a test can assert both the
+// returned verdict and — for the app_type-excluded case — that the matcher
+// was never reached at all (the cheap in-memory gate must run first).
+type fakeDescriptionMatcher struct {
+	calls   []matchCall
+	matches bool
+	err     error
+}
+
+type matchCall struct {
+	description string
+	expression  string
+}
+
+func (f *fakeDescriptionMatcher) MatchesExpression(_ context.Context, description, expression string) (bool, error) {
+	f.calls = append(f.calls, matchCall{description: description, expression: expression})
+	if f.err != nil {
+		return false, f.err
+	}
+	return f.matches, nil
+}
+
 func profileWithTier(t *testing.T, userID string, tier profiles.SubscriptionTier) *profiles.UserProfile {
 	t.Helper()
 	p, err := profiles.NewProfile(userID, "", time.Now())
@@ -149,6 +173,16 @@ func newEnqueuerHarness(t *testing.T, tier profiles.SubscriptionTier) (*Enqueuer
 
 func newEnqueuerHarnessWithZones(t *testing.T, tier profiles.SubscriptionTier, zones *fakeZones) (*Enqueuer, *fakeNotifications, *fakePushQueue, *fakeZones) {
 	t.Helper()
+	enq, notifs, queue, zones, _ := newEnqueuerHarnessWithZonesAndMatcher(t, tier, zones, nil)
+	return enq, notifs, queue, zones
+}
+
+// newEnqueuerHarnessWithZonesAndMatcher is the full harness the filter tests
+// use: it threads a caller-supplied descriptionMatcher (or a fresh
+// zero-value fake, matching nothing, when nil is passed) through to
+// NewEnqueuer alongside the zones fake.
+func newEnqueuerHarnessWithZonesAndMatcher(t *testing.T, tier profiles.SubscriptionTier, zones *fakeZones, matcher *fakeDescriptionMatcher) (*Enqueuer, *fakeNotifications, *fakePushQueue, *fakeZones, *fakeDescriptionMatcher) {
+	t.Helper()
 	notifs := newFakeNotifications()
 	profile := profileWithTier(t, "auth0|alice", tier)
 	profs := &fakeProfiles{byID: map[string]*profiles.UserProfile{"auth0|alice": profile}}
@@ -156,11 +190,14 @@ func newEnqueuerHarnessWithZones(t *testing.T, tier profiles.SubscriptionTier, z
 	if zones == nil {
 		zones = &fakeZones{}
 	}
-	enq := NewEnqueuer(notifs, zones, profs, queue,
+	if matcher == nil {
+		matcher = &fakeDescriptionMatcher{}
+	}
+	enq := NewEnqueuer(notifs, zones, profs, queue, matcher,
 		func() string { return "n-fixed" },
 		func() time.Time { return time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC) },
 		testLogger(t))
-	return enq, notifs, queue, zones
+	return enq, notifs, queue, zones, matcher
 }
 
 func TestEnqueuer_EnqueueForApplication_FansOutToContainingZones(t *testing.T) {
@@ -176,7 +213,7 @@ func TestEnqueuer_EnqueueForApplication_FansOutToContainingZones(t *testing.T) {
 		"auth0|bob":   profileWithTier(t, "auth0|bob", profiles.TierPro),
 	}}
 	fz := zones
-	enq := NewEnqueuer(notifs, zones, profs, &fakePushQueue{},
+	enq := NewEnqueuer(notifs, zones, profs, &fakePushQueue{}, nil,
 		func() string { return "n-fixed" },
 		func() time.Time { return time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC) },
 		testLogger(t))
@@ -378,7 +415,7 @@ func TestEnqueuer_ExpiredPaidTier_CreatesRecordNoPush(t *testing.T) {
 	profile.SubscriptionExpiry = &past
 	profs := &fakeProfiles{byID: map[string]*profiles.UserProfile{"auth0|alice": profile}}
 	queue := &fakePushQueue{}
-	enq := NewEnqueuer(notifs, &fakeZones{}, profs, queue,
+	enq := NewEnqueuer(notifs, &fakeZones{}, profs, queue, nil,
 		func() string { return "n-1" },
 		func() time.Time { return time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC) },
 		testLogger(t))
@@ -531,7 +568,7 @@ func TestEnqueuer_LapsedPaidTier_RankedAgainstFreeLimit(t *testing.T) {
 	z1 := testZoneAt(t, "zone-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
 	z2 := testZoneAt(t, "zone-2", "auth0|alice", time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC))
 	zones := &fakeZones{zones: []watchzones.WatchZone{z1, z2}}
-	enq := NewEnqueuer(notifs, zones, profs, queue,
+	enq := NewEnqueuer(notifs, zones, profs, queue, nil,
 		func() string { return "n-1" },
 		func() time.Time { return time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC) },
 		testLogger(t))
@@ -625,5 +662,141 @@ func TestEnqueuer_UnknownProfile_NoRecord(t *testing.T) {
 	}
 	if len(queue.queued) != 0 {
 		t.Errorf("unknown profile must not queue a push, got %d", len(queue.queued))
+	}
+}
+
+// filteredZoneAt returns a "zone-1"/"auth0|alice" zone identical to
+// testZoneAt but carrying key — GH#1090's watch-zone filters, epic
+// tc-w825j, bead tc-w825j.5.
+func filteredZoneAt(t *testing.T, createdAt time.Time, key watchzones.FilterKey) watchzones.WatchZone {
+	t.Helper()
+	z := testZoneAt(t, "zone-1", "auth0|alice", createdAt)
+	z.FilterKey = key
+	return z
+}
+
+func TestEnqueuer_UnfilteredZone_UnaffectedByMatcher(t *testing.T) {
+	t.Parallel()
+	// FilterKey == "" (the zero value / unfiltered case): the matcher must
+	// never be consulted, and behaviour is exactly as before this bead.
+	matcher := &fakeDescriptionMatcher{matches: false} // would reject if ever called
+	zone := testZoneAt(t, "zone-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	zones := &fakeZones{zones: []watchzones.WatchZone{zone}}
+	enq, notifs, _, _, gotMatcher := newEnqueuerHarnessWithZonesAndMatcher(t, profiles.TierPro, zones, matcher)
+	app := testApplication(t, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
+
+	if err := enq.Enqueue(context.Background(), app, zone); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if len(notifs.created) != 1 {
+		t.Errorf("unfiltered zone must still create a record, got %d", len(notifs.created))
+	}
+	if len(gotMatcher.calls) != 0 {
+		t.Errorf("unfiltered zone must never consult the matcher, got %d calls", len(gotMatcher.calls))
+	}
+}
+
+func TestEnqueuer_FilteredZone_MatchingApplicationCreatesRecord(t *testing.T) {
+	t.Parallel()
+	matcher := &fakeDescriptionMatcher{matches: true}
+	zone := filteredZoneAt(t, time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC), watchzones.FilterKeyHMOHouseShares)
+	zones := &fakeZones{zones: []watchzones.WatchZone{zone}}
+	enq, notifs, _, _, gotMatcher := newEnqueuerHarnessWithZonesAndMatcher(t, profiles.TierPro, zones, matcher)
+	app := testApplication(t, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
+	appType := "Full"
+	app.AppType = &appType
+	app.Description = "Change of use to HMO for 6 occupants"
+
+	if err := enq.Enqueue(context.Background(), app, zone); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if len(notifs.created) != 1 {
+		t.Fatalf("matching filtered application must create a record, got %d", len(notifs.created))
+	}
+	if len(gotMatcher.calls) != 1 {
+		t.Fatalf("expected exactly one MatchesExpression call, got %d", len(gotMatcher.calls))
+	}
+	wantDef, ok := watchzones.FilterDefinitionFor(watchzones.FilterKeyHMOHouseShares)
+	if !ok {
+		t.Fatalf("catalog missing %q", watchzones.FilterKeyHMOHouseShares)
+	}
+	if gotMatcher.calls[0].description != app.Description {
+		t.Errorf("matcher description: got %q, want %q", gotMatcher.calls[0].description, app.Description)
+	}
+	if gotMatcher.calls[0].expression != wantDef.Expression {
+		t.Errorf("matcher expression: got %q, want %q", gotMatcher.calls[0].expression, wantDef.Expression)
+	}
+}
+
+func TestEnqueuer_FilteredZone_NonMatchingExpressionNoRecord(t *testing.T) {
+	t.Parallel()
+	matcher := &fakeDescriptionMatcher{matches: false}
+	zone := filteredZoneAt(t, time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC), watchzones.FilterKeyHMOHouseShares)
+	zones := &fakeZones{zones: []watchzones.WatchZone{zone}}
+	enq, notifs, queue, _, gotMatcher := newEnqueuerHarnessWithZonesAndMatcher(t, profiles.TierPro, zones, matcher)
+	app := testApplication(t, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
+	appType := "Full"
+	app.AppType = &appType
+	app.Description = "Single-storey rear extension"
+
+	if err := enq.Enqueue(context.Background(), app, zone); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if len(notifs.created) != 0 {
+		t.Errorf("non-matching filtered application must NOT create a record, got %d", len(notifs.created))
+	}
+	if len(queue.queued) != 0 {
+		t.Errorf("non-matching filtered application must NOT queue a push, got %d", len(queue.queued))
+	}
+	if len(gotMatcher.calls) != 1 {
+		t.Errorf("expected exactly one MatchesExpression call, got %d", len(gotMatcher.calls))
+	}
+}
+
+func TestEnqueuer_FilteredZone_ExcludedAppTypeSkipsMatcherEntirely(t *testing.T) {
+	t.Parallel()
+	// The app_type gate is a cheap in-memory check that must run BEFORE any
+	// DB-backed keyword match — assert the fake matcher is never invoked.
+	matcher := &fakeDescriptionMatcher{matches: true} // would match if ever called
+	zone := filteredZoneAt(t, time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC), watchzones.FilterKeyHMOHouseShares)
+	zones := &fakeZones{zones: []watchzones.WatchZone{zone}}
+	enq, notifs, queue, _, gotMatcher := newEnqueuerHarnessWithZonesAndMatcher(t, profiles.TierPro, zones, matcher)
+	app := testApplication(t, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
+	excluded := "Trees"
+	app.AppType = &excluded
+	app.Description = "HMO Class C4 conversion"
+
+	if err := enq.Enqueue(context.Background(), app, zone); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if len(notifs.created) != 0 {
+		t.Errorf("excluded app_type must NOT create a record, got %d", len(notifs.created))
+	}
+	if len(queue.queued) != 0 {
+		t.Errorf("excluded app_type must NOT queue a push, got %d", len(queue.queued))
+	}
+	if len(gotMatcher.calls) != 0 {
+		t.Errorf("excluded app_type must skip the matcher entirely, got %d calls", len(gotMatcher.calls))
+	}
+}
+
+func TestEnqueuer_UnrecognisedFilterKeyFailsOpen(t *testing.T) {
+	t.Parallel()
+	// A FilterKey not in the catalog (should not happen — validated at write
+	// time) fails open: matches, same as unfiltered.
+	matcher := &fakeDescriptionMatcher{matches: false} // would reject if ever called
+	zone := filteredZoneAt(t, time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC), watchzones.FilterKey("not_a_real_filter"))
+	zones := &fakeZones{zones: []watchzones.WatchZone{zone}}
+	enq, notifs, _, _, gotMatcher := newEnqueuerHarnessWithZonesAndMatcher(t, profiles.TierPro, zones, matcher)
+	app := testApplication(t, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
+
+	if err := enq.Enqueue(context.Background(), app, zone); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if len(notifs.created) != 1 {
+		t.Errorf("unrecognised FilterKey must fail open and create a record, got %d", len(notifs.created))
+	}
+	if len(gotMatcher.calls) != 0 {
+		t.Errorf("unrecognised FilterKey must never consult the matcher, got %d calls", len(gotMatcher.calls))
 	}
 }

--- a/api-go/internal/watchzones/filter.go
+++ b/api-go/internal/watchzones/filter.go
@@ -124,3 +124,27 @@ func IsValidFilterKey(key string) bool {
 	_, ok := filterCatalog[FilterKey(key)]
 	return ok
 }
+
+// FilterDefinitionFor returns the catalog entry for key and whether key is a
+// member of the catalog. It is the read-only cross-package entry point the
+// notifydispatch enqueuer uses to evaluate a loaded zone's pre-canned filter
+// (GH#1090, epic tc-w825j, bead tc-w825j.5) without duplicating the catalog
+// data outside this package.
+func FilterDefinitionFor(key FilterKey) (FilterDefinition, bool) {
+	def, ok := filterCatalog[key]
+	return def, ok
+}
+
+// IsExcludedAppType reports whether appType is one of the
+// filterExcludedAppTypes values that never generate a notification for any
+// keyword-bearing filter — see that variable's doc comment. The
+// notifydispatch enqueuer checks this in-memory gate before ever calling
+// into a DB-backed keyword matcher.
+func IsExcludedAppType(appType string) bool {
+	for _, t := range filterExcludedAppTypes {
+		if t == appType {
+			return true
+		}
+	}
+	return false
+}

--- a/api-go/internal/watchzones/filter_test.go
+++ b/api-go/internal/watchzones/filter_test.go
@@ -60,6 +60,47 @@ func TestFilterCatalog_FewerNotificationsHasNoExpression(t *testing.T) {
 	}
 }
 
+func TestFilterDefinitionFor(t *testing.T) {
+	t.Parallel()
+
+	def, ok := FilterDefinitionFor(FilterKeyHouseBuilder)
+	if !ok {
+		t.Fatalf("FilterDefinitionFor(%q) = _, false, want true", FilterKeyHouseBuilder)
+	}
+	if def.DisplayName != filterCatalog[FilterKeyHouseBuilder].DisplayName {
+		t.Errorf("FilterDefinitionFor(%q) DisplayName = %q, want %q",
+			FilterKeyHouseBuilder, def.DisplayName, filterCatalog[FilterKeyHouseBuilder].DisplayName)
+	}
+
+	if _, ok := FilterDefinitionFor(FilterKey("not_a_real_filter")); ok {
+		t.Error("FilterDefinitionFor(unknown key) = _, true, want false")
+	}
+}
+
+func TestIsExcludedAppType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		appType string
+		want    bool
+	}{
+		{"Trees is excluded", "Trees", true},
+		{"Telecoms is excluded", "Telecoms", true},
+		{"Full is not excluded", "Full", false},
+		{"empty string is not excluded", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := IsExcludedAppType(tt.appType); got != tt.want {
+				t.Errorf("IsExcludedAppType(%q) = %v, want %v", tt.appType, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFilterCatalog_KeywordFiltersHaveExpressions(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Final piece of the Pro-tier pre-canned watch-zone filters feature (GH#1090, epic tc-w825j — beads .1–.4 already merged): wires the Enqueuer to actually apply a zone's filter before creating a notification.

- `notifydispatch.Enqueuer` gains a `descriptionMatcher` dependency (`*applications.PostgresStore` satisfies it) and a `matchesFilter` gate, called in `Enqueue` right after the dedup check and before the profile load.
- Gate order: unfiltered zone → match; unrecognised `FilterKey` → fail open (matches this file's existing fail-open conventions); `app.AppType` excluded → no match, no DB call; empty catalog expression (`fewer_notifications`) → match once the app_type gate passes; otherwise delegate to `MatchesExpression` (real Postgres `to_tsquery` match).
- `cmd/worker/main.go` wires the existing `applications.PostgresStore` instance into `NewEnqueuer` as the new `matcher` argument — no second store constructed.
- Added two minimal, read-only accessors to `watchzones/filter.go` (`FilterDefinitionFor`, `IsExcludedAppType`) so `notifydispatch` can read the catalog and exclusion list without duplicating that data — no catalog content changed.

## Test plan

- [x] `gofmt -l .` clean
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./...` (full suite) passes
- [x] `go test -race ./...` passes (per implementing worker)
- [x] `golangci-lint run ./...` — 0 issues in touched files (2 pre-existing, unrelated `prealloc` findings elsewhere)
- [x] New hand-written-fake tests in `notifydispatch/enqueuer_test.go`: unfiltered zone unaffected (matcher never called), matching filter creates a notification, non-matching expression skips, app_type-excluded skips without calling the matcher, unrecognised `FilterKey` fails open
- [x] `watchzones/filter_test.go` covers the two new accessors
- [ ] Real-Postgres integration suite — not runnable locally (no Docker in this cloud session); PR gate runs it regardless

Refs: tc-w825j.5, GH#1090

---
_Generated by [Claude Code](https://claude.ai/code/session_01AzYtAW1PcuGcbNt877JtFK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for filtering notifications by application description expressions.
  * Notifications now skip excluded application types.
  * Unknown or unconfigured filters continue processing without blocking notifications.

* **Bug Fixes**
  * Improved notification enqueueing so filters are evaluated before profiles or notifications are created.

* **Tests**
  * Added coverage for matching and non-matching expressions, excluded application types, and unknown filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->