### PR TITLE
fix(android): guard DataStore preference writes against IOException (tc-l31ve)

### DIFF
--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/applications/DataStoreApplicationListPreferencesStore.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/applications/DataStoreApplicationListPreferencesStore.kt
@@ -4,11 +4,13 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import uk.towncrierapp.domain.applications.ApplicationListPreferencesStore
 import uk.towncrierapp.domain.applications.ApplicationSortOrder
 import uk.towncrierapp.domain.watchzones.WatchZoneId
+import java.io.IOException
 
 // Key names reused verbatim from iOS UserDefaults (epic #770 pre-resolved
 // decision) — cross-platform naming consistency, even though nothing else
@@ -25,8 +27,19 @@ public class DataStoreApplicationListPreferencesStore(
             .map { preferences -> preferences[APPLICATIONS_LIST_SORT_KEY]?.let(ApplicationSortOrder::fromWireValue) }
             .first()
 
+    @Suppress("SwallowedException")
+    // Best-effort fire-and-forget preference write (tc-l31ve, module-wide
+    // convention): a disk-IO failure here is rare and recoverable per
+    // DataStore's own edit() contract, and no caller handles a thrown
+    // exception from this method — so it's swallowed rather than propagated.
     override suspend fun writeSort(sort: ApplicationSortOrder) {
-        dataStore.edit { preferences -> preferences[APPLICATIONS_LIST_SORT_KEY] = sort.wireValue }
+        try {
+            dataStore.edit { preferences -> preferences[APPLICATIONS_LIST_SORT_KEY] = sort.wireValue }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: IOException) {
+            // Swallowed: see writeSort's rationale comment above.
+        }
     }
 
     override suspend fun readLastSelectedZoneId(): WatchZoneId? =
@@ -34,7 +47,16 @@ public class DataStoreApplicationListPreferencesStore(
             .map { preferences -> preferences[LAST_SELECTED_ZONE_KEY]?.let(::WatchZoneId) }
             .first()
 
+    @Suppress("SwallowedException")
+    // Best-effort fire-and-forget preference write (tc-l31ve, module-wide
+    // convention): see writeSort's rationale comment above.
     override suspend fun writeLastSelectedZoneId(zoneId: WatchZoneId) {
-        dataStore.edit { preferences -> preferences[LAST_SELECTED_ZONE_KEY] = zoneId.value }
+        try {
+            dataStore.edit { preferences -> preferences[LAST_SELECTED_ZONE_KEY] = zoneId.value }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: IOException) {
+            // Swallowed: see writeSort's rationale comment above.
+        }
     }
 }

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/map/DataStoreMapPreferencesStore.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/map/DataStoreMapPreferencesStore.kt
@@ -4,10 +4,12 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import uk.towncrierapp.domain.map.MapPreferencesStore
 import uk.towncrierapp.domain.watchzones.WatchZoneId
+import java.io.IOException
 
 // Key name reused verbatim from iOS UserDefaults (epic #770 pre-resolved
 // decision) — distinct from the applications list's own
@@ -23,7 +25,18 @@ public class DataStoreMapPreferencesStore(
             .map { preferences -> preferences[LAST_SELECTED_ZONE_KEY]?.let(::WatchZoneId) }
             .first()
 
+    @Suppress("SwallowedException")
+    // Best-effort fire-and-forget preference write (tc-l31ve, module-wide
+    // convention): a disk-IO failure here is rare and recoverable per
+    // DataStore's own edit() contract, and no caller handles a thrown
+    // exception from this method — so it's swallowed rather than propagated.
     override suspend fun writeLastSelectedZoneId(zoneId: WatchZoneId) {
-        dataStore.edit { preferences -> preferences[LAST_SELECTED_ZONE_KEY] = zoneId.value }
+        try {
+            dataStore.edit { preferences -> preferences[LAST_SELECTED_ZONE_KEY] = zoneId.value }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: IOException) {
+            // Swallowed: see class-level rationale above.
+        }
     }
 }

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/onboarding/DataStoreOnboardingRepository.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/onboarding/DataStoreOnboardingRepository.kt
@@ -4,9 +4,11 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import uk.towncrierapp.domain.onboarding.OnboardingRepository
+import java.io.IOException
 
 private val IS_ONBOARDING_COMPLETE_KEY = booleanPreferencesKey("isOnboardingComplete")
 
@@ -24,7 +26,18 @@ public class DataStoreOnboardingRepository(
             .map { preferences -> preferences[IS_ONBOARDING_COMPLETE_KEY] ?: false }
             .first()
 
+    @Suppress("SwallowedException")
+    // Best-effort fire-and-forget preference write (tc-l31ve, module-wide
+    // convention): a disk-IO failure here is rare and recoverable per
+    // DataStore's own edit() contract, and no caller handles a thrown
+    // exception from this method — so it's swallowed rather than propagated.
     override suspend fun setOnboardingComplete(complete: Boolean) {
-        dataStore.edit { preferences -> preferences[IS_ONBOARDING_COMPLETE_KEY] = complete }
+        try {
+            dataStore.edit { preferences -> preferences[IS_ONBOARDING_COMPLETE_KEY] = complete }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: IOException) {
+            // Swallowed: see class-level rationale above.
+        }
     }
 }

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/reviewprompt/DataStoreReviewPromptStore.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/reviewprompt/DataStoreReviewPromptStore.kt
@@ -8,10 +8,12 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import uk.towncrierapp.domain.reviewprompt.ReviewPromptState
 import uk.towncrierapp.domain.reviewprompt.ReviewPromptStore
+import java.io.IOException
 import java.time.Instant
 
 // Key names are this feature's own device-local namespace (GH #628) — no
@@ -51,17 +53,28 @@ public class DataStoreReviewPromptStore(
                 )
             }.first()
 
