### PR TITLE
fix(api): watch-zone PATCH filter gate only fires on an actual filter change (tc-k3ncu)

### DIFF
--- a/api-go/internal/watchzones/handler.go
+++ b/api-go/internal/watchzones/handler.go
@@ -450,14 +450,17 @@ func decodeFilterKeyUpdate(raw json.RawMessage) (*string, error) {
 // patch implements PATCH /v1/me/watch-zones/{zoneId}: range-validate the body
 // (400), decode the tri-state boundary and filterKey fields (400
 // boundary_invalid / filter_key_invalid on a malformed value), load the zone
-// (404 if absent -- needed before the filter gate below, see settingFilter),
-// gate a boundary-setting or actually-changed-filter-setting update on the
-// caller's tier (403 boundary_requires_paid_tier / filter_requires_pro_tier;
-// resending the zone's own unchanged filterKey is never gated, tc-k3ncu),
-// apply the merge (400 boundary_invalid / filter_key_invalid on an invalid
-// shape/key, 500 on any other domain invariant violation e.g. a blank name),
-// gate the resulting radius (400 boundary_too_large), persist, and return the
-// updated summary.
+// (404 if absent -- needed before the filter gate below, see settingFilter;
+// as a side effect this also puts the 404 check ahead of the boundary tier
+// gate now, so a PATCH naming a nonexistent zone 404s even when its body
+// would have tripped the boundary gate -- not found beats not entitled,
+// tc-k3ncu), gate a boundary-setting or actually-changed-filter-setting
+// update on the caller's tier (403 boundary_requires_paid_tier /
+// filter_requires_pro_tier; resending the zone's own unchanged filterKey is
+// never gated, tc-k3ncu), apply the merge (400 boundary_invalid /
+// filter_key_invalid on an invalid shape/key, 500 on any other domain
+// invariant violation e.g. a blank name), gate the resulting radius (400
+// boundary_too_large), persist, and return the updated summary.
 func (h *handler) patch(w http.ResponseWriter, r *http.Request) {
 	userID := auth.Subject(r.Context())
 	zoneID := r.PathValue("zoneId")

--- a/api-go/internal/watchzones/handler.go
+++ b/api-go/internal/watchzones/handler.go
@@ -449,13 +449,15 @@ func decodeFilterKeyUpdate(raw json.RawMessage) (*string, error) {
 
 // patch implements PATCH /v1/me/watch-zones/{zoneId}: range-validate the body
 // (400), decode the tri-state boundary and filterKey fields (400
-// boundary_invalid / filter_key_invalid on a malformed value), gate a
-// boundary-setting or filter-setting update on the caller's tier (403
-// boundary_requires_paid_tier / filter_requires_pro_tier), load the zone (404
-// if absent), apply the merge (400 boundary_invalid / filter_key_invalid on
-// an invalid shape/key, 500 on any other domain invariant violation e.g. a
-// blank name), gate the resulting radius (400 boundary_too_large), persist,
-// and return the updated summary.
+// boundary_invalid / filter_key_invalid on a malformed value), load the zone
+// (404 if absent -- needed before the filter gate below, see settingFilter),
+// gate a boundary-setting or actually-changed-filter-setting update on the
+// caller's tier (403 boundary_requires_paid_tier / filter_requires_pro_tier;
+// resending the zone's own unchanged filterKey is never gated, tc-k3ncu),
+// apply the merge (400 boundary_invalid / filter_key_invalid on an invalid
+// shape/key, 500 on any other domain invariant violation e.g. a blank name),
+// gate the resulting radius (400 boundary_too_large), persist, and return the
+// updated summary.
 func (h *handler) patch(w http.ResponseWriter, r *http.Request) {
 	userID := auth.Subject(r.Context())
 	zoneID := r.PathValue("zoneId")
@@ -486,10 +488,30 @@ func (h *handler) patch(w http.ResponseWriter, r *http.Request) {
 		h.writeErrorCode(w, r, http.StatusBadRequest, filterKeyInvalidCode, filterKeyInvalidMessage)
 		return
 	}
-	// "Setting" a filter (as opposed to leaving it alone, or explicitly
-	// nulling it back to unfiltered) is the only case the Pro-tier gate
-	// applies to (GH#1090, epic tc-w825j) -- mirrors settingBoundary exactly.
-	settingFilter := filterKeyUpdate != nil && *filterKeyUpdate != ""
+
+	// The zone must be loaded before the tier gate below so settingFilter can
+	// tell "the caller is setting a NEW filter" apart from "the caller resent
+	// the zone's own unchanged filterKey" (tc-k3ncu) -- e.g. a client that
+	// always sends full state on every PATCH, including an unrelated field
+	// like name or radius. Loaded once here and reused for WithUpdates below;
+	// do not fetch it a second time.
+	zone, err := h.store.Get(r.Context(), userID, zoneID)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		h.serverError(w, r, "load watch zone", err)
+		return
+	}
+
+	// "Setting" a filter (as opposed to leaving it alone, explicitly nulling
+	// it back to unfiltered, or resending the zone's own already-stored
+	// filterKey unchanged) is the only case the Pro-tier gate applies to
+	// (GH#1090, epic tc-w825j; unchanged-resend exemption tc-k3ncu). A
+	// downgraded caller who retained a pre-existing filter and PATCHes an
+	// unrelated field must not be gated on a filterKey they didn't touch.
+	settingFilter := filterKeyUpdate != nil && *filterKeyUpdate != "" && *filterKeyUpdate != string(zone.FilterKey)
 
 	var tier profiles.SubscriptionTier
 	if settingBoundary || settingFilter {
@@ -514,16 +536,6 @@ func (h *handler) patch(w http.ResponseWriter, r *http.Request) {
 			h.writeErrorCode(w, r, http.StatusForbidden, filterRequiresProTierCode, filterRequiresProTierMessage)
 			return
 		}
-	}
-
-	zone, err := h.store.Get(r.Context(), userID, zoneID)
-	if err != nil {
-		if errors.Is(err, ErrNotFound) {
-			w.WriteHeader(http.StatusNotFound)
-			return
-		}
-		h.serverError(w, r, "load watch zone", err)
-		return
 	}
 
 	updated, err := zone.WithUpdates(req.toUpdate(boundaryUpdate, filterKeyUpdate))

--- a/api-go/internal/watchzones/handler_test.go
+++ b/api-go/internal/watchzones/handler_test.go
@@ -312,6 +312,31 @@ func TestHandler_Patch_NotFound(t *testing.T) {
 	}
 }
 
+// TestHandler_Patch_NotFound_TakesPrecedenceOverBoundaryTierGate pins a
+// precedence change that fell out of tc-k3ncu's fix: the zone load
+// (h.store.Get) now runs before the shared boundary/filter tier-gate block
+// (it has to, so the filter gate can compare against the zone's current
+// FilterKey), so a PATCH naming a nonexistent zone ID now 404s before the
+// tier gate ever runs -- even when the body would otherwise have tripped it.
+// Before the reorder this returned 403 boundary_requires_paid_tier (tier
+// checked first); now it returns 404, without needing a profile reader wired
+// at all (the gate block, including its own-profile-nil check, is never
+// reached). No caller-visible regression: not found beats not entitled.
+func TestHandler_Patch_NotFound_TakesPrecedenceOverBoundaryTierGate(t *testing.T) {
+	t.Parallel()
+	body := mustJSON(t, struct {
+		Boundary *boundaryGeoJSON `json:"boundary"`
+	}{Boundary: boundaryToGeoJSON(mustBoundary(t, squareVertices(51.5, -0.1, 500)))})
+	rec := doReq(t, testMux(t, &fakeZoneStore{}), http.MethodPatch, "/v1/me/watch-zones/missing", body)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("404 must be bodyless, got %s", rec.Body)
+	}
+}
+
 func TestHandler_Patch_BlankNameIsServerError(t *testing.T) {
 	t.Parallel()
 	// Name is not validated at the endpoint; WithUpdates' guard rejects a blank

--- a/api-go/internal/watchzones/handler_test.go
+++ b/api-go/internal/watchzones/handler_test.go
@@ -750,6 +750,68 @@ func TestHandler_Patch_FilterKey_NoProfileReaderWiredIs500(t *testing.T) {
 	}
 }
 
+// TestHandler_Patch_FilterKey_DowngradedTierResendingUnchangedFilterSucceeds
+// proves that a downgraded (Free/Personal) caller who resends the zone's own
+// already-stored filterKey unchanged -- alongside an edit to an unrelated
+// field, as a client that always sends full state on every PATCH would -- is
+// NOT gated by the Pro-tier check (tc-k3ncu). Before the fix, the gate ran on
+// mere presence of a non-empty filterKey and could not tell "setting a new
+// filter" apart from "resending the existing one", so this PATCH wrongly
+// 403'd a Pro-canned filter retained after downgrade.
+func TestHandler_Patch_FilterKey_DowngradedTierResendingUnchangedFilterSucceeds(t *testing.T) {
+	t.Parallel()
+	z := testZone(t)
+	z.FilterKey = FilterKeyHouseBuilder
+	store := &fakeZoneStore{zones: []WatchZone{z}}
+	mux := http.NewServeMux()
+	Routes(mux, store, slog.New(slog.DiscardHandler), WithProfileReader(&fakeProfileReader{profile: freeProfile(t)}))
+
+	body := mustJSON(t, struct {
+		Name      string  `json:"name"`
+		FilterKey *string `json:"filterKey"`
+	}{Name: "Renamed", FilterKey: strPtr(string(FilterKeyHouseBuilder))})
+	rec := doReq(t, mux, http.MethodPatch, "/v1/me/watch-zones/"+z.ID, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (body %s)", rec.Code, rec.Body)
+	}
+	if store.saved == nil || store.saved.Name != "Renamed" || store.saved.FilterKey != FilterKeyHouseBuilder {
+		t.Fatalf("saved zone: got %+v", store.saved)
+	}
+}
+
+// TestHandler_Patch_FilterKey_DowngradedTierChangingFilterStillGated proves
+// the fix above did not weaken the underlying protection: a downgraded caller
+// who changes the zone's filterKey to a genuinely DIFFERENT value is still
+// rejected with 403 filter_requires_pro_tier (tc-k3ncu).
+func TestHandler_Patch_FilterKey_DowngradedTierChangingFilterStillGated(t *testing.T) {
+	t.Parallel()
+	z := testZone(t)
+	z.FilterKey = FilterKeyHouseBuilder
+	store := &fakeZoneStore{zones: []WatchZone{z}}
+	mux := http.NewServeMux()
+	Routes(mux, store, slog.New(slog.DiscardHandler), WithProfileReader(&fakeProfileReader{profile: freeProfile(t)}))
+
+	body := mustJSON(t, struct {
+		FilterKey *string `json:"filterKey"`
+	}{FilterKey: strPtr(string(FilterKeyHMOHouseShares))})
+	rec := doReq(t, mux, http.MethodPatch, "/v1/me/watch-zones/"+z.ID, body)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status: got %d, want 403 (body %s)", rec.Code, rec.Body)
+	}
+	var env apiErrorResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode error envelope: %v", err)
+	}
+	if env.Error != filterRequiresProTierCode {
+		t.Errorf("error code: got %q, want %q", env.Error, filterRequiresProTierCode)
+	}
+	if store.saved != nil {
+		t.Error("must not save when changing to a genuinely different filter on a downgraded tier")
+	}
+}
+
 // strPtr is a tiny test helper for building an inline *string, mirroring
 // mustJSON/mustBoundary's role for filterKey request bodies.
 func strPtr(s string) *string { return &s }


