### PR TITLE
fix(api): watch-zone PATCH boundary gate mirrors resend-unchanged carve-out (tc-h3aov)

### DIFF
--- a/api-go/internal/watchzones/handler.go
+++ b/api-go/internal/watchzones/handler.go
@@ -449,13 +449,16 @@ func decodeFilterKeyUpdate(raw json.RawMessage) (*string, error) {
 
 // patch implements PATCH /v1/me/watch-zones/{zoneId}: range-validate the body
 // (400), decode the tri-state boundary and filterKey fields (400
-// boundary_invalid / filter_key_invalid on a malformed value), gate a
-// boundary-setting or filter-setting update on the caller's tier (403
-// boundary_requires_paid_tier / filter_requires_pro_tier), load the zone (404
-// if absent), apply the merge (400 boundary_invalid / filter_key_invalid on
-// an invalid shape/key, 500 on any other domain invariant violation e.g. a
-// blank name), gate the resulting radius (400 boundary_too_large), persist,
-// and return the updated summary.
+// boundary_invalid / filter_key_invalid on a malformed value), load the zone
+// (404 if absent or not owned by the caller -- this takes precedence over
+// every tier-gate check below, tc-h3aov), gate a boundary-setting or
+// filter-setting update on the caller's tier (403 boundary_requires_paid_tier
+// / filter_requires_pro_tier; "setting" a boundary excludes resending the
+// zone's own currently-stored shape unchanged, tc-h3aov), apply the merge
+// (400 boundary_invalid / filter_key_invalid on an invalid shape/key, 500 on
+// any other domain invariant violation e.g. a blank name), gate the
+// resulting radius (400 boundary_too_large), persist, and return the updated
+// summary.
 func (h *handler) patch(w http.ResponseWriter, r *http.Request) {
 	userID := auth.Subject(r.Context())
 	zoneID := r.PathValue("zoneId")
@@ -476,10 +479,6 @@ func (h *handler) patch(w http.ResponseWriter, r *http.Request) {
 		h.writeErrorCode(w, r, http.StatusBadRequest, boundaryInvalidCode, boundaryInvalidMessage)
 		return
 	}
-	// "Setting" a boundary (as opposed to leaving it alone, or explicitly
-	// nulling it back to a circle) is the only case the paid-tier gate and the
-	// radius ceiling apply to (tc-6he3x.4 acceptance criteria 4 and 6).
-	settingBoundary := boundaryUpdate != nil && len(*boundaryUpdate) > 0
 
 	filterKeyUpdate, err := decodeFilterKeyUpdate(req.FilterKey)
 	if err != nil {
@@ -490,6 +489,29 @@ func (h *handler) patch(w http.ResponseWriter, r *http.Request) {
 	// nulling it back to unfiltered) is the only case the Pro-tier gate
 	// applies to (GH#1090, epic tc-w825j) -- mirrors settingBoundary exactly.
 	settingFilter := filterKeyUpdate != nil && *filterKeyUpdate != ""
+
+	// The zone is loaded here -- before the tier gate below -- for two
+	// reasons: a 404 on a missing/not-owned zone ID must take precedence over
+	// a boundary-tier 403 (tc-h3aov, mirroring the precedence tc-k3ncu's
+	// reviewer flagged for the identical filter-gate fix), and settingBoundary
+	// itself needs the zone's currently-stored Boundary to compare against.
+	zone, err := h.store.Get(r.Context(), userID, zoneID)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		h.serverError(w, r, "load watch zone", err)
+		return
+	}
+
+	// "Setting" a boundary (as opposed to leaving it alone, explicitly nulling
+	// it back to a circle, or resending the SAME shape the zone already has --
+	// e.g. a client that always PATCHes full state on every edit) is the only
+	// case the paid-tier gate and the radius ceiling apply to (tc-6he3x.4
+	// acceptance criteria 4 and 6; the unchanged-resend carve-out is tc-h3aov,
+	// mirroring tc-k3ncu's identical fix for the filter gate).
+	settingBoundary := boundaryUpdate != nil && len(*boundaryUpdate) > 0 && !zone.Boundary.Equal(*boundaryUpdate)
 
 	var tier profiles.SubscriptionTier
 	if settingBoundary || settingFilter {
@@ -514,16 +536,6 @@ func (h *handler) patch(w http.ResponseWriter, r *http.Request) {
 			h.writeErrorCode(w, r, http.StatusForbidden, filterRequiresProTierCode, filterRequiresProTierMessage)
 			return
 		}
-	}
-
-	zone, err := h.store.Get(r.Context(), userID, zoneID)
-	if err != nil {
-		if errors.Is(err, ErrNotFound) {
-			w.WriteHeader(http.StatusNotFound)
-			return
-		}
-		h.serverError(w, r, "load watch zone", err)
-		return
 	}
 
 	updated, err := zone.WithUpdates(req.toUpdate(boundaryUpdate, filterKeyUpdate))

--- a/api-go/internal/watchzones/handler_test.go
+++ b/api-go/internal/watchzones/handler_test.go
@@ -567,6 +567,113 @@ func TestHandler_Patch_Boundary_NoProfileReaderWiredIs500(t *testing.T) {
 	}
 }
 
+// TestHandler_Patch_Boundary_ResendingUnchangedValueSucceedsForDowngradedTier
+// proves the fix for tc-h3aov (the same defect pattern tc-k3ncu fixed for the
+// filter gate): a downgraded (Free-tier) caller who already owns a
+// custom-shape zone and resends its UNCHANGED boundary vertices alongside an
+// unrelated field edit (name here — the same pattern a client that always
+// PATCHes full state on every edit produces) must succeed, because nothing
+// about the boundary actually changed. Before the fix, settingBoundary gated
+// on mere non-emptiness of the incoming boundary and always 403'd here.
+func TestHandler_Patch_Boundary_ResendingUnchangedValueSucceedsForDowngradedTier(t *testing.T) {
+	t.Parallel()
+	base := testZone(t)
+	z, err := base.WithBoundary(squareVertices(base.Latitude, base.Longitude, 500))
+	if err != nil {
+		t.Fatalf("WithBoundary: %v", err)
+	}
+	store := &fakeZoneStore{zones: []WatchZone{z}}
+	mux := http.NewServeMux()
+	Routes(mux, store, slog.New(slog.DiscardHandler), WithProfileReader(&fakeProfileReader{profile: freeProfile(t)}))
+
+	body := mustJSON(t, struct {
+		Name     *string          `json:"name"`
+		Boundary *boundaryGeoJSON `json:"boundary"`
+	}{Name: strPtr("Renamed"), Boundary: boundaryToGeoJSON(z.Boundary)})
+	rec := doReq(t, mux, http.MethodPatch, "/v1/me/watch-zones/"+z.ID, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (body %s)", rec.Code, rec.Body)
+	}
+	if store.saved == nil {
+		t.Fatal("zone must be saved")
+	}
+	if store.saved.Name != "Renamed" {
+		t.Errorf("name: got %q, want %q", store.saved.Name, "Renamed")
+	}
+	if !store.saved.Boundary.Equal(z.Boundary) {
+		t.Errorf("boundary must be unchanged: got %+v, want %+v", store.saved.Boundary, z.Boundary)
+	}
+}
+
+// TestHandler_Patch_Boundary_ChangingExistingBoundaryStillRequiresPaidTier403
+// proves the unchanged-resend carve-out (above) does not weaken the tier gate
+// itself: a downgraded (Free-tier) caller who owns a custom-shape zone and
+// sends a genuinely DIFFERENT set of boundary vertices still gets 403
+// boundary_requires_paid_tier, and the update is never persisted. Complements
+// TestHandler_Patch_Boundary_ValueRequiresPaidTier403, which only covers a
+// zone with no pre-existing boundary (a genuine new-set case) -- this one
+// proves the gate still fires when the zone already has a (different) shape.
+func TestHandler_Patch_Boundary_ChangingExistingBoundaryStillRequiresPaidTier403(t *testing.T) {
+	t.Parallel()
+	base := testZone(t)
+	z, err := base.WithBoundary(squareVertices(base.Latitude, base.Longitude, 500))
+	if err != nil {
+		t.Fatalf("WithBoundary: %v", err)
+	}
+	store := &fakeZoneStore{zones: []WatchZone{z}}
+	mux := http.NewServeMux()
+	Routes(mux, store, slog.New(slog.DiscardHandler), WithProfileReader(&fakeProfileReader{profile: freeProfile(t)}))
+
+	body := mustJSON(t, struct {
+		Boundary *boundaryGeoJSON `json:"boundary"`
+	}{Boundary: boundaryToGeoJSON(mustBoundary(t, squareVertices(z.Latitude, z.Longitude, 700)))})
+	rec := doReq(t, mux, http.MethodPatch, "/v1/me/watch-zones/"+z.ID, body)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status: got %d, want 403 (body %s)", rec.Code, rec.Body)
+	}
+	var env apiErrorResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode error envelope: %v", err)
+	}
+	if env.Error != boundaryRequiresPaidTierCode {
+		t.Errorf("error code: got %q, want %q", env.Error, boundaryRequiresPaidTierCode)
+	}
+	if store.saved != nil {
+		t.Error("must not save a zone when the boundary tier gate rejects the request")
+	}
+}
+
+// TestHandler_Patch_NotFound_TakesPrecedenceOverBoundaryTierGate proves a
+// PATCH to a non-existent (or not-owned) zone ID returns 404, not a
+// boundary-tier 403, even when the request body sets a boundary and the
+// caller's tier would otherwise fail the gate -- the reviewer-flagged
+// precedence question for tc-k3ncu's identical filter-gate fix, verified here
+// for the boundary gate (main does not have a merged fix for either as of
+// tc-h3aov).
+func TestHandler_Patch_NotFound_TakesPrecedenceOverBoundaryTierGate(t *testing.T) {
+	t.Parallel()
+	store := &fakeZoneStore{}
+	mux := http.NewServeMux()
+	Routes(mux, store, slog.New(slog.DiscardHandler), WithProfileReader(&fakeProfileReader{profile: freeProfile(t)}))
+
+	body := mustJSON(t, struct {
+		Boundary *boundaryGeoJSON `json:"boundary"`
+	}{Boundary: boundaryToGeoJSON(mustBoundary(t, squareVertices(51.5074, -0.1278, 500)))})
+	rec := doReq(t, mux, http.MethodPatch, "/v1/me/watch-zones/missing", body)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404 (body %s)", rec.Code, rec.Body)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("404 must be bodyless, got %s", rec.Body)
+	}
+	if store.saved != nil {
+		t.Error("must not save when the zone does not exist")
+	}
+}
+
 // --- PATCH filterKey tri-state tests (GH#1090, epic tc-w825j) --------------
 
 // TestHandler_Patch_FilterKey_FreeOrPersonalTierIs403 proves a non-Pro