+    @Suppress("SwallowedException")
+    // Best-effort fire-and-forget preference write (tc-l31ve, module-wide
+    // convention): a disk-IO failure here is rare and recoverable per
+    // DataStore's own edit() contract, and no caller handles a thrown
+    // exception from this method — so it's swallowed rather than propagated.
     override suspend fun save(state: ReviewPromptState) {
-        dataStore.edit { preferences ->
-            setOrRemove(preferences, FIRST_LAUNCH_DATE_KEY, state.firstLaunchDate?.epochSecond)
-            preferences[ENGAGEMENT_SCORE_KEY] = state.engagementScore
-            preferences[SAVE_COUNT_KEY] = state.saveCount
-            setOrRemove(preferences, LAST_ACTIVE_DAY_KEY_KEY, state.lastActiveDayKey)
-            preferences[DISTINCT_ACTIVE_DAYS_KEY] = state.distinctActiveDays
-            setOrRemove(preferences, LAST_PROMPT_DATE_KEY, state.lastPromptDate?.epochSecond)
-            preferences[PROMPT_TIMESTAMPS_KEY] =
-                state.promptTimestamps.joinToString(TIMESTAMP_SEPARATOR) { it.epochSecond.toString() }
-            preferences[HAS_RECORDED_UPGRADE_KEY] = state.hasRecordedUpgrade
+        try {
+            dataStore.edit { preferences ->
+                setOrRemove(preferences, FIRST_LAUNCH_DATE_KEY, state.firstLaunchDate?.epochSecond)
+                preferences[ENGAGEMENT_SCORE_KEY] = state.engagementScore
+                preferences[SAVE_COUNT_KEY] = state.saveCount
+                setOrRemove(preferences, LAST_ACTIVE_DAY_KEY_KEY, state.lastActiveDayKey)
+                preferences[DISTINCT_ACTIVE_DAYS_KEY] = state.distinctActiveDays
+                setOrRemove(preferences, LAST_PROMPT_DATE_KEY, state.lastPromptDate?.epochSecond)
+                preferences[PROMPT_TIMESTAMPS_KEY] =
+                    state.promptTimestamps.joinToString(TIMESTAMP_SEPARATOR) { it.epochSecond.toString() }
+                preferences[HAS_RECORDED_UPGRADE_KEY] = state.hasRecordedUpgrade
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: IOException) {
+            // Swallowed: see class-level rationale above.
         }
     }
 }

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/settings/DataStoreAppearanceStore.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/settings/DataStoreAppearanceStore.kt
@@ -4,10 +4,12 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import uk.towncrierapp.domain.settings.AppearancePreference
 import uk.towncrierapp.domain.settings.AppearanceStore
+import java.io.IOException
 
 // Key name reused verbatim from iOS's local `appearanceMode` (epic #770
 // pre-resolved decision) — cross-platform naming consistency.
@@ -22,7 +24,18 @@ public class DataStoreAppearanceStore(
             .map { preferences -> preferences[APPEARANCE_MODE_KEY]?.let(AppearancePreference::fromWireValue) }
             .first()
 
+    @Suppress("SwallowedException")
+    // Best-effort fire-and-forget preference write (tc-l31ve, module-wide
+    // convention): a disk-IO failure here is rare and recoverable per
+    // DataStore's own edit() contract, and no caller handles a thrown
+    // exception from this method — so it's swallowed rather than propagated.
     override suspend fun write(preference: AppearancePreference) {
-        dataStore.edit { preferences -> preferences[APPEARANCE_MODE_KEY] = preference.wireValue }
+        try {
+            dataStore.edit { preferences -> preferences[APPEARANCE_MODE_KEY] = preference.wireValue }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: IOException) {
+            // Swallowed: see class-level rationale above.
+        }
     }
 }

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/subscriptions/DataStoreSubscriptionTierCache.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/subscriptions/DataStoreSubscriptionTierCache.kt
@@ -4,10 +4,12 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import uk.towncrierapp.domain.subscriptions.SubscriptionTier
 import uk.towncrierapp.domain.subscriptions.SubscriptionTierCache
+import java.io.IOException
 
 private val CACHED_SUBSCRIPTION_TIER_KEY = stringPreferencesKey("cachedSubscriptionTier")
 
@@ -26,7 +28,18 @@ public class DataStoreSubscriptionTierCache(
                 preferences[CACHED_SUBSCRIPTION_TIER_KEY]?.let { SubscriptionTier.fromWireValue(it) }
             }.first()
 
+    @Suppress("SwallowedException")
+    // Best-effort fire-and-forget preference write (tc-l31ve, module-wide
+    // convention): a disk-IO failure here is rare and recoverable per
+    // DataStore's own edit() contract, and no caller handles a thrown
+    // exception from this method — so it's swallowed rather than propagated.
     override suspend fun write(tier: SubscriptionTier) {
-        dataStore.edit { preferences -> preferences[CACHED_SUBSCRIPTION_TIER_KEY] = tier.wireValue }
+        try {
+            dataStore.edit { preferences -> preferences[CACHED_SUBSCRIPTION_TIER_KEY] = tier.wireValue }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: IOException) {
+            // Swallowed: see class-level rationale above.
+        }
     }
 }

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/applications/DataStoreApplicationListPreferencesStoreTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/applications/DataStoreApplicationListPreferencesStoreTest.kt
@@ -1,13 +1,20 @@
 package uk.towncrierapp.data.applications
 
