### PR TITLE
feat(ios): pre-canned watch-zone filter picker (Pro-tier) (tc-hogkn)

### DIFF
--- a/mobile/ios/packages/town-crier-data/Sources/API/URLSessionAPIClient.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/API/URLSessionAPIClient.swift
@@ -253,13 +253,17 @@ public final class URLSessionAPIClient: Sendable {
   }
 
   /// Maps a watch-zone `400` — a custom-shape boundary whose enclosing
-  /// radius exceeds the server's ceiling. Any other error code, or a
-  /// decode failure, falls back to the generic `serverError` unchanged
-  /// (GH#1085).
+  /// radius exceeds the server's ceiling, or an unrecognised pre-canned
+  /// filter key (GH#1098). Any other error code, or a decode failure, falls
+  /// back to the generic `serverError` unchanged (GH#1085).
   private func mapBadRequest(data: Data) throws {
-    if let body = try? decoder.decode(WatchZoneErrorBody.self, from: data),
-      body.error == "boundary_too_large" {
-      throw DomainError.invalidWatchZoneBoundaryTooLarge
+    if let body = try? decoder.decode(WatchZoneErrorBody.self, from: data) {
+      if body.error == "boundary_too_large" {
+        throw DomainError.invalidWatchZoneBoundaryTooLarge
+      }
+      if body.error == "filter_key_invalid" {
+        throw DomainError.invalidWatchZoneFilterKey
+      }
     }
     let message = String(data: data, encoding: .utf8)
     throw APIError.serverError(statusCode: 400, message: message)

--- a/mobile/ios/packages/town-crier-data/Sources/Repositories/APIWatchZoneRepository.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Repositories/APIWatchZoneRepository.swift
@@ -23,7 +23,8 @@ public final class APIWatchZoneRepository: WatchZoneRepository, Sendable {
       radiusMetres: zone.radiusMetres,
       pushEnabled: zone.pushEnabled,
       emailInstantEnabled: zone.emailInstantEnabled,
-      boundary: zone.boundary.map { GeoJSONPolygon(boundary: $0) }
+      boundary: zone.boundary.map { GeoJSONPolygon(boundary: $0) },
+      filterKey: zone.filterKey?.rawValue
     )
     do {
       let _: EmptyResponse = try await apiClient.request(.post("/v1/me/watch-zones", body: body))
@@ -58,7 +59,8 @@ public final class APIWatchZoneRepository: WatchZoneRepository, Sendable {
       radiusMetres: zone.radiusMetres,
       pushEnabled: zone.pushEnabled,
       emailInstantEnabled: zone.emailInstantEnabled,
-      boundary: zone.boundary.map { GeoJSONPolygon(boundary: $0) }
+      boundary: zone.boundary.map { GeoJSONPolygon(boundary: $0) },
+      filterKey: zone.filterKey?.rawValue
     )
     do {
       let _: EmptyResponse = try await apiClient.request(
@@ -120,19 +122,25 @@ struct CreateWatchZoneRequest: Encodable, Sendable {
   let pushEnabled: Bool
   let emailInstantEnabled: Bool
   let boundary: GeoJSONPolygon?
+  /// Omitted from the payload when `nil` (default `Encodable` synthesis) --
+  /// create has no prior value to distinguish "leave alone" from, so
+  /// omission and explicit absence are the same thing (GH#1098, mirrors
+  /// `boundary`'s create-time treatment).
+  let filterKey: String?
 }
 
-/// PATCH always sends every field, including `boundary`: unlike a partial
-/// update, `update(_:)` always encodes the zone's complete desired state (see
-/// `APIWatchZoneRepository.update(_:)`), matching every other field on this
-/// request. A custom `encode(to:)` is required because Swift's synthesized
-/// `Encodable` conformance calls `encodeIfPresent` for `Optional` properties,
-/// which would omit `boundary` from the payload entirely when `nil` rather
-/// than sending an explicit JSON `null` — the server's PATCH handler
-/// (`decodeBoundaryUpdate`, `api-go/internal/watchzones/handler.go`) treats
-/// an absent `boundary` key as "leave the shape untouched" and an explicit
-/// `null` as "revert to a circle", so this distinction matters: a circle
-/// zone (`boundary == nil`) always needs the latter.
+/// PATCH always sends every field, including `boundary` and `filterKey`:
+/// unlike a partial update, `update(_:)` always encodes the zone's complete
+/// desired state (see `APIWatchZoneRepository.update(_:)`), matching every
+/// other field on this request. A custom `encode(to:)` is required because
+/// Swift's synthesized `Encodable` conformance calls `encodeIfPresent` for
+/// `Optional` properties, which would omit `boundary`/`filterKey` from the
+/// payload entirely when `nil` rather than sending an explicit JSON `null`
+/// -- the server's PATCH handler (`decodeBoundaryUpdate`,
+/// `api-go/internal/watchzones/handler.go`) treats an absent key as "leave
+/// untouched" and an explicit `null` as "clear", so this distinction
+/// matters: a circle zone (`boundary == nil`) and an unfiltered zone
+/// (`filterKey == nil`) always need the latter (GH#1031, GH#1098).
 struct UpdateWatchZoneRequest: Encodable, Sendable {
   let name: String
   let latitude: Double
@@ -141,9 +149,11 @@ struct UpdateWatchZoneRequest: Encodable, Sendable {
   let pushEnabled: Bool
   let emailInstantEnabled: Bool
   let boundary: GeoJSONPolygon?
+  let filterKey: String?
 
   private enum CodingKeys: String, CodingKey {
-    case name, latitude, longitude, radiusMetres, pushEnabled, emailInstantEnabled, boundary
+    case name, latitude, longitude, radiusMetres, pushEnabled, emailInstantEnabled, boundary,
+      filterKey
   }
 
   func encode(to encoder: Encoder) throws {
@@ -156,6 +166,7 @@ struct UpdateWatchZoneRequest: Encodable, Sendable {
     try container.encode(emailInstantEnabled, forKey: .emailInstantEnabled)
     // `encode`, not `encodeIfPresent`: see the type's doc comment.
     try container.encode(boundary, forKey: .boundary)
+    try container.encode(filterKey, forKey: .filterKey)
   }
 }
 
@@ -222,6 +233,13 @@ struct WatchZoneSummaryDTO: Decodable, Sendable {
   /// (GH#1031). Absent on responses predating this field, so it hydrates to
   /// `nil` (a circle) — same back-compat treatment as `paused` above.
   let boundary: GeoJSONPolygon?
+  /// The pre-canned notification filter applied to this zone, or `nil` for
+  /// unfiltered (GH#1098). Absent on responses predating this field hydrates
+  /// to `nil` -- same back-compat treatment as `boundary` above. An
+  /// unrecognised string (e.g. the server's catalog has outrun this build's)
+  /// also fails open to `nil`, mirroring the server's own fail-open read
+  /// path for an unrecognised key.
+  let filterKey: WatchZoneFilterKey?
 
   init(
     id: String,
@@ -232,7 +250,8 @@ struct WatchZoneSummaryDTO: Decodable, Sendable {
     pushEnabled: Bool = true,
     emailInstantEnabled: Bool = true,
     paused: Bool = false,
-    boundary: GeoJSONPolygon? = nil
+    boundary: GeoJSONPolygon? = nil,
+    filterKey: WatchZoneFilterKey? = nil
   ) {
     self.id = id
     self.name = name
@@ -243,6 +262,7 @@ struct WatchZoneSummaryDTO: Decodable, Sendable {
     self.emailInstantEnabled = emailInstantEnabled
     self.paused = paused
     self.boundary = boundary
+    self.filterKey = filterKey
   }
 
   init(from decoder: Decoder) throws {
@@ -260,11 +280,14 @@ struct WatchZoneSummaryDTO: Decodable, Sendable {
     self.paused = try container.decodeIfPresent(Bool.self, forKey: .paused) ?? false
     // GH#1031: absent (older API/back-compat, or a plain circle zone) hydrates to nil.
     self.boundary = try container.decodeIfPresent(GeoJSONPolygon.self, forKey: .boundary)
+    // GH#1098: absent, null, or an unrecognised string all fail open to nil.
+    let rawFilterKey = try container.decodeIfPresent(String.self, forKey: .filterKey)
+    self.filterKey = rawFilterKey.flatMap { WatchZoneFilterKey(rawValue: $0) }
   }
 
   private enum CodingKeys: String, CodingKey {
     case id, name, latitude, longitude, radiusMetres
-    case pushEnabled, emailInstantEnabled, paused, boundary
+    case pushEnabled, emailInstantEnabled, paused, boundary, filterKey
   }
 
   func toDomain() throws -> WatchZone {
@@ -278,7 +301,8 @@ struct WatchZoneSummaryDTO: Decodable, Sendable {
       pushEnabled: pushEnabled,
       emailInstantEnabled: emailInstantEnabled,
       paused: paused,
-      boundary: domainBoundary
+      boundary: domainBoundary,
+      filterKey: filterKey
     )
   }
 }

--- a/mobile/ios/packages/town-crier-domain/Sources/Entities/DomainError.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/Entities/DomainError.swift
@@ -27,6 +27,12 @@ public enum DomainError: Error, Equatable, Sendable {
   /// cases above -- from the user's perspective this is the same category of
   /// problem, fixed the same way (redraw a smaller shape). GH#1085.
   case invalidWatchZoneBoundaryTooLarge
+  /// A pre-canned watch-zone filter key is not recognised by the server's
+  /// catalog. Mirrors the server's `filter_key_invalid` (`400`). Defensive --
+  /// the client only ever submits a key sourced from its own
+  /// `WatchZoneFilterKey.allCases`, so this guards against a stale client
+  /// whose catalog has fallen behind the server's (GH#1098).
+  case invalidWatchZoneFilterKey
   /// Saving a watch zone failed because the name duplicates an existing
   /// watch zone for the same user. Mirrors the server's `zone_name_taken`
   /// (`409`). GH#1085.
@@ -82,6 +88,8 @@ public enum DomainError: Error, Equatable, Sendable {
       .invalidWatchZoneBoundarySelfIntersecting, .invalidWatchZoneBoundaryOutOfBounds,
       .invalidWatchZoneBoundaryTooLarge:
       return "Invalid Area"
+    case .invalidWatchZoneFilterKey:
+      return "Invalid Filter"
     case .watchZoneNameTaken:
       return "Name Already Used"
     case .invalidCoordinate, .invalidWatchZoneRadius,
@@ -128,6 +136,8 @@ public enum DomainError: Error, Equatable, Sendable {
       return "A custom area must be drawn within the UK."
     case .invalidWatchZoneBoundaryTooLarge:
       return "This area is too large. Try drawing a smaller shape."
+    case .invalidWatchZoneFilterKey:
+      return "That filter isn't recognised. Please choose another one."
     case .watchZoneNameTaken:
       return "You already have a watch zone with this name. Choose a different name."
     case .invalidCoordinate, .invalidWatchZoneRadius,
@@ -149,7 +159,7 @@ public enum DomainError: Error, Equatable, Sendable {
       .deviceLocalZoneLimitReached, .invalidWatchZoneBoundaryVertexCount,
       .invalidWatchZoneBoundaryDuplicateVertex, .invalidWatchZoneBoundarySelfIntersecting,
       .invalidWatchZoneBoundaryOutOfBounds, .invalidWatchZoneBoundaryTooLarge,
-      .watchZoneNameTaken:
+      .invalidWatchZoneFilterKey, .watchZoneNameTaken:
       return false
     }
   }

--- a/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/WatchZone.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/WatchZone.swift
@@ -23,6 +23,12 @@ public struct WatchZone: Equatable, Hashable, Identifiable, Sendable {
   /// non-nil boundary is the sole "this is a custom shape" discriminator —
   /// see ``isCustomShape``.
   public let boundary: WatchZoneBoundary?
+  /// The pre-canned notification filter applied to this zone, or `nil` for
+  /// unfiltered (GH#1098). Mirrors `boundary`'s optionality -- there is no
+  /// `.none`/`.unfiltered` case, so "no filter" is never representable two
+  /// different ways. Pro-tier only; see
+  /// ``WatchZoneLimits/allowsWatchZoneFilter``.
+  public let filterKey: WatchZoneFilterKey?
 
   public init(
     id: WatchZoneId = WatchZoneId(),
@@ -32,7 +38,8 @@ public struct WatchZone: Equatable, Hashable, Identifiable, Sendable {
     pushEnabled: Bool = true,
     emailInstantEnabled: Bool = true,
     paused: Bool = false,
-    boundary: WatchZoneBoundary? = nil
+    boundary: WatchZoneBoundary? = nil,
+    filterKey: WatchZoneFilterKey? = nil
   ) throws {
     let trimmed = name.trimmingCharacters(in: .whitespaces)
     guard !trimmed.isEmpty else {
@@ -49,6 +56,7 @@ public struct WatchZone: Equatable, Hashable, Identifiable, Sendable {
     self.emailInstantEnabled = emailInstantEnabled
     self.paused = paused
     self.boundary = boundary
+    self.filterKey = filterKey
   }
 
   /// Convenience initializer that derives the zone name from a validated postcode.
@@ -60,7 +68,8 @@ public struct WatchZone: Equatable, Hashable, Identifiable, Sendable {
     pushEnabled: Bool = true,
     emailInstantEnabled: Bool = true,
     paused: Bool = false,
-    boundary: WatchZoneBoundary? = nil
+    boundary: WatchZoneBoundary? = nil,
+    filterKey: WatchZoneFilterKey? = nil
   ) throws {
     try self.init(
       id: id,
@@ -70,7 +79,8 @@ public struct WatchZone: Equatable, Hashable, Identifiable, Sendable {
       pushEnabled: pushEnabled,
       emailInstantEnabled: emailInstantEnabled,
       paused: paused,
-      boundary: boundary
+      boundary: boundary,
+      filterKey: filterKey
     )
   }
 

--- a/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/WatchZoneFilterKey.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/WatchZoneFilterKey.swift
@@ -1,0 +1,69 @@
+/// A pre-canned notification filter for a watch zone (GH#1090/tc-w825j,
+/// client-side GH#1098/tc-hogkn). Pro-tier only -- see
+/// ``WatchZoneLimits/allowsWatchZoneFilter``.
+///
+/// This catalog must stay in sync with the server's `filterCatalog`
+/// (`api-go/internal/watchzones/filter.go`) -- same duplication precedent as
+/// `WatchZoneLimits`/`EntitlementMap` for tier limits. There is no
+/// catalog-listing endpoint; the server only validates a submitted key
+/// against its own embedded copy.
+public enum WatchZoneFilterKey: String, CaseIterable, Equatable, Hashable, Sendable {
+  case fewerNotifications = "fewer_notifications"
+  case houseBuilder = "house_builder"
+  case newHomes = "new_homes"
+  case extensionsAlterations = "extensions_alterations"
+  case loftExtension = "loft_extension"
+  case kitchenExtension = "kitchen_extension"
+  case hmoHouseShares = "hmo_house_shares"
+
+  /// The picker row's primary label.
+  public var displayName: String {
+    switch self {
+    case .fewerNotifications:
+      return "Fewer notifications"
+    case .houseBuilder:
+      return "House builder"
+    case .newHomes:
+      return "New homes"
+    case .extensionsAlterations:
+      return "Extensions & alterations"
+    case .loftExtension:
+      return "Loft extension"
+    case .kitchenExtension:
+      return "Kitchen extension"
+    case .hmoHouseShares:
+      return "HMO / house shares"
+    }
+  }
+
+  /// The picker row's secondary explanation, run through the `voice` skill.
+  /// `kitchenExtension`'s description is deliberately honest about being a
+  /// rear/single-storey-extension proxy, not true kitchen detection
+  /// (GH#1090's explicit copy constraint).
+  public var description: String {
+    switch self {
+    case .fewerNotifications:
+      return
+        "Cuts out tree works, conditions, amendments, adverts and telecoms applications, "
+        + "so you get fewer notifications overall."
+    case .houseBuilder:
+      return "Deliberately broad: extensions, conversions, refurbishments, new builds and more."
+    case .newHomes:
+      return
+        "New housing only: erecting, building or redeveloping dwellings, "
+        + "plus new-build and self-build mentions."
+    case .extensionsAlterations:
+      return
+        "Nearby building work: extensions, loft and garage conversions, outbuildings, "
+        + "conservatories, dormers, porches, annexes and more."
+    case .loftExtension:
+      return "Loft conversions: loft, dormer, hip-to-gable and roof space mentions."
+    case .kitchenExtension:
+      return
+        "We can't detect kitchen work from the planning description alone, so this shows "
+        + "every rear or single-storey extension nearby instead. Most involve a kitchen."
+    case .hmoHouseShares:
+      return "Houses in multiple occupation, Class C4, and larger shared-house applications."
+    }
+  }
+}

--- a/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/WatchZoneLimits.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/WatchZoneLimits.swift
@@ -10,10 +10,16 @@ public struct WatchZoneLimits: Equatable, Sendable {
   /// only a circle (GH#1031). Mirrors the server's
   /// `SubscriptionTier.AllowsCustomBoundary()` (`t.IsPaid()`).
   public let allowsCustomBoundary: Bool
+  /// Whether this tier may set a pre-canned notification filter on a watch
+  /// zone (GH#1098). Mirrors the server's
+  /// `SubscriptionTier.AllowsWatchZoneFilter()` (`t.IsPaidPro()`) -- Pro
+  /// only, narrower than ``allowsCustomBoundary``'s Personal+Pro gate.
+  public let allowsWatchZoneFilter: Bool
 
   public init(tier: SubscriptionTier) {
     self.tier = tier
     maxZones = EntitlementMap.limit(for: tier, quota: .watchZones)
+    allowsWatchZoneFilter = tier == .pro
     switch tier {
     case .free:
       maxRadiusMetres = 2000

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorView+FilterSection.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorView+FilterSection.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+import TownCrierDomain
+
+/// The pre-canned filter section (GH#1098): a three-way triad following the
+/// exact same structure as `WatchZoneEditorView`'s
+/// `shapeModeSection`/`customShapeUpsellPlaceholder`/`lockedCustomShapeSection`.
+/// A standalone `View` (like `ZoneMapPreview`/`GatedToggle`) rather than an
+/// extension on `WatchZoneEditorView`, so it can hold its own `@ObservedObject`
+/// without loosening that type's `viewModel` below `private` -- also keeps
+/// `WatchZoneEditorView.swift` under the `file_length` SwiftLint threshold.
+struct WatchZoneFilterSection: View {
+  @ObservedObject var viewModel: WatchZoneEditorViewModel
+
+  /// A Pro user gets a `NavigationLink` to the picker, a downgraded Pro
+  /// holding a filtered zone gets a static locked label, and everyone else
+  /// gets the plain-text upsell placeholder.
+  var body: some View {
+    if viewModel.canSetWatchZoneFilter {
+      Section {
+        NavigationLink {
+          WatchZoneFilterPickerView(viewModel: viewModel)
+        } label: {
+          HStack {
+            Text("Filter")
+              .foregroundStyle(Color.tcTextPrimary)
+            Spacer()
+            Text(viewModel.selectedFilterKey?.displayName ?? "None")
+              .foregroundStyle(Color.tcTextSecondary)
+          }
+        }
+      } header: {
+        Text("Filter")
+      } footer: {
+        Text("Only see applications that match a pre-set filter, instead of everything nearby.")
+          .font(TCTypography.caption)
+          .foregroundStyle(Color.tcTextSecondary)
+      }
+    } else if viewModel.isFilterLocked {
+      lockedFilterSection
+    } else {
+      Section {
+        filterUpsellPlaceholder
+      }
+    }
+  }
+
+  /// Shown for a downgraded Pro user editing a zone that already has a
+  /// filter set (``WatchZoneEditorViewModel/isFilterLocked``) -- a static
+  /// label with no picker affordance, mirroring `lockedCustomShapeSection`'s
+  /// visual treatment.
+  private var lockedFilterSection: some View {
+    Section {
+      HStack {
+        Text("Filter")
+          .foregroundStyle(Color.tcTextPrimary)
+        Spacer()
+        Text(viewModel.selectedFilterKey?.displayName ?? "None")
+          .foregroundStyle(Color.tcTextSecondary)
+      }
+    } header: {
+      Text("Filter")
+    } footer: {
+      Text("This zone's filter is locked. Upgrade to Pro to change it.")
+        .font(TCTypography.caption)
+        .foregroundStyle(Color.tcTextSecondary)
+    }
+  }
+
+  /// Minimal upsell affordance for a Free/Personal-tier user, matching
+  /// `customShapeUpsellPlaceholder`'s plain-text tap-through treatment.
+  private var filterUpsellPlaceholder: some View {
+    Button {
+      viewModel.viewPlans()
+    } label: {
+      HStack(spacing: TCSpacing.small) {
+        Image(systemName: "line.3.horizontal.decrease.circle.fill")
+          .foregroundStyle(Color.tcAmber)
+          .accessibilityHidden(true)
+        Text("Filter this zone to specific kinds of applications on Pro.")
+          .font(TCTypography.caption)
+          .foregroundStyle(Color.tcTextSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+        Spacer(minLength: 0)
+        Image(systemName: "chevron.right")
+          .font(TCTypography.caption)
+          .foregroundStyle(Color.tcTextSecondary)
+          .accessibilityHidden(true)
+      }
+    }
+    .buttonStyle(.plain)
+    .accessibilityLabel("Filter this zone to specific kinds of applications on Pro.")
+    .accessibilityHint("Opens subscription plans")
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorView.swift
@@ -29,7 +29,7 @@ public struct WatchZoneEditorView: View {
             } else {
               lockedCustomShapeSection
             }
-            filterSection
+            WatchZoneFilterSection(viewModel: viewModel)
           }
           if viewModel.areNotificationTogglesVisible {
             notificationsSection
@@ -299,92 +299,6 @@ public struct WatchZoneEditorView: View {
           .foregroundStyle(Color.tcTextSecondary)
       }
     }
-  }
-
-  // MARK: - Pre-canned filter (GH#1098)
-
-  /// Three-way triad, following the exact same structure as
-  /// `shapeModeSection`/`customShapeUpsellPlaceholder`/`lockedCustomShapeSection`:
-  /// a Pro user gets a `NavigationLink` to the picker, a downgraded Pro
-  /// holding a filtered zone gets a static locked label, and everyone else
-  /// gets the plain-text upsell placeholder.
-  @ViewBuilder
-  private var filterSection: some View {
-    if viewModel.canSetWatchZoneFilter {
-      Section {
-        NavigationLink {
-          WatchZoneFilterPickerView(viewModel: viewModel)
-        } label: {
-          HStack {
-            Text("Filter")
-              .foregroundStyle(Color.tcTextPrimary)
-            Spacer()
-            Text(viewModel.selectedFilterKey?.displayName ?? "None")
-              .foregroundStyle(Color.tcTextSecondary)
-          }
-        }
-      } header: {
-        Text("Filter")
-      } footer: {
-        Text("Only see applications that match a pre-set filter, instead of everything nearby.")
-          .font(TCTypography.caption)
-          .foregroundStyle(Color.tcTextSecondary)
-      }
-    } else if viewModel.isFilterLocked {
-      lockedFilterSection
-    } else {
-      Section {
-        filterUpsellPlaceholder
-      }
-    }
-  }
-
-  /// Shown for a downgraded Pro user editing a zone that already has a
-  /// filter set (``WatchZoneEditorViewModel/isFilterLocked``) -- a static
-  /// label with no picker affordance, mirroring `lockedCustomShapeSection`'s
-  /// visual treatment.
-  private var lockedFilterSection: some View {
-    Section {
-      HStack {
-        Text("Filter")
-          .foregroundStyle(Color.tcTextPrimary)
-        Spacer()
-        Text(viewModel.selectedFilterKey?.displayName ?? "None")
-          .foregroundStyle(Color.tcTextSecondary)
-      }
-    } header: {
-      Text("Filter")
-    } footer: {
-      Text("This zone's filter is locked. Upgrade to Pro to change it.")
-        .font(TCTypography.caption)
-        .foregroundStyle(Color.tcTextSecondary)
-    }
-  }
-
-  /// Minimal upsell affordance for a Free/Personal-tier user, matching
-  /// `customShapeUpsellPlaceholder`'s plain-text tap-through treatment.
-  private var filterUpsellPlaceholder: some View {
-    Button {
-      viewModel.viewPlans()
-    } label: {
-      HStack(spacing: TCSpacing.small) {
-        Image(systemName: "line.3.horizontal.decrease.circle.fill")
-          .foregroundStyle(Color.tcAmber)
-          .accessibilityHidden(true)
-        Text("Filter this zone to specific kinds of applications on Pro.")
-          .font(TCTypography.caption)
-          .foregroundStyle(Color.tcTextSecondary)
-          .fixedSize(horizontal: false, vertical: true)
-        Spacer(minLength: 0)
-        Image(systemName: "chevron.right")
-          .font(TCTypography.caption)
-          .foregroundStyle(Color.tcTextSecondary)
-          .accessibilityHidden(true)
-      }
-    }
-    .buttonStyle(.plain)
-    .accessibilityLabel("Filter this zone to specific kinds of applications on Pro.")
-    .accessibilityHint("Opens subscription plans")
   }
 
   private var notificationsSection: some View {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorView.swift
@@ -29,6 +29,7 @@ public struct WatchZoneEditorView: View {
             } else {
               lockedCustomShapeSection
             }
+            filterSection
           }
           if viewModel.areNotificationTogglesVisible {
             notificationsSection
@@ -298,6 +299,92 @@ public struct WatchZoneEditorView: View {
           .foregroundStyle(Color.tcTextSecondary)
       }
     }
+  }
+
+  // MARK: - Pre-canned filter (GH#1098)
+
+  /// Three-way triad, following the exact same structure as
+  /// `shapeModeSection`/`customShapeUpsellPlaceholder`/`lockedCustomShapeSection`:
+  /// a Pro user gets a `NavigationLink` to the picker, a downgraded Pro
+  /// holding a filtered zone gets a static locked label, and everyone else
+  /// gets the plain-text upsell placeholder.
+  @ViewBuilder
+  private var filterSection: some View {
+    if viewModel.canSetWatchZoneFilter {
+      Section {
+        NavigationLink {
+          WatchZoneFilterPickerView(viewModel: viewModel)
+        } label: {
+          HStack {
+            Text("Filter")
+              .foregroundStyle(Color.tcTextPrimary)
+            Spacer()
+            Text(viewModel.selectedFilterKey?.displayName ?? "None")
+              .foregroundStyle(Color.tcTextSecondary)
+          }
+        }
+      } header: {
+        Text("Filter")
+      } footer: {
+        Text("Only see applications that match a pre-set filter, instead of everything nearby.")
+          .font(TCTypography.caption)
+          .foregroundStyle(Color.tcTextSecondary)
+      }
+    } else if viewModel.isFilterLocked {
+      lockedFilterSection
+    } else {
+      Section {
+        filterUpsellPlaceholder
+      }
+    }
+  }
+
+  /// Shown for a downgraded Pro user editing a zone that already has a
+  /// filter set (``WatchZoneEditorViewModel/isFilterLocked``) -- a static
+  /// label with no picker affordance, mirroring `lockedCustomShapeSection`'s
+  /// visual treatment.
+  private var lockedFilterSection: some View {
+    Section {
+      HStack {
+        Text("Filter")
+          .foregroundStyle(Color.tcTextPrimary)
+        Spacer()
+        Text(viewModel.selectedFilterKey?.displayName ?? "None")
+          .foregroundStyle(Color.tcTextSecondary)
+      }
+    } header: {
+      Text("Filter")
+    } footer: {
+      Text("This zone's filter is locked. Upgrade to Pro to change it.")
+        .font(TCTypography.caption)
+        .foregroundStyle(Color.tcTextSecondary)
+    }
+  }
+
+  /// Minimal upsell affordance for a Free/Personal-tier user, matching
+  /// `customShapeUpsellPlaceholder`'s plain-text tap-through treatment.
+  private var filterUpsellPlaceholder: some View {
+    Button {
+      viewModel.viewPlans()
+    } label: {
+      HStack(spacing: TCSpacing.small) {
+        Image(systemName: "line.3.horizontal.decrease.circle.fill")
+          .foregroundStyle(Color.tcAmber)
+          .accessibilityHidden(true)
+        Text("Filter this zone to specific kinds of applications on Pro.")
+          .font(TCTypography.caption)
+          .foregroundStyle(Color.tcTextSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+        Spacer(minLength: 0)
+        Image(systemName: "chevron.right")
+          .font(TCTypography.caption)
+          .foregroundStyle(Color.tcTextSecondary)
+          .accessibilityHidden(true)
+      }
+    }
+    .buttonStyle(.plain)
+    .accessibilityLabel("Filter this zone to specific kinds of applications on Pro.")
+    .accessibilityHint("Opens subscription plans")
   }
 
   private var notificationsSection: some View {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorViewModel.swift
@@ -34,6 +34,11 @@ public final class WatchZoneEditorViewModel: ObservableObject, EntitlementGating
   /// `WatchZoneBoundary.init` when ``shapeMode`` is `.custom`.
   @Published public private(set) var boundaryVertices: [Coordinate] = []
 
+  /// The pre-canned notification filter selected for this zone, or `nil` for
+  /// unfiltered (GH#1098). Defaults to `nil`; populated from the edited
+  /// zone's `filterKey` when present.
+  @Published public private(set) var selectedFilterKey: WatchZoneFilterKey?
+
   /// Mirrors `WatchZoneBoundary`'s geometric minimum (3 distinct vertices
   /// are required to form a polygon) so the UI can gate "finish drawing"
   /// without constructing (and discarding) a throwaway boundary just to
@@ -84,6 +89,7 @@ public final class WatchZoneEditorViewModel: ObservableObject, EntitlementGating
         // works with the open sequence and re-closes on save.
         self.boundaryVertices = Array(boundary.vertices.dropLast())
       }
+      self.selectedFilterKey = zone.filterKey
     }
   }
 
@@ -223,6 +229,35 @@ public final class WatchZoneEditorViewModel: ObservableObject, EntitlementGating
     }
   }
 
+  // MARK: - Pre-canned filter (GH#1098)
+
+  /// Whether the current tier may set a pre-canned filter at all -- gates
+  /// showing the filter picker row in the View. Pro only; Free/Personal are
+  /// always `false`. Mirrors the server's
+  /// `SubscriptionTier.AllowsWatchZoneFilter()` via `WatchZoneLimits`.
+  public var canSetWatchZoneFilter: Bool {
+    limits.allowsWatchZoneFilter
+  }
+
+  /// True when editing an existing filtered zone on a tier that can no
+  /// longer set one (a downgraded Pro user who set a filter before
+  /// downgrading) -- same posture as ``isCustomShapeLocked``: the filter
+  /// stays applied and visible, never silently cleared, but the picker is
+  /// unreachable.
+  public var isFilterLocked: Bool {
+    selectedFilterKey != nil && !canSetWatchZoneFilter
+  }
+
+  /// Sets or clears the selected filter. Clearing (`nil`) is always allowed
+  /// regardless of tier, matching the server's "clearing never requires an
+  /// entitlement check". Setting a non-nil value while ineligible
+  /// (``canSetWatchZoneFilter`` is `false`) is a silent no-op, matching
+  /// ``selectShapeMode``'s defence-in-depth pattern.
+  public func selectFilterKey(_ key: WatchZoneFilterKey?) {
+    guard key == nil || canSetWatchZoneFilter else { return }
+    selectedFilterKey = key
+  }
+
   public func submitPostcode() async {
     isLoading = true
     error = nil
@@ -299,7 +334,8 @@ public final class WatchZoneEditorViewModel: ObservableObject, EntitlementGating
         radiusMetres: radius,
         pushEnabled: pushEnabled,
         emailInstantEnabled: emailInstantEnabled,
-        boundary: boundary
+        boundary: boundary,
+        filterKey: selectedFilterKey
       )
       if isEditing {
         try await repository.update(zone)

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneFilterPickerView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneFilterPickerView.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+import TownCrierDomain
+
+/// Picker for the pre-canned watch-zone filter catalog (GH#1098): "None"
+/// plus the 7 `WatchZoneFilterKey` cases, a checkmark on the current
+/// selection. Tapping a row selects it and pops back to the editor,
+/// following this app's existing push-a-list-picker idiom
+/// (`WatchZoneEditorView`'s `Form`/`Section` + `NavigationLink` pattern).
+public struct WatchZoneFilterPickerView: View {
+  @ObservedObject private var viewModel: WatchZoneEditorViewModel
+  @Environment(\.dismiss) private var dismiss
+
+  public init(viewModel: WatchZoneEditorViewModel) {
+    self.viewModel = viewModel
+  }
+
+  public var body: some View {
+    List {
+      row(
+        displayName: "None",
+        description: "Show every application in this zone, with no filter applied.",
+        isSelected: viewModel.selectedFilterKey == nil
+      ) {
+        select(nil)
+      }
+
+      ForEach(WatchZoneFilterKey.allCases, id: \.self) { filterKey in
+        row(
+          displayName: filterKey.displayName,
+          description: filterKey.description,
+          isSelected: viewModel.selectedFilterKey == filterKey
+        ) {
+          select(filterKey)
+        }
+      }
+    }
+    .navigationTitle("Filter")
+    #if os(iOS)
+      .navigationBarTitleDisplayMode(.inline)
+    #endif
+  }
+
+  private func select(_ filterKey: WatchZoneFilterKey?) {
+    viewModel.selectFilterKey(filterKey)
+    dismiss()
+  }
+
+  private func row(
+    displayName: String,
+    description: String,
+    isSelected: Bool,
+    action: @escaping () -> Void
+  ) -> some View {
+    Button(action: action) {
+      HStack(alignment: .top, spacing: TCSpacing.small) {
+        VStack(alignment: .leading, spacing: TCSpacing.extraSmall) {
+          Text(displayName)
+            .font(TCTypography.bodyEmphasis)
+            .foregroundStyle(Color.tcTextPrimary)
+          Text(description)
+            .font(TCTypography.caption)
+            .foregroundStyle(Color.tcTextSecondary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+        Spacer(minLength: TCSpacing.small)
+        if isSelected {
+          Image(systemName: "checkmark")
+            .font(TCTypography.body)
+            .foregroundStyle(Color.tcAmber)
+            .accessibilityHidden(true)
+        }
+      }
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .accessibilityLabel("\(displayName). \(description)")
+    .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/APIWatchZoneRepositoryFilterTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APIWatchZoneRepositoryFilterTests.swift
@@ -1,0 +1,174 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierData
+
+/// Pre-canned filter (`filterKey`) wire-format tests for
+/// `APIWatchZoneRepository` (GH#1098, bead tc-hogkn): create omits an unset
+/// filter, update always sends the field explicitly (a value or JSON
+/// `null`) -- mirroring `boundary`'s exact create/update split.
+@Suite("APIWatchZoneRepository — pre-canned filter")
+struct APIWatchZoneRepositoryFilterTests {
+
+  // swiftlint:disable:next force_unwrapping
+  private let baseURL = URL(string: "https://api-dev.towncrierapp.uk")!
+
+  private func makeSUT(
+    responses: [(Data, URLResponse)]
+  ) -> (APIWatchZoneRepository, StubHTTPTransport) {
+    let authService = SpyAuthenticationService()
+    authService.currentSessionResult = .valid
+    let transport = StubHTTPTransport()
+    transport.responses = responses
+    let apiClient = URLSessionAPIClient(
+      baseURL: baseURL,
+      authService: authService,
+      transport: transport
+    )
+    let sut = APIWatchZoneRepository(apiClient: apiClient)
+    return (sut, transport)
+  }
+
+  // swiftlint:disable force_unwrapping
+  private func httpResponse(statusCode: Int) -> HTTPURLResponse {
+    HTTPURLResponse(
+      url: baseURL,
+      statusCode: statusCode,
+      httpVersion: nil,
+      headerFields: nil
+    )!
+  }
+  // swiftlint:enable force_unwrapping
+
+  private func makeFilteredZone() throws -> WatchZone {
+    try WatchZone(
+      id: WatchZoneId("zone-filtered"),
+      name: "Filtered Area",
+      centre: Coordinate(latitude: 51.5074, longitude: -0.1278),
+      radiusMetres: 1500,
+      filterKey: .loftExtension
+    )
+  }
+
+  // MARK: - save (create)
+
+  @Test("save sends the filterKey's raw value when set")
+  func save_withFilterKey_sendsRawValue() async throws {
+    let zone = try makeFilteredZone()
+    let (sut, transport) = makeSUT(responses: [
+      (Data("{}".utf8), httpResponse(statusCode: 201))
+    ])
+
+    try await sut.save(zone)
+
+    let request = try #require(transport.requests.first)
+    let body = try #require(request.httpBody)
+    let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+    #expect(json["filterKey"] as? String == "loft_extension")
+  }
+
+  @Test("save omits the filterKey key when the zone is unfiltered")
+  func save_withoutFilterKey_omitsKey() async throws {
+    let zone = WatchZone.cambridge
+    let (sut, transport) = makeSUT(responses: [
+      (Data("{}".utf8), httpResponse(statusCode: 201))
+    ])
+
+    try await sut.save(zone)
+
+    let request = try #require(transport.requests.first)
+    let body = try #require(request.httpBody)
+    let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+    #expect(json["filterKey"] == nil)
+  }
+
+  // MARK: - update (patch)
+
+  @Test("update sends the filterKey's raw value when set")
+  func update_withFilterKey_sendsRawValue() async throws {
+    let zone = try makeFilteredZone()
+    let (sut, transport) = makeSUT(responses: [
+      (Data("{}".utf8), httpResponse(statusCode: 200))
+    ])
+
+    try await sut.update(zone)
+
+    let request = try #require(transport.requests.first)
+    let body = try #require(request.httpBody)
+    let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+    #expect(json["filterKey"] as? String == "loft_extension")
+  }
+
+  @Test("update sends an explicit null filterKey when the zone is unfiltered, never omitted")
+  func update_withoutFilterKey_sendsExplicitNull() async throws {
+    let zone = WatchZone.cambridge
+    let (sut, transport) = makeSUT(responses: [
+      (Data("{}".utf8), httpResponse(statusCode: 200))
+    ])
+
+    try await sut.update(zone)
+
+    let request = try #require(transport.requests.first)
+    let body = try #require(request.httpBody)
+    let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+    // The key must be present with an explicit JSON null, not omitted: the
+    // server's PATCH tri-state semantics treat an absent key as "leave
+    // alone" and only an explicit null as "clear" (GH#1090).
+    #expect(json.keys.contains("filterKey"))
+    #expect(json["filterKey"] is NSNull)
+  }
+
+  // MARK: - loadAll (round trip)
+
+  @Test("loadAll decodes a filtered zone's filterKey from the API response")
+  func loadAll_withFilterKey_decodesFilteredZone() async throws {
+    let json = """
+      {
+          "zones": [
+              {
+                  "id": "zone-filtered",
+                  "name": "Filtered Area",
+                  "latitude": 51.5074,
+                  "longitude": -0.1278,
+                  "radiusMetres": 1500,
+                  "filterKey": "hmo_house_shares"
+              }
+          ]
+      }
+      """
+    let (sut, _) = makeSUT(responses: [
+      (Data(json.utf8), httpResponse(statusCode: 200))
+    ])
+
+    let zones = try await sut.loadAll()
+
+    #expect(zones.count == 1)
+    #expect(zones[0].filterKey == .hmoHouseShares)
+  }
+
+  @Test("loadAll decodes an unfiltered zone with filterKey nil (back-compat)")
+  func loadAll_withoutFilterKey_decodesUnfilteredZone() async throws {
+    let json = """
+      {
+          "zones": [
+              {
+                  "id": "zone-001",
+                  "name": "CB1 2AD",
+                  "latitude": 52.2053,
+                  "longitude": 0.1218,
+                  "radiusMetres": 2000
+              }
+          ]
+      }
+      """
+    let (sut, _) = makeSUT(responses: [
+      (Data(json.utf8), httpResponse(statusCode: 200))
+    ])
+
+    let zones = try await sut.loadAll()
+
+    #expect(zones.count == 1)
+    #expect(zones[0].filterKey == nil)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/URLSessionAPIClientWatchZoneErrorMappingTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/URLSessionAPIClientWatchZoneErrorMappingTests.swift
@@ -51,6 +51,17 @@ struct URLSessionAPIClientWatchZoneErrorMappingTests {
     }
   }
 
+  @Test("400 with filter_key_invalid body throws DomainError.invalidWatchZoneFilterKey")
+  func filterKeyInvalidResponse() async throws {
+    let body =
+      #"{"error":"filter_key_invalid","message":"The filter key is not recognised."}"#
+    let sut = makeSUT(responses: [(Data(body.utf8), httpResponse(url: baseURL, statusCode: 400))])
+
+    await #expect(throws: DomainError.invalidWatchZoneFilterKey) {
+      let _: TestResponse = try await sut.request(.post("/watch-zones", body: TestBody(title: "x")))
+    }
+  }
+
   @Test("400 with unrecognized error code falls back to APIError.serverError")
   func unrecognizedBadRequestFallsBackToServerError() async throws {
     let body = #"{"error":"validation_failed","message":"Something else is wrong."}"#

--- a/mobile/ios/town-crier-tests/Sources/Features/WatchZoneEditorViewFilterTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WatchZoneEditorViewFilterTests.swift
@@ -1,0 +1,130 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+/// The pre-canned filter section's three-way triad on `WatchZoneEditorView`
+/// (GH#1098, bead tc-hogkn): open picker (Pro), locked static label
+/// (downgraded Pro holding a filtered zone), or upsell placeholder
+/// (Free/Personal). Split out of `WatchZoneEditorViewTests` to keep that
+/// file under the `file_length` SwiftLint threshold, mirroring the existing
+/// split into `APIWatchZoneRepositoryBoundaryTests`. The View is not
+/// introspectable in this codebase (no ViewInspector), so these are
+/// construction/render smoke tests plus assertions against the ViewModel
+/// state the View reads.
+@MainActor
+@Suite("WatchZoneEditorView — pre-canned filter")
+struct WatchZoneEditorViewFilterTests {
+
+  private func makeViewModel(
+    tier: SubscriptionTier = .pro,
+    editing zone: WatchZone? = nil
+  ) -> WatchZoneEditorViewModel {
+    WatchZoneEditorViewModel(
+      geocoder: SpyPostcodeGeocoder(),
+      repository: SpyWatchZoneRepository(),
+      tier: tier,
+      editing: zone
+    )
+  }
+
+  private func filteredZone(
+    filterKey: WatchZoneFilterKey = .kitchenExtension
+  ) throws -> WatchZone {
+    try WatchZone(
+      id: WatchZoneId("zone-filtered"),
+      name: "Filtered Area",
+      centre: .cambridge,
+      radiusMetres: 1500,
+      filterKey: filterKey
+    )
+  }
+
+  // MARK: - Pro tier: open picker
+
+  @Test func body_renders_proTier_createMode() {
+    let vm = makeViewModel(tier: .pro)
+    #expect(vm.canSetWatchZoneFilter)
+    let sut = WatchZoneEditorView(viewModel: vm)
+    _ = sut.body
+  }
+
+  @Test func body_renders_proTier_editMode_noFilterSelected() {
+    let vm = makeViewModel(tier: .pro, editing: .cambridge)
+    #expect(vm.canSetWatchZoneFilter)
+    #expect(vm.selectedFilterKey == nil)
+    let sut = WatchZoneEditorView(viewModel: vm)
+    _ = sut.body
+  }
+
+  @Test func body_renders_proTier_editMode_withFilterSelected() throws {
+    let vm = makeViewModel(tier: .pro, editing: try filteredZone())
+    #expect(vm.canSetWatchZoneFilter)
+    #expect(vm.selectedFilterKey == .kitchenExtension)
+    #expect(!vm.isFilterLocked)
+    let sut = WatchZoneEditorView(viewModel: vm)
+    _ = sut.body
+  }
+
+  // MARK: - Free/Personal tier: locked upgrade affordance, cannot open picker
+
+  @Test func body_renders_freeTier_createMode_showsUpsellPlaceholder() {
+    let vm = makeViewModel(tier: .free)
+    #expect(!vm.canSetWatchZoneFilter)
+    #expect(!vm.isFilterLocked)
+    let sut = WatchZoneEditorView(viewModel: vm)
+    _ = sut.body
+  }
+
+  @Test func body_renders_personalTier_createMode_showsUpsellPlaceholder() {
+    let vm = makeViewModel(tier: .personal)
+    #expect(!vm.canSetWatchZoneFilter)
+    #expect(!vm.isFilterLocked)
+    let sut = WatchZoneEditorView(viewModel: vm)
+    _ = sut.body
+  }
+
+  /// Tapping the upsell placeholder routes to `viewPlans()`, which invokes
+  /// `onUpgradeRequired` -- the same wiring the shape-mode upsell placeholder
+  /// already exercises.
+  @Test func upsellPlaceholder_tap_routesToUpgradeRequired() {
+    let vm = makeViewModel(tier: .free)
+    var upgradeRequested = false
+    vm.onUpgradeRequired = { upgradeRequested = true }
+
+    vm.viewPlans()
+
+    #expect(upgradeRequested)
+  }
+
+  // MARK: - Downgraded Pro tier holding a filtered zone: locked static label
+
+  @Test func body_renders_freeTier_editingFilteredZone_locked() throws {
+    let vm = makeViewModel(tier: .free, editing: try filteredZone())
+    #expect(vm.selectedFilterKey == .kitchenExtension)
+    #expect(!vm.canSetWatchZoneFilter)
+    #expect(vm.isFilterLocked)
+
+    let sut = WatchZoneEditorView(viewModel: vm)
+    _ = sut.body
+  }
+
+  @Test func body_renders_personalTier_editingFilteredZone_locked() throws {
+    let vm = makeViewModel(tier: .personal, editing: try filteredZone())
+    #expect(vm.isFilterLocked)
+
+    let sut = WatchZoneEditorView(viewModel: vm)
+    _ = sut.body
+  }
+
+  /// Save must stay reachable for a locked filtered zone (renaming or
+  /// toggling notifications is still allowed -- only the filter itself is
+  /// locked, not the whole zone).
+  @Test func saveDisabledCondition_lockedFilter_notBlockedByFilterState() throws {
+    let vm = makeViewModel(tier: .free, editing: try filteredZone())
+
+    #expect(vm.geocodedCoordinate != nil)
+    #expect(!vm.nameInput.trimmingCharacters(in: .whitespaces).isEmpty)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/WatchZoneEditorViewModelFilterTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WatchZoneEditorViewModelFilterTests.swift
@@ -1,0 +1,201 @@
+import Foundation
+import Testing
+
+@testable import TownCrierDomain
+@testable import TownCrierPresentation
+
+/// Pre-canned filter selection and the Pro-tier entitlement gate on
+/// `WatchZoneEditorViewModel` (GH#1098, bead tc-hogkn). Mirrors
+/// `WatchZoneEditorViewModelShapeModeTests`'s structure -- the closest
+/// existing precedent (GH#1031's Circle/Custom shape gate), not the
+/// `GatedToggle`/`Entitlement` sheet mechanism.
+@MainActor
+@Suite("WatchZoneEditorViewModel — pre-canned filter")
+struct WatchZoneEditorViewModelFilterTests {
+  private var spyGeocoder: SpyPostcodeGeocoder!
+  private var spyRepository: SpyWatchZoneRepository!
+
+  init() {
+    spyGeocoder = SpyPostcodeGeocoder()
+    spyRepository = SpyWatchZoneRepository()
+  }
+
+  private func makeSUT(
+    tier: SubscriptionTier = .pro,
+    editing zone: WatchZone? = nil
+  ) -> WatchZoneEditorViewModel {
+    WatchZoneEditorViewModel(
+      geocoder: spyGeocoder,
+      repository: spyRepository,
+      tier: tier,
+      editing: zone
+    )
+  }
+
+  private func filteredZone(filterKey: WatchZoneFilterKey = .loftExtension) throws -> WatchZone {
+    try WatchZone(
+      id: WatchZoneId("zone-filtered"),
+      name: "Filtered Area",
+      centre: .cambridge,
+      radiusMetres: 1500,
+      filterKey: filterKey
+    )
+  }
+
+  // MARK: - Initial state
+
+  @Test func initialState_selectedFilterKeyIsNil() {
+    let sut = makeSUT()
+    #expect(sut.selectedFilterKey == nil)
+  }
+
+  @Test func initialState_editingFilteredZone_populatesSelectedFilterKey() throws {
+    let sut = makeSUT(editing: try filteredZone())
+
+    #expect(sut.selectedFilterKey == .loftExtension)
+  }
+
+  @Test func initialState_editingUnfilteredZone_selectedFilterKeyStaysNil() {
+    let sut = makeSUT(editing: .cambridge)
+
+    #expect(sut.selectedFilterKey == nil)
+  }
+
+  // MARK: - canSetWatchZoneFilter (Pro-only tier gating)
+
+  @Test func canSetWatchZoneFilter_falseOnFreeTier() {
+    #expect(!makeSUT(tier: .free).canSetWatchZoneFilter)
+  }
+
+  @Test func canSetWatchZoneFilter_falseOnPersonalTier() {
+    #expect(!makeSUT(tier: .personal).canSetWatchZoneFilter)
+  }
+
+  @Test func canSetWatchZoneFilter_trueOnProTier() {
+    #expect(makeSUT(tier: .pro).canSetWatchZoneFilter)
+  }
+
+  // MARK: - isFilterLocked (downgraded Pro tier holding a filtered zone)
+
+  @Test func isFilterLocked_falseByDefault() {
+    #expect(!makeSUT().isFilterLocked)
+  }
+
+  @Test func isFilterLocked_falseOnProTier_editingFilteredZone() throws {
+    let sut = makeSUT(tier: .pro, editing: try filteredZone())
+
+    #expect(!sut.isFilterLocked)
+  }
+
+  @Test func isFilterLocked_trueOnFreeTier_editingFilteredZone() throws {
+    // A downgraded Pro user reopening the editor for a filtered zone they
+    // set before downgrading -- same posture as isCustomShapeLocked.
+    let sut = makeSUT(tier: .free, editing: try filteredZone())
+
+    #expect(sut.selectedFilterKey == .loftExtension)
+    #expect(sut.isFilterLocked)
+  }
+
+  @Test func isFilterLocked_trueOnPersonalTier_editingFilteredZone() throws {
+    let sut = makeSUT(tier: .personal, editing: try filteredZone())
+
+    #expect(sut.isFilterLocked)
+  }
+
+  @Test func isFilterLocked_falseOnFreeTier_editingUnfilteredZone() {
+    let sut = makeSUT(tier: .free, editing: .cambridge)
+
+    #expect(!sut.isFilterLocked)
+  }
+
+  // MARK: - selectFilterKey
+
+  @Test func selectFilterKey_settingOnProTier_isAllowed() {
+    let sut = makeSUT(tier: .pro)
+
+    sut.selectFilterKey(.hmoHouseShares)
+
+    #expect(sut.selectedFilterKey == .hmoHouseShares)
+  }
+
+  @Test func selectFilterKey_everyCatalogEntry_settableOnProTier() {
+    let sut = makeSUT(tier: .pro)
+
+    for filterKey in WatchZoneFilterKey.allCases {
+      sut.selectFilterKey(filterKey)
+      #expect(sut.selectedFilterKey == filterKey)
+    }
+  }
+
+  @Test func selectFilterKey_settingOnFreeTier_isSilentNoOp() {
+    let sut = makeSUT(tier: .free)
+
+    sut.selectFilterKey(.hmoHouseShares)
+
+    #expect(sut.selectedFilterKey == nil)
+  }
+
+  @Test func selectFilterKey_settingOnPersonalTier_isSilentNoOp() {
+    let sut = makeSUT(tier: .personal)
+
+    sut.selectFilterKey(.hmoHouseShares)
+
+    #expect(sut.selectedFilterKey == nil)
+  }
+
+  @Test func selectFilterKey_clearingToNil_alwaysAllowedRegardlessOfTier() throws {
+    // Clearing never requires an entitlement check, mirroring the server's
+    // tri-state PATCH semantics (GH#1090): a downgraded Free-tier user must
+    // still be able to clear a filter they can no longer set.
+    let sut = makeSUT(tier: .free, editing: try filteredZone())
+    #expect(sut.selectedFilterKey == .loftExtension)
+
+    sut.selectFilterKey(nil)
+
+    #expect(sut.selectedFilterKey == nil)
+  }
+
+  // MARK: - save() sends the selected filter key
+
+  private func geocode(_ sut: WatchZoneEditorViewModel) async {
+    sut.postcodeInput = "CB1 2AD"
+    spyGeocoder.geocodeResult = .success(.cambridge)
+    await sut.submitPostcode()
+  }
+
+  @Test func save_proTier_sendsSelectedFilterKey() async {
+    let sut = makeSUT(tier: .pro)
+    await geocode(sut)
+    sut.selectFilterKey(.newHomes)
+
+    let didSave = await sut.save()
+
+    #expect(didSave)
+    let saved = spyRepository.saveCalls.first
+    #expect(saved?.filterKey == .newHomes)
+  }
+
+  @Test func save_noFilterSelected_sendsNilFilterKey() async {
+    let sut = makeSUT(tier: .pro)
+    await geocode(sut)
+
+    let didSave = await sut.save()
+
+    #expect(didSave)
+    let saved = spyRepository.saveCalls.first
+    #expect(saved?.filterKey == nil)
+  }
+
+  @Test func save_editingLockedFilteredZone_stillSendsExistingFilterKey() async throws {
+    // A downgraded tier can still save the zone (renaming, toggling
+    // notifications) without losing the locked filter -- it's read-only, not
+    // silently cleared.
+    let sut = makeSUT(tier: .free, editing: try filteredZone())
+
+    let didSave = await sut.save()
+
+    #expect(didSave)
+    let saved = spyRepository.updateCalls.first
+    #expect(saved?.filterKey == .loftExtension)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/WatchZoneFilterKeyTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WatchZoneFilterKeyTests.swift
@@ -1,0 +1,52 @@
+import Testing
+
+@testable import TownCrierDomain
+
+/// Catalog completeness for the pre-canned watch-zone filter keys (GH#1098,
+/// bead tc-hogkn). Mirrors the server's 7-entry catalog
+/// (`api-go/internal/watchzones/filter.go`, GH#1090).
+@Suite("WatchZoneFilterKey")
+struct WatchZoneFilterKeyTests {
+  @Test func allCases_hasSevenEntries() {
+    #expect(WatchZoneFilterKey.allCases.count == 7)
+  }
+
+  @Test func allCases_everyCaseHasNonEmptyDisplayName() {
+    for filterKey in WatchZoneFilterKey.allCases {
+      #expect(!filterKey.displayName.isEmpty)
+    }
+  }
+
+  @Test func allCases_everyCaseHasNonEmptyDescription() {
+    for filterKey in WatchZoneFilterKey.allCases {
+      #expect(!filterKey.description.isEmpty)
+    }
+  }
+
+  @Test func rawValues_matchServerCatalogKeys() {
+    #expect(WatchZoneFilterKey.fewerNotifications.rawValue == "fewer_notifications")
+    #expect(WatchZoneFilterKey.houseBuilder.rawValue == "house_builder")
+    #expect(WatchZoneFilterKey.newHomes.rawValue == "new_homes")
+    #expect(WatchZoneFilterKey.extensionsAlterations.rawValue == "extensions_alterations")
+    #expect(WatchZoneFilterKey.loftExtension.rawValue == "loft_extension")
+    #expect(WatchZoneFilterKey.kitchenExtension.rawValue == "kitchen_extension")
+    #expect(WatchZoneFilterKey.hmoHouseShares.rawValue == "hmo_house_shares")
+  }
+
+  /// GH#1090's explicit copy constraint: the kitchen filter must not imply
+  /// true kitchen detection, since the server can't detect kitchen work
+  /// specifically from a planning description.
+  @Test func kitchenExtension_descriptionDoesNotClaimTrueKitchenDetection() {
+    let description = WatchZoneFilterKey.kitchenExtension.description.lowercased()
+    #expect(!description.contains("detects kitchen"))
+    #expect(description.contains("can't detect kitchen"))
+  }
+
+  @Test func initFromRawValue_recognisedString_returnsCase() {
+    #expect(WatchZoneFilterKey(rawValue: "hmo_house_shares") == .hmoHouseShares)
+  }
+
+  @Test func initFromRawValue_unrecognisedString_returnsNil() {
+    #expect(WatchZoneFilterKey(rawValue: "not_a_real_filter") == nil)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/WatchZoneFilterPickerViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WatchZoneFilterPickerViewTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+/// `WatchZoneFilterPickerView` (GH#1098, bead tc-hogkn). The View is not
+/// introspectable in this codebase (no ViewInspector), so these are
+/// construction/render smoke tests plus assertions against the ViewModel
+/// state the View reads and mutates -- the same pattern as
+/// `WatchZoneEditorViewTests`.
+@MainActor
+@Suite("WatchZoneFilterPickerView")
+struct WatchZoneFilterPickerViewTests {
+
+  private func makeViewModel(
+    tier: SubscriptionTier = .pro,
+    editing zone: WatchZone? = nil
+  ) -> WatchZoneEditorViewModel {
+    WatchZoneEditorViewModel(
+      geocoder: SpyPostcodeGeocoder(),
+      repository: SpyWatchZoneRepository(),
+      tier: tier,
+      editing: zone
+    )
+  }
+
+  @Test func body_renders_withNoSelection() {
+    let vm = makeViewModel()
+    let sut = WatchZoneFilterPickerView(viewModel: vm)
+    _ = sut.body
+  }
+
+  @Test func body_renders_withAnExistingSelection() throws {
+    let zone = try WatchZone(
+      id: WatchZoneId("zone-filtered"),
+      name: "Filtered Area",
+      centre: .cambridge,
+      radiusMetres: 1500,
+      filterKey: .kitchenExtension
+    )
+    let vm = makeViewModel(editing: zone)
+    #expect(vm.selectedFilterKey == .kitchenExtension)
+
+    let sut = WatchZoneFilterPickerView(viewModel: vm)
+    _ = sut.body
+  }
+
+  /// Sanity check that the picker has a row for every catalog entry plus
+  /// "None" available to select from -- exercised via the ViewModel the View
+  /// drives, since the View itself isn't introspectable.
+  @Test func selectingEachCatalogEntry_updatesSelectedFilterKey() {
+    let vm = makeViewModel()
+
+    for filterKey in WatchZoneFilterKey.allCases {
+      vm.selectFilterKey(filterKey)
+      #expect(vm.selectedFilterKey == filterKey)
+    }
+
+    vm.selectFilterKey(nil)
+    #expect(vm.selectedFilterKey == nil)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/WatchZoneLimitsTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WatchZoneLimitsTests.swift
@@ -76,4 +76,21 @@ struct WatchZoneLimitsTests {
     #expect(limits.allowsCustomBoundary)
   }
 
+  // MARK: - allowsWatchZoneFilter (GH#1098, tc-hogkn -- Pro only, narrower than allowsCustomBoundary)
+
+  @Test func freeTier_allowsWatchZoneFilterIsFalse() {
+    let limits = WatchZoneLimits(tier: .free)
+    #expect(!limits.allowsWatchZoneFilter)
+  }
+
+  @Test func personalTier_allowsWatchZoneFilterIsFalse() {
+    let limits = WatchZoneLimits(tier: .personal)
+    #expect(!limits.allowsWatchZoneFilter)
+  }
+
+  @Test func proTier_allowsWatchZoneFilterIsTrue() {
+    let limits = WatchZoneLimits(tier: .pro)
+    #expect(limits.allowsWatchZoneFilter)
+  }
+
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/WatchZoneSummaryDTOFilterTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WatchZoneSummaryDTOFilterTests.swift
@@ -1,0 +1,105 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierData
+
+/// Pre-canned filter (`filterKey`) DTO decode/mapping tests (GH#1098, bead
+/// tc-hogkn). Split out of `WatchZoneSummaryDTOTests` to keep that file under
+/// the `file_length` SwiftLint threshold, mirroring the existing split into
+/// `APIWatchZoneRepositoryBoundaryTests`.
+@Suite("WatchZoneSummaryDTO mapping — pre-canned filter")
+struct WatchZoneSummaryDTOFilterTests {
+
+  @Test("decoding DTO without filterKey hydrates to nil (back-compat)")
+  func decoding_missingFilterKey_hydratesToNil() throws {
+    let json = """
+      {
+          "id": "zone-001",
+          "name": "CB1 2AD",
+          "latitude": 52.2053,
+          "longitude": 0.1218,
+          "radiusMetres": 2000
+      }
+      """
+    let dto = try JSONDecoder().decode(WatchZoneSummaryDTO.self, from: Data(json.utf8))
+    #expect(dto.filterKey == nil)
+  }
+
+  @Test("decoding DTO with filterKey: null hydrates to nil")
+  func decoding_nullFilterKey_hydratesToNil() throws {
+    let json = """
+      {
+          "id": "zone-001",
+          "name": "CB1 2AD",
+          "latitude": 52.2053,
+          "longitude": 0.1218,
+          "radiusMetres": 2000,
+          "filterKey": null
+      }
+      """
+    let dto = try JSONDecoder().decode(WatchZoneSummaryDTO.self, from: Data(json.utf8))
+    #expect(dto.filterKey == nil)
+  }
+
+  @Test("decoding DTO with a recognised filterKey preserves it")
+  func decoding_recognisedFilterKey_isPreserved() throws {
+    let json = """
+      {
+          "id": "zone-001",
+          "name": "CB1 2AD",
+          "latitude": 52.2053,
+          "longitude": 0.1218,
+          "radiusMetres": 2000,
+          "filterKey": "loft_extension"
+      }
+      """
+    let dto = try JSONDecoder().decode(WatchZoneSummaryDTO.self, from: Data(json.utf8))
+    #expect(dto.filterKey == .loftExtension)
+  }
+
+  @Test("decoding DTO with an unrecognised filterKey string fails open to nil")
+  func decoding_unrecognisedFilterKey_failsOpenToNil() throws {
+    let json = """
+      {
+          "id": "zone-001",
+          "name": "CB1 2AD",
+          "latitude": 52.2053,
+          "longitude": 0.1218,
+          "radiusMetres": 2000,
+          "filterKey": "some_future_filter_not_yet_shipped"
+      }
+      """
+    let dto = try JSONDecoder().decode(WatchZoneSummaryDTO.self, from: Data(json.utf8))
+    #expect(dto.filterKey == nil)
+  }
+
+  @Test("toDomain carries filterKey to the domain model")
+  func toDomain_carriesFilterKey() throws {
+    let dto = WatchZoneSummaryDTO(
+      id: "zone-ok",
+      name: "CB1 2AD",
+      latitude: 52.2053,
+      longitude: 0.1218,
+      radiusMetres: 2000,
+      filterKey: .hmoHouseShares
+    )
+
+    let zone = try dto.toDomain()
+    #expect(zone.filterKey == .hmoHouseShares)
+  }
+
+  @Test("toDomain without filterKey produces an unfiltered zone")
+  func toDomain_withoutFilterKey_producesUnfilteredZone() throws {
+    let dto = WatchZoneSummaryDTO(
+      id: "zone-ok",
+      name: "CB1 2AD",
+      latitude: 52.2053,
+      longitude: 0.1218,
+      radiusMetres: 2000
+    )
+
+    let zone = try dto.toDomain()
+    #expect(zone.filterKey == nil)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/WatchZoneTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WatchZoneTests.swift
@@ -168,4 +168,38 @@ struct WatchZoneTests {
     #expect(zone.boundary == boundary)
     #expect(zone.isCustomShape)
   }
+
+  // MARK: - Pre-canned filter (GH#1098, tc-hogkn)
+
+  @Test("filterKey defaults to nil (unfiltered)")
+  func init_defaultsFilterKeyToNil() throws {
+    let centre = try Coordinate(latitude: 52.2053, longitude: 0.1218)
+    let zone = try WatchZone(name: "Home", centre: centre, radiusMetres: 1000)
+    #expect(zone.filterKey == nil)
+  }
+
+  @Test("filterKey round-trips through the name/centre initializer")
+  func init_storesFilterKey() throws {
+    let centre = try Coordinate(latitude: 52.2053, longitude: 0.1218)
+    let zone = try WatchZone(
+      name: "Home",
+      centre: centre,
+      radiusMetres: 1000,
+      filterKey: .loftExtension
+    )
+    #expect(zone.filterKey == .loftExtension)
+  }
+
+  @Test("filterKey round-trips through the postcode initializer")
+  func init_postcodeInitializer_storesFilterKey() throws {
+    let centre = try Coordinate(latitude: 52.2053, longitude: 0.1218)
+    let postcode = try Postcode("CB1 2AD")
+    let zone = try WatchZone(
+      postcode: postcode,
+      centre: centre,
+      radiusMetres: 1000,
+      filterKey: .hmoHouseShares
+    )
+    #expect(zone.filterKey == .hmoHouseShares)
+  }
 }


### PR DESCRIPTION
## Summary
- Wires the iOS client to the server-side pre-canned watch-zone filter feature (GH#1090/tc-w825j): Pro-tier subscribers can set or clear one of 7 catalog filters on a watch zone via a new picker screen in the editor.
- Free/Personal-tier users see the row locked with an upgrade affordance routing to `viewPlans()`; a downgraded Pro user holding an already-filtered zone sees it as a static, non-editable label.
- Gating mirrors the existing custom-shape boundary pattern (GH#1031) — a proactive client-side boolean gate, not the `Entitlement`/`GatedToggle` sheet mechanism.

## Changes
- **Domain**: new `WatchZoneFilterKey` (7-case enum, catalog copy run through the `voice` skill), `WatchZone.filterKey`, `WatchZoneLimits.allowsWatchZoneFilter` (Pro-only), `DomainError.invalidWatchZoneFilterKey`.
- **Data**: `CreateWatchZoneRequest`/`UpdateWatchZoneRequest` `filterKey` encoding (update always sends the key, explicit `null` to clear — mirrors `boundary`), `WatchZoneSummaryDTO.filterKey` decode with fail-open on missing/unrecognised values, `URLSessionAPIClient.mapBadRequest` `filter_key_invalid` → `DomainError.invalidWatchZoneFilterKey`.
- **Presentation**: `WatchZoneEditorViewModel` filter-selection state/gating, `WatchZoneFilterPickerView` (new picker screen), `WatchZoneFilterSection` (new three-way triad: picker / locked label / upsell placeholder) wired into `WatchZoneEditorView`.

## Test plan
- [x] `swift build` — green
- [x] `swift test` — 2036/2036 passing
- [x] `swiftlint lint --strict` — 0 violations
- [x] Live simulator verification (Pro sets/clears each of the 7 filters, persists across reopen; Free-tier sees locked upgrade row routing to the plans screen; visual check of the picker screen) — all pass

Closes GH#1098.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RipDTiNVYiYtvFQ9dNR7aH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added watch-zone notification filters with predefined options and descriptions.
  * Pro subscribers can select, change, or clear filters while creating or editing watch zones.
  * Non-Pro subscribers see upgrade prompts; existing filters remain visible if access changes.
  * Filters are preserved when saving and loading watch zones.

* **Bug Fixes**
  * Added clear messaging when an invalid filter is received from the server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->