--- a/api-go/internal/watchzones/zone.go
+++ b/api-go/internal/watchzones/zone.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"slices"
 	"strings"
 	"time"
 )
@@ -176,6 +177,21 @@ type Coordinate struct {
 // last vertex always equals the first (a closed ring); NewBoundary is the
 // only supported way to obtain a valid, validated Boundary.
 type Boundary []Coordinate
+
+// Equal reports whether b and other hold identical vertices in the same
+// order, by exact float64/struct equality (Coordinate is a plain comparable
+// struct, so slices.Equal is sufficient — no epsilon tolerance, and a nil
+// Boundary compares equal to an empty non-nil one, matching slices.Equal's
+// own nil-vs-empty handling). This is deliberately exact rather than
+// approximate: the only caller (the PATCH handler's boundary tier gate,
+// tc-h3aov) compares an incoming boundary against the zone's
+// currently-stored one to detect a client resending the SAME shape
+// unchanged, and the incoming value is always a JSON round-trip of a value
+// this server itself previously returned via boundaryToGeoJSON — so no
+// floating-point drift between the two is expected.
+func (b Boundary) Equal(other Boundary) bool {
+	return slices.Equal(b, other)
+}
 
 const (
 	// minBoundaryVertices and maxBoundaryVertices bound the ring size,

--- a/api-go/internal/watchzones/zone_test.go
+++ b/api-go/internal/watchzones/zone_test.go
@@ -445,6 +445,47 @@ func TestBoundary_EnclosingRadiusMetres_EmptyBoundaryDoesNotPanic(t *testing.T) 
 	}
 }
 