+import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.emptyPreferences
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import uk.towncrierapp.domain.applications.ApplicationSortOrder
 import uk.towncrierapp.domain.watchzones.WatchZoneId
 import java.io.File
+import java.io.IOException
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 
 /**
@@ -59,4 +66,45 @@ class DataStoreApplicationListPreferencesStoreTest {
 
         assertEquals(WatchZoneId("wz-9"), sut.readLastSelectedZoneId())
     }
+
+    @Test
+    fun `writeSort swallows an IOException from the underlying DataStore`() =
+        runTest {
+            val sut = DataStoreApplicationListPreferencesStore(ThrowingDataStore(IOException("disk full")))
+
+            sut.writeSort(ApplicationSortOrder.OLDEST)
+        }
+
+    @Test
+    fun `writeSort rethrows a CancellationException from the underlying DataStore`() =
+        runTest {
+            val sut = DataStoreApplicationListPreferencesStore(ThrowingDataStore(CancellationException("cancelled")))
+
+            assertFailsWith<CancellationException> { sut.writeSort(ApplicationSortOrder.OLDEST) }
+        }
+
+    @Test
+    fun `writeLastSelectedZoneId swallows an IOException from the underlying DataStore`() =
+        runTest {
+            val sut = DataStoreApplicationListPreferencesStore(ThrowingDataStore(IOException("disk full")))
+
+            sut.writeLastSelectedZoneId(WatchZoneId("wz-9"))
+        }
+
+    @Test
+    fun `writeLastSelectedZoneId rethrows a CancellationException from the underlying DataStore`() =
+        runTest {
+            val sut = DataStoreApplicationListPreferencesStore(ThrowingDataStore(CancellationException("cancelled")))
+
+            assertFailsWith<CancellationException> { sut.writeLastSelectedZoneId(WatchZoneId("wz-9")) }
+        }
+}
+
+/** A [DataStore] whose `updateData` (and so `edit { }`) always throws [exception] — proves write methods guard against it (tc-l31ve). */
+private class ThrowingDataStore(
+    private val exception: Throwable,
+) : DataStore<Preferences> {
+    override val data = flowOf(emptyPreferences())
+
+    override suspend fun updateData(transform: suspend (t: Preferences) -> Preferences): Preferences = throw exception
 }

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/map/DataStoreMapPreferencesStoreTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/map/DataStoreMapPreferencesStoreTest.kt
@@ -1,12 +1,19 @@
 package uk.towncrierapp.data.map
 