### PR DESCRIPTION
## Summary

`PATCH /v1/me/watch-zones/{zoneId}` computed `settingFilter` from a bare "is the incoming filterKey non-empty" check and gated it against the caller's tier **before** loading the zone. It couldn't tell "the caller is setting a new filter" apart from "the caller resent the zone's own unchanged, already-set filterKey" — e.g. a client that sends full state on every PATCH, including an unrelated field like `name` or `radius`.

Concretely: a Pro user sets a pre-canned filter, then downgrades to Free/Personal. Their zone keeps its `FilterKey` (retained-after-downgrade). PATCHing any other field while resending the unchanged filterKey wrongly returned 403 `filter_requires_pro_tier`.

Found via CodeRabbit review on #1100 (iOS PR that always resends the current filterKey on every save) — https://github.com/AmyDe/town-crier/pull/1100#discussion_r3787530793.

## Fix

`api-go/internal/watchzones/handler.go`, `patch()`: load the zone before computing `settingFilter`, and only gate when the incoming filterKey differs from the zone's currently-stored one:

```go
settingFilter := filterKeyUpdate != nil && *filterKeyUpdate != "" && *filterKeyUpdate != string(zone.FilterKey)
```

The zone is fetched once (moved earlier, not duplicated) and reused for the later `zone.WithUpdates(...)` call. `settingBoundary`'s gate and computation are untouched — out of scope here.