+// TestBoundary_Equal proves Boundary.Equal's exact, order-sensitive
+// element-wise comparison (tc-h3aov): the PATCH handler's boundary tier gate
+// uses it to tell "the caller resent the SAME shape unchanged" apart from
+// "the caller is setting a new/different shape".
+func TestBoundary_Equal(t *testing.T) {
+	t.Parallel()
+	square := mustBoundary(t, londonSquare(t))
+	sameVertices := make(Boundary, len(square))
+	copy(sameVertices, square)
+	reordered := append(Boundary{square[1]}, square[2:]...)
+	reordered = append(reordered, square[0])
+	shifted, err := NewBoundary(squareVertices(51.5074, -0.1278, 750))
+	if err != nil {
+		t.Fatalf("NewBoundary: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		a, b Boundary
+		want bool
+	}{
+		{"identical value equal", square, sameVertices, true},
+		{"same vertices, different order not equal", square, reordered, false},
+		{"different shape not equal", square, shifted, false},
+		{"both nil equal", nil, nil, true},
+		{"nil vs empty equal", nil, Boundary{}, true},
+		{"nil vs non-empty not equal", nil, square, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.a.Equal(tc.b); got != tc.want {
+				t.Errorf("Equal: got %v, want %v", got, tc.want)
+			}
+			if got := tc.b.Equal(tc.a); got != tc.want {
+				t.Errorf("Equal (reversed): got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestWatchZone_IsCustomShape(t *testing.T) {
 	t.Parallel()
 	circle := testZone(t)


### PR DESCRIPTION
## Summary
- `handler.patch()`'s `settingBoundary` gate previously fired on mere non-emptiness of the incoming boundary, never comparing it against the zone's currently-stored `Boundary` — so a downgraded (non-paid-tier) caller who owns a custom-shape zone and resends its *unchanged* boundary vertices alongside an unrelated field edit (e.g. renaming the zone) wrongly got `403 boundary_requires_paid_tier`.
- This is the identical defect pattern sibling bead tc-k3ncu is fixing for the `settingFilter` gate (PR #1101, not yet merged) — implemented independently here against current `main` rather than depending on that PR landing first.
- The zone is now loaded once, before the tier-gate block (previously it loaded after), so `settingBoundary` can compare the incoming boundary against `zone.Boundary` and only gate when they actually differ. This also fixes 404-vs-tier-gate precedence: a PATCH to a missing/not-owned zone ID now correctly returns 404 before any tier check runs.
- Added `Boundary.Equal` (exact, order-sensitive `slices.Equal` comparison) — safe here because the incoming boundary is always a JSON round-trip of a value the server itself previously returned, so no floating-point drift is expected.

## Test plan
- `TestHandler_Patch_Boundary_ResendingUnchangedValueSucceedsForDowngradedTier` — downgraded-tier caller resends the same boundary + an unrelated field edit → 200, not 403.
- `TestHandler_Patch_Boundary_ChangingExistingBoundaryStillRequiresPaidTier403` — downgraded-tier caller sends a genuinely different boundary on a zone that already has a shape → still 403 (complements the existing `TestHandler_Patch_Boundary_ValueRequiresPaidTier403`, which only covers a zone with no pre-existing boundary).
- `TestHandler_Patch_NotFound_TakesPrecedenceOverBoundaryTierGate` — PATCH to a non-existent zone ID returns 404, not a boundary-tier 403.
- `TestBoundary_Equal` — table-driven coverage of identical/reordered/different-shape/nil/empty vertex sets.
- `go build ./...`, `go vet ./...`, `gofmt -l .` (clean), `go test ./...` (all packages pass) run locally.

Bead: tc-h3aov (`bd show tc-h3aov`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C2mscEXiEiPvScYj5wNw48)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Existing custom boundaries can be resubmitted without triggering boundary entitlement restrictions.
  * Changed non-empty boundaries remain restricted for users without the required tier.
  * Missing or unauthorized zones now return a not-found error before entitlement checks.
  * Rejected updates are not saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->