+import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.emptyPreferences
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import uk.towncrierapp.domain.watchzones.WatchZoneId
 import java.io.File
+import java.io.IOException
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 
 /** The `lastSelectedZone.map` DataStore latch (GH#776) — port of the DataStore latch pattern established by `DataStoreApplicationListPreferencesStoreTest`. */
@@ -33,4 +40,29 @@ class DataStoreMapPreferencesStoreTest {
 
         assertEquals(WatchZoneId("wz-9"), sut.readLastSelectedZoneId())
     }
+
+    @Test
+    fun `writeLastSelectedZoneId swallows an IOException from the underlying DataStore`() =
+        runTest {
+            val sut = DataStoreMapPreferencesStore(ThrowingDataStore(IOException("disk full")))
+
+            sut.writeLastSelectedZoneId(WatchZoneId("wz-9"))
+        }
+
+    @Test
+    fun `writeLastSelectedZoneId rethrows a CancellationException from the underlying DataStore`() =
+        runTest {
+            val sut = DataStoreMapPreferencesStore(ThrowingDataStore(CancellationException("cancelled")))
+
+            assertFailsWith<CancellationException> { sut.writeLastSelectedZoneId(WatchZoneId("wz-9")) }
+        }
+}
+
+/** A [DataStore] whose `updateData` (and so `edit { }`) always throws [exception] — proves write methods guard against it (tc-l31ve). */
+private class ThrowingDataStore(
+    private val exception: Throwable,
+) : DataStore<Preferences> {
+    override val data = flowOf(emptyPreferences())
+
+    override suspend fun updateData(transform: suspend (t: Preferences) -> Preferences): Preferences = throw exception
 }

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/onboarding/DataStoreOnboardingRepositoryTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/onboarding/DataStoreOnboardingRepositoryTest.kt
@@ -1,11 +1,18 @@
 package uk.towncrierapp.data.onboarding
 