Confirmed the boundary tier gate has the identical defect pattern (`settingBoundary` never compares against the zone's current `Boundary`). Filed as tc-h3aov rather than fixed here, since comparing boundary vertex slices is fiddlier (floating point) and warrants its own decision.

## Tests

Added to `handler_test.go`:
- `TestHandler_Patch_FilterKey_DowngradedTierResendingUnchangedFilterSucceeds` — downgraded user resends unchanged filterKey + edits `name` → 200 (previously 403; verified the test fails against pre-fix code).
- `TestHandler_Patch_FilterKey_DowngradedTierChangingFilterStillGated` — downgraded user changes filterKey to a genuinely different value → still 403, protection not regressed.

Existing tests already covered: explicit-null clears regardless of tier, Pro-tier sets normally, and a zone with no pre-existing filter still gates a downgraded caller setting one.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test ./...` (all packages pass)
- [ ] `make test-integration` — not run (no Docker daemon in this session); change doesn't touch SQL/store queries, only handler control-flow ordering of an existing `store.Get` call, so real-DB coverage isn't expected to differ.

Bead: tc-k3ncu

---
_Generated by [Claude Code](https://claude.ai/code/session_01BV2peUo6CTa29ug1C8RqSa)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Missing watch zones now return a not-found error before entitlement checks.
  * Users on downgraded tiers can resubmit an unchanged filter successfully.
  * Changing a filter on a downgraded tier remains restricted.

* **Tests**
  * Added coverage for error precedence and filter entitlement behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->