### PR TITLE
feat(api): serve watch-zone filter catalog from GET /v1/watch-zones/filter-catalog (tc-m8j90.1)

### DIFF
--- a/api-go/cmd/api/anonymous_patterns_test.go
+++ b/api-go/cmd/api/anonymous_patterns_test.go
@@ -126,3 +126,17 @@ func TestAnonymousPatterns_IncludesAssetLinks(t *testing.T) {
 		t.Errorf("anonymousPatterns must include %q", assetLinks)
 	}
 }
+
+// TestAnonymousPatterns_IncludesFilterCatalog pins the anonymity of the
+// watch-zone filter catalog (GH#1104, tc-m8j90.1): static, non-user-specific
+// display copy for the seven pre-canned filters, readable before a client has
+// created an account, mirroring the legal document endpoint. The auth
+// middleware keys on the registered pattern string byte-for-byte.
+func TestAnonymousPatterns_IncludesFilterCatalog(t *testing.T) {
+	t.Parallel()
+
+	const filterCatalog = "GET /v1/watch-zones/filter-catalog"
+	if _, ok := anonymousPatterns[filterCatalog]; !ok {
+		t.Errorf("anonymousPatterns must include %q", filterCatalog)
+	}
+}

--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -45,6 +45,11 @@ var anonymousPatterns = map[string]struct{}{
 	"GET /v1/health":               {},
 	"GET /v1/version-config":       {},
 	"GET /v1/legal/{documentType}": {},
+	// The watch-zone filter catalog is static, non-user-specific content (the
+	// seven pre-canned filters' display copy) that iOS reads before creating an
+	// account, so it is anonymous to Auth0, mirroring the legal endpoint above
+	// (GH#1104, tc-m8j90.1).
+	"GET /v1/watch-zones/filter-catalog": {},
 	// The demo-account endpoint is anonymous so Apple's App Store reviewer can
 	// reach a fully-provisioned Pro account without a token (no bearer required).
 	"GET /v1/demo-account": {},
@@ -248,6 +253,11 @@ func newRouter(
 	health.Routes(mux, logger)
 	versionconfig.Routes(mux, logger)
 	legal.Routes(mux, logger)
+	// The filter catalog is static Go-literal content with no store dependency
+	// (see filter.go), so it is registered unconditionally, outside the
+	// watchZoneStore-guarded block below, mirroring legal.Routes immediately
+	// above (GH#1104, tc-m8j90.1).
+	watchzones.CatalogRoutes(mux, logger)
 	authorities.Routes(mux, logger)
 	api.Routes(mux, logger)
 	// The Apple App Site Association document (#738 Slice 3) is stateless and needs

--- a/api-go/cmd/api/wiring_test.go
+++ b/api-go/cmd/api/wiring_test.go
@@ -330,6 +330,10 @@ func TestRouter_AnonymousRoutesServedWithoutToken(t *testing.T) {
 		{"/v1/version-config", http.StatusOK},
 		{"/v1/legal/privacy", http.StatusOK},
 		{"/v1/legal/unknown", http.StatusNotFound}, // anonymous route, bodyless 404 backfilled
+		// newTestHandler boots with a nil watchZoneStore; the filter catalog must
+		// still serve because it is registered outside the watchZoneStore-guarded
+		// block (GH#1104, tc-m8j90.1).
+		{"/v1/watch-zones/filter-catalog", http.StatusOK},
 	} {
 		t.Run(tc.path, func(t *testing.T) {
 			t.Parallel()

--- a/api-go/internal/watchzones/catalog_handler.go
+++ b/api-go/internal/watchzones/catalog_handler.go
@@ -1,0 +1,61 @@
+package watchzones
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+)
+
+// filterCatalogEntry is the wire shape for one catalog filter. It
+// deliberately carries no Expression (or any other matching-internals)
+// field: the to_tsquery expression is server-only implementation detail,
+// never served to a client.
+type filterCatalogEntry struct {
+	Key         string `json:"key"`
+	DisplayName string `json:"displayName"`
+	Description string `json:"description"`
+}
+
+// filterCatalogResult is the response body for GET
+// /v1/watch-zones/filter-catalog.
+type filterCatalogResult struct {
+	Filters []filterCatalogEntry `json:"filters"`
+}
+
+// CatalogRoutes registers the read-only, anonymous watch-zone filter catalog
+// endpoint on mux. It needs no store: the catalog is Go-literal static
+// content (see filter.go), so this is wired unconditionally regardless of
+// whether a watch-zone store is configured (GH#1104, tc-m8j90.1).
+func CatalogRoutes(mux *http.ServeMux, logger *slog.Logger) {
+	h := catalogHandler{logger: logger}
+	mux.HandleFunc("GET /v1/watch-zones/filter-catalog", h.catalog)
+}
+
+type catalogHandler struct {
+	logger *slog.Logger
+}
+
+// catalog always returns 200: the catalog is static content baked into the
+// binary, so there is no not-found or error branch to model.
+func (h catalogHandler) catalog(w http.ResponseWriter, r *http.Request) {
+	result := filterCatalogResult{Filters: make([]filterCatalogEntry, 0, len(filterCatalogOrder))}
+	for _, key := range filterCatalogOrder {
+		def, ok := FilterDefinitionFor(key)
+		if !ok {
+			// Unreachable unless filterCatalogOrder and filterCatalog drift out of
+			// sync; skip rather than fail the whole response for the other entries.
+			continue
+		}
+		result.Filters = append(result.Filters, filterCatalogEntry{
+			Key:         string(key),
+			DisplayName: def.DisplayName,
+			Description: def.Description,
+		})
+	}
+
+	w.Header().Set("Cache-Control", "public, max-age=3600")
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	if err := json.NewEncoder(w).Encode(result); err != nil {
+		h.logger.ErrorContext(r.Context(), "write filter catalog response", "error", err)
+	}
+}

--- a/api-go/internal/watchzones/catalog_handler.go
+++ b/api-go/internal/watchzones/catalog_handler.go
@@ -1,9 +1,10 @@
 package watchzones
 
 import (
-	"encoding/json"
 	"log/slog"
 	"net/http"
+
+	"github.com/AmyDe/town-crier/api-go/internal/httputil"
 )
 
 // filterCatalogEntry is the wire shape for one catalog filter. It
@@ -36,7 +37,10 @@ type catalogHandler struct {
 }
 
 // catalog always returns 200: the catalog is static content baked into the
-// binary, so there is no not-found or error branch to model.
+// binary, so there is no not-found branch to model. Encoding can only fail
+// on a filterCatalogEntry that can't be marshalled, which never happens for
+// this all-string struct — the error branch exists to match this package's
+// other handlers' writeJSON pattern, not because it's reachable today.
 func (h catalogHandler) catalog(w http.ResponseWriter, r *http.Request) {
 	result := filterCatalogResult{Filters: make([]filterCatalogEntry, 0, len(filterCatalogOrder))}
 	for _, key := range filterCatalogOrder {
@@ -53,9 +57,16 @@ func (h catalogHandler) catalog(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
+	body, err := httputil.EncodeJSON(result)
+	if err != nil {
+		h.logger.ErrorContext(r.Context(), "encode filter catalog response", "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 	w.Header().Set("Cache-Control", "public, max-age=3600")
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	if err := json.NewEncoder(w).Encode(result); err != nil {
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(body); err != nil {
 		h.logger.ErrorContext(r.Context(), "write filter catalog response", "error", err)
 	}
 }

--- a/api-go/internal/watchzones/catalog_handler_test.go
+++ b/api-go/internal/watchzones/catalog_handler_test.go
@@ -26,7 +26,7 @@ func TestCatalogRoutes_FilterCatalog_StableOrder(t *testing.T) {
 	// Call repeatedly: map iteration order is randomised per-process, so a
 	// regression to iterating filterCatalog directly would show up as
 	// flakiness across these calls even within a single test run.
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/v1/watch-zones/filter-catalog", nil)
 		if err != nil {
 			t.Fatalf("new request: %v", err)
@@ -132,7 +132,7 @@ func TestCatalogRoutes_FilterCatalog_AnonymousNoAuthRequired(t *testing.T) {
 	mux := http.NewServeMux()
 	CatalogRoutes(mux, slog.New(slog.DiscardHandler))
 
-	req := httptest.NewRequest(http.MethodGet, "/v1/watch-zones/filter-catalog", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v1/watch-zones/filter-catalog", nil)
 	rec := httptest.NewRecorder()
 
 	mux.ServeHTTP(rec, req)

--- a/api-go/internal/watchzones/catalog_handler_test.go
+++ b/api-go/internal/watchzones/catalog_handler_test.go
@@ -1,0 +1,164 @@
+package watchzones
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newCatalogServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	CatalogRoutes(mux, slog.New(slog.DiscardHandler))
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestCatalogRoutes_FilterCatalog_StableOrder(t *testing.T) {
+	t.Parallel()
+
+	srv := newCatalogServer(t)
+
+	// Call repeatedly: map iteration order is randomised per-process, so a
+	// regression to iterating filterCatalog directly would show up as
+	// flakiness across these calls even within a single test run.
+	for i := 0; i < 5; i++ {
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/v1/watch-zones/filter-catalog", nil)
+		if err != nil {
+			t.Fatalf("new request: %v", err)
+		}
+		resp, err := srv.Client().Do(req)
+		if err != nil {
+			t.Fatalf("get: %v", err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status: got %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+
+		var body struct {
+			Filters []struct {
+				Key         string `json:"key"`
+				DisplayName string `json:"displayName"`
+				Description string `json:"description"`
+			} `json:"filters"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		resp.Body.Close()
+
+		if len(body.Filters) != len(filterCatalogOrder) {
+			t.Fatalf("filters length: got %d, want %d", len(body.Filters), len(filterCatalogOrder))
+		}
+		for idx, key := range filterCatalogOrder {
+			def, ok := FilterDefinitionFor(key)
+			if !ok {
+				t.Fatalf("filterCatalogOrder[%d] = %q not in catalog", idx, key)
+			}
+			got := body.Filters[idx]
+			if got.Key != string(key) {
+				t.Errorf("iteration %d, entry %d: key: got %q, want %q", i, idx, got.Key, key)
+			}
+			if got.DisplayName != def.DisplayName {
+				t.Errorf("iteration %d, entry %d: displayName: got %q, want %q", i, idx, got.DisplayName, def.DisplayName)
+			}
+			if got.Description != def.Description {
+				t.Errorf("iteration %d, entry %d: description: got %q, want %q", i, idx, got.Description, def.Description)
+			}
+		}
+	}
+}
+
+func TestCatalogRoutes_FilterCatalog_NoExpressionLeaked(t *testing.T) {
+	t.Parallel()
+
+	srv := newCatalogServer(t)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/v1/watch-zones/filter-catalog", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var raw map[string]json.RawMessage
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		t.Fatalf("decode top-level: %v", err)
+	}
+
+	filtersRaw, ok := raw["filters"]
+	if !ok {
+		t.Fatalf("response missing top-level %q field", "filters")
+	}
+
+	var entries []map[string]json.RawMessage
+	if err := json.Unmarshal(filtersRaw, &entries); err != nil {
+		t.Fatalf("decode filters array: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatalf("filters: got 0 entries, want > 0")
+	}
+
+	for i, entry := range entries {
+		for field := range entry {
+			lower := strings.ToLower(field)
+			if strings.Contains(lower, "expression") || strings.Contains(lower, "tsquery") || strings.Contains(lower, "match") {
+				t.Errorf("entry %d exposes matching-internals field %q", i, field)
+			}
+		}
+		allowed := map[string]bool{"key": true, "displayName": true, "description": true}
+		for field := range entry {
+			if !allowed[field] {
+				t.Errorf("entry %d has unexpected field %q", i, field)
+			}
+		}
+	}
+}
+
+func TestCatalogRoutes_FilterCatalog_AnonymousNoAuthRequired(t *testing.T) {
+	t.Parallel()
+
+	// Call the handler directly with no auth context set on the request,
+	// mirroring the pattern legal.Routes' tests use for their anonymous
+	// route: this endpoint must never require an authenticated subject.
+	mux := http.NewServeMux()
+	CatalogRoutes(mux, slog.New(slog.DiscardHandler))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/watch-zones/filter-catalog", nil)
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status: got %d, want %d", rec.Code, http.StatusOK)
+	}
+}
+
+func TestCatalogRoutes_FilterCatalog_CacheControlHeader(t *testing.T) {
+	t.Parallel()
+
+	srv := newCatalogServer(t)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/v1/watch-zones/filter-catalog", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+
+	const want = "public, max-age=3600"
+	if got := resp.Header.Get("Cache-Control"); got != want {
+		t.Errorf("Cache-Control: got %q, want %q", got, want)
+	}
+}

--- a/api-go/internal/watchzones/filter.go
+++ b/api-go/internal/watchzones/filter.go
@@ -115,6 +115,22 @@ var filterCatalog = map[FilterKey]FilterDefinition{
 	},
 }
 
+// filterCatalogOrder lists the seven catalog keys in a fixed, deliberate
+// display order (matching the const block above) for anything that serves
+// the catalog to a client — e.g. catalog_handler.go's GET
+// /v1/watch-zones/filter-catalog. Go map iteration order is randomised, so
+// any caller that needs a stable, repeatable order must walk this slice
+// rather than range over filterCatalog directly.
+var filterCatalogOrder = []FilterKey{
+	FilterKeyFewerNotifications,
+	FilterKeyHouseBuilder,
+	FilterKeyNewHomes,
+	FilterKeyExtensionsAlterations,
+	FilterKeyLoftExtension,
+	FilterKeyKitchenExtension,
+	FilterKeyHMOHouseShares,
+}
+
 // IsValidFilterKey reports whether key is a member of the catalog. The
 // empty string is never valid: "" means "no filter", and callers must gate
 // on a non-empty value before calling IsValidFilterKey (per GH#1090's

--- a/api-go/internal/watchzones/filter_test.go
+++ b/api-go/internal/watchzones/filter_test.go
@@ -123,3 +123,36 @@ func TestFilterCatalog_KeywordFiltersHaveExpressions(t *testing.T) {
 		}
 	}
 }
+
+// TestFilterCatalogOrder_MatchesFilterCatalog guards against filterCatalog
+// and filterCatalogOrder drifting apart. A key added to filterCatalog alone
+// would build and pass every other test, but silently never appear in GET
+// /v1/watch-zones/filter-catalog (catalog_handler.go skips any
+// filterCatalogOrder entry missing from filterCatalog, but nothing catches
+// the reverse) -- defeating GH#1104/GH#1090's "adding a filter is a Go-only
+// deploy" premise.
+func TestFilterCatalogOrder_MatchesFilterCatalog(t *testing.T) {
+	t.Parallel()
+
+	if len(filterCatalogOrder) != len(filterCatalog) {
+		t.Fatalf("filterCatalogOrder has %d entries, filterCatalog has %d -- they must match",
+			len(filterCatalogOrder), len(filterCatalog))
+	}
+
+	seen := make(map[FilterKey]bool, len(filterCatalogOrder))
+	for _, key := range filterCatalogOrder {
+		if _, ok := filterCatalog[key]; !ok {
+			t.Errorf("filterCatalogOrder contains %q, which is not in filterCatalog", key)
+		}
+		if seen[key] {
+			t.Errorf("filterCatalogOrder contains %q more than once", key)
+		}
+		seen[key] = true
+	}
+
+	for key := range filterCatalog {
+		if !seen[key] {
+			t.Errorf("filterCatalog contains %q, which is missing from filterCatalogOrder", key)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds a new anonymous `GET /v1/watch-zones/filter-catalog` endpoint that serves the existing pre-canned watch-zone filter catalog (`api-go/internal/watchzones/filter.go`) to clients, returning `{"filters":[{"key","displayName","description"}, ...]}` in a fixed, deterministic order. Never exposes the internal `Expression` (to_tsquery) field.

This is the **API-only slice** of [GH#1104](https://github.com/AmyDe/town-crier/issues/1104), split out as bead `tc-m8j90.1` because it crosses two worker boundaries (Go + iOS) that this repo's convention keeps to one PR per single-stack worker (see `tc-v6fo0.x` for precedent). The iOS client refactor (deleting the hardcoded `WatchZoneFilterKey` enum and consuming this endpoint) is tracked separately as `tc-m8j90.2`, which depends on this PR landing.

## What changed

- `api-go/internal/watchzones/filter.go` — added `filterCatalogOrder`, an explicit stable-order slice (Go map iteration is randomised, so the existing `filterCatalog` map alone can't back a client-visible list).
- `api-go/internal/watchzones/catalog_handler.go` (new) — `filterCatalogEntry`, `filterCatalogResult`, `CatalogRoutes`, and the handler. Always returns 200 (static content baked into the binary); sets `Cache-Control: public, max-age=3600`.
- `api-go/internal/watchzones/catalog_handler_test.go` (new) — asserts stable order across repeated calls, asserts no `expression`/matching-internals field is exposed, asserts 200 with no auth context, asserts the cache header.
- `api-go/cmd/api/wiring.go` — added the route to `anonymousPatterns`; registered `watchzones.CatalogRoutes(mux, logger)` unconditionally (no store dependency), mirroring the existing `legal.Routes` precedent.
- `api-go/cmd/api/anonymous_patterns_test.go`, `api-go/cmd/api/wiring_test.go` — route-pinning and store-less smoke-test coverage, following each file's existing conventions.

## Out of scope (tracked separately)

- iOS consumption of this endpoint / deletion of the `WatchZoneFilterKey` enum — `tc-m8j90.2`, blocked on this PR merging.
- Any change to POST/PATCH `filterKey` validation, the `filter_key_invalid`/`filter_requires_pro_tier` error codes, or notification matching (`notifydispatch`) — all untouched.
- No DB table, admin UI, or catalog versioning/ETag.

## Test plan

- [x] `gofmt -l .` — clean
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `go test ./...` — all packages pass (full suite, not just the new ones)
- [x] New tests cover fixed ordering, no-expression-leak, anonymous 200, and cache header

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9LGt6BT6EgJJMiwoSiFrg)_