+import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.emptyPreferences
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
+import java.io.IOException
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 
 /**
@@ -49,4 +56,29 @@ class DataStoreOnboardingRepositoryTest {
 
         assertFalse(sut.isOnboardingComplete())
     }
+
+    @Test
+    fun `setOnboardingComplete swallows an IOException from the underlying DataStore`() =
+        runTest {
+            val sut = DataStoreOnboardingRepository(ThrowingDataStore(IOException("disk full")))
+
+            sut.setOnboardingComplete(true)
+        }
+
+    @Test
+    fun `setOnboardingComplete rethrows a CancellationException from the underlying DataStore`() =
+        runTest {
+            val sut = DataStoreOnboardingRepository(ThrowingDataStore(CancellationException("cancelled")))
+
+            assertFailsWith<CancellationException> { sut.setOnboardingComplete(true) }
+        }
+}
+
+/** A [DataStore] whose `updateData` (and so `edit { }`) always throws [exception] — proves write methods guard against it (tc-l31ve). */
+private class ThrowingDataStore(
+    private val exception: Throwable,
+) : DataStore<Preferences> {
+    override val data = flowOf(emptyPreferences())
+
+    override suspend fun updateData(transform: suspend (t: Preferences) -> Preferences): Preferences = throw exception
 }

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/reviewprompt/DataStoreReviewPromptStoreTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/reviewprompt/DataStoreReviewPromptStoreTest.kt
@@ -1,13 +1,20 @@
 package uk.towncrierapp.data.reviewprompt
 
+import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.emptyPreferences
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import uk.towncrierapp.domain.reviewprompt.ReviewPromptState
 import java.io.File
+import java.io.IOException
 import java.time.Instant
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 
 /**
@@ -79,4 +86,29 @@ class DataStoreReviewPromptStoreTest {
 
         assertEquals(ReviewPromptState(), sut.load())
     }
+
+    @Test
+    fun `save swallows an IOException from the underlying DataStore`() =
+        runTest {
+            val sut = DataStoreReviewPromptStore(ThrowingDataStore(IOException("disk full")))
+
+            sut.save(ReviewPromptState())
+        }
+
+    @Test
+    fun `save rethrows a CancellationException from the underlying DataStore`() =
+        runTest {
+            val sut = DataStoreReviewPromptStore(ThrowingDataStore(CancellationException("cancelled")))
+
+            assertFailsWith<CancellationException> { sut.save(ReviewPromptState()) }
+        }
+}
+
+/** A [DataStore] whose `updateData` (and so `edit { }`) always throws [exception] — proves write methods guard against it (tc-l31ve). */
+private class ThrowingDataStore(
+    private val exception: Throwable,
+) : DataStore<Preferences> {
+    override val data = flowOf(emptyPreferences())
+
+    override suspend fun updateData(transform: suspend (t: Preferences) -> Preferences): Preferences = throw exception
 }

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/settings/DataStoreAppearanceStoreTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/settings/DataStoreAppearanceStoreTest.kt
@@ -1,12 +1,19 @@
 package uk.towncrierapp.data.settings
 
+import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.emptyPreferences
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import uk.towncrierapp.domain.settings.AppearancePreference
 import java.io.File
+import java.io.IOException
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 
 /** The `appearanceMode` DataStore latch — same key name as iOS (epic #770 pre-resolved decision). */
@@ -33,4 +40,29 @@ class DataStoreAppearanceStoreTest {
 
         assertEquals(AppearancePreference.OLED_DARK, sut.read())
     }
+
+    @Test
+    fun `write swallows an IOException from the underlying DataStore`() =
+        runTest {
+            val sut = DataStoreAppearanceStore(ThrowingDataStore(IOException("disk full")))
+
+            sut.write(AppearancePreference.OLED_DARK)
+        }
+
+    @Test
+    fun `write rethrows a CancellationException from the underlying DataStore`() =
+        runTest {
+            val sut = DataStoreAppearanceStore(ThrowingDataStore(CancellationException("cancelled")))
+
+            assertFailsWith<CancellationException> { sut.write(AppearancePreference.OLED_DARK) }
+        }
+}
+
+/** A [DataStore] whose `updateData` (and so `edit { }`) always throws [exception] — proves write methods guard against it (tc-l31ve). */
+private class ThrowingDataStore(
+    private val exception: Throwable,
+) : DataStore<Preferences> {
+    override val data = flowOf(emptyPreferences())
+
+    override suspend fun updateData(transform: suspend (t: Preferences) -> Preferences): Preferences = throw exception
 }

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/subscriptions/DataStoreSubscriptionTierCacheTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/subscriptions/DataStoreSubscriptionTierCacheTest.kt
@@ -1,12 +1,19 @@
 package uk.towncrierapp.data.subscriptions
 
