### PR TITLE
chore(ios): bump MARKETING_VERSION 1.2.10 -> 1.2.11

### DIFF
--- a/mobile/ios/project.yml
+++ b/mobile/ios/project.yml
@@ -26,7 +26,7 @@ targets:
         DEVELOPMENT_TEAM: 4574VQ7N2X
         TARGETED_DEVICE_FAMILY: "1"
         INFOPLIST_GENERATION_MODE: GeneratedFile
-        MARKETING_VERSION: "1.2.10"
+        MARKETING_VERSION: "1.2.11"
         CURRENT_PROJECT_VERSION: "1"
         GENERATE_INFOPLIST_FILE: "YES"
         INFOPLIST_KEY_UIApplicationSceneManifest_Generation: "YES"


### PR DESCRIPTION
## Summary
- `cd-ios-testflight` for v0.21.24 failed with altool error 90186: `Invalid Pre-Release Train. The train version '1.2.10' is closed for new build submissions` — 1.2.10 already shipped to the public App Store.
- Bumps `MARKETING_VERSION` in `mobile/ios/project.yml` from `1.2.10` to `1.2.11` to reopen a TestFlight train. The CD beta lane bumps `CURRENT_PROJECT_VERSION` (build number) on its own; this is the version-string half.

## Next step after merge
Re-trigger `cd-ios-testflight` via `workflow_dispatch` on `main` — no need to cut a new version tag, `cd-prod` already deployed `v0.21.24` successfully; only the iOS lane needs a retry.

Precedent: identical fix in PR #1056 (1.2.9 -> 1.2.10).

Bead: tc-fcz6e

🤖 Generated with [Claude Code](https://claude.com/claude-code)