+import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.emptyPreferences
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import uk.towncrierapp.domain.subscriptions.SubscriptionTier
 import java.io.File
+import java.io.IOException
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 
 /**
@@ -51,4 +58,29 @@ class DataStoreSubscriptionTierCacheTest {
 
         assertEquals(SubscriptionTier.FREE, sut.read())
     }
+
+    @Test
+    fun `write swallows an IOException from the underlying DataStore`() =
+        runTest {
+            val sut = DataStoreSubscriptionTierCache(ThrowingDataStore(IOException("disk full")))
+
+            sut.write(SubscriptionTier.PRO)
+        }
+
+    @Test
+    fun `write rethrows a CancellationException from the underlying DataStore`() =
+        runTest {
+            val sut = DataStoreSubscriptionTierCache(ThrowingDataStore(CancellationException("cancelled")))
+
+            assertFailsWith<CancellationException> { sut.write(SubscriptionTier.PRO) }
+        }
+}
+
+/** A [DataStore] whose `updateData` (and so `edit { }`) always throws [exception] — proves write methods guard against it (tc-l31ve). */
+private class ThrowingDataStore(
+    private val exception: Throwable,
+) : DataStore<Preferences> {
+    override val data = flowOf(emptyPreferences())
+
+    override suspend fun updateData(transform: suspend (t: Preferences) -> Preferences): Preferences = throw exception
 }


### PR DESCRIPTION
## Summary

- CodeRabbit flagged in PR #1065 (tc-50cto) that `DataStoreMapPreferencesStore.writeLastSelectedZoneId` doesn't catch `IOException` from `dataStore.edit{}`. It was declined as a one-off fix there because no sibling DataStore-backed store guarded `.edit` either — a module-wide convention question, not a single-file bug.
- This PR makes the module-wide decision: guard consistently. Every `dataStore.edit { ... }` write call across the module's 6 DataStore-backed preference stores now catches `IOException` (swallowed — these are all best-effort fire-and-forget writes with no caller that handles a thrown exception) while rethrowing `CancellationException` first, per structured-concurrency correctness. Rationale: Android's own DataStore guidance treats `IOException` as an expected, recoverable disk-I/O condition, not a programming error.
- No public method signatures changed.

## Files changed

- `data/.../map/DataStoreMapPreferencesStore.kt`
- `data/.../applications/DataStoreApplicationListPreferencesStore.kt` (`writeSort`, `writeLastSelectedZoneId`)
- `data/.../settings/DataStoreAppearanceStore.kt`
- `data/.../reviewprompt/DataStoreReviewPromptStore.kt`
- `data/.../onboarding/DataStoreOnboardingRepository.kt`
- `data/.../subscriptions/DataStoreSubscriptionTierCache.kt`
- Matching `*Test.kt` for each of the above.

## Test plan

- [x] TDD red/green: new tests asserted against the original unguarded code first (failed with uncaught `IOException`), then against the fix (passed). Two commits: `ed3c841` (red), `44e6ea2` (green).
- [x] 12 new unit tests (2 per write method) using a small hand-written `ThrowingDataStore` fake — one per method proving an `IOException` from the underlying `DataStore` is swallowed, one proving `CancellationException` still propagates.
- [x] `./gradlew :data:compileDebugKotlin`
- [x] `./gradlew :data:testDebugUnitTest` (89 tests)
- [x] `./gradlew ktlintCheck detekt` (module-wide)
- [x] `./gradlew :app:assembleDevDebug`

Closes tc-l31ve.

---
_Generated by [Claude Code](https://claude.ai/code/session_011mRNs5YAS6CNLrNuhkwTaC)_